### PR TITLE
Add local files adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This repository is a public-by-design workspace for building source adapters tha
 - keep source-specific logic separate from downstream processing
 - avoid embedding environment-specific details in the codebase
 
-The initial implementation focuses on a **Confluence adapter**, but the repository is intentionally scoped for multiple adapters over time.
+The initial implementation focuses on **Confluence** and **local file** adapters, but the repository is intentionally scoped for additional adapters over time.
 
 ---
 
@@ -70,6 +70,7 @@ The initial implementation focuses on a **Confluence adapter**, but the reposito
 - repository structure
 - initial documentation
 - Confluence adapter scaffold
+- local files adapter scaffold
 - CLI entrypoint
 - basic end-to-end pipeline (resolve → fetch stub → normalize → write)
 - CI (ruff, mypy, pytest)
@@ -84,6 +85,10 @@ The initial implementation focuses on a **Confluence adapter**, but the reposito
   - write local artifacts to a specified output directory
   - track state with a manifest
   - support dry-run behavior
+- local files adapter
+  - accept a runtime-provided file path
+  - normalize file contents into markdown plus metadata
+  - write local artifacts to a specified output directory
 
 ---
 
@@ -146,4 +151,14 @@ knowledge-adapters/
 │   └── knowledge_adapters/
 ├── tests/
 └── .gitignore
+```
+
+## Example
+
+Normalize a local text file into the standard markdown artifact:
+
+```bash
+knowledge-adapters local_files \
+  --file-path ./notes/today.txt \
+  --output-dir ./artifacts
 ```

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -56,6 +56,26 @@ def build_parser() -> argparse.ArgumentParser:
         help="Maximum recursion depth for tree mode. 0 means single page only.",
     )
 
+    local_files_parser = subparsers.add_parser(
+        "local_files",
+        help="Run the local files adapter.",
+    )
+    local_files_parser.add_argument(
+        "--file-path",
+        required=True,
+        help="Path to a local file to normalize.",
+    )
+    local_files_parser.add_argument(
+        "--output-dir",
+        required=True,
+        help="Directory to write normalized local artifacts.",
+    )
+    local_files_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Plan actions without writing files.",
+    )
+
     return parser
 
 
@@ -71,7 +91,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         from knowledge_adapters.confluence.resolve import resolve_target
         from knowledge_adapters.confluence.writer import write_markdown
 
-        config = ConfluenceConfig(
+        confluence_config = ConfluenceConfig(
             base_url=args.base_url,
             target=args.target,
             output_dir=args.output_dir,
@@ -81,27 +101,60 @@ def main(argv: Sequence[str] | None = None) -> int:
             max_depth=args.max_depth,
         )
 
-        target = resolve_target(config.target)
+        target = resolve_target(confluence_config.target)
 
         print("Confluence adapter invoked")
-        print(f"  base_url: {config.base_url}")
+        print(f"  base_url: {confluence_config.base_url}")
         print(f"  target: {target.raw_value}")
-        print(f"  output_dir: {config.output_dir}")
-        print(f"  auth_method: {config.auth_method}")
-        print(f"  dry_run: {config.dry_run}")
-        print(f"  tree: {config.tree}")
-        print(f"  max_depth: {config.max_depth}")
+        print(f"  output_dir: {confluence_config.output_dir}")
+        print(f"  auth_method: {confluence_config.auth_method}")
+        print(f"  dry_run: {confluence_config.dry_run}")
+        print(f"  tree: {confluence_config.tree}")
+        print(f"  max_depth: {confluence_config.max_depth}")
 
         page = fetch_page(target)
         markdown = normalize_to_markdown(page)
 
-        if config.dry_run:
+        if confluence_config.dry_run:
             print("\n--- DRY RUN OUTPUT ---\n")
             print(markdown)
             return 0
 
         page_id = str(page["canonical_id"])
-        output_path = write_markdown(config.output_dir, page_id, markdown)
+        output_path = write_markdown(confluence_config.output_dir, page_id, markdown)
+        print(f"\nWrote: {output_path}")
+        return 0
+
+    if args.command == "local_files":
+        from pathlib import Path
+
+        from knowledge_adapters.local_files.client import fetch_file
+        from knowledge_adapters.local_files.config import LocalFilesConfig
+        from knowledge_adapters.local_files.normalize import normalize_to_markdown
+        from knowledge_adapters.local_files.writer import write_markdown
+
+        local_files_config = LocalFilesConfig(
+            file_path=args.file_path,
+            output_dir=args.output_dir,
+            dry_run=args.dry_run,
+        )
+
+        print("Local files adapter invoked")
+        print(f"  file_path: {local_files_config.file_path}")
+        print(f"  output_dir: {local_files_config.output_dir}")
+        print(f"  dry_run: {local_files_config.dry_run}")
+
+        page = fetch_file(local_files_config.file_path)
+        markdown = normalize_to_markdown(page)
+
+        if local_files_config.dry_run:
+            print("\n--- DRY RUN OUTPUT ---\n")
+            print(markdown)
+            return 0
+
+        input_path = Path(local_files_config.file_path)
+        output_name = input_path.stem or input_path.name
+        output_path = write_markdown(local_files_config.output_dir, output_name, markdown)
         print(f"\nWrote: {output_path}")
         return 0
 

--- a/src/knowledge_adapters/confluence/normalize.py
+++ b/src/knowledge_adapters/confluence/normalize.py
@@ -9,19 +9,24 @@ def normalize_to_markdown(page: Mapping[str, object]) -> str:
     """Normalize a fetched page payload into markdown."""
     title = str(page.get("title", "untitled"))
     canonical_id = str(page.get("canonical_id", ""))
+    parent_id = str(page.get("parent_id", ""))
     source_url = str(page.get("source_url", ""))
-    content = str(page.get("content", ""))
+    fetched_at = str(page.get("fetched_at", ""))
+    updated_at = str(page.get("updated_at", ""))
+    source = str(page.get("source", "confluence"))
+    adapter = str(page.get("adapter", "confluence"))
+    content = str(page.get("content", "")).rstrip("\n")
 
     return f"""# {title}
 
 ## Metadata
-- source: confluence
+- source: {source}
 - canonical_id: {canonical_id}
-- parent_id:
+- parent_id:{f" {parent_id}" if parent_id else ""}
 - source_url: {source_url}
-- fetched_at:
-- updated_at:
-- adapter: confluence
+- fetched_at:{f" {fetched_at}" if fetched_at else ""}
+- updated_at:{f" {updated_at}" if updated_at else ""}
+- adapter: {adapter}
 
 ## Content
 

--- a/src/knowledge_adapters/local_files/__init__.py
+++ b/src/knowledge_adapters/local_files/__init__.py
@@ -1,0 +1,1 @@
+"""Local files adapter package."""

--- a/src/knowledge_adapters/local_files/client.py
+++ b/src/knowledge_adapters/local_files/client.py
@@ -1,0 +1,20 @@
+"""File-reading layer for the local files adapter."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def fetch_file(file_path: str) -> dict[str, object]:
+    """Read a local file into the shared normalized payload shape."""
+    path = Path(file_path).expanduser().resolve()
+    content = path.read_text(encoding="utf-8")
+
+    return {
+        "title": path.name,
+        "canonical_id": str(path),
+        "source_url": path.as_uri(),
+        "content": content,
+        "source": "local_files",
+        "adapter": "local_files",
+    }

--- a/src/knowledge_adapters/local_files/config.py
+++ b/src/knowledge_adapters/local_files/config.py
@@ -1,0 +1,14 @@
+"""Configuration models for the local files adapter."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class LocalFilesConfig:
+    """Runtime configuration for the local files adapter."""
+
+    file_path: str
+    output_dir: str
+    dry_run: bool = False

--- a/src/knowledge_adapters/local_files/normalize.py
+++ b/src/knowledge_adapters/local_files/normalize.py
@@ -1,0 +1,5 @@
+"""Normalization logic for the local files adapter."""
+
+from knowledge_adapters.confluence.normalize import normalize_to_markdown
+
+__all__ = ["normalize_to_markdown"]

--- a/src/knowledge_adapters/local_files/writer.py
+++ b/src/knowledge_adapters/local_files/writer.py
@@ -1,0 +1,5 @@
+"""File writing utilities for the local files adapter."""
+
+from knowledge_adapters.confluence.writer import write_markdown
+
+__all__ = ["write_markdown"]

--- a/tests/test_local_files.py
+++ b/tests/test_local_files.py
@@ -1,0 +1,77 @@
+from pathlib import Path
+
+from knowledge_adapters.cli import main
+from knowledge_adapters.local_files.client import fetch_file
+from knowledge_adapters.local_files.normalize import normalize_to_markdown
+
+
+def test_fetch_file_reads_local_path_into_adapter_payload(tmp_path: Path) -> None:
+    source_file = tmp_path / "notes.txt"
+    source_file.write_text("Hello from disk.\n", encoding="utf-8")
+
+    payload = fetch_file(str(source_file))
+
+    assert payload == {
+        "title": "notes.txt",
+        "canonical_id": str(source_file.resolve()),
+        "source_url": source_file.resolve().as_uri(),
+        "content": "Hello from disk.\n",
+        "source": "local_files",
+        "adapter": "local_files",
+    }
+
+
+def test_local_files_reuses_shared_normalizer() -> None:
+    markdown = normalize_to_markdown(
+        {
+            "title": "notes.txt",
+            "canonical_id": "/tmp/notes.txt",
+            "source_url": "file:///tmp/notes.txt",
+            "content": "Hello from disk.",
+            "source": "local_files",
+            "adapter": "local_files",
+        }
+    )
+
+    assert "- source: local_files\n" in markdown
+    assert "- adapter: local_files\n" in markdown
+    assert markdown.endswith("Hello from disk.\n")
+
+
+def test_local_files_cli_writes_normalized_markdown(tmp_path: Path) -> None:
+    source_file = tmp_path / "meeting-notes.txt"
+    source_file.write_text("Line one.\nLine two.\n", encoding="utf-8")
+    output_dir = tmp_path / "out"
+
+    exit_code = main(
+        [
+            "local_files",
+            "--file-path",
+            str(source_file),
+            "--output-dir",
+            str(output_dir),
+        ]
+    )
+
+    assert exit_code == 0
+
+    output_path = output_dir / "pages" / "meeting-notes.md"
+    assert output_path.exists()
+    assert output_path.read_text(encoding="utf-8") == (
+        f"""# meeting-notes.txt
+
+## Metadata
+- source: local_files
+- canonical_id: {source_file.resolve()}
+- parent_id:
+- source_url: {source_file.resolve().as_uri()}
+- fetched_at:
+- updated_at:
+- adapter: local_files
+
+## Content
+
+Line one.
+Line two.
+"""
+    )


### PR DESCRIPTION
## Summary
- add a new local_files adapter that reads a local file path into the shared payload shape
- reuse the existing normalize_to_markdown output path and wire the adapter into the CLI
- add unit tests and a short README example

## Testing
- make check