### PR TITLE
chore: add check-env target for GitHub tooling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,10 +11,12 @@ This project is designed to be **public-safe, reproducible, and adapter-focused*
 Bootstrap your local development environment:
 
 ```bash
+make check-env
 make dev
 ```
 
-This will:
+These commands will:
+- verify GitHub CLI (`gh`) is installed and authenticated
 - create a local `.venv`
 - install all development dependencies (`pytest`, `ruff`, `mypy`, etc.)
 
@@ -25,6 +27,7 @@ This will:
 ## Common Commands
 
 ```bash
+make check-env   # verify required GitHub tooling
 make test        # run tests
 make lint        # check linting (ruff)
 make fix         # auto-fix lint issues where possible

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev test lint fix format typecheck check clean
+.PHONY: dev test lint fix format typecheck check check-env clean
 
 VENV = .venv
 PYTHON = $(VENV)/bin/python
@@ -13,6 +13,10 @@ $(VENV)/bin/activate:
 	$(PIP) install -e '.[dev]'
 
 dev: $(VENV)/bin/activate
+
+check-env:
+	@command -v gh >/dev/null 2>&1 || { echo "Error: GitHub CLI (gh) is required but is not installed." >&2; exit 1; }
+	@gh auth status >/dev/null 2>&1 || { echo "Error: GitHub CLI authentication is required. Run 'gh auth login' and try again." >&2; exit 1; }
 
 test: $(VENV)/bin/activate
 	$(PYTEST)

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Generic adapters for acquiring knowledge from external sources and normalizing i
 git clone <repo>
 cd <repo>
 
+make check-env
 make dev
 make check
 ```
@@ -17,6 +18,7 @@ make check
 Common commands:
 
 ```bash
+make check-env
 make test
 make lint
 make fix


### PR DESCRIPTION
Summary
- add a Makefile check-env target that verifies GitHub CLI availability and authentication
- document make check-env in the README quickstart and common commands
- mention the environment check in CONTRIBUTING setup guidance

Testing
- make check
- make check-env