### PR TITLE
feat: add dry-run write preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,3 +164,12 @@ knowledge-adapters local_files \
   --file-path ./notes/today.txt \
   --output-dir ./artifacts
 ```
+
+Preview the normalized markdown without writing files:
+
+```bash
+knowledge-adapters local_files \
+  --file-path ./notes/today.txt \
+  --output-dir ./artifacts \
+  --dry-run
+```

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -115,13 +115,18 @@ def main(argv: Sequence[str] | None = None) -> int:
         page = fetch_page(target)
         markdown = normalize_to_markdown(page)
 
+        page_id = str(page["canonical_id"])
+        output_path = write_markdown(
+            confluence_config.output_dir,
+            page_id,
+            markdown,
+            dry_run=confluence_config.dry_run,
+        )
         if confluence_config.dry_run:
-            print("\n--- DRY RUN OUTPUT ---\n")
+            print(f"\nDry run: would write {output_path}\n")
             print(markdown)
             return 0
 
-        page_id = str(page["canonical_id"])
-        output_path = write_markdown(confluence_config.output_dir, page_id, markdown)
         print(f"\nWrote: {output_path}")
         return 0
 
@@ -147,14 +152,19 @@ def main(argv: Sequence[str] | None = None) -> int:
         page = fetch_file(local_files_config.file_path)
         markdown = normalize_to_markdown(page)
 
+        input_path = Path(local_files_config.file_path)
+        output_name = input_path.stem or input_path.name
+        output_path = write_markdown(
+            local_files_config.output_dir,
+            output_name,
+            markdown,
+            dry_run=local_files_config.dry_run,
+        )
         if local_files_config.dry_run:
-            print("\n--- DRY RUN OUTPUT ---\n")
+            print(f"\nDry run: would write {output_path}\n")
             print(markdown)
             return 0
 
-        input_path = Path(local_files_config.file_path)
-        output_name = input_path.stem or input_path.name
-        output_path = write_markdown(local_files_config.output_dir, output_name, markdown)
         print(f"\nWrote: {output_path}")
         return 0
 

--- a/src/knowledge_adapters/confluence/writer.py
+++ b/src/knowledge_adapters/confluence/writer.py
@@ -5,11 +5,20 @@ from __future__ import annotations
 from pathlib import Path
 
 
-def write_markdown(output_dir: str, page_id: str, markdown: str) -> Path:
+def write_markdown(
+    output_dir: str,
+    page_id: str,
+    markdown: str,
+    *,
+    dry_run: bool = False,
+) -> Path:
     """Write normalized markdown to a deterministic local path."""
     pages_dir = Path(output_dir) / "pages"
-    pages_dir.mkdir(parents=True, exist_ok=True)
-
     output_path = pages_dir / f"{page_id}.md"
+
+    if dry_run:
+        return output_path
+
+    pages_dir.mkdir(parents=True, exist_ok=True)
     output_path.write_text(markdown, encoding="utf-8")
     return output_path

--- a/tests/test_local_files.py
+++ b/tests/test_local_files.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+from pytest import CaptureFixture
+
 from knowledge_adapters.cli import main
 from knowledge_adapters.local_files.client import fetch_file
 from knowledge_adapters.local_files.normalize import normalize_to_markdown
@@ -75,3 +77,32 @@ Line one.
 Line two.
 """
     )
+
+
+def test_local_files_cli_dry_run_reports_output_without_writing(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    source_file = tmp_path / "meeting-notes.txt"
+    source_file.write_text("Line one.\nLine two.\n", encoding="utf-8")
+    output_dir = tmp_path / "out"
+
+    exit_code = main(
+        [
+            "local_files",
+            "--file-path",
+            str(source_file),
+            "--output-dir",
+            str(output_dir),
+            "--dry-run",
+        ]
+    )
+
+    assert exit_code == 0
+
+    output_path = output_dir / "pages" / "meeting-notes.md"
+    assert not output_path.exists()
+
+    captured = capsys.readouterr()
+    assert f"Dry run: would write {output_path}" in captured.out
+    assert "Line one." in captured.out

--- a/tests/test_normalize_writer.py
+++ b/tests/test_normalize_writer.py
@@ -1,5 +1,8 @@
 from pathlib import Path
 
+from pytest import CaptureFixture
+
+from knowledge_adapters.cli import main
 from knowledge_adapters.confluence.normalize import normalize_to_markdown
 from knowledge_adapters.confluence.writer import write_markdown
 
@@ -49,3 +52,41 @@ def test_write_markdown_writes_to_pages_subdirectory(tmp_path: Path) -> None:
 
     assert output_path == tmp_path / "pages" / "page-42.md"
     assert output_path.read_text(encoding="utf-8") == markdown
+
+
+def test_write_markdown_dry_run_returns_path_without_writing(tmp_path: Path) -> None:
+    markdown = "# Title\n"
+
+    output_path = write_markdown(str(tmp_path), "page-42", markdown, dry_run=True)
+
+    assert output_path == tmp_path / "pages" / "page-42.md"
+    assert not output_path.exists()
+
+
+def test_confluence_cli_dry_run_reports_output_without_writing(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    output_dir = tmp_path / "out"
+
+    exit_code = main(
+        [
+            "confluence",
+            "--base-url",
+            "https://example.com/wiki",
+            "--target",
+            "12345",
+            "--output-dir",
+            str(output_dir),
+            "--dry-run",
+        ]
+    )
+
+    assert exit_code == 0
+
+    output_path = output_dir / "pages" / "12345.md"
+    assert not output_path.exists()
+
+    captured = capsys.readouterr()
+    assert f"Dry run: would write {output_path}" in captured.out
+    assert "# stub-page-12345" in captured.out


### PR DESCRIPTION
Summary
- add shared dry-run support to the markdown writer so output paths are computed without creating files
- update both CLI adapter paths to report the destination path and markdown content when --dry-run is passed
- add dry-run coverage for the writer and both CLI entrypoints, plus a README example

Testing
- make check