### PR TITLE
test: expand resolve_target edge cases

### DIFF
--- a/src/knowledge_adapters/confluence/resolve.py
+++ b/src/knowledge_adapters/confluence/resolve.py
@@ -18,6 +18,7 @@ def resolve_target(target: str) -> ResolvedTarget:
     - URLs containing a page ID
     """
     cleaned = target.strip()
+    is_url = "://" in cleaned
 
     if _PAGE_ID_RE.fullmatch(cleaned):
         return ResolvedTarget(
@@ -26,7 +27,7 @@ def resolve_target(target: str) -> ResolvedTarget:
             page_url=None,
         )
 
-    url_match = _PAGE_ID_IN_URL_RE.search(cleaned)
+    url_match = _PAGE_ID_IN_URL_RE.search(cleaned) if is_url else None
     if url_match:
         return ResolvedTarget(
             raw_value=cleaned,
@@ -37,5 +38,5 @@ def resolve_target(target: str) -> ResolvedTarget:
     return ResolvedTarget(
         raw_value=cleaned,
         page_id=None,
-        page_url=cleaned if "://" in cleaned else None,
+        page_url=cleaned if is_url else None,
     )

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -22,3 +22,48 @@ def test_resolve_unknown_format() -> None:
 
     assert target.page_id is None
     assert target.page_url is None
+
+
+def test_resolve_numeric_page_id_trims_surrounding_whitespace() -> None:
+    target = resolve_target("  123456  ")
+
+    assert target.raw_value == "123456"
+    assert target.page_id == "123456"
+    assert target.page_url is None
+
+
+def test_resolve_url_with_page_id_trims_surrounding_whitespace() -> None:
+    target = resolve_target("  https://example.com/pages/viewpage.action?pageId=7890  ")
+
+    assert target.raw_value == "https://example.com/pages/viewpage.action?pageId=7890"
+    assert target.page_id == "7890"
+    assert target.page_url == "https://example.com/pages/viewpage.action?pageId=7890"
+
+
+def test_resolve_blank_target_as_unknown_format() -> None:
+    target = resolve_target("   ")
+
+    assert target.raw_value == ""
+    assert target.page_id is None
+    assert target.page_url is None
+
+
+def test_resolve_url_without_page_id_preserves_url_without_resolving_id() -> None:
+    target = resolve_target("https://example.com/pages/viewpage.action")
+
+    assert target.page_id is None
+    assert target.page_url == "https://example.com/pages/viewpage.action"
+
+
+def test_resolve_url_with_missing_page_id_value_preserves_url_without_resolving_id() -> None:
+    target = resolve_target("https://example.com/pages/viewpage.action?pageId=")
+
+    assert target.page_id is None
+    assert target.page_url == "https://example.com/pages/viewpage.action?pageId="
+
+
+def test_resolve_path_like_target_with_page_id_pattern_does_not_count_as_url() -> None:
+    target = resolve_target("example.com/pages/viewpage.action?pageId=7890")
+
+    assert target.page_id is None
+    assert target.page_url is None


### PR DESCRIPTION
Summary
- add focused resolve_target coverage for whitespace, blank input, and malformed URL-like targets
- preserve URL-like inputs without page IDs as URLs without resolving a page ID
- tighten target resolution so page ID extraction only applies to URL-like inputs with a scheme

Testing
- make check