### PR TITLE
fix: clarify invalid Confluence target errors

### DIFF
--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import sys
 from collections.abc import Sequence
 
 
@@ -79,6 +80,12 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def exit_with_cli_error(message: str) -> None:
+    """Exit the CLI with a stable user-facing error message."""
+    print(f"knowledge-adapters confluence: error: {message}", file=sys.stderr)
+    raise SystemExit(2)
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     """Run the CLI."""
     parser = build_parser()
@@ -102,6 +109,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
 
         target = resolve_target(confluence_config.target)
+        if target.page_id is None:
+            exit_with_cli_error(
+                f"Could not resolve target {target.raw_value!r}. "
+                "Expected a Confluence page ID or full Confluence page URL."
+            )
 
         print("Confluence adapter invoked")
         print(f"  base_url: {confluence_config.base_url}")

--- a/tests/test_normalize_writer.py
+++ b/tests/test_normalize_writer.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import pytest
 from pytest import CaptureFixture
 
 from knowledge_adapters.cli import main
@@ -90,3 +91,31 @@ def test_confluence_cli_dry_run_reports_output_without_writing(
     captured = capsys.readouterr()
     assert f"Dry run: would write {output_path}" in captured.out
     assert "# stub-page-12345" in captured.out
+
+
+def test_confluence_cli_invalid_target_reports_expected_shapes(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    output_dir = tmp_path / "out"
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(
+            [
+                "confluence",
+                "--base-url",
+                "https://example.com/wiki",
+                "--target",
+                "not-a-page",
+                "--output-dir",
+                str(output_dir),
+            ]
+        )
+
+    assert exc_info.value.code == 2
+
+    captured = capsys.readouterr()
+    assert (
+        "knowledge-adapters confluence: error: Could not resolve target "
+        "'not-a-page'. Expected a Confluence page ID or full Confluence page URL.\n"
+    ) in captured.err


### PR DESCRIPTION
Summary
- clarify the Confluence CLI error for unresolved targets
- fail fast before fetching or writing an unknown page
- add a focused CLI test for the invalid-target message

Testing
- make check