### PR TITLE
docs: require make targets for validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,9 @@ Before committing or opening a PR:
 make check
 ```
 
+Run validation through the Makefile targets for this repository.
+Do not invoke `pytest`, `mypy`, or `ruff` directly; use `make check` and other documented `make` targets instead.
+
 If lint issues are auto-fixable:
 
 ```bash

--- a/docs/codex-workflow.md
+++ b/docs/codex-workflow.md
@@ -174,6 +174,9 @@ The canonical validation steps for this repo are defined in `AGENTS.md`.
 
 A Codex task is not considered complete until validation succeeds.
 
+Run validation through the Makefile targets for this repository.
+Do not invoke `pytest`, `mypy`, or `ruff` directly; use `make check` and other documented `make` targets instead.
+
 At the time of writing, validation is:
 
 ```bash


### PR DESCRIPTION
Summary
- clarify in AGENTS.md that validation should run through Makefile targets
- align docs/codex-workflow.md with the same guidance and explicitly discourage direct pytest, mypy, and ruff invocation

Testing
- make check