### PR TITLE
feat: implement recursive Confluence traversal

### DIFF
--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -92,14 +92,18 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     if args.command == "confluence":
+        from pathlib import Path
+
         from knowledge_adapters.confluence.client import fetch_page
         from knowledge_adapters.confluence.config import ConfluenceConfig
         from knowledge_adapters.confluence.manifest import (
             build_manifest_entry,
             write_manifest,
+            write_manifest_with_context,
         )
         from knowledge_adapters.confluence.normalize import normalize_to_markdown
         from knowledge_adapters.confluence.resolve import resolve_target
+        from knowledge_adapters.confluence.traversal import walk_pages
         from knowledge_adapters.confluence.writer import write_markdown
 
         confluence_config = ConfluenceConfig(
@@ -111,6 +115,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             tree=args.tree,
             max_depth=args.max_depth,
         )
+        if confluence_config.max_depth < 0:
+            exit_with_cli_error("--max-depth must be greater than or equal to 0.")
 
         target = resolve_target(confluence_config.target)
         if target.page_id is None:
@@ -127,6 +133,54 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"  dry_run: {confluence_config.dry_run}")
         print(f"  tree: {confluence_config.tree}")
         print(f"  max_depth: {confluence_config.max_depth}")
+
+        if confluence_config.tree:
+            root_page_id, pages = walk_pages(
+                target,
+                max_depth=confluence_config.max_depth,
+                fetch_page=fetch_page,
+            )
+            page_records: list[tuple[dict[str, object], Path]] = []
+            for page in pages:
+                markdown = normalize_to_markdown(page)
+                canonical_id = str(page.get("canonical_id") or "")
+                output_path = write_markdown(
+                    confluence_config.output_dir,
+                    canonical_id,
+                    markdown,
+                    dry_run=confluence_config.dry_run,
+                )
+                page_records.append((page, output_path))
+
+            if confluence_config.dry_run:
+                print("\nDry run: recursive fetch plan")
+                print(f"  resolved_root_page_id: {root_page_id}")
+                print(f"  tree: {confluence_config.tree}")
+                print(f"  max_depth: {confluence_config.max_depth}")
+                for _page, output_path in page_records:
+                    print(f"  would write {output_path}")
+                print(f"  {len(page_records)} unique pages")
+                return 0
+
+            files = [
+                build_manifest_entry(
+                    canonical_id=str(page.get("canonical_id") or ""),
+                    source_url=str(page.get("source_url", "")),
+                    output_path=output_path,
+                    output_dir=confluence_config.output_dir,
+                    title=str(page["title"]) if page.get("title") else None,
+                )
+                for page, output_path in page_records
+            ]
+            write_manifest_with_context(
+                confluence_config.output_dir,
+                files,
+                root_page_id=root_page_id,
+                max_depth=confluence_config.max_depth,
+            )
+            for _page, output_path in page_records:
+                print(f"\nWrote: {output_path}")
+            return 0
 
         page = fetch_page(target)
         markdown = normalize_to_markdown(page)

--- a/src/knowledge_adapters/confluence/manifest.py
+++ b/src/knowledge_adapters/confluence/manifest.py
@@ -35,11 +35,26 @@ def build_manifest_entry(
 
 def write_manifest(output_dir: str, files: list[dict[str, str]]) -> Path:
     """Write a per-run manifest describing generated files."""
+    return write_manifest_with_context(output_dir, files)
+
+
+def write_manifest_with_context(
+    output_dir: str,
+    files: list[dict[str, str]],
+    *,
+    root_page_id: str | None = None,
+    max_depth: int | None = None,
+) -> Path:
+    """Write a per-run manifest describing generated files."""
     path = manifest_path(output_dir)
     payload: dict[str, object] = {
         "generated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
-        "files": files,
     }
+    if root_page_id is not None:
+        payload["root_page_id"] = root_page_id
+    if max_depth is not None:
+        payload["max_depth"] = max_depth
+    payload["files"] = files
 
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(f"{json.dumps(payload, indent=2)}\n", encoding="utf-8")

--- a/src/knowledge_adapters/confluence/traversal.py
+++ b/src/knowledge_adapters/confluence/traversal.py
@@ -1,0 +1,68 @@
+"""Recursive traversal helpers for the Confluence adapter."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+
+from knowledge_adapters.confluence.models import ResolvedTarget
+
+PagePayload = Mapping[str, object]
+FetchPage = Callable[[ResolvedTarget], dict[str, object]]
+
+
+def _canonical_id(page: PagePayload, fallback_page_id: str) -> str:
+    """Return the canonical page ID for a fetched page."""
+    return str(page.get("canonical_id") or fallback_page_id)
+
+
+def _child_page_ids(page: PagePayload) -> list[str]:
+    """Extract child page IDs from a fetched page payload."""
+    children = page.get("children", [])
+    if not isinstance(children, list):
+        return []
+    return [str(child) for child in children]
+
+
+def walk_pages(
+    root_target: ResolvedTarget,
+    *,
+    max_depth: int,
+    fetch_page: FetchPage,
+) -> tuple[str, list[dict[str, object]]]:
+    """Fetch pages breadth-first up to the requested depth."""
+    root_page = fetch_page(root_target)
+    root_page_id = _canonical_id(root_page, root_target.page_id or "")
+
+    ordered_pages = [root_page]
+    fetched_pages = {root_page_id: root_page}
+    current_level = [root_page]
+
+    for _depth in range(max_depth):
+        child_ids = {
+            child_id
+            for page in current_level
+            for child_id in _child_page_ids(page)
+            if child_id not in fetched_pages
+        }
+
+        next_level: list[dict[str, object]] = []
+        for child_id in sorted(child_ids):
+            child_target = ResolvedTarget(
+                raw_value=child_id,
+                page_id=child_id,
+                page_url=None,
+            )
+            page = fetch_page(child_target)
+            canonical_id = _canonical_id(page, child_id)
+            if canonical_id in fetched_pages:
+                continue
+            fetched_pages[canonical_id] = page
+            next_level.append(page)
+
+        current_level = sorted(
+            next_level,
+            key=lambda page: _canonical_id(page, ""),
+        )
+        ordered_pages.extend(current_level)
+
+    return root_page_id, ordered_pages

--- a/tests/test_confluence_recursive_contract.py
+++ b/tests/test_confluence_recursive_contract.py
@@ -8,11 +8,6 @@ from pytest import CaptureFixture, MonkeyPatch
 from knowledge_adapters.cli import main
 from knowledge_adapters.confluence.models import ResolvedTarget
 
-pytestmark = pytest.mark.xfail(
-    reason="Recursive Confluence traversal is not implemented yet.",
-    strict=True,
-)
-
 
 def _synthetic_pages() -> dict[str, dict[str, object]]:
     return {

--- a/tests/test_normalize_writer.py
+++ b/tests/test_normalize_writer.py
@@ -197,3 +197,34 @@ def test_confluence_cli_invalid_target_reports_expected_shapes(
         "knowledge-adapters confluence: error: Could not resolve target "
         "'not-a-page'. Expected a Confluence page ID or full Confluence page URL.\n"
     ) in captured.err
+
+
+def test_confluence_cli_rejects_negative_max_depth(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    output_dir = tmp_path / "out"
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(
+            [
+                "confluence",
+                "--base-url",
+                "https://example.com/wiki",
+                "--target",
+                "12345",
+                "--output-dir",
+                str(output_dir),
+                "--tree",
+                "--max-depth",
+                "-1",
+            ]
+        )
+
+    assert exc_info.value.code == 2
+
+    captured = capsys.readouterr()
+    assert (
+        "knowledge-adapters confluence: error: --max-depth must be greater than or "
+        "equal to 0.\n"
+    ) in captured.err


### PR DESCRIPTION
Summary
- implement breadth-first Confluence tree traversal for tree mode with root depth 0 and max-depth limits
- deduplicate fetched pages by canonical page ID, preserve deterministic manifest and dry-run ordering, and add recursive manifest context
- enable the recursive contract tests and add negative max-depth validation coverage

Testing
- make check