### PR TITLE
chore(release): prepare 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 0.2.0
+
+- Added recursive Confluence traversal with `--tree` and depth-limited traversal via `--max-depth`.
+- Added canonical page ID deduplication so repeated pages are fetched, written, and listed in the manifest once per run.
+- Added deterministic recursive ordering with breadth-first traversal by depth and lexical canonical ID ordering within each depth.
+- Updated recursive manifests to include `root_page_id` and `max_depth` while keeping per-file entries minimal.
+- Improved recursive dry runs with human-readable planning output and a unique page summary such as `5 unique pages`.
+- Added recursive contract coverage and synthetic stress tests for deeper, wider, and duplicate-heavy traversal shapes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "knowledge-adapters"
-version = "0.1.0"
+version = "0.2.0"
 description = "Generic adapters for acquiring and normalizing knowledge sources into local LLM-ready artifacts."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/knowledge_adapters/__init__.py
+++ b/src/knowledge_adapters/__init__.py
@@ -1,1 +1,3 @@
 """knowledge_adapters package."""
+
+__version__ = "0.2.0"


### PR DESCRIPTION
Summary
- add a changelog entry for the 0.2.0 release
- bump the project version for the recursive traversal feature
- expose the package version from knowledge_adapters.__init__

Testing
- make check