### PR TITLE
chore: release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.3.0
+
+- Added manifest-based incremental sync for Confluence so repeated runs can skip rewriting pages that were already written.
+- Defined skip eligibility using only matching `canonical_id`, matching `output_path`, and on-disk file existence for the expected artifact.
+- Improved recursive dry-run reporting to show both would-write and would-skip counts alongside the planned output paths.
+- Updated replacement manifests to include both newly written pages and skipped pages from the current run.
+- Added hardening coverage and README guidance for incremental sync, including artifact-based output-directory reuse behavior.
+
 ## 0.2.0
 
 - Added recursive Confluence traversal with `--tree` and depth-limited traversal via `--max-depth`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "knowledge-adapters"
-version = "0.2.0"
+version = "0.3.0"
 description = "Generic adapters for acquiring and normalizing knowledge sources into local LLM-ready artifacts."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/knowledge_adapters/__init__.py
+++ b/src/knowledge_adapters/__init__.py
@@ -1,3 +1,3 @@
 """knowledge_adapters package."""
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"


### PR DESCRIPTION
Summary
- add the 0.3.0 changelog entry for Confluence incremental sync and its hardening follow-up
- bump the project version to 0.3.0 in package metadata

Testing
- make check