### PR TITLE
docs: align Confluence docs with shipped adapter behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,33 @@
 # Changelog
 
+Confluence release notes below describe shipped CLI wiring, manifest behavior,
+design docs, and contract coverage in this repository. The default Confluence
+client in `src/knowledge_adapters/confluence/client.py` is still a stub and does
+not yet perform live network fetches against Confluence.
+
 ## 0.3.0
 
-- Added manifest-based incremental sync for Confluence so repeated runs can skip rewriting pages that were already written.
+- Added manifest-based incremental sync rules to the Confluence CLI flow so
+  repeated runs can skip rewriting artifacts that were already recorded locally.
 - Defined skip eligibility using only matching `canonical_id`, matching `output_path`, and on-disk file existence for the expected artifact.
-- Improved recursive dry-run reporting to show both would-write and would-skip counts alongside the planned output paths.
-- Updated replacement manifests to include both newly written pages and skipped pages from the current run.
-- Added hardening coverage and README guidance for incremental sync, including artifact-based output-directory reuse behavior.
+- Improved recursive dry-run reporting to show both would-write and would-skip
+  counts alongside the planned output paths in the scaffolded tree-mode flow.
+- Updated replacement manifests to include both newly written pages and skipped
+  pages from the current run.
+- Added hardening coverage and README guidance for incremental sync, including
+  artifact-based output-directory reuse behavior.
 
 ## 0.2.0
 
-- Added recursive Confluence traversal with `--tree` and depth-limited traversal via `--max-depth`.
-- Added canonical page ID deduplication so repeated pages are fetched, written, and listed in the manifest once per run.
-- Added deterministic recursive ordering with breadth-first traversal by depth and lexical canonical ID ordering within each depth.
-- Updated recursive manifests to include `root_page_id` and `max_depth` while keeping per-file entries minimal.
-- Improved recursive dry runs with human-readable planning output and a unique page summary such as `5 unique pages`.
-- Added recursive contract coverage and synthetic stress tests for deeper, wider, and duplicate-heavy traversal shapes.
+- Added scaffolded recursive Confluence traversal to the CLI with `--tree` and
+  depth-limited traversal via `--max-depth`.
+- Added canonical page ID deduplication so repeated pages in tree-mode flows are
+  fetched, written, and listed in the manifest once per run.
+- Added deterministic recursive ordering with breadth-first traversal by depth
+  and lexical canonical ID ordering within each depth.
+- Updated tree-mode manifests to include `root_page_id` and `max_depth` while
+  keeping per-file entries minimal.
+- Improved recursive dry runs with human-readable planning output and a unique
+  page summary such as `5 unique pages`.
+- Added recursive contract coverage and synthetic stress tests for deeper,
+  wider, and duplicate-heavy traversal shapes.

--- a/README.md
+++ b/README.md
@@ -71,22 +71,19 @@ The initial implementation focuses on **Confluence** and **local file** adapters
 ### Implemented
 - repository structure
 - initial documentation
-- Confluence adapter scaffold
+- Confluence adapter scaffold with a default stub client
 - local files adapter scaffold
 - CLI entrypoint
 - basic end-to-end pipeline (resolve → fetch stub → normalize → write)
+- Confluence single-page CLI flow for resolve, dry-run, write, and manifest generation
 - CI (ruff, mypy, pytest)
 - initial unit tests
 
 ### Planned MVP
 - Confluence adapter
-  - accept a page URL or page ID
-  - accept runtime-provided auth
-  - fetch a target page or page tree
-  - normalize output to markdown plus metadata
-  - write local artifacts to a specified output directory
-  - track state with a manifest
-  - support dry-run behavior
+  - use runtime-provided auth and base URL for live Confluence fetches
+  - fetch real page content for a target page or page tree
+  - back recursive traversal and incremental sync with a non-stub client
 - local files adapter
   - accept a runtime-provided file path
   - normalize file contents into markdown plus metadata
@@ -155,6 +152,35 @@ knowledge-adapters/
 └── .gitignore
 ```
 
+## Confluence Status
+
+The Confluence adapter is currently a scaffolded CLI flow with a default stub
+client.
+
+### Implemented in the default CLI
+
+- resolves a numeric page ID or full Confluence page URL into a canonical page ID
+- accepts `--base-url`, `--auth-method`, `--output-dir`, `--dry-run`, `--tree`,
+  and `--max-depth`
+- generates stub page content for the resolved page without contacting a live
+  Confluence instance
+- normalizes that stub content into markdown and writes `pages/<canonical_id>.md`
+- writes `manifest.json` for normal runs
+- supports dry-run output and manifest-based skip logic for the resolved page
+
+### Design-level or contract-tested behavior
+
+- live Confluence fetches that actually use `--base-url` and `--auth-method`
+- child-page discovery that produces multi-page recursive tree runs
+- recursive dry-run summaries over real discovered descendants
+- production-oriented incremental sync against live-fetched Confluence content
+
+The recursive traversal and incremental sync docs still matter: they define the
+intended contract for a real or monkeypatched client. See
+[`docs/confluence-recursive-fetch.md`](docs/confluence-recursive-fetch.md) and
+[`docs/confluence-incremental-sync.md`](docs/confluence-incremental-sync.md) for
+that design surface.
+
 ## Example
 
 Normalize a local text file into the standard markdown artifact:
@@ -174,59 +200,59 @@ knowledge-adapters local_files \
   --dry-run
 ```
 
-Fetch a Confluence page tree with the root page at depth `0` and direct children at
-depth `1`:
+Run the default Confluence adapter for a single resolved page:
 
 ```bash
 knowledge-adapters confluence \
   --base-url https://example.com/wiki \
   --target 12345 \
-  --output-dir ./artifacts \
-  --tree \
-  --max-depth 1
+  --output-dir ./artifacts
 ```
 
-`--tree` enables recursive traversal from the resolved root page. `--max-depth`
-limits descendant traversal depth relative to that root, so `0` fetches only the
-root page, `1` includes direct children, and `2` includes grandchildren.
+Out of the box, this resolves page `12345`, generates stub content for that page,
+writes `pages/12345.md`, and writes `manifest.json`. The default Confluence client
+does not contact a live Confluence instance yet.
 
-Preview a recursive Confluence run without writing files:
+Preview the default Confluence run without writing files:
 
 ```bash
 knowledge-adapters confluence \
   --base-url https://example.com/wiki \
   --target 12345 \
   --output-dir ./artifacts \
-  --tree \
-  --max-depth 2 \
   --dry-run
 ```
 
-Recursive dry runs stay human-readable: they show the resolved root page, whether
-tree mode is enabled, the effective `max_depth`, one planned output path per unique
-page, a summary line such as `Summary: would write 2, would skip 3`, and a final
-line such as `5 unique pages`.
+The dry run prints the planned output path and the normalized stub markdown. If an
+existing `manifest.json` entry and on-disk artifact already match the resolved page,
+the default CLI reports `would skip` instead of `would write`.
 
-Confluence incremental sync uses the existing `manifest.json` plus on-disk file
-existence to decide whether a page is already written. A page counts as already
-written only when:
+The Confluence CLI also includes scaffolded tree-mode and incremental-sync plumbing.
+Those paths are covered by design docs and contract tests, but the default stub
+client does not discover child pages, so `--tree` still yields only the resolved
+root page out of the box.
+
+Confluence incremental skip eligibility uses the existing `manifest.json` plus
+on-disk file existence. A page counts as already written only when:
 
 - `canonical_id` matches a prior manifest entry
 - `output_path` matches the current deterministic path such as `pages/12345.md`
 - that file still exists on disk
 
 If any of those checks fail, the page is treated as a write. Skipped pages still
-appear in dry-run output, and successful normal runs write a replacement manifest
-that includes both written and skipped pages from the current run.
+appear in dry-run output. With the default client, this behavior applies to the
+resolved root-page artifact only.
 
 Incremental sync is artifact-based within the chosen output directory, not
 target-based. Reusing an output directory for a different target is allowed, but
 overlapping canonical page IDs may still be skipped when the manifest and on-disk
 artifact match.
 
-During a normal write run, the tool also writes exactly one `manifest.json` file in the output directory. The manifest is intentionally minimal for v1 and describes only the files generated by that run.
+During a normal write run, the tool also writes exactly one `manifest.json` file in
+the output directory. With the default single-page client, the manifest describes
+the resolved page artifact written by that run.
 
-Example shape:
+Example shape from the default single-page Confluence client:
 
 ```json
 {
@@ -234,16 +260,16 @@ Example shape:
   "files": [
     {
       "canonical_id": "12345",
-      "source_url": "https://example.com/wiki/spaces/ENG/pages/12345",
+      "source_url": "",
       "output_path": "pages/12345.md",
-      "title": "Team Notes"
+      "title": "stub-page-12345"
     }
   ]
 }
 ```
 
-For recursive Confluence tree runs, the manifest keeps the same per-file entries and
-adds only minimal root-run context:
+For scaffolded tree-mode runs, the manifest keeps the same per-file entries and adds
+only minimal root-run context:
 
 ```json
 {
@@ -253,14 +279,16 @@ adds only minimal root-run context:
   "files": [
     {
       "canonical_id": "12345",
-      "source_url": "https://example.com/wiki/spaces/ENG/pages/12345",
+      "source_url": "",
       "output_path": "pages/12345.md",
-      "title": "Team Notes"
+      "title": "stub-page-12345"
     }
   ]
 }
 ```
 
+With the default stub client, tree mode still produces only the resolved root page
+unless you replace or monkeypatch the client in tests or other integration code.
 `title` is included only when it is already available as part of the current run. In
-`--dry-run` mode, the tool does not create or update `manifest.json`, and it does not
-create directories for the manifest.
+`--dry-run` mode, the tool does not create or update `manifest.json`, and it does
+not create directories for the manifest.

--- a/adapters/confluence/README.md
+++ b/adapters/confluence/README.md
@@ -2,25 +2,41 @@
 
 ## Purpose
 
-The Confluence adapter fetches content from a target Confluence page or page tree and normalizes it into local markdown artifacts with metadata.
+The Confluence adapter is the repository's first adapter scaffold. This document is
+the authoritative status page for what the default Confluence CLI currently does.
 
 This adapter is the first implementation of the generic adapter contract for `knowledge-adapters`.
 
-## Initial Scope
+## Current Behavior
 
-The first version should support:
+Out of the box, the default Confluence CLI:
 
-- page URL or page ID as input
-- runtime-provided auth
-- single page fetch
-- optional tree mode after single-page flow works
-- markdown plus metadata output
-- manifest generation
-- dry-run mode
+- accepts a page URL or page ID as input
+- accepts `--base-url`, `--auth-method`, `--output-dir`, `--dry-run`, `--tree`,
+  and `--max-depth`
+- resolves the target into a canonical page ID
+- fetches stub page data for that resolved page
+- normalizes the stub page into markdown plus metadata
+- writes a deterministic page artifact and `manifest.json` on normal runs
+- supports dry-run output and manifest-based skip logic for the resolved page
+- includes tree-mode plumbing, but the default client returns no children, so
+  out-of-the-box tree runs still produce only the root page
 
-## Runtime-Specific Inputs
+## Known Limitations
 
-These values must be provided at runtime and must not be committed:
+- the default client does not make live Confluence network requests
+- `--base-url` and `--auth-method` are accepted by the CLI but are not yet used to
+  authenticate or fetch from Confluence
+- the default client returns synthetic stub content rather than live page content
+- recursive traversal semantics are defined and tested, but multi-page tree runs
+  require a real or monkeypatched client that returns child pages
+- incremental sync semantics are defined and tested, but with the default client
+  they only affect the resolved root-page artifact
+
+## Runtime Inputs
+
+These values are still part of the intended adapter surface and must be provided at
+runtime rather than committed:
 
 - Confluence base URL
 - auth method and credential reference
@@ -28,17 +44,21 @@ These values must be provided at runtime and must not be committed:
 - output directory
 - optional fetch mode and limits
 
-## Responsibilities
+## Design and Contract Docs
 
-The adapter should:
+The following docs define intended behavior beyond the current default client:
 
-1. resolve page input into a canonical page ID
-2. fetch source content and metadata
-3. normalize source content into markdown
-4. write stable local artifacts
-5. update a manifest with fetch results
+- [`docs/adapter-spec.md`](../../docs/adapter-spec.md): generic adapter contract
+- [`docs/confluence-recursive-fetch.md`](../../docs/confluence-recursive-fetch.md):
+  recursive traversal semantics for `--tree` and `--max-depth`
+- [`docs/confluence-incremental-sync.md`](../../docs/confluence-incremental-sync.md):
+  incremental sync rules and manifest-based skip semantics
 
-## Non-Goals for Initial Version
+Those docs describe the intended contract for a real or monkeypatched Confluence
+client. They should not be read as evidence that the default client already
+performs live recursive fetches.
+
+## Non-Goals for the Current Default Client
 
 - browser automation
 - attachments
@@ -46,13 +66,3 @@ The adapter should:
 - complete macro fidelity
 - every auth flow
 - publishing to external systems
-
-## Suggested Next Steps
-
-1. define CLI inputs
-2. define config model
-3. implement target resolution
-4. implement fixture-based fetch path
-5. normalize to markdown
-6. write output files and manifest
-7. add tests

--- a/docs/feature-delivery-workflow.md
+++ b/docs/feature-delivery-workflow.md
@@ -126,6 +126,15 @@ In practice, that means prompts should explicitly state:
 - what must not change
 - how success will be validated
 - what completion requires, including commit, push, and PR creation
+- whether the PR should be ready for review or draft when the task is complete
+
+Open PRs as ready for review by default.
+
+Use a draft PR only when:
+
+- the task explicitly asks for a draft PR
+- the work is intentionally incomplete
+- feedback is needed before the task is considered complete
 
 ## Release Process
 


### PR DESCRIPTION
Summary
- align user-facing Confluence docs with the shipped default stub client behavior
- distinguish implemented CLI behavior from design-level and contract-tested recursive/incremental features
- reword release notes so they stop implying a live-ready Confluence client

Testing
- make check