### PR TITLE
test: add installed CLI smoke coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev test lint fix format typecheck check check-env clean
+.PHONY: dev test smoke lint fix format typecheck check check-env clean
 
 VENV = .venv
 PYTHON = $(VENV)/bin/python
@@ -6,6 +6,7 @@ PIP = $(VENV)/bin/pip
 RUFF = $(VENV)/bin/ruff
 MYPY = $(VENV)/bin/mypy
 PYTEST = $(VENV)/bin/pytest
+CLI = $(VENV)/bin/knowledge-adapters
 
 $(VENV)/bin/activate:
 	python3 -m venv $(VENV)
@@ -20,6 +21,9 @@ check-env:
 
 test: $(VENV)/bin/activate
 	$(PYTEST)
+
+smoke: $(VENV)/bin/activate
+	$(PYTEST) tests/test_cli_smoke.py
 
 lint: $(VENV)/bin/activate
 	$(RUFF) check .

--- a/README.md
+++ b/README.md
@@ -15,11 +15,18 @@ make dev
 make check
 ```
 
+After `make dev`, the installed CLI entrypoint for this repo is:
+
+```bash
+.venv/bin/knowledge-adapters
+```
+
 Common commands:
 
 ```bash
 make check-env
 make test
+make smoke
 make lint
 make fix
 make format
@@ -186,7 +193,7 @@ that design surface.
 Normalize a local text file into the standard markdown artifact:
 
 ```bash
-knowledge-adapters local_files \
+.venv/bin/knowledge-adapters local_files \
   --file-path ./notes/today.txt \
   --output-dir ./artifacts
 ```
@@ -194,7 +201,7 @@ knowledge-adapters local_files \
 Preview the normalized markdown without writing files:
 
 ```bash
-knowledge-adapters local_files \
+.venv/bin/knowledge-adapters local_files \
   --file-path ./notes/today.txt \
   --output-dir ./artifacts \
   --dry-run
@@ -203,7 +210,7 @@ knowledge-adapters local_files \
 Run the default Confluence adapter for a single resolved page:
 
 ```bash
-knowledge-adapters confluence \
+.venv/bin/knowledge-adapters confluence \
   --base-url https://example.com/wiki \
   --target 12345 \
   --output-dir ./artifacts
@@ -216,7 +223,7 @@ does not contact a live Confluence instance yet.
 Preview the default Confluence run without writing files:
 
 ```bash
-knowledge-adapters confluence \
+.venv/bin/knowledge-adapters confluence \
   --base-url https://example.com/wiki \
   --target 12345 \
   --output-dir ./artifacts \

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _cli_path() -> Path:
+    return _repo_root() / ".venv" / "bin" / "knowledge-adapters"
+
+
+def _run_cli(tmp_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    cli_path = _cli_path()
+    assert cli_path.exists()
+
+    return subprocess.run(
+        [str(cli_path), *args],
+        cwd=tmp_path,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+
+def test_local_files_cli_smoke_uses_installed_entrypoint_with_readme_style_args(
+    tmp_path: Path,
+) -> None:
+    notes_dir = tmp_path / "notes"
+    notes_dir.mkdir()
+    source_file = notes_dir / "today.txt"
+    source_file.write_text("Hello from smoke test.\n", encoding="utf-8")
+
+    result = _run_cli(
+        tmp_path,
+        "local_files",
+        "--file-path",
+        "./notes/today.txt",
+        "--output-dir",
+        "./artifacts",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Local files adapter invoked" in result.stdout
+    assert "Wrote:" in result.stdout
+
+    output_path = tmp_path / "artifacts" / "pages" / "today.md"
+    assert output_path.read_text(encoding="utf-8") == (
+        f"""# today.txt
+
+## Metadata
+- source: local_files
+- canonical_id: {source_file.resolve()}
+- parent_id:
+- source_url: {source_file.resolve().as_uri()}
+- fetched_at:
+- updated_at:
+- adapter: local_files
+
+## Content
+
+Hello from smoke test.
+"""
+    )
+
+    payload = json.loads((tmp_path / "artifacts" / "manifest.json").read_text(encoding="utf-8"))
+    assert payload["files"] == [
+        {
+            "canonical_id": str(source_file.resolve()),
+            "source_url": source_file.resolve().as_uri(),
+            "output_path": "pages/today.md",
+            "title": "today.txt",
+        }
+    ]
+
+
+def test_confluence_cli_smoke_uses_installed_entrypoint_with_default_stub_client(
+    tmp_path: Path,
+) -> None:
+    result = _run_cli(
+        tmp_path,
+        "confluence",
+        "--base-url",
+        "https://example.com/wiki",
+        "--target",
+        "12345",
+        "--output-dir",
+        "./artifacts",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Confluence adapter invoked" in result.stdout
+    assert "Wrote:" in result.stdout
+
+    output_path = tmp_path / "artifacts" / "pages" / "12345.md"
+    assert output_path.read_text(encoding="utf-8") == (
+        """# stub-page-12345
+
+## Metadata
+- source: confluence
+- canonical_id: 12345
+- parent_id:
+- source_url: 
+- fetched_at:
+- updated_at:
+- adapter: confluence
+
+## Content
+
+Stub content for page 12345.
+"""
+    )
+
+    payload = json.loads((tmp_path / "artifacts" / "manifest.json").read_text(encoding="utf-8"))
+    assert payload["files"] == [
+        {
+            "canonical_id": "12345",
+            "source_url": "",
+            "output_path": "pages/12345.md",
+            "title": "stub-page-12345",
+        }
+    ]

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
 from pathlib import Path
 
 
@@ -9,16 +10,17 @@ def _repo_root() -> Path:
     return Path(__file__).resolve().parents[1]
 
 
-def _cli_path() -> Path:
-    return _repo_root() / ".venv" / "bin" / "knowledge-adapters"
+def _cli_command() -> list[str]:
+    repo_local_cli = _repo_root() / ".venv" / "bin" / "knowledge-adapters"
+    if repo_local_cli.exists():
+        return [str(repo_local_cli)]
+
+    return [sys.executable, "-m", "knowledge_adapters.cli"]
 
 
 def _run_cli(tmp_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
-    cli_path = _cli_path()
-    assert cli_path.exists()
-
     return subprocess.run(
-        [str(cli_path), *args],
+        [*_cli_command(), *args],
         cwd=tmp_path,
         capture_output=True,
         check=False,


### PR DESCRIPTION
Summary
- add a small CLI smoke layer that exercises the installed repo entrypoint instead of calling internal Python functions
- cover one README-style local_files invocation and one default-client Confluence invocation
- document the supported repo-local CLI path after make dev and add a focused make smoke target

Testing
- make smoke
- make check