### PR TITLE
docs: require initial PR CI verification

### DIFF
--- a/docs/feature-delivery-workflow.md
+++ b/docs/feature-delivery-workflow.md
@@ -136,6 +136,13 @@ Use a draft PR only when:
 - the work is intentionally incomplete
 - feedback is needed before the task is considered complete
 
+For PR-based tasks, local validation passing is necessary but not sufficient.
+After opening the PR, check the initial CI result for that branch or PR.
+
+If that initial CI signal fails because of task-related changes, the task is not
+complete yet. Continue until the failure is fixed or clearly reported as the
+remaining blocker.
+
 ## Release Process
 
 For release preparation:


### PR DESCRIPTION
Summary
- clarify that local validation is necessary but not sufficient for PR-based tasks
- require checking the initial CI signal after opening the PR
- state that task-related CI failures keep the task open until fixed or clearly reported

Testing
- make check