### PR TITLE
docs: clarify release history and tag conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ design docs, and contract coverage in this repository. The default Confluence
 client in `src/knowledge_adapters/confluence/client.py` is still a stub and does
 not yet perform live network fetches against Confluence.
 
+Formal changelog coverage begins at `0.2.0`, when this repository started using
+`CHANGELOG.md` as part of the release flow. Earlier tagged releases `v0.1.0` and
+`v0.1.1` predate that practice and are not backfilled here.
+
 ## 0.3.0
 
 - Added manifest-based incremental sync rules to the Confluence CLI flow so

--- a/docs/feature-delivery-workflow.md
+++ b/docs/feature-delivery-workflow.md
@@ -148,7 +148,8 @@ remaining blocker.
 For release preparation:
 
 1. create or update the changelog entry
-2. bump the version in all relevant places
+2. bump the version in all relevant places so the version number, changelog
+   entry, and release tag all match
 3. run validation
 4. commit and open a release PR with Summary and Testing sections
 5. merge the release PR to the mainline branch through an allowed repository
@@ -164,9 +165,10 @@ The release is not complete until the release PR is actually merged into `main`.
 Auto-merge may not be available in every repository, and an admin merge may be
 required when allowed by repository policy.
 
-Tag format must follow the repository's established convention. In this
-repository, release tags use plain version numbers such as `0.3.0`, not prefixed
-forms such as `v0.3.0`.
+Tag format must follow the repository's established convention going forward. In
+this repository, new release tags use plain version numbers such as `0.3.0`, not
+prefixed forms such as `v0.3.0`. Older tags before that convention changed may
+still use the `v` prefix.
 
 Release completion requires all of the following:
 


### PR DESCRIPTION
Summary
- clarify the forward-looking release tag convention while acknowledging older v-prefixed historical tags
- explain why changelog coverage begins at 0.2.0 instead of backfilling 0.1.x entries
- tighten release workflow wording so version, changelog entry, and release tag are kept aligned

Testing
- make check