### PR TITLE
feat: add confluence real client mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,17 +167,18 @@ client.
 ### Implemented in the default CLI
 
 - resolves a numeric page ID or full Confluence page URL into a canonical page ID
-- accepts `--base-url`, `--auth-method`, `--output-dir`, `--dry-run`, `--tree`,
-  and `--max-depth`
+- accepts `--base-url`, `--client-mode`, `--auth-method`, `--output-dir`,
+  `--dry-run`, `--tree`, and `--max-depth`
 - generates stub page content for the resolved page without contacting a live
   Confluence instance
+- supports an opt-in real client path with `--client-mode real` for a single live
+  page fetch using `bearer-env` auth
 - normalizes that stub content into markdown and writes `pages/<canonical_id>.md`
 - writes `manifest.json` for normal runs
 - supports dry-run output and manifest-based skip logic for the resolved page
 
 ### Design-level or contract-tested behavior
 
-- live Confluence fetches that actually use `--base-url` and `--auth-method`
 - child-page discovery that produces multi-page recursive tree runs
 - recursive dry-run summaries over real discovered descendants
 - production-oriented incremental sync against live-fetched Confluence content
@@ -219,6 +220,19 @@ Run the default Confluence adapter for a single resolved page:
 Out of the box, this resolves page `12345`, generates stub content for that page,
 writes `pages/12345.md`, and writes `manifest.json`. The default Confluence client
 does not contact a live Confluence instance yet.
+
+Run the opt-in real Confluence client for a single resolved page:
+
+```bash
+CONFLUENCE_BEARER_TOKEN=... .venv/bin/knowledge-adapters confluence \
+  --client-mode real \
+  --base-url https://example.com/wiki \
+  --target 12345 \
+  --output-dir ./artifacts
+```
+
+In v1, `--client-mode real` supports only single-page fetches with `bearer-env`
+auth. It rejects `--tree` and `--max-depth > 0`.
 
 Preview the default Confluence run without writing files:
 

--- a/adapters/confluence/README.md
+++ b/adapters/confluence/README.md
@@ -12,10 +12,12 @@ This adapter is the first implementation of the generic adapter contract for `kn
 Out of the box, the default Confluence CLI:
 
 - accepts a page URL or page ID as input
-- accepts `--base-url`, `--auth-method`, `--output-dir`, `--dry-run`, `--tree`,
-  and `--max-depth`
+- accepts `--base-url`, `--client-mode`, `--auth-method`, `--output-dir`,
+  `--dry-run`, `--tree`, and `--max-depth`
 - resolves the target into a canonical page ID
 - fetches stub page data for that resolved page
+- supports an opt-in real client path with `--client-mode real` for a single live
+  page fetch using `bearer-env` auth
 - normalizes the stub page into markdown plus metadata
 - writes a deterministic page artifact and `manifest.json` on normal runs
 - supports dry-run output and manifest-based skip logic for the resolved page
@@ -25,9 +27,9 @@ Out of the box, the default Confluence CLI:
 ## Known Limitations
 
 - the default client does not make live Confluence network requests
-- `--base-url` and `--auth-method` are accepted by the CLI but are not yet used to
-  authenticate or fetch from Confluence
-- the default client returns synthetic stub content rather than live page content
+- `--client-mode real` currently supports only single-page fetches
+- `--client-mode real` supports only `bearer-env` auth via
+  `CONFLUENCE_BEARER_TOKEN`
 - recursive traversal semantics are defined and tested, but multi-page tree runs
   require a real or monkeypatched client that returns child pages
 - incremental sync semantics are defined and tested, but with the default client

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import argparse
 import sys
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -34,6 +34,12 @@ def build_parser() -> argparse.ArgumentParser:
         "--output-dir",
         required=True,
         help="Directory to write normalized local artifacts.",
+    )
+    confluence_parser.add_argument(
+        "--client-mode",
+        choices=("stub", "real"),
+        default="stub",
+        help="Client mode. Defaults to the stub client.",
     )
     confluence_parser.add_argument(
         "--auth-method",
@@ -92,7 +98,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     if args.command == "confluence":
-        from knowledge_adapters.confluence.client import fetch_page
+        from knowledge_adapters.confluence.client import fetch_page, fetch_real_page
         from knowledge_adapters.confluence.config import ConfluenceConfig
         from knowledge_adapters.confluence.incremental import (
             is_already_written,
@@ -103,6 +109,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             write_manifest,
             write_manifest_with_context,
         )
+        from knowledge_adapters.confluence.models import ResolvedTarget
         from knowledge_adapters.confluence.normalize import normalize_to_markdown
         from knowledge_adapters.confluence.resolve import resolve_target
         from knowledge_adapters.confluence.traversal import walk_pages
@@ -112,6 +119,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             base_url=args.base_url,
             target=args.target,
             output_dir=args.output_dir,
+            client_mode=args.client_mode,
             auth_method=args.auth_method,
             dry_run=args.dry_run,
             tree=args.tree,
@@ -131,10 +139,32 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"  base_url: {confluence_config.base_url}")
         print(f"  target: {target.raw_value}")
         print(f"  output_dir: {confluence_config.output_dir}")
+        print(f"  client_mode: {confluence_config.client_mode}")
         print(f"  auth_method: {confluence_config.auth_method}")
         print(f"  dry_run: {confluence_config.dry_run}")
         print(f"  tree: {confluence_config.tree}")
         print(f"  max_depth: {confluence_config.max_depth}")
+
+        if confluence_config.client_mode == "real":
+            if confluence_config.tree:
+                exit_with_cli_error(
+                    "--client-mode real does not support --tree in v1."
+                )
+            if confluence_config.max_depth > 0:
+                exit_with_cli_error(
+                    "--client-mode real does not support --max-depth greater than 0 in v1."
+                )
+
+        selected_fetch_page: Callable[[ResolvedTarget], dict[str, object]]
+        if confluence_config.client_mode == "real":
+            def selected_fetch_page(resolved_target: ResolvedTarget) -> dict[str, object]:
+                return fetch_real_page(
+                    resolved_target,
+                    base_url=confluence_config.base_url,
+                    auth_method=confluence_config.auth_method,
+                )
+        else:
+            selected_fetch_page = fetch_page
 
         def _build_manifest_entry_for_page(
             page: dict[str, object],
@@ -152,7 +182,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             root_page_id, pages = walk_pages(
                 target,
                 max_depth=confluence_config.max_depth,
-                fetch_page=fetch_page,
+                fetch_page=selected_fetch_page,
             )
             previous_manifest_index = load_previous_manifest_index(
                 confluence_config.output_dir
@@ -213,7 +243,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             print(f"\nManifest: {manifest}")
             return 0
 
-        page = fetch_page(target)
+        page = selected_fetch_page(target)
         page_id = str(page["canonical_id"])
         output_path = markdown_path(confluence_config.output_dir, page_id)
         previous_manifest_index = load_previous_manifest_index(confluence_config.output_dir)

--- a/src/knowledge_adapters/confluence/auth.py
+++ b/src/knowledge_adapters/confluence/auth.py
@@ -2,15 +2,18 @@
 
 from __future__ import annotations
 
+import os
 from collections.abc import Mapping
 
 
 def build_auth_headers(auth_method: str) -> Mapping[str, str]:
     """Build auth headers for a supported auth method.
-
-    This is intentionally stubbed for the initial scaffold.
-    Runtime-specific credential injection will be added later.
     """
-    if auth_method == "bearer-env":
-        return {}
-    raise ValueError(f"Unsupported auth method: {auth_method}")
+    if auth_method != "bearer-env":
+        raise ValueError(f"Unsupported auth method: {auth_method}")
+
+    token = os.getenv("CONFLUENCE_BEARER_TOKEN", "").strip()
+    if not token:
+        raise ValueError("CONFLUENCE_BEARER_TOKEN must be set for --client-mode real.")
+
+    return {"Authorization": f"Bearer {token}"}

--- a/src/knowledge_adapters/confluence/client.py
+++ b/src/knowledge_adapters/confluence/client.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+import json
+from urllib import parse, request
+from urllib.error import HTTPError, URLError
+
+from knowledge_adapters.confluence.auth import build_auth_headers
 from knowledge_adapters.confluence.models import ResolvedTarget
 
 
@@ -18,3 +23,112 @@ def fetch_page(target: ResolvedTarget) -> dict[str, object]:
         "source_url": target.page_url or "",
         "content": f"Stub content for page {canonical_id}.",
     }
+
+
+def _content_api_url(base_url: str, page_id: str) -> str:
+    normalized_base = base_url.rstrip("/")
+    encoded_page_id = parse.quote(page_id, safe="")
+    return (
+        f"{normalized_base}/rest/api/content/{encoded_page_id}"
+        "?expand=body.storage,_links"
+    )
+
+
+def _require_string(payload: dict[str, object], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"Response error: missing or invalid {key}.")
+    return value
+
+
+def _storage_content(payload: dict[str, object]) -> str:
+    body = payload.get("body")
+    if not isinstance(body, dict):
+        raise ValueError("Response error: missing content.")
+    storage = body.get("storage")
+    if not isinstance(storage, dict):
+        raise ValueError("Response error: missing content.")
+    value = storage.get("value")
+    if not isinstance(value, str):
+        raise ValueError("Response error: missing content.")
+    return value
+
+
+def _absolute_source_url(payload: dict[str, object]) -> str:
+    links = payload.get("_links")
+    if not isinstance(links, dict):
+        raise ValueError("Response error: missing source_url.")
+
+    webui = links.get("webui")
+    if not isinstance(webui, str) or not webui:
+        raise ValueError("Response error: missing source_url.")
+
+    parsed_webui = parse.urlparse(webui)
+    if parsed_webui.scheme and parsed_webui.netloc:
+        return webui
+
+    base = links.get("base")
+    if not isinstance(base, str) or not base:
+        raise ValueError("Response error: missing source_url.")
+
+    parsed_base = parse.urlparse(base)
+    if not parsed_base.scheme or not parsed_base.netloc:
+        raise ValueError("Response error: missing source_url.")
+
+    if webui.startswith("/"):
+        return f"{base.rstrip('/')}{webui}"
+    return f"{base.rstrip('/')}/{webui.lstrip('/')}"
+
+
+def _map_real_page(payload: dict[str, object], requested_page_id: str) -> dict[str, object]:
+    canonical_id = _require_string(payload, "id")
+    if canonical_id != requested_page_id:
+        raise ValueError("Response error: canonical_id mismatch.")
+
+    title = _require_string(payload, "title")
+    content = _storage_content(payload)
+    source_url = _absolute_source_url(payload)
+
+    return {
+        "canonical_id": canonical_id,
+        "title": title,
+        "content": content,
+        "source_url": source_url,
+    }
+
+
+def fetch_real_page(
+    target: ResolvedTarget,
+    *,
+    base_url: str,
+    auth_method: str,
+) -> dict[str, object]:
+    """Fetch one Confluence page through the opt-in real client path."""
+    page_id = target.page_id
+    if not page_id:
+        raise ValueError("Response error: canonical_id mismatch.")
+
+    headers = dict(build_auth_headers(auth_method))
+    api_request = request.Request(
+        _content_api_url(base_url, page_id),
+        headers=headers,
+    )
+
+    try:
+        with request.urlopen(api_request) as response:
+            raw_payload = json.loads(response.read().decode("utf-8"))
+    except HTTPError as exc:
+        if exc.code in {401, 403}:
+            raise RuntimeError("Confluence auth failure.") from exc
+        if exc.code == 404:
+            raise RuntimeError("Confluence page not found.") from exc
+        raise RuntimeError(f"Confluence request failed with status {exc.code}.") from exc
+    except URLError as exc:
+        raise RuntimeError("Confluence request failed.") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError("Response error: invalid JSON payload.") from exc
+
+    if not isinstance(raw_payload, dict):
+        raise ValueError("Response error: invalid payload shape.")
+
+    return _map_real_page(raw_payload, page_id)

--- a/src/knowledge_adapters/confluence/config.py
+++ b/src/knowledge_adapters/confluence/config.py
@@ -12,6 +12,7 @@ class ConfluenceConfig:
     base_url: str
     target: str
     output_dir: str
+    client_mode: str = "stub"
     auth_method: str = "bearer-env"
     dry_run: bool = False
     tree: bool = False

--- a/tests/test_confluence_real_client_contract.py
+++ b/tests/test_confluence_real_client_contract.py
@@ -143,8 +143,6 @@ Stub content for page 12345.
         }
     ]
 
-
-@pytest.mark.xfail(strict=True, reason="real client CLI mode is not implemented yet")
 def test_explicit_real_client_mode_selects_real_fetch_path(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -178,8 +176,6 @@ def test_explicit_real_client_mode_selects_real_fetch_path(
     assert "<p>Hello from Confluence.</p>" in rendered
     assert "Stub content for page 12345." not in rendered
 
-
-@pytest.mark.xfail(strict=True, reason="real client tree guardrails are not implemented yet")
 @pytest.mark.parametrize(
     ("extra_args", "expected_fragment"),
     [
@@ -204,8 +200,6 @@ def test_real_client_mode_rejects_tree_or_depth_usage_in_v1(
     assert "real" in captured.err
     assert expected_fragment in captured.err
 
-
-@pytest.mark.xfail(strict=True, reason="bearer-env token validation is not implemented yet")
 @pytest.mark.parametrize(
     "token_value",
     [
@@ -236,8 +230,6 @@ def test_real_fetch_requires_nonempty_bearer_token_before_request(
 
     assert request_count == 0
 
-
-@pytest.mark.xfail(strict=True, reason="real response mapping is not implemented yet")
 def test_real_fetch_maps_valid_confluence_response_into_adapter_payload(
     monkeypatch: MonkeyPatch,
 ) -> None:
@@ -257,8 +249,6 @@ def test_real_fetch_maps_valid_confluence_response_into_adapter_payload(
     }
     assert str(page["source_url"]).startswith("https://")
 
-
-@pytest.mark.xfail(strict=True, reason="real HTTP error mapping is not implemented yet")
 @pytest.mark.parametrize(
     ("status_code", "expected_fragment"),
     [
@@ -281,8 +271,6 @@ def test_real_fetch_maps_http_status_failures(
     with pytest.raises(RuntimeError, match=expected_fragment):
         _fetch_real_page(_real_target())
 
-
-@pytest.mark.xfail(strict=True, reason="real response validation is not implemented yet")
 @pytest.mark.parametrize(
     ("payload", "expected_fragment"),
     [


### PR DESCRIPTION
## Summary
- add an explicit client mode selector so the existing stub client stays the default and real mode opts into a live single-page Confluence fetch path
- implement the v1 real client with isolated bearer-env auth, absolute source_url construction, and fail-fast error handling for auth failures, not-found responses, malformed payloads, URL construction failures, and page ID mismatches
- activate the real-client contract tests and update the Confluence status docs to describe the new opt-in behavior accurately

## Testing
- make check