### PR TITLE
feat: add real Confluence tree traversal

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,8 +231,8 @@ CONFLUENCE_BEARER_TOKEN=... .venv/bin/knowledge-adapters confluence \
   --output-dir ./artifacts
 ```
 
-In v1, `--client-mode real` supports only single-page fetches with `bearer-env`
-auth. It rejects `--tree` and `--max-depth > 0`.
+In v1, `--client-mode real` supports both single-page fetches and real breadth-first
+tree traversal with `--tree` and `--max-depth`, using `bearer-env` auth.
 
 Preview the default Confluence run without writing files:
 
@@ -248,10 +248,10 @@ The dry run prints the planned output path and the normalized stub markdown. If 
 existing `manifest.json` entry and on-disk artifact already match the resolved page,
 the default CLI reports `would skip` instead of `would write`.
 
-The Confluence CLI also includes scaffolded tree-mode and incremental-sync plumbing.
-Those paths are covered by design docs and contract tests, but the default stub
-client does not discover child pages, so `--tree` still yields only the resolved
-root page out of the box.
+The Confluence CLI also includes tree-mode and incremental-sync plumbing. The
+default stub client still does not discover child pages, so out-of-the-box stub
+tree runs yield only the resolved root page. In `--client-mode real`, the CLI
+can traverse real child pages breadth-first up to `--max-depth`.
 
 Confluence incremental skip eligibility uses the existing `manifest.json` plus
 on-disk file existence. A page counts as already written only when:

--- a/adapters/confluence/README.md
+++ b/adapters/confluence/README.md
@@ -16,8 +16,8 @@ Out of the box, the default Confluence CLI:
   `--dry-run`, `--tree`, and `--max-depth`
 - resolves the target into a canonical page ID
 - fetches stub page data for that resolved page
-- supports an opt-in real client path with `--client-mode real` for a single live
-  page fetch using `bearer-env` auth
+- supports an opt-in real client path with `--client-mode real` for live page
+  fetches and breadth-first tree traversal using `bearer-env` auth
 - normalizes the stub page into markdown plus metadata
 - writes a deterministic page artifact and `manifest.json` on normal runs
 - supports dry-run output and manifest-based skip logic for the resolved page
@@ -27,11 +27,11 @@ Out of the box, the default Confluence CLI:
 ## Known Limitations
 
 - the default client does not make live Confluence network requests
-- `--client-mode real` currently supports only single-page fetches
 - `--client-mode real` supports only `bearer-env` auth via
   `CONFLUENCE_BEARER_TOKEN`
 - recursive traversal semantics are defined and tested, but multi-page tree runs
-  require a real or monkeypatched client that returns child pages
+  still require `--client-mode real` or a monkeypatched client that returns child
+  pages
 - incremental sync semantics are defined and tested, but with the default client
   they only affect the resolved root-page artifact
 

--- a/docs/confluence-real-client.md
+++ b/docs/confluence-real-client.md
@@ -119,26 +119,27 @@ Why this is the right v1 choice:
 
 ### Child-page discovery surface
 
-Tree support is intentionally not part of the real client v1.
-
-To preserve a clean future path without broadening implementation now, reserve an optional payload field:
-
-- `children`: optional list of canonical child page IDs
+Real tree traversal uses a separate client function for child discovery rather than
+overloading the page payload.
 
 v1 rules:
 
-- the real client is not required to populate `children`
-- traversal behavior outside the client is unchanged
-- future tree support may populate `children` without changing manifest, writer, or normalization contracts
+- `fetch_real_page(...)` continues to return one page payload
+- `list_real_child_page_ids(...)` returns only direct canonical child page IDs
+- traversal behavior, deduplication, ordering, and depth handling remain outside
+  the client
 
 ### Interaction with tree mode
 
-Because the real client v1 is single-page only, `--client-mode real` should reject traversal-oriented usage before any network request:
+`--client-mode real` supports tree traversal through the existing traversal layer.
 
-- `--tree`
-- `--max-depth > 0`
+The real client remains responsible only for:
 
-This is preferable to silently pretending live traversal exists when it does not.
+- fetching one page by canonical page ID
+- listing one page's direct child page IDs
+
+Tree semantics are defined separately in
+[`docs/confluence-real-traversal.md`](./confluence-real-traversal.md).
 
 ## Auth Design
 
@@ -317,7 +318,6 @@ The following are explicitly out of scope for v1:
 - mTLS
 - attachments
 - comments
-- full tree traversal over live Confluence data
 - pagination or rate-limit sophistication
 - macro fidelity improvements
 - write-path refactors
@@ -332,6 +332,6 @@ The implementation guided by this design should support tests that verify at lea
 - default CLI behavior still uses the stub client when `--client-mode` is omitted
 - explicit `--client-mode real` uses the real client path
 - real mode fetches one page by canonical page ID and returns adapter payload fields required by the current pipeline
-- real mode rejects unsupported tree-oriented usage in v1
+- real mode keeps page fetch and child discovery as separate client responsibilities
 - auth failures, not found responses, and malformed responses fail fast without writing artifacts
 - future auth additions can be implemented inside the auth/config boundary without changing traversal, manifest, or writer contracts

--- a/docs/confluence-real-traversal.md
+++ b/docs/confluence-real-traversal.md
@@ -4,8 +4,6 @@
 
 This document defines a minimal v1 design for enabling real child-page traversal when `knowledge-adapters confluence` runs with `--client-mode real`.
 
-Today, the shipped implementation still rejects `--client-mode real` together with real tree traversal. This document defines the next minimal phase for lifting that restriction.
-
 The goal is to turn the existing scaffolded tree mode into real behavior for the opt-in real client path without expanding scope beyond what is required for:
 
 - child-page discovery

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -183,12 +183,23 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
 
         if confluence_config.tree:
-            root_page_id, pages = walk_pages(
-                target,
-                max_depth=confluence_config.max_depth,
-                fetch_page=selected_fetch_page,
-                list_child_page_ids=selected_list_child_page_ids,
-            )
+            if confluence_config.client_mode == "real":
+                try:
+                    root_page_id, pages = walk_pages(
+                        target,
+                        max_depth=confluence_config.max_depth,
+                        fetch_page=selected_fetch_page,
+                        list_child_page_ids=selected_list_child_page_ids,
+                    )
+                except (RuntimeError, ValueError) as exc:
+                    exit_with_cli_error(str(exc))
+            else:
+                root_page_id, pages = walk_pages(
+                    target,
+                    max_depth=confluence_config.max_depth,
+                    fetch_page=selected_fetch_page,
+                    list_child_page_ids=selected_list_child_page_ids,
+                )
             previous_manifest_index = load_previous_manifest_index(
                 confluence_config.output_dir
             )

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -98,7 +98,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     if args.command == "confluence":
-        from knowledge_adapters.confluence.client import fetch_page, fetch_real_page
+        from knowledge_adapters.confluence.client import (
+            fetch_page,
+            fetch_real_page,
+            list_real_child_page_ids,
+        )
         from knowledge_adapters.confluence.config import ConfluenceConfig
         from knowledge_adapters.confluence.incremental import (
             is_already_written,
@@ -145,20 +149,20 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"  tree: {confluence_config.tree}")
         print(f"  max_depth: {confluence_config.max_depth}")
 
-        if confluence_config.client_mode == "real":
-            if confluence_config.tree:
-                exit_with_cli_error(
-                    "--client-mode real does not support --tree in v1."
-                )
-            if confluence_config.max_depth > 0:
-                exit_with_cli_error(
-                    "--client-mode real does not support --max-depth greater than 0 in v1."
-                )
-
         selected_fetch_page: Callable[[ResolvedTarget], dict[str, object]]
+        selected_list_child_page_ids: Callable[[ResolvedTarget], list[str]] | None = None
         if confluence_config.client_mode == "real":
             def selected_fetch_page(resolved_target: ResolvedTarget) -> dict[str, object]:
                 return fetch_real_page(
+                    resolved_target,
+                    base_url=confluence_config.base_url,
+                    auth_method=confluence_config.auth_method,
+                )
+
+            def selected_list_child_page_ids(
+                resolved_target: ResolvedTarget,
+            ) -> list[str]:
+                return list_real_child_page_ids(
                     resolved_target,
                     base_url=confluence_config.base_url,
                     auth_method=confluence_config.auth_method,
@@ -183,6 +187,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 target,
                 max_depth=confluence_config.max_depth,
                 fetch_page=selected_fetch_page,
+                list_child_page_ids=selected_list_child_page_ids,
             )
             previous_manifest_index = load_previous_manifest_index(
                 confluence_config.output_dir

--- a/src/knowledge_adapters/confluence/client.py
+++ b/src/knowledge_adapters/confluence/client.py
@@ -34,6 +34,12 @@ def _content_api_url(base_url: str, page_id: str) -> str:
     )
 
 
+def _child_page_api_url(base_url: str, page_id: str) -> str:
+    normalized_base = base_url.rstrip("/")
+    encoded_page_id = parse.quote(page_id, safe="")
+    return f"{normalized_base}/rest/api/content/{encoded_page_id}/child/page"
+
+
 def _require_string(payload: dict[str, object], key: str) -> str:
     value = payload.get(key)
     if not isinstance(value, str) or not value:
@@ -97,20 +103,27 @@ def _map_real_page(payload: dict[str, object], requested_page_id: str) -> dict[s
     }
 
 
-def fetch_real_page(
-    target: ResolvedTarget,
-    *,
-    base_url: str,
-    auth_method: str,
-) -> dict[str, object]:
-    """Fetch one Confluence page through the opt-in real client path."""
-    page_id = target.page_id
-    if not page_id:
-        raise ValueError("Response error: canonical_id mismatch.")
+def _map_child_page_ids(payload: dict[str, object]) -> list[str]:
+    results = payload.get("results")
+    if not isinstance(results, list):
+        raise ValueError("Response error: invalid child-list payload.")
 
+    child_page_ids: list[str] = []
+    for result in results:
+        if not isinstance(result, dict):
+            raise ValueError("Response error: invalid child-list payload.")
+        child_page_id = result.get("id")
+        if not isinstance(child_page_id, str) or not child_page_id:
+            raise ValueError("Response error: invalid child page ID.")
+        child_page_ids.append(child_page_id)
+
+    return child_page_ids
+
+
+def _request_json(api_url: str, *, auth_method: str) -> dict[str, object]:
     headers = dict(build_auth_headers(auth_method))
     api_request = request.Request(
-        _content_api_url(base_url, page_id),
+        api_url,
         headers=headers,
     )
 
@@ -131,4 +144,40 @@ def fetch_real_page(
     if not isinstance(raw_payload, dict):
         raise ValueError("Response error: invalid payload shape.")
 
+    return raw_payload
+
+
+def fetch_real_page(
+    target: ResolvedTarget,
+    *,
+    base_url: str,
+    auth_method: str,
+) -> dict[str, object]:
+    """Fetch one Confluence page through the opt-in real client path."""
+    page_id = target.page_id
+    if not page_id:
+        raise ValueError("Response error: canonical_id mismatch.")
+
+    raw_payload = _request_json(
+        _content_api_url(base_url, page_id),
+        auth_method=auth_method,
+    )
     return _map_real_page(raw_payload, page_id)
+
+
+def list_real_child_page_ids(
+    target: ResolvedTarget,
+    *,
+    base_url: str,
+    auth_method: str,
+) -> list[str]:
+    """List direct child page IDs for one Confluence page in real mode."""
+    page_id = target.page_id
+    if not page_id:
+        raise ValueError("Response error: invalid child page ID.")
+
+    raw_payload = _request_json(
+        _child_page_api_url(base_url, page_id),
+        auth_method=auth_method,
+    )
+    return _map_child_page_ids(raw_payload)

--- a/src/knowledge_adapters/confluence/traversal.py
+++ b/src/knowledge_adapters/confluence/traversal.py
@@ -8,6 +8,7 @@ from knowledge_adapters.confluence.models import ResolvedTarget
 
 PagePayload = Mapping[str, object]
 FetchPage = Callable[[ResolvedTarget], dict[str, object]]
+ListChildPageIds = Callable[[ResolvedTarget], list[str]]
 
 
 def _canonical_id(page: PagePayload, fallback_page_id: str) -> str:
@@ -23,11 +24,25 @@ def _child_page_ids(page: PagePayload) -> list[str]:
     return [str(child) for child in children]
 
 
+def _target_for_page(page: PagePayload) -> ResolvedTarget:
+    """Build a resolved target from an already-fetched page payload."""
+    canonical_id = _canonical_id(page, "")
+    if not canonical_id:
+        raise ValueError("Response error: invalid canonical_id.")
+
+    return ResolvedTarget(
+        raw_value=canonical_id,
+        page_id=canonical_id,
+        page_url=None,
+    )
+
+
 def walk_pages(
     root_target: ResolvedTarget,
     *,
     max_depth: int,
     fetch_page: FetchPage,
+    list_child_page_ids: ListChildPageIds | None = None,
 ) -> tuple[str, list[dict[str, object]]]:
     """Fetch pages breadth-first up to the requested depth."""
     root_page = fetch_page(root_target)
@@ -38,12 +53,18 @@ def walk_pages(
     current_level = [root_page]
 
     for _depth in range(max_depth):
-        child_ids = {
-            child_id
-            for page in current_level
-            for child_id in _child_page_ids(page)
-            if child_id not in fetched_pages
-        }
+        child_ids: set[str] = set()
+        for page in current_level:
+            page_child_ids = (
+                list_child_page_ids(_target_for_page(page))
+                if list_child_page_ids is not None
+                else _child_page_ids(page)
+            )
+            child_ids.update(
+                child_id
+                for child_id in page_child_ids
+                if child_id not in fetched_pages
+            )
 
         next_level: list[dict[str, object]] = []
         for child_id in sorted(child_ids):

--- a/tests/test_confluence_real_client_contract.py
+++ b/tests/test_confluence_real_client_contract.py
@@ -57,6 +57,23 @@ def _fetch_real_page(
     return cast(dict[str, object], page)
 
 
+def _list_real_child_page_ids(
+    target: ResolvedTarget,
+    *,
+    base_url: str = "https://example.com/wiki",
+    auth_method: str = "bearer-env",
+) -> list[str]:
+    from knowledge_adapters.confluence import client as client_module
+
+    client_module_any = cast(Any, client_module)
+    child_page_ids = client_module_any.list_real_child_page_ids(
+        target,
+        base_url=base_url,
+        auth_method=auth_method,
+    )
+    return cast(list[str], child_page_ids)
+
+
 class _FakeHTTPResponse:
     def __init__(self, payload: dict[str, object], *, status: int = 200) -> None:
         self.status = status
@@ -91,6 +108,17 @@ def _valid_confluence_payload(
             "base": "https://example.com/wiki",
             "webui": f"/spaces/ENG/pages/{page_id}",
         },
+    }
+
+
+def _valid_child_list_payload(*, child_page_ids: list[str]) -> dict[str, object]:
+    return {
+        "results": [
+            {
+                "id": child_page_id,
+            }
+            for child_page_id in child_page_ids
+        ]
     }
 
 
@@ -179,31 +207,6 @@ def test_explicit_real_client_mode_selects_real_fetch_path(
 
 
 @pytest.mark.parametrize(
-    ("extra_args", "expected_fragment"),
-    [
-        (["--client-mode", "real", "--tree"], "--tree"),
-        (["--client-mode", "real", "--max-depth", "1"], "--max-depth"),
-    ],
-)
-def test_real_client_mode_rejects_tree_or_depth_usage_in_v1(
-    tmp_path: Path,
-    capsys: CaptureFixture[str],
-    extra_args: list[str],
-    expected_fragment: str,
-) -> None:
-    output_dir = tmp_path / "out"
-
-    with pytest.raises(SystemExit) as exc_info:
-        main(_confluence_argv(output_dir, *extra_args))
-
-    assert exc_info.value.code == 2
-
-    captured = capsys.readouterr()
-    assert "real" in captured.err
-    assert expected_fragment in captured.err
-
-
-@pytest.mark.parametrize(
     "token_value",
     [
         None,
@@ -252,6 +255,22 @@ def test_real_fetch_maps_valid_confluence_response_into_adapter_payload(
         "source_url": "https://example.com/wiki/spaces/ENG/pages/12345",
     }
     assert str(page["source_url"]).startswith("https://")
+
+
+def test_real_child_list_maps_valid_confluence_response_into_child_page_ids(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *args, **kwargs: _FakeHTTPResponse(
+            _valid_child_list_payload(child_page_ids=["200", "300", "300"])
+        ),
+    )
+
+    child_page_ids = _list_real_child_page_ids(_real_target())
+
+    assert child_page_ids == ["200", "300", "300"]
 
 
 @pytest.mark.parametrize(
@@ -491,6 +510,30 @@ def test_real_fetch_fails_fast_on_invalid_response_shapes(
 
     with pytest.raises(ValueError, match=expected_fragment):
         _fetch_real_page(_real_target())
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_fragment"),
+    [
+        ({}, "child-list payload"),
+        ({"results": [123]}, "child-list payload"),
+        ({"results": [{"id": ""}]}, "child page ID"),
+        ({"results": [{"id": None}]}, "child page ID"),
+    ],
+)
+def test_real_child_list_fails_fast_on_invalid_response_shapes(
+    monkeypatch: MonkeyPatch,
+    payload: dict[str, object],
+    expected_fragment: str,
+) -> None:
+    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *args, **kwargs: _FakeHTTPResponse(payload),
+    )
+
+    with pytest.raises(ValueError, match=expected_fragment):
+        _list_real_child_page_ids(_real_target())
 
 
 @pytest.mark.parametrize(

--- a/tests/test_confluence_real_traversal_contract.py
+++ b/tests/test_confluence_real_traversal_contract.py
@@ -10,14 +10,6 @@ from pytest import MonkeyPatch
 from knowledge_adapters.cli import main
 from knowledge_adapters.confluence.models import ResolvedTarget
 
-pytestmark = pytest.mark.xfail(
-    reason=(
-        "Real Confluence tree traversal is documented but not implemented yet; "
-        "the CLI still rejects --client-mode real with --tree."
-    ),
-    strict=True,
-)
-
 ChildDiscoveryResult = list[str] | Exception
 
 

--- a/tests/test_confluence_real_traversal_contract.py
+++ b/tests/test_confluence_real_traversal_contract.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import cast
 
 import pytest
-from pytest import MonkeyPatch
+from pytest import CaptureFixture, MonkeyPatch
 
 from knowledge_adapters.cli import main
 from knowledge_adapters.confluence.models import ResolvedTarget
@@ -130,6 +130,18 @@ def _assert_no_artifacts_written(output_dir: Path) -> None:
     pages_dir = output_dir / "pages"
     markdown_outputs = list(pages_dir.glob("*.md")) if pages_dir.exists() else []
     assert markdown_outputs == []
+
+
+def _assert_concise_cli_error(
+    capsys: CaptureFixture[str],
+    *,
+    expected_message: str,
+) -> None:
+    captured = capsys.readouterr()
+    assert (
+        captured.err
+        == f"knowledge-adapters confluence: error: {expected_message}\n"
+    )
 
 
 def _run_real_recursive_cli(
@@ -308,13 +320,14 @@ def test_real_tree_deduplicates_repeated_child_ids_across_levels_without_refetch
 def test_real_tree_stops_immediately_when_child_list_fetch_fails(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
 ) -> None:
     output_dir = tmp_path / "out"
     children_by_parent: dict[str, ChildDiscoveryResult] = {
         "100": RuntimeError("synthetic child-list failure for 100"),
     }
 
-    with pytest.raises(RuntimeError, match="synthetic child-list failure for 100"):
+    with pytest.raises(SystemExit) as exc_info:
         _run_real_recursive_cli(
             tmp_path,
             monkeypatch,
@@ -322,19 +335,25 @@ def test_real_tree_stops_immediately_when_child_list_fetch_fails(
             children_by_parent=children_by_parent,
         )
 
+    assert exc_info.value.code == 2
+    _assert_concise_cli_error(
+        capsys,
+        expected_message="synthetic child-list failure for 100",
+    )
     _assert_no_artifacts_written(output_dir)
 
 
 def test_real_tree_stops_immediately_on_malformed_child_list_response(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
 ) -> None:
     output_dir = tmp_path / "out"
     children_by_parent: dict[str, ChildDiscoveryResult] = {
         "100": ValueError("Response error: invalid child-list payload."),
     }
 
-    with pytest.raises(ValueError, match="invalid child-list payload"):
+    with pytest.raises(SystemExit) as exc_info:
         _run_real_recursive_cli(
             tmp_path,
             monkeypatch,
@@ -342,19 +361,25 @@ def test_real_tree_stops_immediately_on_malformed_child_list_response(
             children_by_parent=children_by_parent,
         )
 
+    assert exc_info.value.code == 2
+    _assert_concise_cli_error(
+        capsys,
+        expected_message="Response error: invalid child-list payload.",
+    )
     _assert_no_artifacts_written(output_dir)
 
 
 def test_real_tree_stops_immediately_on_missing_or_invalid_child_ids(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
 ) -> None:
     output_dir = tmp_path / "out"
     children_by_parent: dict[str, ChildDiscoveryResult] = {
         "100": ValueError("Response error: invalid child page ID."),
     }
 
-    with pytest.raises(ValueError, match="invalid child page ID"):
+    with pytest.raises(SystemExit) as exc_info:
         _run_real_recursive_cli(
             tmp_path,
             monkeypatch,
@@ -362,16 +387,22 @@ def test_real_tree_stops_immediately_on_missing_or_invalid_child_ids(
             children_by_parent=children_by_parent,
         )
 
+    assert exc_info.value.code == 2
+    _assert_concise_cli_error(
+        capsys,
+        expected_message="Response error: invalid child page ID.",
+    )
     _assert_no_artifacts_written(output_dir)
 
 
 def test_real_tree_stops_immediately_on_descendant_page_fetch_failure(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
 ) -> None:
     output_dir = tmp_path / "out"
 
-    with pytest.raises(RuntimeError, match="synthetic page fetch failure for 200"):
+    with pytest.raises(SystemExit) as exc_info:
         _run_real_recursive_cli(
             tmp_path,
             monkeypatch,
@@ -379,4 +410,9 @@ def test_real_tree_stops_immediately_on_descendant_page_fetch_failure(
             fail_on_page_ids={"200"},
         )
 
+    assert exc_info.value.code == 2
+    _assert_concise_cli_error(
+        capsys,
+        expected_message="synthetic page fetch failure for 200",
+    )
     _assert_no_artifacts_written(output_dir)


### PR DESCRIPTION
## Summary
- add real child-page discovery for the opt-in Confluence client and wire it into tree mode
- keep traversal policy in the traversal layer with breadth-first ordering and canonical-ID deduplication
- enable the documented real traversal contract tests and update concise docs for the shipped behavior

## Testing
- make check