### PR TITLE
chore: release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ Formal changelog coverage begins at `0.2.0`, when this repository started using
 `CHANGELOG.md` as part of the release flow. Earlier tagged releases `v0.1.0` and
 `v0.1.1` predate that practice and are not backfilled here.
 
+## 0.5.0
+
+- Added opt-in real Confluence tree traversal via `--client-mode real --tree`
+  with depth-limited traversal using the existing `--max-depth` flag.
+- Shipped deterministic breadth-first traversal for the real client path, with
+  lexical canonical page ID ordering within each depth level.
+- Added canonical page ID deduplication across real traversal runs so repeated
+  child discovery fetches, writes, and lists each page at most once.
+- Added fail-fast real traversal behavior so child-list failures, malformed
+  child-list payloads, invalid child IDs, and descendant page-fetch failures
+  stop the run without partial markdown or manifest writes.
+- Added hardened contract coverage for real traversal edge cases, including
+  duplicate-heavy child lists, unsorted child discovery input, shallow-depth
+  no-extra-fetch cases, and mixed success/failure runs.
+- This release does not add pagination, retries/backoff, auth expansion, or
+  richer child metadata beyond canonical child page IDs.
+
 ## 0.4.0
 
 - Added opt-in real Confluence client support through `--client-mode real` while

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "knowledge-adapters"
-version = "0.4.0"
+version = "0.5.0"
 description = "Generic adapters for acquiring and normalizing knowledge sources into local LLM-ready artifacts."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/knowledge_adapters/__init__.py
+++ b/src/knowledge_adapters/__init__.py
@@ -1,3 +1,3 @@
 """knowledge_adapters package."""
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"


### PR DESCRIPTION
## Summary
- bump the package version to 0.5.0
- add changelog notes for opt-in real Confluence tree traversal and its scope boundaries
- keep the release PR limited to version and changelog updates

## Testing
- make check