### PR TITLE
docs: capture sanity-check value

### DIFF
--- a/docs/feature-delivery-workflow.md
+++ b/docs/feature-delivery-workflow.md
@@ -168,6 +168,11 @@ This check is:
 - not required for all PRs
 - focused on behavior, consistency, and scope discipline
 
+In practice, it has been especially valuable for multi-interaction behavior where
+correctness is not trivially obvious, such as CLI error handling consistency
+across modes or traversal behavior that combines ordering, deduplication, and
+fail-fast logic.
+
 It should not expand scope or turn into another implementation phase. The goal is
 to confirm that the PR is ready to merge, not to reopen design or add new work by
 default.


### PR DESCRIPTION
## Summary
- add a short note to the optional pre-merge sanity-check guidance based on observed usage
- call out multi-interaction behavior as the clearest place where the review pass adds value
- keep the sanity-check optional and avoid introducing a new workflow phase

## Testing
- make check