### PR TITLE
chore: align baseline enforcement and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,16 +18,5 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e ".[dev]"
-
-      - name: Run ruff
-        run: ruff check .
-
-      - name: Run mypy
-        run: mypy src
-
-      - name: Run pytest
-        run: pytest
+      - name: Run make check
+        run: make check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,15 @@ Pull requests must:
 - include a clear summary of changes
 - include a testing/verification section
 
+GitHub enforcement on `main` is intentionally minimal:
+
+- pull requests are required
+- admins are subject to the same branch protection
+- the required status check is `test`
+- approving reviews are not required
+
+The rest of this document describes the expected Codex workflow, which is stricter than the enforced minimum.
+
 Preferred PR structure:
 
 Summary

--- a/docs/codex-workflow.md
+++ b/docs/codex-workflow.md
@@ -20,7 +20,7 @@ Preferred pattern:
 4. Review the diff
 5. Run validation
 6. Commit, push, and open a PR
-7. Merge only after review and CI pass
+7. Merge only after any intended review and CI pass
 
 Do not use Codex as the source of truth for architecture. Use it to implement and refine within an already-defined repo structure.
 
@@ -176,6 +176,14 @@ A Codex task is not considered complete until validation succeeds.
 
 Run validation through the Makefile targets for this repository.
 Do not invoke `pytest`, `mypy`, or `ruff` directly; use `make check` and other documented `make` targets instead.
+
+The enforced branch-protection baseline on `main` is intentionally minimal:
+- pull requests are required
+- admin enforcement is enabled
+- the required GitHub status check is `test`
+- approving reviews are not required
+
+Those enforcement settings are lighter than the workflow expectations in this document. GitHub Actions should mirror the canonical local validation path through the `test` job.
 
 At the time of writing, validation is:
 

--- a/docs/feature-delivery-workflow.md
+++ b/docs/feature-delivery-workflow.md
@@ -137,6 +137,8 @@ In practice, that means prompts should explicitly state:
 
 Open PRs as ready for review by default.
 
+In this repository, `main` enforces a minimal PR gate: pull requests are required, admins are included in branch protection, the required status check is `test`, and approving reviews are not required. That enforced baseline is intentionally lighter than the full workflow guidance in this document.
+
 Use a draft PR only when:
 
 - the task explicitly asks for a draft PR


### PR DESCRIPTION
Summary
- align GitHub Actions CI with the documented canonical validation path by running make check in the existing test job
- document the intentionally minimal main branch protection baseline in AGENTS.md and workflow docs
- update main branch protection to enforce admins, require only the test status check, and keep approvals at zero

Testing
- make check
- validated .github/workflows/ci.yml syntax with Ruby YAML parsing
- verified main branch protection now requires the test check and enforces admins