### PR TITLE
docs: tighten repo-specific workflow guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,10 @@
 # AGENTS
 
-This file defines repository-specific expectations for Codex agents.
+This file defines repository-specific expectations for Codex agents working in
+`knowledge-adapters`.
+
+Reusable AI workflow patterns now belong in `ai-workflow-playbook`. Keep this
+file focused on how this repository operates.
 
 ---
 
@@ -107,9 +111,10 @@ GitHub enforcement on `main` is intentionally minimal:
 - pull requests are required
 - admins are subject to the same branch protection
 - the required status check is `test`
-- approving reviews are not required
+- required approving review count is `0`
 
-The rest of this document describes the expected Codex workflow, which is stricter than the enforced minimum.
+This file documents the repo-local working agreement on top of that enforced
+baseline.
 
 Preferred PR structure:
 

--- a/docs/codex-workflow.md
+++ b/docs/codex-workflow.md
@@ -2,191 +2,79 @@
 
 ## Purpose
 
-This document captures the preferred way to use Codex in this repository.
+This document captures how to use Codex effectively in `knowledge-adapters`.
 
-Codex is most effective here when used for small, bounded, reviewable tasks in an isolated branch or worktree. The goal is to accelerate implementation without losing control of scope, repo hygiene, or validation.
+For reusable prompt structures, thread habits, and broader AI workflow patterns,
+see `ai-workflow-playbook`. This file keeps only the local operating details
+that matter in this repository.
 
----
+## What Codex Is Best Used For Here
 
-## Core model
+Codex is most useful in this repo for small, reviewable changes such as:
 
-Use Codex as a focused contributor for PR-sized changes.
+- adapter contract and edge-case tests
+- CLI behavior and smoke-test updates
+- normalization, traversal, resolve, and manifest logic changes
+- focused documentation updates tied to current repo behavior
+- small refactors inside an existing adapter or shared CLI path
 
-Preferred pattern:
+Use extra care before asking Codex to drive:
 
-1. Start from a clean `main`
-2. Work in an isolated branch or worktree
-3. Give Codex one bounded task
-4. Review the diff
-5. Run validation
-6. Commit, push, and open a PR
-7. Merge only after any intended review and CI pass
+- broad architecture changes across multiple adapters
+- new abstractions before a shared pattern is proven
+- live private-system integration work without explicit task constraints
+- unrelated cleanup mixed into the same branch
 
-Do not use Codex as the source of truth for architecture. Use it to implement and refine within an already-defined repo structure.
+## Repo-Specific Working Agreement
 
-A task is not complete until a pull request has been created.
+`AGENTS.md` is the canonical source for task completion requirements in this
+repo. In practice, that means:
 
----
+1. start from `main` and work on a new branch
+2. keep the branch scoped to one PR-sized change
+3. run validation through the Makefile, not direct tool invocations
+4. do not consider the task complete until the change is committed, pushed, and
+   opened as a PR targeting `main`
 
-## Where Codex fits
+Branch names should follow the patterns in `AGENTS.md`, such as
+`feat/<short-name>` or `docs/<short-name>`.
 
-Use Codex for:
-- adding or improving tests
-- tightening edge-case handling
-- improving CLI behavior
-- refining normalization logic
-- making small, focused refactors
-- preparing commit and PR summaries
+PRs should be ready for review by default and should include:
 
-Do not use Codex first for:
-- broad architectural redesigns
-- large cross-cutting refactors
-- live private-system integrations
-- browser automation
-- adding multiple new adapters at once
+- a short `Summary` section
+- a short `Testing` section
 
----
+## Repository Guardrails
 
-## Thread strategy
+Keep changes aligned with the shape of this repository:
 
-Use one Codex project for this repository.
+- preserve the separation between adapter-specific code and shared CLI behavior
+- keep Confluence-specific behavior isolated to the Confluence adapter paths
+- avoid committing secrets, private URLs, tokens, or internal content
+- prefer contract and smoke coverage when changing adapter behavior
+- keep changes minimal and reversible when working on traversal, normalization,
+  or incremental-sync behavior
 
-Use one Codex thread per PR-sized task.
+## Validation And CI
 
-Stay in the same thread when:
-- continuing the same task
-- making follow-up fixes for the same PR
-- addressing review comments on the same change
-
-Start a new thread when:
-- starting a new branch/worktree
-- changing task scope
-- moving to a different PR-sized change
-- the previous thread has become confusing or overloaded
-
-Good rule:
-- one thread = one branch/worktree = one PR-sized task
-
----
-
-## Branch and PR strategy
-
-Preferred branch naming format:
-
-<type>/<area>-<short-description>
-
-Examples:
-- test/resolve-edge-cases
-- test/normalize-writer
-- feat/confluence-cli-smoke-test
-- fix/resolve-url-parsing
-
-Keep branch names:
-- lowercase
-- hyphen-separated
-- short but descriptive
-- scoped to one change
-
-PR titles should mirror branch intent, for example:
-- test: expand resolve_target edge cases
-- feat: add CLI dry-run smoke test
-
-PR descriptions should follow this structure:
-
-Summary
-- high-level description of the change
-- key implementation details
-
-Testing
-- how the change was validated (typically `make check`)
-
----
-
-## Task prompt pattern
-
-Use prompts that are explicit about:
-- isolation from `main`
-- task scope
-- constraints
-- validation
-- delivery format
-
-Example:
-
-Work in an isolated branch or worktree based on main. Never work directly on main.
-
-Task:
-Add edge-case tests for resolve_target().
-
-Focus on:
-- URLs without page IDs
-- malformed or unexpected inputs
-- whitespace handling
-- preserving current intended behavior unless a small, clearly justified fix is needed
-
-Constraints:
-- Follow AGENTS.md
-- Keep changes minimal, focused, and reversible
-- Do not introduce live Confluence access
-- Do not add new dependencies
-- Do not refactor unrelated code
-- Prefer tests first; only change production code if necessary to support correct behavior
-
-Validation:
-Run the full local validation before considering the task complete:
-- make check
-
-Do not consider the task complete until:
-- changes are committed
-- the branch is pushed
-- a pull request is created
-
-Delivery:
-When done:
-1. summarize files changed
-2. summarize behavior covered by the new tests
-3. list any assumptions
-4. commit using Conventional Commits format
-5. push the branch
-6. open a PR with a concise summary
-
-If anything blocks completion, stop and explain the blocker clearly instead of broadening scope.
-
----
-
-## Planning guidance
-
-For simple tasks, ask Codex to implement directly.
-
-For harder or less clearly scoped tasks, ask Codex to plan first before changing code.
-
-Use planning first when:
-- the task touches multiple modules
-- the task is ambiguous
-- the task might require production-code changes
-- there are several possible implementation paths
-
----
-
-## Validation
-
-The canonical validation steps for this repo are defined in `AGENTS.md`.
-
-A Codex task is not considered complete until validation succeeds.
-
-Run validation through the Makefile targets for this repository.
-Do not invoke `pytest`, `mypy`, or `ruff` directly; use `make check` and other documented `make` targets instead.
-
-The enforced branch-protection baseline on `main` is intentionally minimal:
-- pull requests are required
-- admin enforcement is enabled
-- the required GitHub status check is `test`
-- approving reviews are not required
-
-Those enforcement settings are lighter than the workflow expectations in this document. GitHub Actions should mirror the canonical local validation path through the `test` job.
-
-At the time of writing, validation is:
+The canonical local validation command is:
 
 ```bash
 make check
 ```
+
+Use the Makefile targets documented in this repo. Do not invoke `pytest`,
+`mypy`, or `ruff` directly when validating a task for completion.
+
+GitHub Actions mirrors that local path in `.github/workflows/ci.yml` through the
+`test` job, which runs `make check`.
+
+The enforced baseline on `main` is currently:
+
+- pull requests are required
+- admin enforcement is enabled
+- the required GitHub status check is `test`
+- required approving review count is `0`
+
+Do not rely on stronger GitHub enforcement than that baseline when writing or
+updating repo docs.

--- a/docs/feature-delivery-workflow.md
+++ b/docs/feature-delivery-workflow.md
@@ -2,255 +2,68 @@
 
 ## Purpose
 
-This document defines a repeatable workflow for AI-assisted feature delivery.
+This document explains what "feature delivery" should look like in
+`knowledge-adapters`.
 
-It exists to keep feature work bounded, reviewable, and learnable across the full
-lifecycle from idea to release. The goal is not just faster execution, but more
-predictable outcomes and a workflow that improves over time.
+Reusable lifecycle models, review patterns, and prompt templates now belong in
+`ai-workflow-playbook`. This file keeps the repo-specific guidance needed to
+ship changes here without depending on that playbook.
 
-## Core Model
+## What A Feature Usually Looks Like In This Repo
 
-Use this lifecycle as the default model for delivering a feature:
+Most feature work in this repository should land as a small, reviewable PR that
+improves one of these areas:
 
-1. idea
-2. design doc
-3. contract tests
-4. implementation
-5. hardening
-6. docs
-7. release
+- an adapter contract or implementation
+- CLI behavior around resolve, traversal, dry-run, or writing artifacts
+- normalization and manifest generation
+- repo documentation tied to current adapter behavior
 
-Each phase should produce a clear artifact or decision before moving forward.
+Prefer one bounded change per branch and PR. If a request is too large, split it
+along repository seams such as:
 
-## Roles
+- contract tests first
+- adapter implementation next
+- CLI or documentation follow-up after behavior is stable
 
-### Human
+## Repo-Specific Delivery Expectations
 
-The human is responsible for:
+When delivering a feature in this repo:
 
-- defining the problem and intended outcome
-- setting constraints, scope, and tradeoffs
-- reviewing designs, diffs, and release readiness
-- deciding whether to tighten, defer, or broaden work
+1. work from a new branch based on `main`
+2. keep the change focused on the requested adapter, CLI path, or doc surface
+3. preserve public-safe defaults and avoid checking in secrets or private system
+   details
+4. validate through `make check`
+5. commit, push, and open a PR targeting `main`
 
-### Codex
+Open the PR as ready for review by default unless the task explicitly calls for
+a draft.
 
-Codex is responsible for:
+`AGENTS.md` remains the canonical source for branch naming, validation, commit
+messages, and completion requirements.
 
-- executing bounded tasks within the stated constraints
-- drafting or refining design docs and tests when asked
-- implementing the requested change without expanding scope
-- running validation, preparing commits, pushing branches, and opening PRs
+## Feature-Specific Guardrails
 
-## Feature Lifecycle
+Keep feature work grounded in the current design of this repo:
 
-### Design
+- avoid broad shared abstractions unless multiple adapters already need them
+- keep source-specific logic inside the relevant adapter package
+- update tests when behavior changes, especially around contract boundaries
+- avoid mixing live-integration work with unrelated cleanup
+- keep docs accurate to the current CLI, CI, and branch-protection baseline
 
-Define the feature in a short design doc before implementation when behavior is
-non-trivial. The design should clarify semantics, success criteria, expected
-outputs, and out-of-scope items.
+## CI And Merge Baseline
 
-### Contract Tests
+The local and CI validation path for feature work is `make check`.
 
-Write tests that express the intended behavior before or alongside implementation.
-These tests should be stable, readable, and close to user-facing expectations.
+The current enforced baseline on `main` is:
 
-### Implementation
+- pull requests are required
+- admins are included in branch protection
+- the required status check is `test`
+- required approving review count is `0`
 
-Implement only what is required to satisfy the design and contract tests. Avoid
-adding adjacent features while code is in flight.
-
-### Hardening
-
-Add a small follow-up pass for edge cases, stress cases, and user-facing polish.
-This phase should strengthen confidence without turning into a redesign.
-
-### Docs & UX
-
-Document how to use the feature and make small output improvements that help
-people understand what happened. Keep output human-readable and concise.
-
-### Release
-
-Prepare the feature for release with versioning, changelog updates, and a release
-PR. Once the release changes land on the mainline branch, create and push the
-matching version tag.
-
-## Key Principles
-
-- Contract-first development: define expected behavior before or alongside code.
-- Minimal scope per PR: one branch and one pull request should represent one
-  bounded step.
-- New branch and PR per lifecycle phase after merge: once a phase PR is merged,
-  the next phase of the same feature starts from current `main` on a new branch
-  and opens a new PR.
-- Deterministic behavior: ordering, output, and failure modes should be stable
-  enough to test.
-- Fail-fast over partial state: stop on unrecoverable errors instead of producing
-  ambiguous partial results.
-- Human-readable output: prefer concise output people can understand without extra
-  tooling.
-- No scope expansion during implementation: new ideas should be captured for later,
-  not folded into the current task.
-
-## Task Sizing Guidance
-
-Good Codex tasks are:
-
-- narrow enough to fit in one PR
-- specific about behavior, constraints, and validation
-- backed by a clear design or obvious acceptance criteria
-- small enough to review comfortably
-
-Avoid tasks that are:
-
-- open-ended or architecture-first
-- spread across many unrelated concerns
-- dependent on unclear product decisions
-- likely to trigger broad refactors just to get started
-
-If a task feels too large, split it by lifecycle phase rather than asking for the
-entire feature at once.
-
-When a lifecycle phase already landed through a merged PR, do not keep using that
-branch or PR for the next phase. Reuse an existing branch or PR only when the
-task explicitly says to continue that still-open PR.
-
-## Prompt Pattern
-
-Use a consistent structure for Codex prompts:
-
-1. isolation
-2. task definition
-3. constraints
-4. validation
-5. delivery expectations
-
-In practice, that means prompts should explicitly state:
-
-- work in an isolated branch or worktree based on main
-- the exact task to perform
-- what must not change
-- how success will be validated
-- what completion requires, including commit, push, and PR creation
-- whether the PR should be ready for review or draft when the task is complete
-
-Open PRs as ready for review by default.
-
-In this repository, `main` enforces a minimal PR gate: pull requests are required, admins are included in branch protection, the required status check is `test`, and approving reviews are not required. That enforced baseline is intentionally lighter than the full workflow guidance in this document.
-
-Use a draft PR only when:
-
-- the task explicitly asks for a draft PR
-- the work is intentionally incomplete
-- feedback is needed before the task is considered complete
-
-For PR-based tasks, local validation passing is necessary but not sufficient.
-After opening the PR, check the initial CI result for that branch or PR.
-
-If that initial CI signal fails because of task-related changes, the task is not
-complete yet. Continue until the failure is fixed or clearly reported as the
-remaining blocker.
-
-## Optional Pre-Merge Sanity Check
-
-For higher-risk PRs, an optional pre-merge sanity check can add one last
-behavior-focused review pass before merge.
-
-Use it selectively for changes such as:
-
-- auth handling
-- CLI behavior
-- error handling
-- release flow
-
-This check is:
-
-- review-only
-- not required for all PRs
-- focused on behavior, consistency, and scope discipline
-
-In practice, it has been especially valuable for multi-interaction behavior where
-correctness is not trivially obvious, such as CLI error handling consistency
-across modes or traversal behavior that combines ordering, deduplication, and
-fail-fast logic.
-
-It should not expand scope or turn into another implementation phase. The goal is
-to confirm that the PR is ready to merge, not to reopen design or add new work by
-default.
-
-## Release Process
-
-For release preparation:
-
-1. create or update the changelog entry
-2. bump the version in all relevant places so the version number, changelog
-   entry, and release tag all match
-3. run validation
-4. commit and open a release PR with Summary and Testing sections
-5. merge the release PR to the mainline branch through an allowed repository
-   merge policy path
-6. create a version tag that matches the released version from the merged `main`
-   commit, not the branch tip
-7. push the tag to origin
-
-Keep release changes focused on release metadata and documentation. Do not mix new
-feature implementation into the release PR.
-
-The release is not complete until the release PR is actually merged into `main`.
-Direct merge may be blocked by repository policy. Auto-merge may not be available
-in every repository, and an admin merge may be required when allowed by
-repository policy.
-
-Tag format must follow the repository's established convention going forward. In
-this repository, new release tags use plain version numbers such as `0.3.0`, not
-prefixed forms such as `v0.3.0`. Older tags before that convention changed may
-still use the `v` prefix.
-
-Release completion requires all of the following:
-
-- the release PR is merged to `main` through an allowed policy path
-- the correct version tag is created from the merged commit
-- the tag is pushed to `origin`
-
-## Post-Release Capture
-
-This step is required after the release PR is merged and the version tag has been
-created and pushed. It must happen before starting the next feature.
-
-A feature arc is not complete until post-release capture is performed. Do not
-start the next feature arc until capture is complete. If capture produces a clear
-workflow or prompt improvement, commit it in a small follow-up PR before starting
-the next feature.
-
-### Trigger
-
-- after merge
-- after tag push
-
-### Goals
-
-- capture what worked well in the feature lifecycle
-- identify friction in prompts, handoffs, review, validation, or release
-- refine the workflow so the next feature is easier to deliver
-
-### Actions
-
-- summarize the lifecycle from design through release
-- note where scope drift, ambiguity, or unnecessary rework appeared
-- capture workflow friction such as merge policy handling, permissions, or tagging
-  issues and feed it back into workflow docs when a clear improvement is available
-- update workflow docs, prompt patterns, or task templates if a clear improvement
-  is available
-
-### Principles
-
-- lightweight
-- immediate
-- actionable
-
-### Outcome
-
-The workflow improves after each feature instead of staying static. Post-release
-capture turns delivery experience into a reusable operating model for the next
-feature.
+That baseline is intentionally minimal. Repo docs may recommend a stricter
+working style, but they should not imply stronger enforced GitHub rules than
+those settings.


### PR DESCRIPTION
Summary
- tighten AGENTS.md so it stays repo-specific while pointing reusable workflow guidance to ai-workflow-playbook
- refocus docs/codex-workflow.md on how Codex should operate inside knowledge-adapters instead of repeating generic prompt and thread guidance
- reduce docs/feature-delivery-workflow.md to repo-local feature-delivery expectations, adapter guardrails, and the current CI/branch-protection baseline

Testing
- make check