### PR TITLE
fix: add Confluence client certificate auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ client.
 - generates stub page content for the resolved page without contacting a live
   Confluence instance
 - supports an opt-in real client path with `--client-mode real` for a single live
-  page fetch using `bearer-env` auth
+  page fetch using `bearer-env` or `client-cert-env` auth
 - normalizes that stub content into markdown and writes `pages/<canonical_id>.md`
 - writes `manifest.json` for normal runs
 - supports dry-run output and manifest-based skip logic for the resolved page
@@ -232,7 +232,12 @@ CONFLUENCE_BEARER_TOKEN=... .venv/bin/knowledge-adapters confluence \
 ```
 
 In v1, `--client-mode real` supports both single-page fetches and real breadth-first
-tree traversal with `--tree` and `--max-depth`, using `bearer-env` auth.
+tree traversal with `--tree` and `--max-depth`, using `bearer-env` auth and
+optional client certificates or `client-cert-env` auth.
+
+For certificate-based auth, set `CONFLUENCE_CLIENT_CERT_FILE` to a combined PEM
+file, or set `CONFLUENCE_CLIENT_CERT_FILE` plus `CONFLUENCE_CLIENT_KEY_FILE` for
+split cert/key files.
 
 Preview the default Confluence run without writing files:
 

--- a/adapters/confluence/README.md
+++ b/adapters/confluence/README.md
@@ -17,7 +17,8 @@ Out of the box, the default Confluence CLI:
 - resolves the target into a canonical page ID
 - fetches stub page data for that resolved page
 - supports an opt-in real client path with `--client-mode real` for live page
-  fetches and breadth-first tree traversal using `bearer-env` auth
+  fetches and breadth-first tree traversal using `bearer-env` or
+  `client-cert-env` auth
 - normalizes the stub page into markdown plus metadata
 - writes a deterministic page artifact and `manifest.json` on normal runs
 - supports dry-run output and manifest-based skip logic for the resolved page
@@ -27,8 +28,9 @@ Out of the box, the default Confluence CLI:
 ## Known Limitations
 
 - the default client does not make live Confluence network requests
-- `--client-mode real` supports only `bearer-env` auth via
-  `CONFLUENCE_BEARER_TOKEN`
+- `--client-mode real` supports `bearer-env` via `CONFLUENCE_BEARER_TOKEN`
+  and `client-cert-env` via `CONFLUENCE_CLIENT_CERT_FILE` plus optional
+  `CONFLUENCE_CLIENT_KEY_FILE`
 - recursive traversal semantics are defined and tested, but multi-page tree runs
   still require `--client-mode real` or a monkeypatched client that returns child
   pages

--- a/docs/confluence-real-client.md
+++ b/docs/confluence-real-client.md
@@ -184,11 +184,13 @@ This keeps future auth growth localized to config/auth modules instead of spilli
 
 ### Deferred future auth modes
 
-The following are explicitly deferred:
+The following auth work beyond minimal environment-driven `bearer-env` and
+`client-cert-env` support is explicitly deferred:
 
-- certificate-based auth
-- mTLS
-- enterprise certificate or client-cert flows
+- broader auth abstractions or multi-provider auth systems
+- advanced certificate handling such as passphrase-protected keys
+- enterprise-specific auth combinations beyond `bearer-env` and
+  `client-cert-env`
 - OAuth variants
 - cookie/session-based auth
 - other runtime-specific enterprise auth mechanisms

--- a/docs/confluence-real-client.md
+++ b/docs/confluence-real-client.md
@@ -145,17 +145,25 @@ Tree semantics are defined separately in
 
 ### v1 auth mode
 
-v1 supports exactly one real auth mode:
+v1 supports these real auth modes:
 
 - `bearer-env`
+- `client-cert-env`
 
 Behavior:
 
-- the real client reads a bearer token from `CONFLUENCE_BEARER_TOKEN`
-- the auth helper builds the `Authorization: Bearer ...` header for the request
-- if the token is missing or empty, the run fails before any request is made
+- `bearer-env` reads a bearer token from `CONFLUENCE_BEARER_TOKEN`
+- `bearer-env` builds the `Authorization: Bearer ...` header for the request
+- `client-cert-env` reads a client certificate from `CONFLUENCE_CLIENT_CERT_FILE`
+- `client-cert-env` optionally reads a separate private key from
+  `CONFLUENCE_CLIENT_KEY_FILE`
+- when `CONFLUENCE_CLIENT_KEY_FILE` is omitted, `CONFLUENCE_CLIENT_CERT_FILE`
+  may point to a combined PEM file
+- if required auth material is missing or empty, the run fails before any request
+  is made
 
-The existing `auth_method` field can continue to name the selected auth strategy, but only `bearer-env` is supported for real mode in v1.
+The existing `auth_method` field continues to name the selected auth strategy for
+real mode.
 
 ### Auth boundary
 
@@ -283,7 +291,7 @@ If a future implementation starts populating `children`, any failure to retrieve
 v1 test coverage should rely on mocked or fixture-based tests for:
 
 - CLI mode selection: default stub vs explicit real mode
-- auth config validation for `bearer-env`
+- auth config validation for `bearer-env` and `client-cert-env`
 - request construction for the real client
 - response-to-payload mapping
 - error mapping for `401/403`, `404`, and malformed response bodies
@@ -305,6 +313,8 @@ Optional manual validation may exist outside normal repository validation, for e
 - developer-run command with `--client-mode real`
 - real `--base-url`
 - real bearer token in `CONFLUENCE_BEARER_TOKEN`
+- real client certificate material in `CONFLUENCE_CLIENT_CERT_FILE` and optional
+  `CONFLUENCE_CLIENT_KEY_FILE`
 
 That live check is opt-in only and is not part of `make check`.
 
@@ -313,9 +323,8 @@ That live check is opt-in only and is not part of `make check`.
 The following are explicitly out of scope for v1:
 
 - making the real client the default
-- live enterprise auth beyond `bearer-env`
-- certificate-based auth
-- mTLS
+- live enterprise auth beyond `bearer-env` and `client-cert-env`
+- broader auth abstractions or multi-provider auth systems
 - attachments
 - comments
 - pagination or rate-limit sophistication

--- a/src/knowledge_adapters/confluence/auth.py
+++ b/src/knowledge_adapters/confluence/auth.py
@@ -3,17 +3,64 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Mapping
+import ssl
+from dataclasses import dataclass
 
 
-def build_auth_headers(auth_method: str) -> Mapping[str, str]:
-    """Build auth headers for a supported auth method.
-    """
-    if auth_method != "bearer-env":
+@dataclass(frozen=True)
+class RequestAuth:
+    """Request auth material for the Confluence real client."""
+
+    headers: dict[str, str]
+    ssl_context: ssl.SSLContext | None
+
+
+def build_request_auth(auth_method: str) -> RequestAuth:
+    """Build auth material for a supported auth method."""
+    if auth_method == "bearer-env":
+        headers = _bearer_env_headers()
+    elif auth_method == "client-cert-env":
+        headers = {}
+    else:
         raise ValueError(f"Unsupported auth method: {auth_method}")
 
+    return RequestAuth(
+        headers=headers,
+        ssl_context=_client_cert_ssl_context(auth_method),
+    )
+
+
+def _bearer_env_headers() -> dict[str, str]:
     token = os.getenv("CONFLUENCE_BEARER_TOKEN", "").strip()
     if not token:
         raise ValueError("CONFLUENCE_BEARER_TOKEN must be set for --client-mode real.")
 
     return {"Authorization": f"Bearer {token}"}
+
+
+def _client_cert_ssl_context(auth_method: str) -> ssl.SSLContext | None:
+    cert_file = os.getenv("CONFLUENCE_CLIENT_CERT_FILE", "").strip()
+    key_file = os.getenv("CONFLUENCE_CLIENT_KEY_FILE", "").strip()
+
+    if key_file and not cert_file:
+        raise ValueError(
+            "CONFLUENCE_CLIENT_CERT_FILE must be set when CONFLUENCE_CLIENT_KEY_FILE is set."
+        )
+    if auth_method == "client-cert-env" and not cert_file:
+        raise ValueError(
+            "CONFLUENCE_CLIENT_CERT_FILE must be set for --client-mode real "
+            "when --auth-method client-cert-env."
+        )
+    if not cert_file:
+        return None
+
+    ssl_context = ssl.create_default_context()
+    try:
+        ssl_context.load_cert_chain(
+            certfile=cert_file,
+            keyfile=key_file or None,
+        )
+    except (OSError, ssl.SSLError, ValueError) as exc:
+        raise ValueError("Confluence client certificate configuration is invalid.") from exc
+
+    return ssl_context

--- a/src/knowledge_adapters/confluence/client.py
+++ b/src/knowledge_adapters/confluence/client.py
@@ -6,7 +6,7 @@ import json
 from urllib import parse, request
 from urllib.error import HTTPError, URLError
 
-from knowledge_adapters.confluence.auth import build_auth_headers
+from knowledge_adapters.confluence.auth import build_request_auth
 from knowledge_adapters.confluence.models import ResolvedTarget
 
 
@@ -121,14 +121,14 @@ def _map_child_page_ids(payload: dict[str, object]) -> list[str]:
 
 
 def _request_json(api_url: str, *, auth_method: str) -> dict[str, object]:
-    headers = dict(build_auth_headers(auth_method))
+    request_auth = build_request_auth(auth_method)
     api_request = request.Request(
         api_url,
-        headers=headers,
+        headers=dict(request_auth.headers),
     )
 
     try:
-        with request.urlopen(api_request) as response:
+        with request.urlopen(api_request, context=request_auth.ssl_context) as response:
             raw_payload = json.loads(response.read().decode("utf-8"))
     except HTTPError as exc:
         if exc.code in {401, 403}:

--- a/tests/test_confluence_real_client_contract.py
+++ b/tests/test_confluence_real_client_contract.py
@@ -92,6 +92,14 @@ class _FakeHTTPResponse:
         return self.status
 
 
+class _FakeSSLContext:
+    def __init__(self) -> None:
+        self.loaded_cert_chain: tuple[str, str | None] | None = None
+
+    def load_cert_chain(self, *, certfile: str, keyfile: str | None = None) -> None:
+        self.loaded_cert_chain = (certfile, keyfile)
+
+
 def _valid_confluence_payload(
     *,
     page_id: str = "12345",
@@ -257,6 +265,89 @@ def test_real_fetch_maps_valid_confluence_response_into_adapter_payload(
     assert str(page["source_url"]).startswith("https://")
 
 
+def test_real_fetch_passes_no_client_cert_context_by_default(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    observed_contexts: list[object | None] = []
+
+    def fake_urlopen(*args: object, **kwargs: object) -> _FakeHTTPResponse:
+        del args
+        observed_contexts.append(kwargs.get("context"))
+        return _FakeHTTPResponse(_valid_confluence_payload())
+
+    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
+    monkeypatch.delenv("CONFLUENCE_CLIENT_CERT_FILE", raising=False)
+    monkeypatch.delenv("CONFLUENCE_CLIENT_KEY_FILE", raising=False)
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    page = _fetch_real_page(_real_target())
+
+    assert page["canonical_id"] == "12345"
+    assert observed_contexts == [None]
+
+
+def test_real_fetch_uses_combined_client_cert_pem_when_configured(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    ssl_context = _FakeSSLContext()
+    observed_contexts: list[object | None] = []
+    observed_request_headers: list[dict[str, str]] = []
+
+    def fake_urlopen(*args: object, **kwargs: object) -> _FakeHTTPResponse:
+        request_obj = cast(Any, args[0])
+        observed_request_headers.append(dict(request_obj.headers))
+        observed_contexts.append(kwargs.get("context"))
+        return _FakeHTTPResponse(_valid_confluence_payload())
+
+    monkeypatch.setattr(
+        "knowledge_adapters.confluence.auth.ssl.create_default_context",
+        lambda: ssl_context,
+    )
+    monkeypatch.setenv("CONFLUENCE_CLIENT_CERT_FILE", "/tmp/confluence-client.pem")
+    monkeypatch.delenv("CONFLUENCE_CLIENT_KEY_FILE", raising=False)
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    page = _fetch_real_page(_real_target(), auth_method="client-cert-env")
+
+    assert page["canonical_id"] == "12345"
+    assert ssl_context.loaded_cert_chain == ("/tmp/confluence-client.pem", None)
+    assert observed_contexts == [ssl_context]
+    assert observed_request_headers == [{}]
+
+
+def test_real_fetch_uses_split_client_cert_and_key_with_bearer_auth(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    ssl_context = _FakeSSLContext()
+    observed_contexts: list[object | None] = []
+    observed_request_headers: list[dict[str, str]] = []
+
+    def fake_urlopen(*args: object, **kwargs: object) -> _FakeHTTPResponse:
+        request_obj = cast(Any, args[0])
+        observed_request_headers.append(dict(request_obj.headers))
+        observed_contexts.append(kwargs.get("context"))
+        return _FakeHTTPResponse(_valid_confluence_payload())
+
+    monkeypatch.setattr(
+        "knowledge_adapters.confluence.auth.ssl.create_default_context",
+        lambda: ssl_context,
+    )
+    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
+    monkeypatch.setenv("CONFLUENCE_CLIENT_CERT_FILE", "/tmp/confluence-client.crt")
+    monkeypatch.setenv("CONFLUENCE_CLIENT_KEY_FILE", "/tmp/confluence-client.key")
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    page = _fetch_real_page(_real_target())
+
+    assert page["canonical_id"] == "12345"
+    assert ssl_context.loaded_cert_chain == (
+        "/tmp/confluence-client.crt",
+        "/tmp/confluence-client.key",
+    )
+    assert observed_contexts == [ssl_context]
+    assert observed_request_headers == [{"Authorization": "Bearer test-token"}]
+
+
 def test_real_child_list_maps_valid_confluence_response_into_child_page_ids(
     monkeypatch: MonkeyPatch,
 ) -> None:
@@ -395,6 +486,49 @@ def test_real_fetch_maps_http_status_failures(
 
     with pytest.raises(RuntimeError, match=f"^{expected_message}$"):
         _fetch_real_page(_real_target())
+
+
+def test_real_fetch_requires_client_cert_file_for_client_cert_auth_before_request(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    request_count = 0
+
+    def fail_if_requested(*args: object, **kwargs: object) -> object:
+        nonlocal request_count
+        del args, kwargs
+        request_count += 1
+        raise AssertionError("network request should not be attempted without client cert")
+
+    monkeypatch.delenv("CONFLUENCE_CLIENT_CERT_FILE", raising=False)
+    monkeypatch.delenv("CONFLUENCE_CLIENT_KEY_FILE", raising=False)
+    monkeypatch.setattr("urllib.request.urlopen", fail_if_requested)
+
+    with pytest.raises(ValueError, match="CONFLUENCE_CLIENT_CERT_FILE"):
+        _fetch_real_page(_real_target(), auth_method="client-cert-env")
+
+    assert request_count == 0
+
+
+def test_real_fetch_rejects_client_key_without_cert_before_request(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    request_count = 0
+
+    def fail_if_requested(*args: object, **kwargs: object) -> object:
+        nonlocal request_count
+        del args, kwargs
+        request_count += 1
+        raise AssertionError("network request should not be attempted with invalid cert config")
+
+    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
+    monkeypatch.delenv("CONFLUENCE_CLIENT_CERT_FILE", raising=False)
+    monkeypatch.setenv("CONFLUENCE_CLIENT_KEY_FILE", "/tmp/confluence-client.key")
+    monkeypatch.setattr("urllib.request.urlopen", fail_if_requested)
+
+    with pytest.raises(ValueError, match="CONFLUENCE_CLIENT_CERT_FILE"):
+        _fetch_real_page(_real_target())
+
+    assert request_count == 0
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Summary
- add client certificate support to the Confluence real client without changing the broader adapter shape
- support cert-only auth via `client-cert-env` and optional client certificates alongside existing `bearer-env` requests
- validate client certificate environment configuration before making network requests and document the new inputs

Testing
- make check