### PR TITLE
docs: document pipx GitHub install

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,19 @@ Generic adapters for acquiring knowledge from external sources and normalizing i
 
 ---
 
+## Install (without cloning)
+
+If you only want the CLI, install it directly from GitHub with `pipx`:
+
+```bash
+pipx install git+https://github.com/ctrl-alt-keith/knowledge-adapters.git
+knowledge-adapters --help
+```
+
+When installed this way, use `knowledge-adapters` in place of `.venv/bin/knowledge-adapters` in the examples below.
+
+---
+
 ## Quickstart
 
 ```bash

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+
+def test_pyproject_exposes_installed_cli_entrypoint() -> None:
+    pyproject = tomllib.loads(
+        (Path(__file__).resolve().parents[1] / "pyproject.toml").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    assert pyproject["project"]["name"] == "knowledge-adapters"
+    assert pyproject["project"]["scripts"] == {
+        "knowledge-adapters": "knowledge_adapters.cli:main",
+    }


### PR DESCRIPTION
Summary
- add a concise README section for installing the CLI directly from GitHub with pipx
- add a packaging metadata test that keeps the knowledge-adapters console entrypoint wired to knowledge_adapters.cli:main
- validate the direct GitHub pipx install path and the local pipx install path with the installed CLI

Testing
- make check
- pipx install git+https://github.com/ctrl-alt-keith/knowledge-adapters.git
- pipx install /Users/keith/src/ctrl-alt-keith/knowledge-adapters
- run the installed CLI with --help and a local_files --dry-run smoke check