### PR TITLE
fix: improve confluence first-run CLI UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,37 @@ When installed this way, use `knowledge-adapters` in place of `.venv/bin/knowled
 
 ---
 
-## Quickstart
+## First Run (installed CLI)
+
+Start with the built-in help:
+
+```bash
+knowledge-adapters --help
+knowledge-adapters confluence --help
+```
+
+Confluence auth quick reference:
+
+- `bearer-env` -> `CONFLUENCE_BEARER_TOKEN`
+- `client-cert-env` -> `CONFLUENCE_CLIENT_CERT_FILE` and optional `CONFLUENCE_CLIENT_KEY_FILE`
+
+Minimal live Confluence example with bearer auth:
+
+```bash
+CONFLUENCE_BEARER_TOKEN=... knowledge-adapters confluence \
+  --client-mode real \
+  --auth-method bearer-env \
+  --base-url https://example.com/wiki \
+  --target 12345 \
+  --output-dir ./artifacts
+```
+
+Use the default `stub` client mode when you want to preview the artifact shape
+without contacting a live Confluence instance.
+
+---
+
+## Developer Quickstart
 
 ```bash
 git clone <repo>

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -6,6 +6,31 @@ import argparse
 import sys
 from collections.abc import Callable, Sequence
 
+from knowledge_adapters.confluence.auth import SUPPORTED_AUTH_METHODS
+
+CONFLUENCE_HELP_EXAMPLES = """Examples:
+  knowledge-adapters confluence \\
+    --base-url https://example.com/wiki \\
+    --target 12345 \\
+    --output-dir ./artifacts
+  CONFLUENCE_BEARER_TOKEN=... knowledge-adapters confluence \\
+    --client-mode real \\
+    --auth-method bearer-env \\
+    --base-url https://example.com/wiki \\
+    --target 12345 \\
+    --output-dir ./artifacts
+"""
+
+
+def _parse_confluence_auth_method(value: str) -> str:
+    """Parse and validate a supported Confluence auth method."""
+    normalized_value = value.strip()
+    if normalized_value in SUPPORTED_AUTH_METHODS:
+        return normalized_value
+
+    supported_values = " or ".join(repr(method) for method in SUPPORTED_AUTH_METHODS)
+    raise argparse.ArgumentTypeError(f"unsupported value {value!r}. Choose {supported_values}.")
+
 
 def build_parser() -> argparse.ArgumentParser:
     """Build the top-level CLI parser."""
@@ -19,6 +44,13 @@ def build_parser() -> argparse.ArgumentParser:
     confluence_parser = subparsers.add_parser(
         "confluence",
         help="Run the Confluence adapter.",
+        description=(
+            "Normalize a Confluence page or page tree into local markdown artifacts. "
+            "The default stub mode writes scaffolded output without contacting "
+            "Confluence. Use --client-mode real for live Confluence fetches."
+        ),
+        epilog=CONFLUENCE_HELP_EXAMPLES,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     confluence_parser.add_argument(
         "--base-url",
@@ -39,12 +71,23 @@ def build_parser() -> argparse.ArgumentParser:
         "--client-mode",
         choices=("stub", "real"),
         default="stub",
-        help="Client mode. Defaults to the stub client.",
+        help=(
+            "Client behavior: 'stub' writes scaffolded local output with no "
+            "network call; 'real' fetches from Confluence using --auth-method. "
+            "Defaults to 'stub'."
+        ),
     )
     confluence_parser.add_argument(
         "--auth-method",
+        type=_parse_confluence_auth_method,
         default="bearer-env",
-        help="Authentication method identifier.",
+        metavar="AUTH_METHOD",
+        help=(
+            "Auth for --client-mode real: 'bearer-env' reads "
+            "CONFLUENCE_BEARER_TOKEN; 'client-cert-env' reads "
+            "CONFLUENCE_CLIENT_CERT_FILE and optional "
+            "CONFLUENCE_CLIENT_KEY_FILE. Defaults to 'bearer-env'."
+        ),
     )
     confluence_parser.add_argument(
         "--dry-run",
@@ -139,19 +182,10 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "Expected a Confluence page ID or full Confluence page URL."
             )
 
-        print("Confluence adapter invoked")
-        print(f"  base_url: {confluence_config.base_url}")
-        print(f"  target: {target.raw_value}")
-        print(f"  output_dir: {confluence_config.output_dir}")
-        print(f"  client_mode: {confluence_config.client_mode}")
-        print(f"  auth_method: {confluence_config.auth_method}")
-        print(f"  dry_run: {confluence_config.dry_run}")
-        print(f"  tree: {confluence_config.tree}")
-        print(f"  max_depth: {confluence_config.max_depth}")
-
         selected_fetch_page: Callable[[ResolvedTarget], dict[str, object]]
         selected_list_child_page_ids: Callable[[ResolvedTarget], list[str]] | None = None
         if confluence_config.client_mode == "real":
+
             def selected_fetch_page(resolved_target: ResolvedTarget) -> dict[str, object]:
                 return fetch_real_page(
                     resolved_target,
@@ -169,6 +203,17 @@ def main(argv: Sequence[str] | None = None) -> int:
                 )
         else:
             selected_fetch_page = fetch_page
+
+        def _print_confluence_invocation() -> None:
+            print("Confluence adapter invoked")
+            print(f"  base_url: {confluence_config.base_url}")
+            print(f"  target: {target.raw_value}")
+            print(f"  output_dir: {confluence_config.output_dir}")
+            print(f"  client_mode: {confluence_config.client_mode}")
+            print(f"  auth_method: {confluence_config.auth_method}")
+            print(f"  dry_run: {confluence_config.dry_run}")
+            print(f"  tree: {confluence_config.tree}")
+            print(f"  max_depth: {confluence_config.max_depth}")
 
         def _build_manifest_entry_for_page(
             page: dict[str, object],
@@ -200,19 +245,22 @@ def main(argv: Sequence[str] | None = None) -> int:
                     fetch_page=selected_fetch_page,
                     list_child_page_ids=selected_list_child_page_ids,
                 )
-            previous_manifest_index = load_previous_manifest_index(
-                confluence_config.output_dir
-            )
+            _print_confluence_invocation()
+            previous_manifest_index = load_previous_manifest_index(confluence_config.output_dir)
             page_records: list[tuple[dict[str, object], Path, str]] = []
             for page in pages:
                 canonical_id = str(page.get("canonical_id") or "")
                 output_path = markdown_path(confluence_config.output_dir, canonical_id)
-                action = "skip" if is_already_written(
-                    confluence_config.output_dir,
-                    previous_manifest_index,
-                    canonical_id=canonical_id,
-                    output_path=output_path,
-                ) else "write"
+                action = (
+                    "skip"
+                    if is_already_written(
+                        confluence_config.output_dir,
+                        previous_manifest_index,
+                        canonical_id=canonical_id,
+                        output_path=output_path,
+                    )
+                    else "write"
+                )
                 page_records.append((page, output_path, action))
 
             write_count = sum(
@@ -263,15 +311,21 @@ def main(argv: Sequence[str] | None = None) -> int:
             page = selected_fetch_page(target)
         except (RuntimeError, ValueError) as exc:
             exit_with_cli_error(str(exc))
+
+        _print_confluence_invocation()
         page_id = str(page["canonical_id"])
         output_path = markdown_path(confluence_config.output_dir, page_id)
         previous_manifest_index = load_previous_manifest_index(confluence_config.output_dir)
-        action = "skip" if is_already_written(
-            confluence_config.output_dir,
-            previous_manifest_index,
-            canonical_id=page_id,
-            output_path=output_path,
-        ) else "write"
+        action = (
+            "skip"
+            if is_already_written(
+                confluence_config.output_dir,
+                previous_manifest_index,
+                canonical_id=page_id,
+                output_path=output_path,
+            )
+            else "write"
+        )
 
         if confluence_config.dry_run:
             print(f"\nDry run: would {action} {output_path}\n")

--- a/src/knowledge_adapters/confluence/auth.py
+++ b/src/knowledge_adapters/confluence/auth.py
@@ -6,6 +6,8 @@ import os
 import ssl
 from dataclasses import dataclass
 
+SUPPORTED_AUTH_METHODS = ("bearer-env", "client-cert-env")
+
 
 @dataclass(frozen=True)
 class RequestAuth:
@@ -22,7 +24,10 @@ def build_request_auth(auth_method: str) -> RequestAuth:
     elif auth_method == "client-cert-env":
         headers = {}
     else:
-        raise ValueError(f"Unsupported auth method: {auth_method}")
+        supported_values = " or ".join(repr(method) for method in SUPPORTED_AUTH_METHODS)
+        raise ValueError(
+            f"Unsupported Confluence auth method {auth_method!r}. Use {supported_values}."
+        )
 
     return RequestAuth(
         headers=headers,
@@ -33,7 +38,10 @@ def build_request_auth(auth_method: str) -> RequestAuth:
 def _bearer_env_headers() -> dict[str, str]:
     token = os.getenv("CONFLUENCE_BEARER_TOKEN", "").strip()
     if not token:
-        raise ValueError("CONFLUENCE_BEARER_TOKEN must be set for --client-mode real.")
+        raise ValueError(
+            "Missing Confluence bearer token. Set CONFLUENCE_BEARER_TOKEN for "
+            "--client-mode real --auth-method bearer-env."
+        )
 
     return {"Authorization": f"Bearer {token}"}
 
@@ -44,12 +52,15 @@ def _client_cert_ssl_context(auth_method: str) -> ssl.SSLContext | None:
 
     if key_file and not cert_file:
         raise ValueError(
-            "CONFLUENCE_CLIENT_CERT_FILE must be set when CONFLUENCE_CLIENT_KEY_FILE is set."
+            "Incomplete Confluence client certificate config. Set "
+            "CONFLUENCE_CLIENT_CERT_FILE, and set CONFLUENCE_CLIENT_KEY_FILE only "
+            "when the key is in a separate file."
         )
     if auth_method == "client-cert-env" and not cert_file:
         raise ValueError(
-            "CONFLUENCE_CLIENT_CERT_FILE must be set for --client-mode real "
-            "when --auth-method client-cert-env."
+            "Missing Confluence client certificate. Set "
+            "CONFLUENCE_CLIENT_CERT_FILE for --client-mode real --auth-method "
+            "client-cert-env."
         )
     if not cert_file:
         return None
@@ -62,7 +73,7 @@ def _client_cert_ssl_context(auth_method: str) -> ssl.SSLContext | None:
         )
     except (OSError, ssl.SSLError, ValueError) as exc:
         raise ValueError(
-            "Confluence client certificate configuration is invalid. "
+            "Invalid Confluence client certificate configuration. "
             "Check CONFLUENCE_CLIENT_CERT_FILE and optional "
             "CONFLUENCE_CLIENT_KEY_FILE."
         ) from exc

--- a/src/knowledge_adapters/confluence/client.py
+++ b/src/knowledge_adapters/confluence/client.py
@@ -28,10 +28,7 @@ def fetch_page(target: ResolvedTarget) -> dict[str, object]:
 def _content_api_url(base_url: str, page_id: str) -> str:
     normalized_base = base_url.rstrip("/")
     encoded_page_id = parse.quote(page_id, safe="")
-    return (
-        f"{normalized_base}/rest/api/content/{encoded_page_id}"
-        "?expand=body.storage,_links"
-    )
+    return f"{normalized_base}/rest/api/content/{encoded_page_id}?expand=body.storage,_links"
 
 
 def _child_page_api_url(base_url: str, page_id: str) -> str:
@@ -132,7 +129,10 @@ def _request_json(api_url: str, *, auth_method: str) -> dict[str, object]:
             raw_payload = json.loads(response.read().decode("utf-8"))
     except HTTPError as exc:
         if exc.code in {401, 403}:
-            raise RuntimeError("Confluence auth failure.") from exc
+            raise RuntimeError(
+                "Confluence auth failed. Check --auth-method and the required "
+                "CONFLUENCE_* environment variables."
+            ) from exc
         if exc.code == 404:
             raise RuntimeError("Confluence page not found.") from exc
         raise RuntimeError(f"Confluence request failed with status {exc.code}.") from exc

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -125,3 +125,19 @@ Stub content for page 12345.
             "title": "stub-page-12345",
         }
     ]
+
+
+def test_confluence_help_lists_supported_auth_methods_and_examples(
+    tmp_path: Path,
+) -> None:
+    result = _run_cli(
+        tmp_path,
+        "confluence",
+        "--help",
+    )
+
+    assert result.returncode == 0
+    assert "CONFLUENCE_BEARER_TOKEN" in result.stdout
+    assert "CONFLUENCE_CLIENT_CERT_FILE" in result.stdout
+    assert "client-cert-env" in result.stdout
+    assert "CONFLUENCE_BEARER_TOKEN=... knowledge-adapters confluence" in result.stdout

--- a/tests/test_confluence_real_client_contract.py
+++ b/tests/test_confluence_real_client_contract.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import io
 import json
+import re
 from email.message import Message
 from pathlib import Path
 from typing import Any, Literal, cast
@@ -195,9 +196,7 @@ def test_explicit_real_client_mode_selects_real_fetch_path(
         }
 
     def fail_if_stub_used(target: ResolvedTarget) -> dict[str, object]:
-        raise AssertionError(
-            f"stub client should not be used in real mode for {target.page_id}"
-        )
+        raise AssertionError(f"stub client should not be used in real mode for {target.page_id}")
 
     monkeypatch.setattr(client_module, "fetch_real_page", stub_real_fetch, raising=False)
     monkeypatch.setattr(client_module, "fetch_page", fail_if_stub_used)
@@ -239,7 +238,13 @@ def test_real_fetch_requires_nonempty_bearer_token_before_request(
 
     monkeypatch.setattr("urllib.request.urlopen", fail_if_requested)
 
-    with pytest.raises(ValueError, match="CONFLUENCE_BEARER_TOKEN"):
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Missing Confluence bearer token\\. Set CONFLUENCE_BEARER_TOKEN for "
+            "--client-mode real --auth-method bearer-env\\."
+        ),
+    ):
         _fetch_real_page(_real_target())
 
     assert request_count == 0
@@ -547,8 +552,16 @@ def test_real_fetch_ignores_extra_irrelevant_fields_in_valid_response(
 @pytest.mark.parametrize(
     ("status_code", "expected_message"),
     [
-        (401, "Confluence auth failure."),
-        (403, "Confluence auth failure."),
+        (
+            401,
+            "Confluence auth failed. Check --auth-method and the required "
+            "CONFLUENCE_* environment variables.",
+        ),
+        (
+            403,
+            "Confluence auth failed. Check --auth-method and the required "
+            "CONFLUENCE_* environment variables.",
+        ),
         (404, "Confluence page not found."),
     ],
 )
@@ -563,7 +576,7 @@ def test_real_fetch_maps_http_status_failures(
     monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
     monkeypatch.setattr("urllib.request.urlopen", raise_http_error)
 
-    with pytest.raises(RuntimeError, match=f"^{expected_message}$"):
+    with pytest.raises(RuntimeError, match=f"^{re.escape(expected_message)}$"):
         _fetch_real_page(_real_target())
 
 
@@ -582,7 +595,14 @@ def test_real_fetch_requires_client_cert_file_for_client_cert_auth_before_reques
     monkeypatch.delenv("CONFLUENCE_CLIENT_KEY_FILE", raising=False)
     monkeypatch.setattr("urllib.request.urlopen", fail_if_requested)
 
-    with pytest.raises(ValueError, match="CONFLUENCE_CLIENT_CERT_FILE"):
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Missing Confluence client certificate\\. Set "
+            "CONFLUENCE_CLIENT_CERT_FILE for --client-mode real --auth-method "
+            "client-cert-env\\."
+        ),
+    ):
         _fetch_real_page(_real_target(), auth_method="client-cert-env")
 
     assert request_count == 0
@@ -604,7 +624,14 @@ def test_real_fetch_rejects_client_key_without_cert_before_request(
     monkeypatch.setenv("CONFLUENCE_CLIENT_KEY_FILE", "/tmp/confluence-client.key")
     monkeypatch.setattr("urllib.request.urlopen", fail_if_requested)
 
-    with pytest.raises(ValueError, match="CONFLUENCE_CLIENT_CERT_FILE"):
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Incomplete Confluence client certificate config\\. Set "
+            "CONFLUENCE_CLIENT_CERT_FILE, and set CONFLUENCE_CLIENT_KEY_FILE only "
+            "when the key is in a separate file\\."
+        ),
+    ):
         _fetch_real_page(_real_target())
 
     assert request_count == 0
@@ -625,7 +652,14 @@ def test_real_fetch_treats_empty_client_cert_env_as_missing_for_client_cert_auth
     monkeypatch.setenv("CONFLUENCE_CLIENT_KEY_FILE", "   ")
     monkeypatch.setattr("urllib.request.urlopen", fail_if_requested)
 
-    with pytest.raises(ValueError, match="CONFLUENCE_CLIENT_CERT_FILE"):
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Missing Confluence client certificate\\. Set "
+            "CONFLUENCE_CLIENT_CERT_FILE for --client-mode real --auth-method "
+            "client-cert-env\\."
+        ),
+    ):
         _fetch_real_page(_real_target(), auth_method="client-cert-env")
 
     assert request_count == 0
@@ -658,7 +692,7 @@ def test_real_fetch_surfaces_clear_invalid_client_cert_configuration(
     with pytest.raises(
         ValueError,
         match=(
-            "Confluence client certificate configuration is invalid\\. "
+            "Invalid Confluence client certificate configuration\\. "
             "Check CONFLUENCE_CLIENT_CERT_FILE and optional "
             "CONFLUENCE_CLIENT_KEY_FILE\\."
         ),
@@ -841,7 +875,14 @@ def test_real_child_list_fails_fast_on_invalid_response_shapes(
 @pytest.mark.parametrize(
     ("raised_error", "expected_message"),
     [
-        (RuntimeError("Confluence auth failure."), "Confluence auth failure."),
+        (
+            RuntimeError(
+                "Confluence auth failed. Check --auth-method and the required "
+                "CONFLUENCE_* environment variables."
+            ),
+            "Confluence auth failed. Check --auth-method and the required "
+            "CONFLUENCE_* environment variables.",
+        ),
         (RuntimeError("Confluence page not found."), "Confluence page not found."),
         (ValueError("Response error: missing source_url."), "Response error: missing source_url."),
     ],

--- a/tests/test_normalize_writer.py
+++ b/tests/test_normalize_writer.py
@@ -226,6 +226,36 @@ def test_confluence_cli_invalid_target_reports_expected_shapes(
     ) in captured.err
 
 
+def test_confluence_cli_rejects_unknown_auth_method_with_supported_values(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    output_dir = tmp_path / "out"
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(
+            [
+                "confluence",
+                "--base-url",
+                "https://example.com/wiki",
+                "--target",
+                "12345",
+                "--output-dir",
+                str(output_dir),
+                "--auth-method",
+                "not-real",
+            ]
+        )
+
+    assert exc_info.value.code == 2
+
+    captured = capsys.readouterr()
+    assert (
+        "argument --auth-method: unsupported value 'not-real'. Choose "
+        "'bearer-env' or 'client-cert-env'.\n" in captured.err
+    )
+
+
 def test_confluence_cli_rejects_negative_max_depth(
     tmp_path: Path,
     capsys: CaptureFixture[str],
@@ -252,6 +282,5 @@ def test_confluence_cli_rejects_negative_max_depth(
 
     captured = capsys.readouterr()
     assert (
-        "knowledge-adapters confluence: error: --max-depth must be greater than or "
-        "equal to 0.\n"
+        "knowledge-adapters confluence: error: --max-depth must be greater than or equal to 0.\n"
     ) in captured.err


### PR DESCRIPTION
Summary
- tighten `knowledge-adapters confluence --help` so first-time users can see the supported real-mode auth methods and a minimal usage example directly from the CLI
- clarify Confluence auth and certificate configuration failures with concise, actionable error messages
- add an installed-CLI quickstart to the README with help commands, an auth quick reference, and a minimal bearer-auth example

Testing
- `make check`
- verified `.venv/bin/knowledge-adapters confluence --help` lists `bearer-env` and `client-cert-env` with inline env var guidance
- verified real mode without auth now fails with `Missing Confluence bearer token. Set CONFLUENCE_BEARER_TOKEN for --client-mode real --auth-method bearer-env.`
- verified unknown auth values fail with `argument --auth-method: unsupported value 'nope'. Choose 'bearer-env' or 'client-cert-env'.`