### PR TITLE
fix: add confluence debug request context

### DIFF
--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -90,6 +90,11 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     confluence_parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Show Confluence request debug details for real-client failures.",
+    )
+    confluence_parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Plan actions without writing files.",
@@ -129,9 +134,12 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def exit_with_cli_error(message: str) -> None:
+def exit_with_cli_error(message: str, *, debug_lines: Sequence[str] | None = None) -> None:
     """Exit the CLI with a stable user-facing error message."""
     print(f"knowledge-adapters confluence: error: {message}", file=sys.stderr)
+    if debug_lines:
+        for line in debug_lines:
+            print(f"  {line}", file=sys.stderr)
     raise SystemExit(2)
 
 
@@ -142,6 +150,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if args.command == "confluence":
         from knowledge_adapters.confluence.client import (
+            ConfluenceRequestError,
             fetch_page,
             fetch_real_page,
             list_real_child_page_ids,
@@ -168,6 +177,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             output_dir=args.output_dir,
             client_mode=args.client_mode,
             auth_method=args.auth_method,
+            debug=args.debug,
             dry_run=args.dry_run,
             tree=args.tree,
             max_depth=args.max_depth,
@@ -215,6 +225,19 @@ def main(argv: Sequence[str] | None = None) -> int:
             print(f"  tree: {confluence_config.tree}")
             print(f"  max_depth: {confluence_config.max_depth}")
 
+        def _confluence_debug_lines(
+            exc: RuntimeError | ValueError,
+        ) -> tuple[str, ...] | None:
+            if not confluence_config.debug or not isinstance(exc, ConfluenceRequestError):
+                return None
+
+            return (
+                f"debug request_url: {exc.request_url}",
+                f"debug client_mode: {confluence_config.client_mode}",
+                f"debug auth_method: {exc.auth_method}",
+                f"debug exception: {exc.underlying_error}",
+            )
+
         def _build_manifest_entry_for_page(
             page: dict[str, object],
             output_path: Path,
@@ -237,7 +260,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                         list_child_page_ids=selected_list_child_page_ids,
                     )
                 except (RuntimeError, ValueError) as exc:
-                    exit_with_cli_error(str(exc))
+                    exit_with_cli_error(str(exc), debug_lines=_confluence_debug_lines(exc))
             else:
                 root_page_id, pages = walk_pages(
                     target,
@@ -310,7 +333,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         try:
             page = selected_fetch_page(target)
         except (RuntimeError, ValueError) as exc:
-            exit_with_cli_error(str(exc))
+            exit_with_cli_error(str(exc), debug_lines=_confluence_debug_lines(exc))
 
         _print_confluence_invocation()
         page_id = str(page["canonical_id"])

--- a/src/knowledge_adapters/confluence/client.py
+++ b/src/knowledge_adapters/confluence/client.py
@@ -3,11 +3,29 @@
 from __future__ import annotations
 
 import json
+import os
 from urllib import parse, request
 from urllib.error import HTTPError, URLError
 
 from knowledge_adapters.confluence.auth import build_request_auth
 from knowledge_adapters.confluence.models import ResolvedTarget
+
+
+class ConfluenceRequestError(RuntimeError):
+    """Stable request failure with Confluence-specific debug context."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        request_url: str,
+        auth_method: str,
+        underlying_error: str,
+    ) -> None:
+        super().__init__(message)
+        self.request_url = request_url
+        self.auth_method = auth_method
+        self.underlying_error = underlying_error
 
 
 def fetch_page(target: ResolvedTarget) -> dict[str, object]:
@@ -117,6 +135,23 @@ def _map_child_page_ids(payload: dict[str, object]) -> list[str]:
     return child_page_ids
 
 
+def _sanitize_debug_value(value: str) -> str:
+    bearer_token = os.getenv("CONFLUENCE_BEARER_TOKEN", "").strip()
+    sanitized = value
+    if bearer_token:
+        sanitized = sanitized.replace(bearer_token, "[redacted]")
+    if "-----BEGIN " in sanitized or "-----END " in sanitized:
+        return "[redacted secret material]"
+    return sanitized
+
+
+def _underlying_request_error_message(exc: HTTPError | URLError) -> str:
+    if isinstance(exc, HTTPError):
+        return _sanitize_debug_value(str(exc))
+
+    return _sanitize_debug_value(str(exc.reason))
+
+
 def _request_json(api_url: str, *, auth_method: str) -> dict[str, object]:
     request_auth = build_request_auth(auth_method)
     api_request = request.Request(
@@ -129,15 +164,27 @@ def _request_json(api_url: str, *, auth_method: str) -> dict[str, object]:
             raw_payload = json.loads(response.read().decode("utf-8"))
     except HTTPError as exc:
         if exc.code in {401, 403}:
-            raise RuntimeError(
+            message = (
                 "Confluence auth failed. Check --auth-method and the required "
                 "CONFLUENCE_* environment variables."
-            ) from exc
-        if exc.code == 404:
-            raise RuntimeError("Confluence page not found.") from exc
-        raise RuntimeError(f"Confluence request failed with status {exc.code}.") from exc
+            )
+        elif exc.code == 404:
+            message = "Confluence page not found."
+        else:
+            message = f"Confluence request failed with status {exc.code}."
+        raise ConfluenceRequestError(
+            message,
+            request_url=api_url,
+            auth_method=auth_method,
+            underlying_error=_underlying_request_error_message(exc),
+        ) from exc
     except URLError as exc:
-        raise RuntimeError("Confluence request failed.") from exc
+        raise ConfluenceRequestError(
+            "Confluence request failed.",
+            request_url=api_url,
+            auth_method=auth_method,
+            underlying_error=_underlying_request_error_message(exc),
+        ) from exc
     except json.JSONDecodeError as exc:
         raise ValueError("Response error: invalid JSON payload.") from exc
 

--- a/src/knowledge_adapters/confluence/config.py
+++ b/src/knowledge_adapters/confluence/config.py
@@ -14,6 +14,7 @@ class ConfluenceConfig:
     output_dir: str
     client_mode: str = "stub"
     auth_method: str = "bearer-env"
+    debug: bool = False
     dry_run: bool = False
     tree: bool = False
     max_depth: int = 0

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -140,4 +140,7 @@ def test_confluence_help_lists_supported_auth_methods_and_examples(
     assert "CONFLUENCE_BEARER_TOKEN" in result.stdout
     assert "CONFLUENCE_CLIENT_CERT_FILE" in result.stdout
     assert "client-cert-env" in result.stdout
+    assert "--debug" in result.stdout
+    assert "request debug details" in result.stdout
+    assert "real-client" in result.stdout
     assert "CONFLUENCE_BEARER_TOKEN=... knowledge-adapters confluence" in result.stdout

--- a/tests/test_confluence_real_client_contract.py
+++ b/tests/test_confluence_real_client_contract.py
@@ -6,7 +6,7 @@ import re
 from email.message import Message
 from pathlib import Path
 from typing import Any, Literal, cast
-from urllib.error import HTTPError
+from urllib.error import HTTPError, URLError
 
 import pytest
 from pytest import CaptureFixture, MonkeyPatch
@@ -140,6 +140,10 @@ def _http_error(status_code: int) -> HTTPError:
         hdrs=headers,
         fp=io.BytesIO(b"{}"),
     )
+
+
+def _url_error(reason: str | BaseException) -> URLError:
+    return URLError(reason)
 
 
 def test_default_cli_behavior_without_client_mode_still_uses_stub_client(
@@ -910,3 +914,57 @@ def test_real_client_cli_surfaces_fetch_failures_as_concise_cli_errors(
     assert captured.err == f"knowledge-adapters confluence: error: {expected_message}\n"
     assert not (tmp_path / "out" / "manifest.json").exists()
     assert not (tmp_path / "out" / "pages" / "12345.md").exists()
+
+
+def test_real_client_cli_debug_mode_surfaces_request_context_for_request_failures(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
+
+    def raise_url_error(*args: object, **kwargs: object) -> object:
+        raise _url_error(ValueError("synthetic transport failure"))
+
+    monkeypatch.setattr("urllib.request.urlopen", raise_url_error)
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(_confluence_argv(tmp_path / "out", "--client-mode", "real", "--debug"))
+
+    assert exc_info.value.code == 2
+
+    captured = capsys.readouterr()
+    assert (
+        captured.err
+        == "knowledge-adapters confluence: error: Confluence request failed.\n"
+        "  debug request_url: https://example.com/wiki/rest/api/content/12345"
+        "?expand=body.storage,_links\n"
+        "  debug client_mode: real\n"
+        "  debug auth_method: bearer-env\n"
+        "  debug exception: synthetic transport failure\n"
+    )
+    assert not (tmp_path / "out" / "manifest.json").exists()
+    assert not (tmp_path / "out" / "pages" / "12345.md").exists()
+
+
+def test_real_client_cli_default_mode_hides_debug_request_context(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
+
+    def raise_url_error(*args: object, **kwargs: object) -> object:
+        raise _url_error(ValueError("synthetic transport failure"))
+
+    monkeypatch.setattr("urllib.request.urlopen", raise_url_error)
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(_confluence_argv(tmp_path / "out", "--client-mode", "real"))
+
+    assert exc_info.value.code == 2
+
+    captured = capsys.readouterr()
+    assert captured.err == "knowledge-adapters confluence: error: Confluence request failed.\n"
+    assert "synthetic transport failure" not in captured.err
+    assert "rest/api/content/12345" not in captured.err


### PR DESCRIPTION
Summary
- add a Confluence-only --debug flag for real-client request failures
- surface request URL, client mode, auth method, and underlying exception text without changing default error output
- keep the help text and CLI contract tests focused on the new troubleshooting path

Testing
- make check