### PR TITLE
fix: improve local_files first-run UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,21 @@ Start with the built-in help:
 
 ```bash
 knowledge-adapters --help
+knowledge-adapters local_files --help
 knowledge-adapters confluence --help
 ```
+
+Minimal local file first run:
+
+```bash
+knowledge-adapters local_files \
+  --file-path ./notes/today.txt \
+  --output-dir ./artifacts
+```
+
+This reads one UTF-8 text file, writes `artifacts/pages/today.md`, and writes
+`artifacts/manifest.json`. Add `--dry-run` to preview the normalized markdown
+and planned output path without writing files.
 
 Confluence auth quick reference:
 
@@ -234,10 +247,10 @@ that design surface.
 
 ## Example
 
-Normalize a local text file into the standard markdown artifact:
+Normalize a local UTF-8 text file into the standard markdown artifact:
 
 ```bash
-.venv/bin/knowledge-adapters local_files \
+knowledge-adapters local_files \
   --file-path ./notes/today.txt \
   --output-dir ./artifacts
 ```
@@ -245,7 +258,7 @@ Normalize a local text file into the standard markdown artifact:
 Preview the normalized markdown without writing files:
 
 ```bash
-.venv/bin/knowledge-adapters local_files \
+knowledge-adapters local_files \
   --file-path ./notes/today.txt \
   --output-dir ./artifacts \
   --dry-run

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -21,6 +21,16 @@ CONFLUENCE_HELP_EXAMPLES = """Examples:
     --output-dir ./artifacts
 """
 
+LOCAL_FILES_HELP_EXAMPLES = """Examples:
+  knowledge-adapters local_files \\
+    --file-path ./notes/today.txt \\
+    --output-dir ./artifacts
+  knowledge-adapters local_files \\
+    --file-path ./notes/today.txt \\
+    --output-dir ./artifacts \\
+    --dry-run
+"""
+
 
 def _parse_confluence_auth_method(value: str) -> str:
     """Parse and validate a supported Confluence auth method."""
@@ -114,29 +124,42 @@ def build_parser() -> argparse.ArgumentParser:
     local_files_parser = subparsers.add_parser(
         "local_files",
         help="Run the local files adapter.",
+        description=(
+            "Normalize a single local UTF-8 text file into a markdown artifact. "
+            "Writes pages/<file-stem>.md and manifest.json under --output-dir."
+        ),
+        epilog=LOCAL_FILES_HELP_EXAMPLES,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     local_files_parser.add_argument(
         "--file-path",
         required=True,
-        help="Path to a local file to normalize.",
+        metavar="FILE",
+        help="Readable UTF-8 text file to normalize.",
     )
     local_files_parser.add_argument(
         "--output-dir",
         required=True,
-        help="Directory to write normalized local artifacts.",
+        metavar="DIR",
+        help="Directory for generated artifacts: pages/<name>.md and manifest.json.",
     )
     local_files_parser.add_argument(
         "--dry-run",
         action="store_true",
-        help="Plan actions without writing files.",
+        help="Print the planned output path and normalized markdown without writing files.",
     )
 
     return parser
 
 
-def exit_with_cli_error(message: str, *, debug_lines: Sequence[str] | None = None) -> None:
+def exit_with_cli_error(
+    message: str,
+    *,
+    command: str,
+    debug_lines: Sequence[str] | None = None,
+) -> None:
     """Exit the CLI with a stable user-facing error message."""
-    print(f"knowledge-adapters confluence: error: {message}", file=sys.stderr)
+    print(f"knowledge-adapters {command}: error: {message}", file=sys.stderr)
     if debug_lines:
         for line in debug_lines:
             print(f"  {line}", file=sys.stderr)
@@ -183,13 +206,17 @@ def main(argv: Sequence[str] | None = None) -> int:
             max_depth=args.max_depth,
         )
         if confluence_config.max_depth < 0:
-            exit_with_cli_error("--max-depth must be greater than or equal to 0.")
+            exit_with_cli_error(
+                "--max-depth must be greater than or equal to 0.",
+                command="confluence",
+            )
 
         target = resolve_target(confluence_config.target)
         if target.page_id is None:
             exit_with_cli_error(
                 f"Could not resolve target {target.raw_value!r}. "
-                "Expected a Confluence page ID or full Confluence page URL."
+                "Expected a Confluence page ID or full Confluence page URL.",
+                command="confluence",
             )
 
         selected_fetch_page: Callable[[ResolvedTarget], dict[str, object]]
@@ -260,7 +287,11 @@ def main(argv: Sequence[str] | None = None) -> int:
                         list_child_page_ids=selected_list_child_page_ids,
                     )
                 except (RuntimeError, ValueError) as exc:
-                    exit_with_cli_error(str(exc), debug_lines=_confluence_debug_lines(exc))
+                    exit_with_cli_error(
+                        str(exc),
+                        command="confluence",
+                        debug_lines=_confluence_debug_lines(exc),
+                    )
             else:
                 root_page_id, pages = walk_pages(
                     target,
@@ -333,7 +364,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         try:
             page = selected_fetch_page(target)
         except (RuntimeError, ValueError) as exc:
-            exit_with_cli_error(str(exc), debug_lines=_confluence_debug_lines(exc))
+            exit_with_cli_error(
+                str(exc),
+                command="confluence",
+                debug_lines=_confluence_debug_lines(exc),
+            )
 
         _print_confluence_invocation()
         page_id = str(page["canonical_id"])
@@ -393,39 +428,102 @@ def main(argv: Sequence[str] | None = None) -> int:
             dry_run=args.dry_run,
         )
 
+        output_dir = Path(local_files_config.output_dir).expanduser()
+        if output_dir.exists() and not output_dir.is_dir():
+            exit_with_cli_error(
+                (
+                    f"Output path is not a directory: {output_dir}. "
+                    "Choose a directory path for --output-dir."
+                ),
+                command="local_files",
+            )
+
+        try:
+            page = fetch_file(local_files_config.file_path)
+        except ValueError as exc:
+            exit_with_cli_error(str(exc), command="local_files")
+        markdown = normalize_to_markdown(page)
+
         print("Local files adapter invoked")
         print(f"  file_path: {local_files_config.file_path}")
         print(f"  output_dir: {local_files_config.output_dir}")
         print(f"  dry_run: {local_files_config.dry_run}")
 
-        page = fetch_file(local_files_config.file_path)
-        markdown = normalize_to_markdown(page)
-
         input_path = Path(local_files_config.file_path)
         output_name = input_path.stem or input_path.name
-        output_path = write_markdown(
-            local_files_config.output_dir,
-            output_name,
-            markdown,
-            dry_run=local_files_config.dry_run,
-        )
+        try:
+            output_path = write_markdown(
+                local_files_config.output_dir,
+                output_name,
+                markdown,
+                dry_run=local_files_config.dry_run,
+            )
+        except PermissionError:
+            exit_with_cli_error(
+                (
+                    f"Output directory is not writable: {output_dir}. "
+                    "Check the path and permissions for --output-dir."
+                ),
+                command="local_files",
+            )
+        except NotADirectoryError:
+            exit_with_cli_error(
+                (
+                    f"Output path is not a directory: {output_dir}. "
+                    "Choose a directory path for --output-dir."
+                ),
+                command="local_files",
+            )
+        except OSError:
+            exit_with_cli_error(
+                (
+                    f"Could not write output under {output_dir}. "
+                    "Check --output-dir and try again."
+                ),
+                command="local_files",
+            )
         if local_files_config.dry_run:
             print(f"\nDry run: would write {output_path}\n")
             print(markdown)
             return 0
 
-        write_manifest(
-            local_files_config.output_dir,
-            [
-                build_manifest_entry(
-                    canonical_id=str(page["canonical_id"]),
-                    source_url=str(page.get("source_url", "")),
-                    output_path=output_path,
-                    output_dir=local_files_config.output_dir,
-                    title=str(page["title"]) if page.get("title") else None,
-                )
-            ],
-        )
+        try:
+            write_manifest(
+                local_files_config.output_dir,
+                [
+                    build_manifest_entry(
+                        canonical_id=str(page["canonical_id"]),
+                        source_url=str(page.get("source_url", "")),
+                        output_path=output_path,
+                        output_dir=local_files_config.output_dir,
+                        title=str(page["title"]) if page.get("title") else None,
+                    )
+                ],
+            )
+        except PermissionError:
+            exit_with_cli_error(
+                (
+                    f"Output directory is not writable: {output_dir}. "
+                    "Check the path and permissions for --output-dir."
+                ),
+                command="local_files",
+            )
+        except NotADirectoryError:
+            exit_with_cli_error(
+                (
+                    f"Output path is not a directory: {output_dir}. "
+                    "Choose a directory path for --output-dir."
+                ),
+                command="local_files",
+            )
+        except OSError:
+            exit_with_cli_error(
+                (
+                    f"Could not write output under {output_dir}. "
+                    "Check --output-dir and try again."
+                ),
+                command="local_files",
+            )
         print(f"\nWrote: {output_path}")
         return 0
 

--- a/src/knowledge_adapters/local_files/client.py
+++ b/src/knowledge_adapters/local_files/client.py
@@ -7,8 +7,27 @@ from pathlib import Path
 
 def fetch_file(file_path: str) -> dict[str, object]:
     """Read a local file into the shared normalized payload shape."""
-    path = Path(file_path).expanduser().resolve()
-    content = path.read_text(encoding="utf-8")
+    input_path = Path(file_path).expanduser()
+    if not input_path.exists():
+        raise ValueError(f"File does not exist: {input_path}. Check --file-path and try again.")
+    if not input_path.is_file():
+        raise ValueError(
+            f"Path is not a regular file: {input_path}. Supply a single UTF-8 text file."
+        )
+
+    path = input_path.resolve()
+    try:
+        content = path.read_text(encoding="utf-8")
+    except PermissionError as exc:
+        raise ValueError(
+            f"File is not readable: {path}. Check the file permissions."
+        ) from exc
+    except UnicodeDecodeError as exc:
+        raise ValueError(
+            f"File is not readable as UTF-8 text: {path}. Supply a UTF-8 text file."
+        ) from exc
+    except OSError as exc:
+        raise ValueError(f"Could not read file: {path}. Check --file-path and try again.") from exc
 
     return {
         "title": path.name,

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -79,6 +79,23 @@ Hello from smoke test.
     ]
 
 
+def test_local_files_cli_help_includes_first_run_guidance(tmp_path: Path) -> None:
+    result = _run_cli(tmp_path, "local_files", "--help")
+
+    assert result.returncode == 0, result.stderr
+    assert (
+        "Normalize a single local UTF-8 text file into a markdown artifact."
+        in result.stdout
+    )
+    assert "--file-path FILE" in result.stdout
+    assert "Readable UTF-8 text file to normalize." in result.stdout
+    assert "--output-dir DIR" in result.stdout
+    assert "Print the planned output path and normalized markdown" in result.stdout
+    assert "without writing files." in result.stdout
+    assert "knowledge-adapters local_files" in result.stdout
+    assert "--dry-run" in result.stdout
+
+
 def test_confluence_cli_smoke_uses_installed_entrypoint_with_default_stub_client(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_local_files.py
+++ b/tests/test_local_files.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 
+import pytest
 from pytest import CaptureFixture
 
 from knowledge_adapters.cli import main
@@ -119,3 +120,97 @@ def test_local_files_cli_dry_run_reports_output_without_writing(
     captured = capsys.readouterr()
     assert f"Dry run: would write {output_path}" in captured.out
     assert "Line one." in captured.out
+
+
+def test_fetch_file_reports_permission_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    source_file = tmp_path / "notes.txt"
+    source_file.write_text("Hello from disk.\n", encoding="utf-8")
+
+    def _raise_permission_error(self: Path, *, encoding: str) -> str:
+        raise PermissionError("permission denied")
+
+    monkeypatch.setattr(Path, "read_text", _raise_permission_error)
+
+    with pytest.raises(
+        ValueError,
+        match=rf"File is not readable: {source_file.resolve()}\. Check the file permissions\.",
+    ):
+        fetch_file(str(source_file))
+
+
+def test_local_files_cli_reports_missing_file_with_actionable_error(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    missing_file = tmp_path / "missing.txt"
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(
+            [
+                "local_files",
+                "--file-path",
+                str(missing_file),
+                "--output-dir",
+                str(tmp_path / "out"),
+            ]
+        )
+
+    assert exc_info.value.code == 2
+    captured = capsys.readouterr()
+    assert "Local files adapter invoked" not in captured.out
+    assert "knowledge-adapters local_files: error:" in captured.err
+    assert f"File does not exist: {missing_file}." in captured.err
+    assert "Check --file-path and try again." in captured.err
+
+
+def test_local_files_cli_reports_non_file_input_path(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    source_dir = tmp_path / "notes"
+    source_dir.mkdir()
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(
+            [
+                "local_files",
+                "--file-path",
+                str(source_dir),
+                "--output-dir",
+                str(tmp_path / "out"),
+            ]
+        )
+
+    assert exc_info.value.code == 2
+    captured = capsys.readouterr()
+    assert f"Path is not a regular file: {source_dir}." in captured.err
+    assert "Supply a single UTF-8 text file." in captured.err
+
+
+def test_local_files_cli_reports_invalid_output_dir(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    source_file = tmp_path / "notes.txt"
+    source_file.write_text("Hello from disk.\n", encoding="utf-8")
+    output_path = tmp_path / "artifacts.txt"
+    output_path.write_text("not a directory\n", encoding="utf-8")
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(
+            [
+                "local_files",
+                "--file-path",
+                str(source_file),
+                "--output-dir",
+                str(output_path),
+            ]
+        )
+
+    assert exc_info.value.code == 2
+    captured = capsys.readouterr()
+    assert f"Output path is not a directory: {output_path}." in captured.err
+    assert "Choose a directory path for --output-dir." in captured.err


### PR DESCRIPTION
Summary
- make the local_files help output clearer for first-time CLI use
- return concise, actionable file and output path errors for common failures
- add minimal README onboarding and focused user-facing tests

Testing
- make check
- verified `.venv/bin/knowledge-adapters local_files --help`
- verified representative local_files errors for missing input files and invalid output paths