### PR TITLE
fix: improve Confluence target input handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ Confluence auth quick reference:
 - `bearer-env` -> `CONFLUENCE_BEARER_TOKEN`
 - `client-cert-env` -> `CONFLUENCE_CLIENT_CERT_FILE` and optional `CONFLUENCE_CLIENT_KEY_FILE`
 
+For Confluence runs, `--target` accepts either a numeric page ID or a full page
+URL under `--base-url`.
+
 Minimal live Confluence example with bearer auth:
 
 ```bash

--- a/adapters/confluence/README.md
+++ b/adapters/confluence/README.md
@@ -11,7 +11,9 @@ This adapter is the first implementation of the generic adapter contract for `kn
 
 Out of the box, the default Confluence CLI:
 
-- accepts a page URL or page ID as input
+- accepts a page ID or full page URL as input
+- validates full page URLs against `--base-url` and requires the URL to include
+  the page ID
 - accepts `--base-url`, `--client-mode`, `--auth-method`, `--output-dir`,
   `--dry-run`, `--tree`, and `--max-depth`
 - resolves the target into a canonical page ID

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -70,7 +70,7 @@ def build_parser() -> argparse.ArgumentParser:
     confluence_parser.add_argument(
         "--target",
         required=True,
-        help="Confluence page URL or page ID.",
+        help="Confluence page ID or full page URL under --base-url.",
     )
     confluence_parser.add_argument(
         "--output-dir",
@@ -190,7 +190,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         from knowledge_adapters.confluence.models import ResolvedTarget
         from knowledge_adapters.confluence.normalize import normalize_to_markdown
-        from knowledge_adapters.confluence.resolve import resolve_target
+        from knowledge_adapters.confluence.resolve import resolve_target_for_base_url
         from knowledge_adapters.confluence.traversal import walk_pages
         from knowledge_adapters.confluence.writer import markdown_path, write_markdown
 
@@ -211,11 +211,14 @@ def main(argv: Sequence[str] | None = None) -> int:
                 command="confluence",
             )
 
-        target = resolve_target(confluence_config.target)
-        if target.page_id is None:
+        try:
+            target = resolve_target_for_base_url(
+                confluence_config.target,
+                base_url=confluence_config.base_url,
+            )
+        except ValueError as exc:
             exit_with_cli_error(
-                f"Could not resolve target {target.raw_value!r}. "
-                "Expected a Confluence page ID or full Confluence page URL.",
+                str(exc),
                 command="confluence",
             )
 

--- a/src/knowledge_adapters/confluence/models.py
+++ b/src/knowledge_adapters/confluence/models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Literal
 
 
 @dataclass(frozen=True)
@@ -12,3 +13,4 @@ class ResolvedTarget:
     raw_value: str
     page_id: str | None
     page_url: str | None
+    input_kind: Literal["page_id", "url", "empty", "invalid_url", "unknown"] = "unknown"

--- a/src/knowledge_adapters/confluence/resolve.py
+++ b/src/knowledge_adapters/confluence/resolve.py
@@ -3,11 +3,58 @@
 from __future__ import annotations
 
 import re
+from urllib import parse
 
 from knowledge_adapters.confluence.models import ResolvedTarget
 
 _PAGE_ID_RE = re.compile(r"^\d+$")
-_PAGE_ID_IN_URL_RE = re.compile(r"/pages/(?:viewpage\.action\?pageId=)?(\d+)")
+_PAGE_ID_IN_PATH_RE = re.compile(r"/pages/(\d+)(?:/|$)")
+
+
+def _parse_absolute_http_url(value: str) -> parse.ParseResult | None:
+    parsed = parse.urlparse(value)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return None
+    return parsed
+
+
+def _page_id_from_url(parsed_url: parse.ParseResult) -> str | None:
+    query_page_ids = parse.parse_qs(parsed_url.query).get("pageId", [])
+    if query_page_ids:
+        page_id = query_page_ids[0]
+        if _PAGE_ID_RE.fullmatch(page_id):
+            return page_id
+
+    path_match = _PAGE_ID_IN_PATH_RE.search(parsed_url.path)
+    if path_match:
+        return path_match.group(1)
+
+    return None
+
+
+def _url_matches_base_url(*, page_url: str, base_url: str) -> bool:
+    parsed_page_url = _parse_absolute_http_url(page_url)
+    parsed_base_url = _parse_absolute_http_url(base_url.strip())
+    if parsed_page_url is None or parsed_base_url is None:
+        return True
+
+    if (
+        parsed_page_url.scheme,
+        parsed_page_url.netloc,
+    ) != (
+        parsed_base_url.scheme,
+        parsed_base_url.netloc,
+    ):
+        return False
+
+    normalized_base_path = parsed_base_url.path.rstrip("/")
+    if not normalized_base_path:
+        return True
+
+    normalized_target_path = parsed_page_url.path.rstrip("/")
+    return normalized_target_path == normalized_base_path or normalized_target_path.startswith(
+        f"{normalized_base_path}/"
+    )
 
 
 def resolve_target(target: str) -> ResolvedTarget:
@@ -18,25 +65,81 @@ def resolve_target(target: str) -> ResolvedTarget:
     - URLs containing a page ID
     """
     cleaned = target.strip()
-    is_url = "://" in cleaned
 
     if _PAGE_ID_RE.fullmatch(cleaned):
         return ResolvedTarget(
             raw_value=cleaned,
             page_id=cleaned,
             page_url=None,
+            input_kind="page_id",
         )
 
-    url_match = _PAGE_ID_IN_URL_RE.search(cleaned) if is_url else None
-    if url_match:
+    if not cleaned:
         return ResolvedTarget(
             raw_value=cleaned,
-            page_id=url_match.group(1),
+            page_id=None,
+            page_url=None,
+            input_kind="empty",
+        )
+
+    if "://" in cleaned:
+        parsed_url = _parse_absolute_http_url(cleaned)
+        if parsed_url is None:
+            return ResolvedTarget(
+                raw_value=cleaned,
+                page_id=None,
+                page_url=None,
+                input_kind="invalid_url",
+            )
+
+        return ResolvedTarget(
+            raw_value=cleaned,
+            page_id=_page_id_from_url(parsed_url),
             page_url=cleaned,
+            input_kind="url",
         )
 
     return ResolvedTarget(
         raw_value=cleaned,
         page_id=None,
-        page_url=cleaned if is_url else None,
+        page_url=None,
+        input_kind="unknown",
+    )
+
+
+def resolve_target_for_base_url(target: str, *, base_url: str) -> ResolvedTarget:
+    """Resolve and validate a target for CLI-facing Confluence usage."""
+    resolved = resolve_target(target)
+
+    if resolved.input_kind == "page_id":
+        return resolved
+
+    if resolved.input_kind == "empty":
+        raise ValueError("--target cannot be empty. Provide a page ID or full Confluence page URL.")
+
+    if resolved.input_kind == "invalid_url":
+        raise ValueError(
+            f"Target URL {resolved.raw_value!r} is malformed. "
+            "Provide a full Confluence page URL or page ID."
+        )
+
+    if resolved.input_kind == "url":
+        if resolved.page_id is None:
+            raise ValueError(
+                f"Target URL {resolved.raw_value!r} does not include a Confluence page ID. "
+                "Use a page URL containing the page ID or pass the page ID directly."
+            )
+        if resolved.page_url and not _url_matches_base_url(
+            page_url=resolved.page_url,
+            base_url=base_url,
+        ):
+            raise ValueError(
+                f"Target URL {resolved.raw_value!r} does not match --base-url {base_url!r}. "
+                "Use a URL under that base URL or pass the page ID directly."
+            )
+        return resolved
+
+    raise ValueError(
+        f"Could not resolve target {resolved.raw_value!r}. "
+        "Provide a numeric page ID or full Confluence page URL."
     )

--- a/tests/test_normalize_writer.py
+++ b/tests/test_normalize_writer.py
@@ -222,7 +222,94 @@ def test_confluence_cli_invalid_target_reports_expected_shapes(
     captured = capsys.readouterr()
     assert (
         "knowledge-adapters confluence: error: Could not resolve target "
-        "'not-a-page'. Expected a Confluence page ID or full Confluence page URL.\n"
+        "'not-a-page'. Provide a numeric page ID or full Confluence page URL.\n"
+    ) in captured.err
+
+
+def test_confluence_cli_rejects_empty_target(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    output_dir = tmp_path / "out"
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(
+            [
+                "confluence",
+                "--base-url",
+                "https://example.com/wiki",
+                "--target",
+                "   ",
+                "--output-dir",
+                str(output_dir),
+            ]
+        )
+
+    assert exc_info.value.code == 2
+
+    captured = capsys.readouterr()
+    assert (
+        "knowledge-adapters confluence: error: --target cannot be empty. "
+        "Provide a page ID or full Confluence page URL.\n"
+    ) in captured.err
+
+
+def test_confluence_cli_rejects_malformed_target_url(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    output_dir = tmp_path / "out"
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(
+            [
+                "confluence",
+                "--base-url",
+                "https://example.com/wiki",
+                "--target",
+                "https:///pages/viewpage.action?pageId=12345",
+                "--output-dir",
+                str(output_dir),
+            ]
+        )
+
+    assert exc_info.value.code == 2
+
+    captured = capsys.readouterr()
+    assert (
+        "knowledge-adapters confluence: error: Target URL "
+        "'https:///pages/viewpage.action?pageId=12345' is malformed. "
+        "Provide a full Confluence page URL or page ID.\n"
+    ) in captured.err
+
+
+def test_confluence_cli_rejects_target_url_outside_base_url(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    output_dir = tmp_path / "out"
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(
+            [
+                "confluence",
+                "--base-url",
+                "https://example.com/wiki",
+                "--target",
+                "https://other.example.com/wiki/spaces/ENG/pages/12345/Runbook",
+                "--output-dir",
+                str(output_dir),
+            ]
+        )
+
+    assert exc_info.value.code == 2
+
+    captured = capsys.readouterr()
+    assert (
+        "knowledge-adapters confluence: error: Target URL "
+        "'https://other.example.com/wiki/spaces/ENG/pages/12345/Runbook' does not "
+        "match --base-url 'https://example.com/wiki'. Use a URL under that base URL "
+        "or pass the page ID directly.\n"
     ) in captured.err
 
 

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -1,4 +1,6 @@
-from knowledge_adapters.confluence.resolve import resolve_target
+import pytest
+
+from knowledge_adapters.confluence.resolve import resolve_target, resolve_target_for_base_url
 
 
 def test_resolve_numeric_page_id() -> None:
@@ -6,6 +8,7 @@ def test_resolve_numeric_page_id() -> None:
 
     assert target.page_id == "123456"
     assert target.page_url is None
+    assert target.input_kind == "page_id"
 
 
 def test_resolve_url_with_page_id() -> None:
@@ -15,6 +18,17 @@ def test_resolve_url_with_page_id() -> None:
 
     assert target.page_id == "7890"
     assert target.page_url == url
+    assert target.input_kind == "url"
+
+
+def test_resolve_url_with_page_id_in_path() -> None:
+    url = "https://example.com/wiki/spaces/ENG/pages/7890/Team+Runbook"
+
+    target = resolve_target(url)
+
+    assert target.page_id == "7890"
+    assert target.page_url == url
+    assert target.input_kind == "url"
 
 
 def test_resolve_unknown_format() -> None:
@@ -22,6 +36,7 @@ def test_resolve_unknown_format() -> None:
 
     assert target.page_id is None
     assert target.page_url is None
+    assert target.input_kind == "unknown"
 
 
 def test_resolve_numeric_page_id_trims_surrounding_whitespace() -> None:
@@ -46,6 +61,7 @@ def test_resolve_blank_target_as_unknown_format() -> None:
     assert target.raw_value == ""
     assert target.page_id is None
     assert target.page_url is None
+    assert target.input_kind == "empty"
 
 
 def test_resolve_url_without_page_id_preserves_url_without_resolving_id() -> None:
@@ -53,6 +69,7 @@ def test_resolve_url_without_page_id_preserves_url_without_resolving_id() -> Non
 
     assert target.page_id is None
     assert target.page_url == "https://example.com/pages/viewpage.action"
+    assert target.input_kind == "url"
 
 
 def test_resolve_url_with_missing_page_id_value_preserves_url_without_resolving_id() -> None:
@@ -60,6 +77,15 @@ def test_resolve_url_with_missing_page_id_value_preserves_url_without_resolving_
 
     assert target.page_id is None
     assert target.page_url == "https://example.com/pages/viewpage.action?pageId="
+    assert target.input_kind == "url"
+
+
+def test_resolve_malformed_url_marks_invalid_url() -> None:
+    target = resolve_target("https:///pages/viewpage.action?pageId=7890")
+
+    assert target.page_id is None
+    assert target.page_url is None
+    assert target.input_kind == "invalid_url"
 
 
 def test_resolve_path_like_target_with_page_id_pattern_does_not_count_as_url() -> None:
@@ -67,3 +93,35 @@ def test_resolve_path_like_target_with_page_id_pattern_does_not_count_as_url() -
 
     assert target.page_id is None
     assert target.page_url is None
+    assert target.input_kind == "unknown"
+
+
+def test_resolve_target_for_base_url_accepts_matching_page_url() -> None:
+    target = resolve_target_for_base_url(
+        "https://example.com/wiki/spaces/ENG/pages/7890/Team+Runbook",
+        base_url="https://example.com/wiki",
+    )
+
+    assert target.page_id == "7890"
+
+
+def test_resolve_target_for_base_url_rejects_url_without_page_id() -> None:
+    with pytest.raises(
+        ValueError,
+        match="does not include a Confluence page ID",
+    ):
+        resolve_target_for_base_url(
+            "https://example.com/wiki/spaces/ENG/overview",
+            base_url="https://example.com/wiki",
+        )
+
+
+def test_resolve_target_for_base_url_rejects_base_url_mismatch() -> None:
+    with pytest.raises(
+        ValueError,
+        match="does not match --base-url",
+    ):
+        resolve_target_for_base_url(
+            "https://other.example.com/wiki/spaces/ENG/pages/7890/Team+Runbook",
+            base_url="https://example.com/wiki",
+        )


### PR DESCRIPTION
Summary
- improve Confluence `--target` parsing so empty values, malformed URLs, URL/page-ID mismatches, and unsupported target shapes fail with concise actionable messages
- resolve full page URLs through structured URL parsing, including page IDs carried in standard `pageId` query params or `/pages/<id>` paths
- reject full target URLs that do not live under the provided `--base-url`, and clarify the `--target` help/docs accordingly

Testing
- `make check`
- `.venv/bin/knowledge-adapters confluence --base-url https://example.com/wiki --target https://example.com/wiki/spaces/ENG/pages/12345/Runbook --output-dir /tmp/ka-confluence-target-ux-success --dry-run`
- `.venv/bin/knowledge-adapters confluence --base-url https://example.com/wiki --target https://other.example.com/wiki/spaces/ENG/pages/12345/Runbook --output-dir /tmp/ka-confluence-target-ux-failure`

Risks
- URL validation stays intentionally narrow around common Confluence page URL shapes and `--base-url` matching, so unusual deployment URL layouts may still require passing the page ID directly.