### PR TITLE
fix: clarify confluence dry-run target details

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ Example shape from the default single-page Confluence client:
   "files": [
     {
       "canonical_id": "12345",
-      "source_url": "",
+      "source_url": "https://example.com/wiki/pages/viewpage.action?pageId=12345",
       "output_path": "pages/12345.md",
       "title": "stub-page-12345"
     }
@@ -366,7 +366,7 @@ only minimal root-run context:
   "files": [
     {
       "canonical_id": "12345",
-      "source_url": "",
+      "source_url": "https://example.com/wiki/pages/viewpage.action?pageId=12345",
       "output_path": "pages/12345.md",
       "title": "stub-page-12345"
     }

--- a/adapters/confluence/README.md
+++ b/adapters/confluence/README.md
@@ -17,6 +17,8 @@ Out of the box, the default Confluence CLI:
 - accepts `--base-url`, `--client-mode`, `--auth-method`, `--output-dir`,
   `--dry-run`, `--tree`, and `--max-depth`
 - resolves the target into a canonical page ID
+- normalizes page ID and full page URL targets into the same resolved source URL
+  for stub-mode metadata and dry-run reporting
 - fetches stub page data for that resolved page
 - supports an opt-in real client path with `--client-mode real` for live page
   fetches and breadth-first tree traversal using `bearer-env` or

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -280,6 +280,23 @@ def main(argv: Sequence[str] | None = None) -> int:
                 title=str(page["title"]) if page.get("title") else None,
             )
 
+        def _print_single_page_dry_run(
+            *,
+            page_id: str,
+            source_url: str,
+            output_path: Path,
+            action: str,
+            markdown: str | None = None,
+        ) -> None:
+            print("\nDry run: Confluence page plan")
+            print(f"  resolved_page_id: {page_id}")
+            print(f"  source_url: {source_url}")
+            print(f"  output_path: {output_path}")
+            print(f"  action: would {action}")
+            if markdown is not None:
+                print()
+                print(markdown)
+
         if confluence_config.tree:
             if confluence_config.client_mode == "real":
                 try:
@@ -389,9 +406,14 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
 
         if confluence_config.dry_run:
-            print(f"\nDry run: would {action} {output_path}\n")
-            if action == "write":
-                print(normalize_to_markdown(page))
+            planned_markdown = normalize_to_markdown(page) if action == "write" else None
+            _print_single_page_dry_run(
+                page_id=page_id,
+                source_url=str(page.get("source_url", "")),
+                output_path=output_path,
+                action=action,
+                markdown=planned_markdown,
+            )
             return 0
 
         if action == "write":

--- a/src/knowledge_adapters/confluence/resolve.py
+++ b/src/knowledge_adapters/confluence/resolve.py
@@ -57,6 +57,12 @@ def _url_matches_base_url(*, page_url: str, base_url: str) -> bool:
     )
 
 
+def _canonical_page_url(*, base_url: str, page_id: str) -> str:
+    normalized_base_url = base_url.strip().rstrip("/")
+    encoded_page_id = parse.quote(page_id, safe="")
+    return f"{normalized_base_url}/pages/viewpage.action?pageId={encoded_page_id}"
+
+
 def resolve_target(target: str) -> ResolvedTarget:
     """Resolve a user-provided target into a canonical form.
 
@@ -112,7 +118,12 @@ def resolve_target_for_base_url(target: str, *, base_url: str) -> ResolvedTarget
     resolved = resolve_target(target)
 
     if resolved.input_kind == "page_id":
-        return resolved
+        return ResolvedTarget(
+            raw_value=resolved.raw_value,
+            page_id=resolved.page_id,
+            page_url=_canonical_page_url(base_url=base_url, page_id=resolved.page_id or ""),
+            input_kind=resolved.input_kind,
+        )
 
     if resolved.input_kind == "empty":
         raise ValueError("--target cannot be empty. Provide a page ID or full Confluence page URL.")
@@ -137,7 +148,12 @@ def resolve_target_for_base_url(target: str, *, base_url: str) -> ResolvedTarget
                 f"Target URL {resolved.raw_value!r} does not match --base-url {base_url!r}. "
                 "Use a URL under that base URL or pass the page ID directly."
             )
-        return resolved
+        return ResolvedTarget(
+            raw_value=resolved.raw_value,
+            page_id=resolved.page_id,
+            page_url=_canonical_page_url(base_url=base_url, page_id=resolved.page_id),
+            input_kind=resolved.input_kind,
+        )
 
     raise ValueError(
         f"Could not resolve target {resolved.raw_value!r}. "

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -122,7 +122,7 @@ def test_confluence_cli_smoke_uses_installed_entrypoint_with_default_stub_client
 - source: confluence
 - canonical_id: 12345
 - parent_id:
-- source_url: 
+- source_url: https://example.com/wiki/pages/viewpage.action?pageId=12345
 - fetched_at:
 - updated_at:
 - adapter: confluence
@@ -137,7 +137,7 @@ Stub content for page 12345.
     assert payload["files"] == [
         {
             "canonical_id": "12345",
-            "source_url": "",
+            "source_url": "https://example.com/wiki/pages/viewpage.action?pageId=12345",
             "output_path": "pages/12345.md",
             "title": "stub-page-12345",
         }

--- a/tests/test_confluence_real_client_contract.py
+++ b/tests/test_confluence_real_client_contract.py
@@ -164,7 +164,7 @@ def test_default_cli_behavior_without_client_mode_still_uses_stub_client(
 - source: confluence
 - canonical_id: 12345
 - parent_id:
-- source_url: 
+- source_url: https://example.com/wiki/pages/viewpage.action?pageId=12345
 - fetched_at:
 - updated_at:
 - adapter: confluence
@@ -179,7 +179,7 @@ Stub content for page 12345.
     assert payload["files"] == [
         {
             "canonical_id": "12345",
-            "source_url": "",
+            "source_url": "https://example.com/wiki/pages/viewpage.action?pageId=12345",
             "output_path": "pages/12345.md",
             "title": "stub-page-12345",
         }

--- a/tests/test_normalize_writer.py
+++ b/tests/test_normalize_writer.py
@@ -138,8 +138,43 @@ def test_confluence_cli_dry_run_reports_output_without_writing(
     assert not (output_dir / "manifest.json").exists()
 
     captured = capsys.readouterr()
-    assert f"Dry run: would write {output_path}" in captured.out
+    assert "Dry run: Confluence page plan" in captured.out
+    assert "resolved_page_id: 12345" in captured.out
+    assert "source_url: https://example.com/wiki/pages/viewpage.action?pageId=12345" in captured.out
+    assert f"output_path: {output_path}" in captured.out
+    assert "action: would write" in captured.out
     assert "# stub-page-12345" in captured.out
+
+
+def test_confluence_cli_dry_run_reports_same_resolved_target_details_for_full_url_input(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    output_dir = tmp_path / "out"
+
+    exit_code = main(
+        [
+            "confluence",
+            "--base-url",
+            "https://example.com/wiki",
+            "--target",
+            "https://example.com/wiki/spaces/ENG/pages/12345/Runbook",
+            "--output-dir",
+            str(output_dir),
+            "--dry-run",
+        ]
+    )
+
+    assert exit_code == 0
+
+    captured = capsys.readouterr()
+    assert "resolved_page_id: 12345" in captured.out
+    assert "source_url: https://example.com/wiki/pages/viewpage.action?pageId=12345" in captured.out
+    assert f"output_path: {output_dir / 'pages' / '12345.md'}" in captured.out
+    assert (
+        "- source_url: https://example.com/wiki/pages/viewpage.action?pageId=12345"
+        in captured.out
+    )
 
 
 def test_confluence_cli_writes_manifest_for_normal_run(tmp_path: Path) -> None:
@@ -163,7 +198,7 @@ def test_confluence_cli_writes_manifest_for_normal_run(tmp_path: Path) -> None:
     assert payload["files"] == [
         {
             "canonical_id": "12345",
-            "source_url": "",
+            "source_url": "https://example.com/wiki/pages/viewpage.action?pageId=12345",
             "output_path": "pages/12345.md",
             "title": "stub-page-12345",
         }

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -103,6 +103,17 @@ def test_resolve_target_for_base_url_accepts_matching_page_url() -> None:
     )
 
     assert target.page_id == "7890"
+    assert target.page_url == "https://example.com/wiki/pages/viewpage.action?pageId=7890"
+
+
+def test_resolve_target_for_base_url_builds_canonical_page_url_for_page_id_input() -> None:
+    target = resolve_target_for_base_url(
+        "7890",
+        base_url="https://example.com/wiki/",
+    )
+
+    assert target.page_id == "7890"
+    assert target.page_url == "https://example.com/wiki/pages/viewpage.action?pageId=7890"
 
 
 def test_resolve_target_for_base_url_rejects_url_without_page_id() -> None:


### PR DESCRIPTION
Summary
- canonicalize resolved stub-mode source URLs so page ID and full URL targets converge on the same source metadata
- show the resolved page ID, source URL, output path, and action in the single-page dry-run plan
- update focused tests and docs to match the resolved target behavior

Testing
- make check
- verified representative --dry-run output for both page ID and full page URL targets