### PR TITLE
fix: align confluence first-run flow

### DIFF
--- a/adapters/confluence/README.md
+++ b/adapters/confluence/README.md
@@ -19,10 +19,14 @@ Out of the box, the default Confluence CLI:
 - resolves the target into a canonical page ID
 - normalizes page ID and full page URL targets into the same resolved source URL
   for stub-mode metadata and dry-run reporting
+- keeps dry-run and write output aligned around the same resolved page ID,
+  canonical source URL, page artifact path, and manifest path
 - fetches stub page data for that resolved page
 - supports an opt-in real client path with `--client-mode real` for live page
   fetches and breadth-first tree traversal using `bearer-env` or
   `client-cert-env` auth
+- keeps `stub` and `real` modes on the same CLI flow and artifact layout, with
+  only the content source changing between modes
 - normalizes the stub page into markdown plus metadata
 - writes a deterministic page artifact and `manifest.json` on normal runs
 - supports dry-run output and manifest-based skip logic for the resolved page

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -13,6 +13,11 @@ CONFLUENCE_HELP_EXAMPLES = """Examples:
     --base-url https://example.com/wiki \\
     --target 12345 \\
     --output-dir ./artifacts
+  knowledge-adapters confluence \\
+    --base-url https://example.com/wiki \\
+    --target https://example.com/wiki/spaces/ENG/pages/12345/Runbook \\
+    --output-dir ./artifacts \\
+    --dry-run
   CONFLUENCE_BEARER_TOKEN=... knowledge-adapters confluence \\
     --client-mode real \\
     --auth-method bearer-env \\
@@ -56,7 +61,8 @@ def build_parser() -> argparse.ArgumentParser:
         help="Run the Confluence adapter.",
         description=(
             "Normalize a Confluence page or page tree into local markdown artifacts. "
-            "The default stub mode writes scaffolded output without contacting "
+            "Both stub and real modes follow the same target resolution and artifact "
+            "flow. The default stub mode writes scaffolded output without contacting "
             "Confluence. Use --client-mode real for live Confluence fetches."
         ),
         epilog=CONFLUENCE_HELP_EXAMPLES,
@@ -82,9 +88,10 @@ def build_parser() -> argparse.ArgumentParser:
         choices=("stub", "real"),
         default="stub",
         help=(
-            "Client behavior: 'stub' writes scaffolded local output with no "
-            "network call; 'real' fetches from Confluence using --auth-method. "
-            "Defaults to 'stub'."
+            "Client behavior: 'stub' uses scaffolded page content with no network "
+            "call; 'real' fetches from Confluence using --auth-method. Both modes "
+            "resolve --target and write the same local artifact paths. Defaults to "
+            "'stub'."
         ),
     )
     confluence_parser.add_argument(
@@ -107,7 +114,7 @@ def build_parser() -> argparse.ArgumentParser:
     confluence_parser.add_argument(
         "--dry-run",
         action="store_true",
-        help="Plan actions without writing files.",
+        help="Plan the resolved page, output path, and manifest without writing files.",
     )
     confluence_parser.add_argument(
         "--tree",
@@ -185,6 +192,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         from knowledge_adapters.confluence.manifest import (
             build_manifest_entry,
+            manifest_path,
             write_manifest,
             write_manifest_with_context,
         )
@@ -285,14 +293,19 @@ def main(argv: Sequence[str] | None = None) -> int:
             page_id: str,
             source_url: str,
             output_path: Path,
+            manifest_output_path: Path,
             action: str,
             markdown: str | None = None,
         ) -> None:
+            write_count = 1 if action == "write" else 0
+            skip_count = 1 if action == "skip" else 0
             print("\nDry run: Confluence page plan")
             print(f"  resolved_page_id: {page_id}")
             print(f"  source_url: {source_url}")
             print(f"  output_path: {output_path}")
+            print(f"  manifest_path: {manifest_output_path}")
             print(f"  action: would {action}")
+            print(f"  Summary: would write {write_count}, would skip {skip_count}")
             if markdown is not None:
                 print()
                 print(markdown)
@@ -343,10 +356,12 @@ def main(argv: Sequence[str] | None = None) -> int:
             skip_count = len(page_records) - write_count
 
             if confluence_config.dry_run:
+                manifest_output_path = manifest_path(confluence_config.output_dir)
                 print("\nDry run: recursive fetch plan")
                 print(f"  resolved_root_page_id: {root_page_id}")
                 print(f"  tree: {confluence_config.tree}")
                 print(f"  max_depth: {confluence_config.max_depth}")
+                print(f"  manifest_path: {manifest_output_path}")
                 for _page, output_path, action in page_records:
                     print(f"  would {action} {output_path}")
                 print(f"  Summary: would write {write_count}, would skip {skip_count}")
@@ -393,6 +408,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         _print_confluence_invocation()
         page_id = str(page["canonical_id"])
         output_path = markdown_path(confluence_config.output_dir, page_id)
+        manifest_output_path = manifest_path(confluence_config.output_dir)
         previous_manifest_index = load_previous_manifest_index(confluence_config.output_dir)
         action = (
             "skip"
@@ -411,6 +427,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 page_id=page_id,
                 source_url=str(page.get("source_url", "")),
                 output_path=output_path,
+                manifest_output_path=manifest_output_path,
                 action=action,
                 markdown=planned_markdown,
             )
@@ -427,12 +444,16 @@ def main(argv: Sequence[str] | None = None) -> int:
         else:
             print(f"\nSkipped: {output_path}")
 
-        write_manifest(
+        manifest = write_manifest(
             confluence_config.output_dir,
             [
                 _build_manifest_entry_for_page(page, output_path),
             ],
         )
+        write_count = 1 if action == "write" else 0
+        skip_count = 1 if action == "skip" else 0
+        print(f"\nSummary: wrote {write_count}, skipped {skip_count}")
+        print(f"Manifest: {manifest}")
         return 0
 
     if args.command == "local_files":

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -113,6 +113,8 @@ def test_confluence_cli_smoke_uses_installed_entrypoint_with_default_stub_client
     assert result.returncode == 0, result.stderr
     assert "Confluence adapter invoked" in result.stdout
     assert "Wrote:" in result.stdout
+    assert "Summary: wrote 1, skipped 0" in result.stdout
+    assert "Manifest:" in result.stdout
 
     output_path = tmp_path / "artifacts" / "pages" / "12345.md"
     assert output_path.read_text(encoding="utf-8") == (
@@ -160,4 +162,7 @@ def test_confluence_help_lists_supported_auth_methods_and_examples(
     assert "--debug" in result.stdout
     assert "request debug details" in result.stdout
     assert "real-client" in result.stdout
+    assert "same target resolution and artifact flow" in result.stdout
+    assert "same local artifact paths" in result.stdout
     assert "CONFLUENCE_BEARER_TOKEN=... knowledge-adapters confluence" in result.stdout
+    assert "--dry-run" in result.stdout

--- a/tests/test_normalize_writer.py
+++ b/tests/test_normalize_writer.py
@@ -142,7 +142,9 @@ def test_confluence_cli_dry_run_reports_output_without_writing(
     assert "resolved_page_id: 12345" in captured.out
     assert "source_url: https://example.com/wiki/pages/viewpage.action?pageId=12345" in captured.out
     assert f"output_path: {output_path}" in captured.out
+    assert f"manifest_path: {output_dir / 'manifest.json'}" in captured.out
     assert "action: would write" in captured.out
+    assert "Summary: would write 1, would skip 0" in captured.out
     assert "# stub-page-12345" in captured.out
 
 
@@ -206,6 +208,73 @@ def test_confluence_cli_writes_manifest_for_normal_run(tmp_path: Path) -> None:
     assert isinstance(payload["generated_at"], str)
 
 
+def test_confluence_cli_full_flow_keeps_dry_run_and_write_artifacts_in_sync(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    output_dir = tmp_path / "out"
+    target_url = "https://example.com/wiki/spaces/ENG/pages/12345/Runbook"
+    page_output_path = output_dir / "pages" / "12345.md"
+    manifest_output_path = output_dir / "manifest.json"
+    canonical_source_url = "https://example.com/wiki/pages/viewpage.action?pageId=12345"
+
+    dry_run_exit_code = main(
+        [
+            "confluence",
+            "--base-url",
+            "https://example.com/wiki",
+            "--target",
+            target_url,
+            "--output-dir",
+            str(output_dir),
+            "--dry-run",
+        ]
+    )
+
+    assert dry_run_exit_code == 0
+    assert not page_output_path.exists()
+    assert not manifest_output_path.exists()
+
+    dry_run_output = capsys.readouterr().out
+    assert "resolved_page_id: 12345" in dry_run_output
+    assert f"source_url: {canonical_source_url}" in dry_run_output
+    assert f"output_path: {page_output_path}" in dry_run_output
+    assert f"manifest_path: {manifest_output_path}" in dry_run_output
+    assert "action: would write" in dry_run_output
+    assert "Summary: would write 1, would skip 0" in dry_run_output
+
+    write_exit_code = main(
+        [
+            "confluence",
+            "--base-url",
+            "https://example.com/wiki",
+            "--target",
+            target_url,
+            "--output-dir",
+            str(output_dir),
+        ]
+    )
+
+    assert write_exit_code == 0
+    assert page_output_path.exists()
+    assert manifest_output_path.exists()
+
+    write_output = capsys.readouterr().out
+    assert f"Wrote: {page_output_path}" in write_output
+    assert "Summary: wrote 1, skipped 0" in write_output
+    assert f"Manifest: {manifest_output_path}" in write_output
+
+    payload = json.loads(manifest_output_path.read_text(encoding="utf-8"))
+    assert payload["files"] == [
+        {
+            "canonical_id": "12345",
+            "source_url": canonical_source_url,
+            "output_path": "pages/12345.md",
+            "title": "stub-page-12345",
+        }
+    ]
+
+
 def test_confluence_cli_tree_run_reports_manifest_path(
     tmp_path: Path,
     capsys: CaptureFixture[str],
@@ -231,6 +300,35 @@ def test_confluence_cli_tree_run_reports_manifest_path(
 
     captured = capsys.readouterr()
     assert f"Manifest: {output_dir / 'manifest.json'}" in captured.out
+
+
+def test_confluence_cli_tree_dry_run_reports_manifest_path(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    output_dir = tmp_path / "out"
+
+    exit_code = main(
+        [
+            "confluence",
+            "--base-url",
+            "https://example.com/wiki",
+            "--target",
+            "12345",
+            "--output-dir",
+            str(output_dir),
+            "--tree",
+            "--max-depth",
+            "0",
+            "--dry-run",
+        ]
+    )
+
+    assert exit_code == 0
+
+    captured = capsys.readouterr()
+    assert f"manifest_path: {output_dir / 'manifest.json'}" in captured.out
+    assert "Summary: would write 1, would skip 0" in captured.out
 
 
 def test_confluence_cli_invalid_target_reports_expected_shapes(


### PR DESCRIPTION
Summary
- align the Confluence CLI so dry-run and write report the same page artifact and manifest expectations across the first-run flow
- make single-page and tree runs consistently surface manifest paths and summary counts, while keeping stub and real mode messaging on the same CLI path
- add focused end-to-end coverage for dry-run to write consistency and update Confluence help/docs language

Testing
- make check
- verified representative Confluence dry-run and write behavior for a full page URL target