### PR TITLE
fix: align confluence mode messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,9 @@ Preview the default Confluence run without writing files:
 The dry run prints the planned output path and the normalized stub markdown. If an
 existing `manifest.json` entry and on-disk artifact already match the resolved page,
 the default CLI reports `would skip` instead of `would write`.
+In both `stub` and `real` modes, the CLI keeps the same resolve, plan, and
+summary shape: it reports the resolved page ID, planned artifact paths, and the
+same write-versus-skip summary before any files are written.
 
 The Confluence CLI also includes tree-mode and incremental-sync plumbing. The
 default stub client still does not discover child pages, so out-of-the-box stub

--- a/adapters/confluence/README.md
+++ b/adapters/confluence/README.md
@@ -27,6 +27,8 @@ Out of the box, the default Confluence CLI:
   `client-cert-env` auth
 - keeps `stub` and `real` modes on the same CLI flow and artifact layout, with
   only the content source changing between modes
+- keeps dry-run and write messaging aligned across `stub` and `real`, including
+  the same plan header, artifact-path reporting, and write/skip summary shape
 - normalizes the stub page into markdown plus metadata
 - writes a deterministic page artifact and `manifest.json` on normal runs
 - supports dry-run output and manifest-based skip logic for the resolved page

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -61,9 +61,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="Run the Confluence adapter.",
         description=(
             "Normalize a Confluence page or page tree into local markdown artifacts. "
-            "Both stub and real modes follow the same target resolution and artifact "
-            "flow. The default stub mode writes scaffolded output without contacting "
-            "Confluence. Use --client-mode real for live Confluence fetches."
+            "Both stub and real modes follow the same resolve, plan, and artifact "
+            "flow. Use --dry-run to preview the same page and manifest plan a write "
+            "run would use. The default stub mode uses scaffolded content without "
+            "contacting Confluence. Use --client-mode real for live Confluence "
+            "fetches."
         ),
         epilog=CONFLUENCE_HELP_EXAMPLES,
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -88,10 +90,10 @@ def build_parser() -> argparse.ArgumentParser:
         choices=("stub", "real"),
         default="stub",
         help=(
-            "Client behavior: 'stub' uses scaffolded page content with no network "
-            "call; 'real' fetches from Confluence using --auth-method. Both modes "
-            "resolve --target and write the same local artifact paths. Defaults to "
-            "'stub'."
+            "Choose the content source: 'stub' uses scaffolded page content with no "
+            "network call; 'real' fetches from Confluence using --auth-method. Both "
+            "modes keep the same resolve, dry-run, and write artifact flow. Defaults "
+            "to 'stub'."
         ),
     )
     confluence_parser.add_argument(
@@ -114,7 +116,10 @@ def build_parser() -> argparse.ArgumentParser:
     confluence_parser.add_argument(
         "--dry-run",
         action="store_true",
-        help="Plan the resolved page, output path, and manifest without writing files.",
+        help=(
+            "Preview the same page, output path, manifest path, and write/skip summary "
+            "a write run would use, without writing files."
+        ),
     )
     confluence_parser.add_argument(
         "--tree",
@@ -253,15 +258,25 @@ def main(argv: Sequence[str] | None = None) -> int:
             selected_fetch_page = fetch_page
 
         def _print_confluence_invocation() -> None:
+            content_source = (
+                "scaffolded page content"
+                if confluence_config.client_mode == "stub"
+                else "live Confluence content"
+            )
+            fetch_scope = "tree" if confluence_config.tree else "page"
+            run_mode = "dry-run" if confluence_config.dry_run else "write"
             print("Confluence adapter invoked")
             print(f"  base_url: {confluence_config.base_url}")
             print(f"  target: {target.raw_value}")
             print(f"  output_dir: {confluence_config.output_dir}")
             print(f"  client_mode: {confluence_config.client_mode}")
-            print(f"  auth_method: {confluence_config.auth_method}")
-            print(f"  dry_run: {confluence_config.dry_run}")
-            print(f"  tree: {confluence_config.tree}")
-            print(f"  max_depth: {confluence_config.max_depth}")
+            print(f"  content_source: {content_source}")
+            print(f"  fetch_scope: {fetch_scope}")
+            print(f"  run_mode: {run_mode}")
+            if confluence_config.tree:
+                print(f"  max_depth: {confluence_config.max_depth}")
+            if confluence_config.client_mode == "real":
+                print(f"  auth_method: {confluence_config.auth_method}")
 
         def _confluence_debug_lines(
             exc: RuntimeError | ValueError,
@@ -299,7 +314,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         ) -> None:
             write_count = 1 if action == "write" else 0
             skip_count = 1 if action == "skip" else 0
-            print("\nDry run: Confluence page plan")
+            print("\nPlan: Confluence run")
             print(f"  resolved_page_id: {page_id}")
             print(f"  source_url: {source_url}")
             print(f"  output_path: {output_path}")
@@ -357,9 +372,8 @@ def main(argv: Sequence[str] | None = None) -> int:
 
             if confluence_config.dry_run:
                 manifest_output_path = manifest_path(confluence_config.output_dir)
-                print("\nDry run: recursive fetch plan")
+                print("\nPlan: Confluence run")
                 print(f"  resolved_root_page_id: {root_page_id}")
-                print(f"  tree: {confluence_config.tree}")
                 print(f"  max_depth: {confluence_config.max_depth}")
                 print(f"  manifest_path: {manifest_output_path}")
                 for _page, output_path, action in page_records:

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -112,6 +112,11 @@ def test_confluence_cli_smoke_uses_installed_entrypoint_with_default_stub_client
 
     assert result.returncode == 0, result.stderr
     assert "Confluence adapter invoked" in result.stdout
+    assert "client_mode: stub" in result.stdout
+    assert "content_source: scaffolded page content" in result.stdout
+    assert "fetch_scope: page" in result.stdout
+    assert "run_mode: write" in result.stdout
+    assert "auth_method:" not in result.stdout
     assert "Wrote:" in result.stdout
     assert "Summary: wrote 1, skipped 0" in result.stdout
     assert "Manifest:" in result.stdout
@@ -162,7 +167,8 @@ def test_confluence_help_lists_supported_auth_methods_and_examples(
     assert "--debug" in result.stdout
     assert "request debug details" in result.stdout
     assert "real-client" in result.stdout
-    assert "same target resolution and artifact flow" in result.stdout
-    assert "same local artifact paths" in result.stdout
+    assert "same resolve, plan, and artifact flow" in result.stdout
+    assert "same page and manifest plan a write run would use" in result.stdout
+    assert "same resolve, dry-run, and write artifact flow" in result.stdout
     assert "CONFLUENCE_BEARER_TOKEN=... knowledge-adapters confluence" in result.stdout
     assert "--dry-run" in result.stdout

--- a/tests/test_confluence_real_client_contract.py
+++ b/tests/test_confluence_real_client_contract.py
@@ -218,6 +218,109 @@ def test_explicit_real_client_mode_selects_real_fetch_path(
     assert "Stub content for page 12345." not in rendered
 
 
+def test_stub_and_real_single_page_write_runs_share_the_same_cli_shape(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    from knowledge_adapters.confluence import client as client_module
+
+    stub_output_dir = tmp_path / "stub-out"
+    stub_exit_code = main(_confluence_argv(stub_output_dir))
+    assert stub_exit_code == 0
+
+    stub_output = capsys.readouterr().out
+    assert "Confluence adapter invoked" in stub_output
+    assert "client_mode: stub" in stub_output
+    assert "content_source: scaffolded page content" in stub_output
+    assert "fetch_scope: page" in stub_output
+    assert "run_mode: write" in stub_output
+    assert "auth_method:" not in stub_output
+    assert f"Manifest: {stub_output_dir / 'manifest.json'}" in stub_output
+    assert "Summary: wrote 1, skipped 0" in stub_output
+
+    def stub_real_fetch(*args: object, **kwargs: object) -> dict[str, object]:
+        return {
+            "canonical_id": "12345",
+            "title": "Real Page",
+            "content": "<p>Hello from Confluence.</p>",
+            "source_url": "https://example.com/wiki/spaces/ENG/pages/12345",
+        }
+
+    def fail_if_stub_used(target: ResolvedTarget) -> dict[str, object]:
+        raise AssertionError(f"stub client should not be used in real mode for {target.page_id}")
+
+    monkeypatch.setattr(client_module, "fetch_real_page", stub_real_fetch, raising=False)
+    monkeypatch.setattr(client_module, "fetch_page", fail_if_stub_used)
+
+    real_output_dir = tmp_path / "real-out"
+    real_exit_code = main(_confluence_argv(real_output_dir, "--client-mode", "real"))
+    assert real_exit_code == 0
+
+    real_output = capsys.readouterr().out
+    assert "Confluence adapter invoked" in real_output
+    assert "client_mode: real" in real_output
+    assert "content_source: live Confluence content" in real_output
+    assert "fetch_scope: page" in real_output
+    assert "run_mode: write" in real_output
+    assert "auth_method: bearer-env" in real_output
+    assert f"Manifest: {real_output_dir / 'manifest.json'}" in real_output
+    assert "Summary: wrote 1, skipped 0" in real_output
+
+
+def test_stub_and_real_single_page_dry_runs_share_the_same_plan_shape(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    from knowledge_adapters.confluence import client as client_module
+
+    stub_output_dir = tmp_path / "stub-out"
+    stub_exit_code = main(_confluence_argv(stub_output_dir, "--dry-run"))
+    assert stub_exit_code == 0
+
+    stub_output = capsys.readouterr().out
+    assert "client_mode: stub" in stub_output
+    assert "content_source: scaffolded page content" in stub_output
+    assert "fetch_scope: page" in stub_output
+    assert "run_mode: dry-run" in stub_output
+    assert "Plan: Confluence run" in stub_output
+    assert "resolved_page_id: 12345" in stub_output
+    assert f"manifest_path: {stub_output_dir / 'manifest.json'}" in stub_output
+    assert "action: would write" in stub_output
+    assert "Summary: would write 1, would skip 0" in stub_output
+
+    def stub_real_fetch(*args: object, **kwargs: object) -> dict[str, object]:
+        return {
+            "canonical_id": "12345",
+            "title": "Real Page",
+            "content": "<p>Hello from Confluence.</p>",
+            "source_url": "https://example.com/wiki/spaces/ENG/pages/12345",
+        }
+
+    def fail_if_stub_used(target: ResolvedTarget) -> dict[str, object]:
+        raise AssertionError(f"stub client should not be used in real mode for {target.page_id}")
+
+    monkeypatch.setattr(client_module, "fetch_real_page", stub_real_fetch, raising=False)
+    monkeypatch.setattr(client_module, "fetch_page", fail_if_stub_used)
+
+    real_output_dir = tmp_path / "real-out"
+    real_exit_code = main(_confluence_argv(real_output_dir, "--client-mode", "real", "--dry-run"))
+    assert real_exit_code == 0
+
+    real_output = capsys.readouterr().out
+    assert "client_mode: real" in real_output
+    assert "content_source: live Confluence content" in real_output
+    assert "fetch_scope: page" in real_output
+    assert "run_mode: dry-run" in real_output
+    assert "auth_method: bearer-env" in real_output
+    assert "Plan: Confluence run" in real_output
+    assert "resolved_page_id: 12345" in real_output
+    assert f"manifest_path: {real_output_dir / 'manifest.json'}" in real_output
+    assert "action: would write" in real_output
+    assert "Summary: would write 1, would skip 0" in real_output
+
+
 @pytest.mark.parametrize(
     "token_value",
     [

--- a/tests/test_normalize_writer.py
+++ b/tests/test_normalize_writer.py
@@ -138,7 +138,12 @@ def test_confluence_cli_dry_run_reports_output_without_writing(
     assert not (output_dir / "manifest.json").exists()
 
     captured = capsys.readouterr()
-    assert "Dry run: Confluence page plan" in captured.out
+    assert "Confluence adapter invoked" in captured.out
+    assert "client_mode: stub" in captured.out
+    assert "content_source: scaffolded page content" in captured.out
+    assert "fetch_scope: page" in captured.out
+    assert "run_mode: dry-run" in captured.out
+    assert "Plan: Confluence run" in captured.out
     assert "resolved_page_id: 12345" in captured.out
     assert "source_url: https://example.com/wiki/pages/viewpage.action?pageId=12345" in captured.out
     assert f"output_path: {output_path}" in captured.out
@@ -236,6 +241,11 @@ def test_confluence_cli_full_flow_keeps_dry_run_and_write_artifacts_in_sync(
     assert not manifest_output_path.exists()
 
     dry_run_output = capsys.readouterr().out
+    assert "client_mode: stub" in dry_run_output
+    assert "content_source: scaffolded page content" in dry_run_output
+    assert "fetch_scope: page" in dry_run_output
+    assert "run_mode: dry-run" in dry_run_output
+    assert "Plan: Confluence run" in dry_run_output
     assert "resolved_page_id: 12345" in dry_run_output
     assert f"source_url: {canonical_source_url}" in dry_run_output
     assert f"output_path: {page_output_path}" in dry_run_output
@@ -260,6 +270,10 @@ def test_confluence_cli_full_flow_keeps_dry_run_and_write_artifacts_in_sync(
     assert manifest_output_path.exists()
 
     write_output = capsys.readouterr().out
+    assert "client_mode: stub" in write_output
+    assert "content_source: scaffolded page content" in write_output
+    assert "fetch_scope: page" in write_output
+    assert "run_mode: write" in write_output
     assert f"Wrote: {page_output_path}" in write_output
     assert "Summary: wrote 1, skipped 0" in write_output
     assert f"Manifest: {manifest_output_path}" in write_output
@@ -328,6 +342,7 @@ def test_confluence_cli_tree_dry_run_reports_manifest_path(
 
     captured = capsys.readouterr()
     assert f"manifest_path: {output_dir / 'manifest.json'}" in captured.out
+    assert "Plan: Confluence run" in captured.out
     assert "Summary: would write 1, would skip 0" in captured.out
 
 


### PR DESCRIPTION
Summary
- align stub and real Confluence CLI runs around the same mode, content source, fetch scope, and run mode header
- normalize dry-run plan messaging so both modes preview the same artifact and summary shape while keeping real-only auth details concise
- add focused CLI coverage for paired stub and real single-page flows and document the shared UX contract

Testing
- make check
- .venv/bin/knowledge-adapters confluence --base-url https://example.com/wiki --target 12345 --output-dir /tmp/ka-stub-preview --dry-run
- .venv/bin/python -c "from knowledge_adapters.cli import main; from knowledge_adapters.confluence import client; client.fetch_real_page=lambda *args, **kwargs: {'canonical_id': '12345', 'title': 'Real Page', 'content': '<p>Hello from Confluence.</p>', 'source_url': 'https://example.com/wiki/spaces/ENG/pages/12345'}; client.fetch_page=lambda target: (_ for _ in ()).throw(AssertionError(f'stub client should not be used in real mode for {target.page_id}')); raise SystemExit(main(['confluence','--base-url','https://example.com/wiki','--target','12345','--output-dir','/tmp/ka-real-preview','--client-mode','real','--dry-run']))"