### PR TITLE
docs: align confluence onboarding and status

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,36 @@ knowledge-adapters local_files --help
 knowledge-adapters confluence --help
 ```
 
+Minimal Confluence first run (default `stub` mode):
+
+```bash
+knowledge-adapters confluence \
+  --base-url https://example.com/wiki \
+  --target 12345 \
+  --output-dir ./artifacts
+```
+
+This resolves page `12345`, writes `artifacts/pages/12345.md`, and writes
+`artifacts/manifest.json` without contacting a live Confluence instance.
+
+For Confluence runs, `--target` accepts either a numeric page ID or a full page
+URL under `--base-url`. Full page URLs are validated and normalized to canonical
+`pageId` form for output and manifests.
+
+Next step: opt into real mode with bearer auth:
+
+- `bearer-env` -> `CONFLUENCE_BEARER_TOKEN`
+- `client-cert-env` -> `CONFLUENCE_CLIENT_CERT_FILE` and optional `CONFLUENCE_CLIENT_KEY_FILE`
+
+```bash
+CONFLUENCE_BEARER_TOKEN=... knowledge-adapters confluence \
+  --client-mode real \
+  --auth-method bearer-env \
+  --base-url https://example.com/wiki \
+  --target 12345 \
+  --output-dir ./artifacts
+```
+
 Minimal local file first run:
 
 ```bash
@@ -38,28 +68,6 @@ knowledge-adapters local_files \
 This reads one UTF-8 text file, writes `artifacts/pages/today.md`, and writes
 `artifacts/manifest.json`. Add `--dry-run` to preview the normalized markdown
 and planned output path without writing files.
-
-Confluence auth quick reference:
-
-- `bearer-env` -> `CONFLUENCE_BEARER_TOKEN`
-- `client-cert-env` -> `CONFLUENCE_CLIENT_CERT_FILE` and optional `CONFLUENCE_CLIENT_KEY_FILE`
-
-For Confluence runs, `--target` accepts either a numeric page ID or a full page
-URL under `--base-url`.
-
-Minimal live Confluence example with bearer auth:
-
-```bash
-CONFLUENCE_BEARER_TOKEN=... knowledge-adapters confluence \
-  --client-mode real \
-  --auth-method bearer-env \
-  --base-url https://example.com/wiki \
-  --target 12345 \
-  --output-dir ./artifacts
-```
-
-Use the default `stub` client mode when you want to preview the artifact shape
-without contacting a live Confluence instance.
 
 ---
 
@@ -147,9 +155,8 @@ The initial implementation focuses on **Confluence** and **local file** adapters
 
 ### Planned MVP
 - Confluence adapter
-  - use runtime-provided auth and base URL for live Confluence fetches
-  - fetch real page content for a target page or page tree
-  - back recursive traversal and incremental sync with a non-stub client
+  - keep the default stub flow and opt-in real mode aligned around one CLI contract
+  - continue hardening contract-tested real-mode fetch, traversal, and incremental sync behavior against live environments
 - local files adapter
   - accept a runtime-provided file path
   - normalize file contents into markdown plus metadata
@@ -230,8 +237,9 @@ client.
   `--dry-run`, `--tree`, and `--max-depth`
 - generates stub page content for the resolved page without contacting a live
   Confluence instance
-- supports an opt-in real client path with `--client-mode real` for a single live
-  page fetch using `bearer-env` or `client-cert-env` auth
+- supports an opt-in real client path with `--client-mode real` for
+  contract-tested live page fetches and tree traversal using `bearer-env` or
+  `client-cert-env` auth
 - normalizes that stub content into markdown and writes `pages/<canonical_id>.md`
 - writes `manifest.json` for normal runs
 - supports dry-run output and manifest-based skip logic for the resolved page
@@ -280,6 +288,9 @@ Out of the box, this resolves page `12345`, generates stub content for that page
 writes `pages/12345.md`, and writes `manifest.json`. The default Confluence client
 does not contact a live Confluence instance yet.
 
+Full page URL targets are also accepted under `--base-url` and are normalized to
+canonical `pageId` form for output and manifests.
+
 Run the opt-in real Confluence client for a single resolved page:
 
 ```bash
@@ -292,7 +303,8 @@ CONFLUENCE_BEARER_TOKEN=... .venv/bin/knowledge-adapters confluence \
 
 In v1, `--client-mode real` supports both single-page fetches and real breadth-first
 tree traversal with `--tree` and `--max-depth`, using `bearer-env` auth and
-optional client certificates or `client-cert-env` auth.
+optional client certificates or `client-cert-env` auth. This opt-in path is
+contract-tested, but not fully live-validated across Confluence environments.
 
 For certificate-based auth, set `CONFLUENCE_CLIENT_CERT_FILE` to a combined PEM
 file, or set `CONFLUENCE_CLIENT_CERT_FILE` plus `CONFLUENCE_CLIENT_KEY_FILE` for

--- a/adapters/confluence/README.md
+++ b/adapters/confluence/README.md
@@ -22,9 +22,9 @@ Out of the box, the default Confluence CLI:
 - keeps dry-run and write output aligned around the same resolved page ID,
   canonical source URL, page artifact path, and manifest path
 - fetches stub page data for that resolved page
-- supports an opt-in real client path with `--client-mode real` for live page
-  fetches and breadth-first tree traversal using `bearer-env` or
-  `client-cert-env` auth
+- supports an opt-in real client path with `--client-mode real` for
+  contract-tested live page fetches and breadth-first tree traversal using
+  `bearer-env` or `client-cert-env` auth
 - keeps `stub` and `real` modes on the same CLI flow and artifact layout, with
   only the content source changing between modes
 - normalizes the stub page into markdown plus metadata
@@ -39,6 +39,8 @@ Out of the box, the default Confluence CLI:
 - `--client-mode real` supports `bearer-env` via `CONFLUENCE_BEARER_TOKEN`
   and `client-cert-env` via `CONFLUENCE_CLIENT_CERT_FILE` plus optional
   `CONFLUENCE_CLIENT_KEY_FILE`
+- real mode is contract-tested, but not fully live-validated across Confluence
+  environments
 - recursive traversal semantics are defined and tested, but multi-page tree runs
   still require `--client-mode real` or a monkeypatched client that returns child
   pages

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -61,9 +61,12 @@ def build_parser() -> argparse.ArgumentParser:
         help="Run the Confluence adapter.",
         description=(
             "Normalize a Confluence page or page tree into local markdown artifacts. "
-            "Both stub and real modes follow the same target resolution and artifact "
-            "flow. The default stub mode writes scaffolded output without contacting "
-            "Confluence. Use --client-mode real for live Confluence fetches."
+            "Both stub and real modes follow the same target resolution, plan, and "
+            "artifact flow. Use --dry-run to preview the same page and manifest plan "
+            "a write "
+            "run would use. The default stub mode writes scaffolded output without "
+            "contacting Confluence. Use --client-mode real for contract-tested live "
+            "Confluence fetches."
         ),
         epilog=CONFLUENCE_HELP_EXAMPLES,
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -76,7 +79,11 @@ def build_parser() -> argparse.ArgumentParser:
     confluence_parser.add_argument(
         "--target",
         required=True,
-        help="Confluence page ID or full page URL under --base-url.",
+        help=(
+            "Confluence page ID or full page URL under --base-url. Full URLs are "
+            "validated and normalized to canonical pageId form for output and "
+            "manifests."
+        ),
     )
     confluence_parser.add_argument(
         "--output-dir",

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -162,7 +162,11 @@ def test_confluence_help_lists_supported_auth_methods_and_examples(
     assert "--debug" in result.stdout
     assert "request debug details" in result.stdout
     assert "real-client" in result.stdout
-    assert "same target resolution and artifact flow" in result.stdout
+    assert "same target resolution, plan, and artifact flow" in result.stdout
     assert "same local artifact paths" in result.stdout
+    assert "same page and manifest plan a write run would use" in result.stdout
+    assert "contract-tested live Confluence fetches" in result.stdout
+    assert "validated and normalized to canonical" in result.stdout
+    assert "pageId form for output and manifests" in result.stdout
     assert "CONFLUENCE_BEARER_TOKEN=... knowledge-adapters confluence" in result.stdout
     assert "--dry-run" in result.stdout


### PR DESCRIPTION
Summary
- clarify README first-run Confluence onboarding by showing the default stub flow before opt-in real mode
- update Confluence status wording to describe real mode as opt-in and contract-tested rather than planned
- clarify in the README and Confluence help that full page URLs are normalized to canonical pageId form for output and manifests

Testing
- make check