### PR TITLE
chore: align adapter CLI wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,9 @@ knowledge-adapters local_files \
 ```
 
 This reads one UTF-8 text file, writes `artifacts/pages/today.md`, and writes
-`artifacts/manifest.json`. Add `--dry-run` to preview the normalized markdown
-and planned output path without writing files.
+`artifacts/manifest.json`. Add `--dry-run` to preview the same output paths and
+write summary a write run would use, plus the normalized markdown, without
+writing files.
 
 ---
 

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -61,11 +61,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="Run the Confluence adapter.",
         description=(
             "Normalize a Confluence page or page tree into local markdown artifacts. "
-            "Both stub and real modes follow the same resolve, plan, and artifact "
-            "flow. Use --dry-run to preview the same page and manifest plan a write "
-            "run would use. The default stub mode uses scaffolded content without "
-            "contacting Confluence. Use --client-mode real for contract-tested live "
-            "Confluence fetches."
+            "Both stub and real modes follow the same resolve, plan, and write flow. "
+            "Use --dry-run to preview the same output paths and write/skip summary a "
+            "write run would use. The default stub mode uses scaffolded content "
+            "without contacting Confluence. Use --client-mode real for "
+            "contract-tested live Confluence fetches."
         ),
         epilog=CONFLUENCE_HELP_EXAMPLES,
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -96,8 +96,7 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "Choose the content source: 'stub' uses scaffolded page content with no "
             "network call; 'real' fetches from Confluence using --auth-method. Both "
-            "modes keep the same resolve, dry-run, and write artifact flow. Defaults "
-            "to 'stub'."
+            "modes keep the same resolve, plan, and write flow. Defaults to 'stub'."
         ),
     )
     confluence_parser.add_argument(
@@ -121,8 +120,8 @@ def build_parser() -> argparse.ArgumentParser:
         "--dry-run",
         action="store_true",
         help=(
-            "Preview the same page, output path, manifest path, and write/skip summary "
-            "a write run would use, without writing files."
+            "Preview the same output paths and write/skip summary a write run would "
+            "use, without writing files."
         ),
     )
     confluence_parser.add_argument(
@@ -141,8 +140,9 @@ def build_parser() -> argparse.ArgumentParser:
         "local_files",
         help="Run the local files adapter.",
         description=(
-            "Normalize a single local UTF-8 text file into a markdown artifact. "
-            "Writes pages/<file-stem>.md and manifest.json under --output-dir."
+            "Normalize a single local UTF-8 text file into local markdown artifacts. "
+            "Use --dry-run to preview the same output paths and write summary a "
+            "write run would use."
         ),
         epilog=LOCAL_FILES_HELP_EXAMPLES,
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -151,18 +151,21 @@ def build_parser() -> argparse.ArgumentParser:
         "--file-path",
         required=True,
         metavar="FILE",
-        help="Readable UTF-8 text file to normalize.",
+        help="Local UTF-8 text file to normalize.",
     )
     local_files_parser.add_argument(
         "--output-dir",
         required=True,
         metavar="DIR",
-        help="Directory for generated artifacts: pages/<name>.md and manifest.json.",
+        help="Directory to write normalized local artifacts.",
     )
     local_files_parser.add_argument(
         "--dry-run",
         action="store_true",
-        help="Print the planned output path and normalized markdown without writing files.",
+        help=(
+            "Preview the same output paths and write summary a write run would use, "
+            "without writing files."
+        ),
     )
 
     return parser
@@ -479,6 +482,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 
         from knowledge_adapters.confluence.manifest import (
             build_manifest_entry,
+            manifest_path,
             write_manifest,
         )
         from knowledge_adapters.local_files.client import fetch_file
@@ -497,7 +501,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             exit_with_cli_error(
                 (
                     f"Output path is not a directory: {output_dir}. "
-                    "Choose a directory path for --output-dir."
+                    "Verify --output-dir and use a directory path."
                 ),
                 command="local_files",
             )
@@ -511,10 +515,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         print("Local files adapter invoked")
         print(f"  file_path: {local_files_config.file_path}")
         print(f"  output_dir: {local_files_config.output_dir}")
-        print(f"  dry_run: {local_files_config.dry_run}")
+        print(f"  run_mode: {'dry-run' if local_files_config.dry_run else 'write'}")
 
         input_path = Path(local_files_config.file_path)
         output_name = input_path.stem or input_path.name
+        manifest_output_path = manifest_path(local_files_config.output_dir)
         try:
             output_path = write_markdown(
                 local_files_config.output_dir,
@@ -526,7 +531,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             exit_with_cli_error(
                 (
                     f"Output directory is not writable: {output_dir}. "
-                    "Check the path and permissions for --output-dir."
+                    "Verify --output-dir and check the path permissions."
                 ),
                 command="local_files",
             )
@@ -534,7 +539,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             exit_with_cli_error(
                 (
                     f"Output path is not a directory: {output_dir}. "
-                    "Choose a directory path for --output-dir."
+                    "Verify --output-dir and use a directory path."
                 ),
                 command="local_files",
             )
@@ -542,17 +547,23 @@ def main(argv: Sequence[str] | None = None) -> int:
             exit_with_cli_error(
                 (
                     f"Could not write output under {output_dir}. "
-                    "Check --output-dir and try again."
+                    "Verify --output-dir and try again."
                 ),
                 command="local_files",
             )
         if local_files_config.dry_run:
-            print(f"\nDry run: would write {output_path}\n")
+            print("\nPlan: Local files run")
+            print(f"  source_path: {input_path.resolve()}")
+            print(f"  output_path: {output_path}")
+            print(f"  manifest_path: {manifest_output_path}")
+            print("  action: would write")
+            print("  Summary: would write 1, would skip 0")
+            print()
             print(markdown)
             return 0
 
         try:
-            write_manifest(
+            manifest = write_manifest(
                 local_files_config.output_dir,
                 [
                     build_manifest_entry(
@@ -568,7 +579,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             exit_with_cli_error(
                 (
                     f"Output directory is not writable: {output_dir}. "
-                    "Check the path and permissions for --output-dir."
+                    "Verify --output-dir and check the path permissions."
                 ),
                 command="local_files",
             )
@@ -576,7 +587,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             exit_with_cli_error(
                 (
                     f"Output path is not a directory: {output_dir}. "
-                    "Choose a directory path for --output-dir."
+                    "Verify --output-dir and use a directory path."
                 ),
                 command="local_files",
             )
@@ -584,11 +595,13 @@ def main(argv: Sequence[str] | None = None) -> int:
             exit_with_cli_error(
                 (
                     f"Could not write output under {output_dir}. "
-                    "Check --output-dir and try again."
+                    "Verify --output-dir and try again."
                 ),
                 command="local_files",
             )
         print(f"\nWrote: {output_path}")
+        print("\nSummary: wrote 1, skipped 0")
+        print(f"Manifest: {manifest}")
         return 0
 
     parser.error("Unknown command")

--- a/src/knowledge_adapters/local_files/client.py
+++ b/src/knowledge_adapters/local_files/client.py
@@ -9,11 +9,9 @@ def fetch_file(file_path: str) -> dict[str, object]:
     """Read a local file into the shared normalized payload shape."""
     input_path = Path(file_path).expanduser()
     if not input_path.exists():
-        raise ValueError(f"File does not exist: {input_path}. Check --file-path and try again.")
+        raise ValueError(f"File does not exist: {input_path}. Verify --file-path and try again.")
     if not input_path.is_file():
-        raise ValueError(
-            f"Path is not a regular file: {input_path}. Supply a single UTF-8 text file."
-        )
+        raise ValueError(f"Path is not a regular file: {input_path}. Use a UTF-8 text file.")
 
     path = input_path.resolve()
     try:
@@ -24,10 +22,10 @@ def fetch_file(file_path: str) -> dict[str, object]:
         ) from exc
     except UnicodeDecodeError as exc:
         raise ValueError(
-            f"File is not readable as UTF-8 text: {path}. Supply a UTF-8 text file."
+            f"File is not readable as UTF-8 text: {path}. Use a UTF-8 text file."
         ) from exc
     except OSError as exc:
-        raise ValueError(f"Could not read file: {path}. Check --file-path and try again.") from exc
+        raise ValueError(f"Could not read file: {path}. Verify --file-path and try again.") from exc
 
     return {
         "title": path.name,

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -47,7 +47,10 @@ def test_local_files_cli_smoke_uses_installed_entrypoint_with_readme_style_args(
 
     assert result.returncode == 0, result.stderr
     assert "Local files adapter invoked" in result.stdout
+    assert "run_mode: write" in result.stdout
     assert "Wrote:" in result.stdout
+    assert "Summary: wrote 1, skipped 0" in result.stdout
+    assert "Manifest:" in result.stdout
 
     output_path = tmp_path / "artifacts" / "pages" / "today.md"
     assert output_path.read_text(encoding="utf-8") == (
@@ -84,13 +87,14 @@ def test_local_files_cli_help_includes_first_run_guidance(tmp_path: Path) -> Non
 
     assert result.returncode == 0, result.stderr
     assert (
-        "Normalize a single local UTF-8 text file into a markdown artifact."
+        "Normalize a single local UTF-8 text file into local markdown artifacts."
         in result.stdout
     )
     assert "--file-path FILE" in result.stdout
-    assert "Readable UTF-8 text file to normalize." in result.stdout
+    assert "Local UTF-8 text file to normalize." in result.stdout
     assert "--output-dir DIR" in result.stdout
-    assert "Print the planned output path and normalized markdown" in result.stdout
+    assert "Directory to write normalized local artifacts." in result.stdout
+    assert "Preview the same output paths and write summary" in result.stdout
     assert "without writing files." in result.stdout
     assert "knowledge-adapters local_files" in result.stdout
     assert "--dry-run" in result.stdout
@@ -167,9 +171,10 @@ def test_confluence_help_lists_supported_auth_methods_and_examples(
     assert "--debug" in result.stdout
     assert "request debug details" in result.stdout
     assert "real-client" in result.stdout
-    assert "same resolve, plan, and artifact flow" in result.stdout
-    assert "same page and manifest plan a write run would use" in result.stdout
-    assert "same resolve, dry-run, and write artifact flow" in result.stdout
+    assert "same output paths and write/skip summary a write run would use" in result.stdout
+    assert "same resolve, plan, and write flow" in result.stdout
+    assert "'real' fetches from" in result.stdout
+    assert "using --auth-method" in result.stdout
     assert "contract-tested live Confluence fetches" in result.stdout
     assert "validated and normalized to canonical" in result.stdout
     assert "pageId form for output and manifests" in result.stdout

--- a/tests/test_local_files.py
+++ b/tests/test_local_files.py
@@ -118,7 +118,14 @@ def test_local_files_cli_dry_run_reports_output_without_writing(
     assert not (output_dir / "manifest.json").exists()
 
     captured = capsys.readouterr()
-    assert f"Dry run: would write {output_path}" in captured.out
+    assert "Local files adapter invoked" in captured.out
+    assert "run_mode: dry-run" in captured.out
+    assert "Plan: Local files run" in captured.out
+    assert f"source_path: {source_file.resolve()}" in captured.out
+    assert f"output_path: {output_path}" in captured.out
+    assert f"manifest_path: {output_dir / 'manifest.json'}" in captured.out
+    assert "action: would write" in captured.out
+    assert "Summary: would write 1, would skip 0" in captured.out
     assert "Line one." in captured.out
 
 
@@ -163,7 +170,7 @@ def test_local_files_cli_reports_missing_file_with_actionable_error(
     assert "Local files adapter invoked" not in captured.out
     assert "knowledge-adapters local_files: error:" in captured.err
     assert f"File does not exist: {missing_file}." in captured.err
-    assert "Check --file-path and try again." in captured.err
+    assert "Verify --file-path and try again." in captured.err
 
 
 def test_local_files_cli_reports_non_file_input_path(
@@ -187,7 +194,7 @@ def test_local_files_cli_reports_non_file_input_path(
     assert exc_info.value.code == 2
     captured = capsys.readouterr()
     assert f"Path is not a regular file: {source_dir}." in captured.err
-    assert "Supply a single UTF-8 text file." in captured.err
+    assert "Use a UTF-8 text file." in captured.err
 
 
 def test_local_files_cli_reports_invalid_output_dir(
@@ -213,4 +220,4 @@ def test_local_files_cli_reports_invalid_output_dir(
     assert exc_info.value.code == 2
     captured = capsys.readouterr()
     assert f"Output path is not a directory: {output_path}." in captured.err
-    assert "Choose a directory path for --output-dir." in captured.err
+    assert "Verify --output-dir and use a directory path." in captured.err


### PR DESCRIPTION
Summary
- align Confluence and local_files help text around the same plan-and-write vocabulary
- make local_files dry-run and write output follow the same plan, action, summary, and manifest shape as Confluence where the behavior overlaps
- tighten local_files error phrasing and refresh smoke, CLI, and README coverage for the updated wording

Testing
- make check
- .venv/bin/knowledge-adapters local_files --help
- .venv/bin/knowledge-adapters local_files --file-path <tmp>/meeting-notes.txt --output-dir <tmp>/out --dry-run
- .venv/bin/knowledge-adapters local_files --file-path <tmp>/meeting-notes.txt --output-dir <tmp>/out
- .venv/bin/knowledge-adapters confluence --help
- .venv/bin/knowledge-adapters confluence --base-url https://example.com/wiki --target 12345 --output-dir <tmp>/out --dry-run
- .venv/bin/knowledge-adapters confluence --base-url https://example.com/wiki --target 12345 --output-dir <tmp>/out