### PR TITLE
chore: align adapter cli experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # knowledge-adapters
 
-Generic adapters for acquiring knowledge from external sources and normalizing it into local, LLM-ready artifacts.
+Generic adapters for acquiring knowledge from external sources and normalizing
+them into one predictable local artifact layout.
 
 ---
 
@@ -19,7 +20,8 @@ When installed this way, use `knowledge-adapters` in place of `.venv/bin/knowled
 
 ## First Run (installed CLI)
 
-Start with the built-in help:
+Start with the built-in help so the shared flow is visible before you pick an
+adapter:
 
 ```bash
 knowledge-adapters --help
@@ -27,23 +29,57 @@ knowledge-adapters local_files --help
 knowledge-adapters confluence --help
 ```
 
+Every adapter follows the same high-level shape:
+
+- inspect one source input
+- plan a markdown artifact under `pages/`
+- plan `manifest.json` in the selected output directory
+- write only when `--dry-run` is not set
+
+Recommended first run: start with `--dry-run`, confirm the planned source,
+artifact path, and manifest path, then rerun the same command without
+`--dry-run`.
+
+Minimal local file first run:
+
+```bash
+knowledge-adapters local_files \
+  --file-path ./notes/today.txt \
+  --output-dir ./artifacts \
+  --dry-run
+```
+
+This resolves the file path, previews `artifacts/pages/today.md`, previews
+`artifacts/manifest.json`, and prints the normalized markdown without writing
+files.
+
 Minimal Confluence first run (default `stub` mode):
 
 ```bash
 knowledge-adapters confluence \
   --base-url https://example.com/wiki \
   --target 12345 \
-  --output-dir ./artifacts
+  --output-dir ./artifacts \
+  --dry-run
 ```
 
-This resolves page `12345`, writes `artifacts/pages/12345.md`, and writes
-`artifacts/manifest.json` without contacting a live Confluence instance.
+This resolves page `12345`, previews `artifacts/pages/12345.md`, previews
+`artifacts/manifest.json`, and prints the normalized markdown without
+contacting a live Confluence instance.
 
 For Confluence runs, `--target` accepts either a numeric page ID or a full page
 URL under `--base-url`. Full page URLs are validated and normalized to canonical
-`pageId` form for output and manifests.
+`pageId` form for artifact and manifest reporting.
 
-Next step: opt into real mode with bearer auth:
+Confluence is also the adapter that currently uses manifest-based skip logic, so
+its dry runs and write runs may report `write` or `skip` for a page when an
+existing artifact already matches the planned output. `local_files` always plans
+one write.
+
+When the dry run looks right, rerun the same command without `--dry-run` to
+write the artifact and manifest.
+
+Next step for Confluence: opt into real mode with bearer auth:
 
 - `bearer-env` -> `CONFLUENCE_BEARER_TOKEN`
 - `client-cert-env` -> `CONFLUENCE_CLIENT_CERT_FILE` and optional `CONFLUENCE_CLIENT_KEY_FILE`
@@ -56,19 +92,6 @@ CONFLUENCE_BEARER_TOKEN=... knowledge-adapters confluence \
   --target 12345 \
   --output-dir ./artifacts
 ```
-
-Minimal local file first run:
-
-```bash
-knowledge-adapters local_files \
-  --file-path ./notes/today.txt \
-  --output-dir ./artifacts
-```
-
-This reads one UTF-8 text file, writes `artifacts/pages/today.md`, and writes
-`artifacts/manifest.json`. Add `--dry-run` to preview the same output paths and
-write summary a write run would use, plus the normalized markdown, without
-writing files.
 
 ---
 
@@ -257,17 +280,9 @@ intended contract for a real or monkeypatched client. See
 [`docs/confluence-incremental-sync.md`](docs/confluence-incremental-sync.md) for
 that design surface.
 
-## Example
+## Examples
 
-Normalize a local UTF-8 text file into the standard markdown artifact:
-
-```bash
-knowledge-adapters local_files \
-  --file-path ./notes/today.txt \
-  --output-dir ./artifacts
-```
-
-Preview the normalized markdown without writing files:
+Start with a dry run for the local files adapter:
 
 ```bash
 knowledge-adapters local_files \
@@ -276,7 +291,32 @@ knowledge-adapters local_files \
   --dry-run
 ```
 
-Run the default Confluence adapter for a single resolved page:
+Write the same local file artifact after reviewing the plan:
+
+```bash
+knowledge-adapters local_files \
+  --file-path ./notes/today.txt \
+  --output-dir ./artifacts
+```
+
+Start with a dry run for the default Confluence adapter:
+
+```bash
+.venv/bin/knowledge-adapters confluence \
+  --base-url https://example.com/wiki \
+  --target 12345 \
+  --output-dir ./artifacts \
+  --dry-run
+```
+
+Out of the box, this resolves page `12345`, generates stub content for that
+page, previews `pages/12345.md`, previews `manifest.json`, and does not contact
+a live Confluence instance.
+
+Full page URL targets are also accepted under `--base-url` and are normalized to
+canonical `pageId` form for artifact and manifest reporting.
+
+Write the same Confluence artifact after reviewing the plan:
 
 ```bash
 .venv/bin/knowledge-adapters confluence \
@@ -284,13 +324,6 @@ Run the default Confluence adapter for a single resolved page:
   --target 12345 \
   --output-dir ./artifacts
 ```
-
-Out of the box, this resolves page `12345`, generates stub content for that page,
-writes `pages/12345.md`, and writes `manifest.json`. The default Confluence client
-does not contact a live Confluence instance yet.
-
-Full page URL targets are also accepted under `--base-url` and are normalized to
-canonical `pageId` form for output and manifests.
 
 Run the opt-in real Confluence client for a single resolved page:
 
@@ -313,22 +346,11 @@ split cert/key files.
 This v1 path is intentionally minimal: passphrase-protected keys, broader auth
 combinations, and live certificate validation are out of scope for `make check`.
 
-Preview the default Confluence run without writing files:
-
-```bash
-.venv/bin/knowledge-adapters confluence \
-  --base-url https://example.com/wiki \
-  --target 12345 \
-  --output-dir ./artifacts \
-  --dry-run
-```
-
-The dry run prints the planned output path and the normalized stub markdown. If an
-existing `manifest.json` entry and on-disk artifact already match the resolved page,
-the default CLI reports `would skip` instead of `would write`.
-In both `stub` and `real` modes, the CLI keeps the same resolve, plan, and
-summary shape: it reports the resolved page ID, planned artifact paths, and the
-same write-versus-skip summary before any files are written.
+In both `stub` and `real` modes, the CLI keeps the same resolve, plan, action,
+and summary shape. The dry run prints the planned artifact path and normalized
+markdown. If an existing `manifest.json` entry and on-disk artifact already
+match the resolved page, the Confluence CLI reports `would skip` instead of
+`would write`.
 
 The Confluence CLI also includes tree-mode and incremental-sync plumbing. The
 default stub client still does not discover child pages, so out-of-the-box stub

--- a/adapters/confluence/README.md
+++ b/adapters/confluence/README.md
@@ -7,6 +7,19 @@ the authoritative status page for what the default Confluence CLI currently does
 
 This adapter is the first implementation of the generic adapter contract for `knowledge-adapters`.
 
+## Shared CLI Flow
+
+Confluence follows the same product-level CLI flow as `local_files`:
+
+- inspect one source input
+- plan a markdown artifact under `pages/`
+- plan `manifest.json` in the output directory
+- write only when `--dry-run` is not set
+
+The Confluence-specific difference is that dry runs and write runs may report
+`write` or `skip` for a page when an existing manifest entry and on-disk
+artifact already match the planned output.
+
 ## Current Behavior
 
 Out of the box, the default Confluence CLI:
@@ -18,7 +31,7 @@ Out of the box, the default Confluence CLI:
   `--dry-run`, `--tree`, and `--max-depth`
 - resolves the target into a canonical page ID
 - normalizes page ID and full page URL targets into the same resolved source URL
-  for stub-mode metadata and dry-run reporting
+  for metadata, dry-run reporting, and write reporting
 - keeps dry-run and write output aligned around the same resolved page ID,
   canonical source URL, page artifact path, and manifest path
 - fetches stub page data for that resolved page
@@ -28,7 +41,7 @@ Out of the box, the default Confluence CLI:
 - keeps `stub` and `real` modes on the same CLI flow and artifact layout, with
   only the content source changing between modes
 - keeps dry-run and write messaging aligned across `stub` and `real`, including
-  the same plan header, artifact-path reporting, and write/skip summary shape
+  the same invocation, plan, action, and summary shape for single-page runs
 - normalizes the stub page into markdown plus metadata
 - writes a deterministic page artifact and `manifest.json` on normal runs
 - supports dry-run output and manifest-based skip logic for the resolved page

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -5,19 +5,32 @@ from __future__ import annotations
 import argparse
 import sys
 from collections.abc import Callable, Sequence
+from pathlib import Path
 
 from knowledge_adapters.confluence.auth import SUPPORTED_AUTH_METHODS
+
+TOP_LEVEL_HELP_EXAMPLES = """First steps:
+  knowledge-adapters --help
+  knowledge-adapters local_files --help
+  knowledge-adapters confluence --help
+
+Typical flow:
+  1. Start with --dry-run to preview the source, artifact path, manifest path,
+     and action.
+  2. Re-run without --dry-run to write the same artifact layout under
+     ./artifacts.
+"""
 
 CONFLUENCE_HELP_EXAMPLES = """Examples:
   knowledge-adapters confluence \\
     --base-url https://example.com/wiki \\
     --target 12345 \\
-    --output-dir ./artifacts
-  knowledge-adapters confluence \\
-    --base-url https://example.com/wiki \\
-    --target https://example.com/wiki/spaces/ENG/pages/12345/Runbook \\
     --output-dir ./artifacts \\
     --dry-run
+  knowledge-adapters confluence \\
+    --base-url https://example.com/wiki \\
+    --target 12345 \\
+    --output-dir ./artifacts
   CONFLUENCE_BEARER_TOKEN=... knowledge-adapters confluence \\
     --client-mode real \\
     --auth-method bearer-env \\
@@ -29,11 +42,11 @@ CONFLUENCE_HELP_EXAMPLES = """Examples:
 LOCAL_FILES_HELP_EXAMPLES = """Examples:
   knowledge-adapters local_files \\
     --file-path ./notes/today.txt \\
-    --output-dir ./artifacts
-  knowledge-adapters local_files \\
-    --file-path ./notes/today.txt \\
     --output-dir ./artifacts \\
     --dry-run
+  knowledge-adapters local_files \\
+    --file-path ./notes/today.txt \\
+    --output-dir ./artifacts
 """
 
 
@@ -47,25 +60,65 @@ def _parse_confluence_auth_method(value: str) -> str:
     raise argparse.ArgumentTypeError(f"unsupported value {value!r}. Choose {supported_values}.")
 
 
+def exit_with_output_error(
+    output_dir: str | Path,
+    *,
+    command: str,
+    exc: OSError,
+) -> None:
+    """Exit with a consistent filesystem error for output writes."""
+    resolved_output_dir = Path(output_dir).expanduser()
+    if isinstance(exc, PermissionError):
+        exit_with_cli_error(
+            (
+                f"Output directory is not writable: {resolved_output_dir}. "
+                "Verify --output-dir and check the path permissions."
+            ),
+            command=command,
+        )
+    if isinstance(exc, NotADirectoryError):
+        exit_with_cli_error(
+            (
+                f"Output path is not a directory: {resolved_output_dir}. "
+                "Verify --output-dir and use a directory path."
+            ),
+            command=command,
+        )
+
+    exit_with_cli_error(
+        (
+            f"Could not write output under {resolved_output_dir}. "
+            "Verify --output-dir and try again."
+        ),
+        command=command,
+    )
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Build the top-level CLI parser."""
     parser = argparse.ArgumentParser(
         prog="knowledge-adapters",
-        description="Acquire and normalize knowledge sources into local artifacts.",
+        description=(
+            "Normalize knowledge sources into a shared local artifact layout. "
+            "Every run inspects a source, plans a markdown artifact under pages/ "
+            "plus manifest.json, and writes only when --dry-run is not set."
+        ),
+        epilog=TOP_LEVEL_HELP_EXAMPLES,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
 
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     confluence_parser = subparsers.add_parser(
         "confluence",
-        help="Run the Confluence adapter.",
+        help="Normalize Confluence content into shared artifacts.",
         description=(
-            "Normalize a Confluence page or page tree into local markdown artifacts. "
-            "Both stub and real modes follow the same resolve, plan, and write flow. "
-            "Use --dry-run to preview the same output paths and write/skip summary a "
-            "write run would use. The default stub mode uses scaffolded content "
-            "without contacting Confluence. Use --client-mode real for "
-            "contract-tested live Confluence fetches."
+            "Normalize a Confluence page or page tree into the shared artifact "
+            "layout. Stub and real modes keep the same resolve, plan, and write "
+            "flow. Use --dry-run to preview resolved page IDs, artifact paths, and "
+            "write/skip decisions before writing. The default stub mode uses "
+            "scaffolded content without contacting Confluence. Use --client-mode "
+            "real for contract-tested live fetches."
         ),
         epilog=CONFLUENCE_HELP_EXAMPLES,
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -73,21 +126,24 @@ def build_parser() -> argparse.ArgumentParser:
     confluence_parser.add_argument(
         "--base-url",
         required=True,
-        help="Base Confluence URL, provided at runtime.",
+        help=(
+            "Base Confluence URL used to validate full page URLs and build "
+            "canonical source URLs."
+        ),
     )
     confluence_parser.add_argument(
         "--target",
         required=True,
         help=(
-            "Confluence page ID or full page URL under --base-url. Full URLs are "
-            "validated and normalized to canonical pageId form for output and "
-            "manifests."
+            "Confluence page ID or full page URL under --base-url. The CLI resolves "
+            "either input into one canonical page ID and source URL for artifact "
+            "and manifest reporting."
         ),
     )
     confluence_parser.add_argument(
         "--output-dir",
         required=True,
-        help="Directory to write normalized local artifacts.",
+        help="Directory where pages/ and manifest.json are written.",
     )
     confluence_parser.add_argument(
         "--client-mode",
@@ -96,7 +152,7 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "Choose the content source: 'stub' uses scaffolded page content with no "
             "network call; 'real' fetches from Confluence using --auth-method. Both "
-            "modes keep the same resolve, plan, and write flow. Defaults to 'stub'."
+            "modes keep the same artifact layout and reporting. Defaults to 'stub'."
         ),
     )
     confluence_parser.add_argument(
@@ -120,8 +176,8 @@ def build_parser() -> argparse.ArgumentParser:
         "--dry-run",
         action="store_true",
         help=(
-            "Preview the same output paths and write/skip summary a write run would "
-            "use, without writing files."
+            "Preview resolved page IDs, artifact paths, manifest path, and "
+            "write/skip decisions without writing files."
         ),
     )
     confluence_parser.add_argument(
@@ -138,11 +194,13 @@ def build_parser() -> argparse.ArgumentParser:
 
     local_files_parser = subparsers.add_parser(
         "local_files",
-        help="Run the local files adapter.",
+        help="Normalize a local text file into shared artifacts.",
         description=(
-            "Normalize a single local UTF-8 text file into local markdown artifacts. "
-            "Use --dry-run to preview the same output paths and write summary a "
-            "write run would use."
+            "Normalize one local UTF-8 text file into the shared artifact layout. "
+            "Use --dry-run to preview the resolved file path, artifact path, "
+            "manifest path, and normalized markdown before writing. Unlike "
+            "Confluence, local_files always plans one write and does not use "
+            "manifest-based skip logic."
         ),
         epilog=LOCAL_FILES_HELP_EXAMPLES,
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -151,20 +209,20 @@ def build_parser() -> argparse.ArgumentParser:
         "--file-path",
         required=True,
         metavar="FILE",
-        help="Local UTF-8 text file to normalize.",
+        help="Local UTF-8 text file to normalize. Relative paths resolve from the cwd.",
     )
     local_files_parser.add_argument(
         "--output-dir",
         required=True,
         metavar="DIR",
-        help="Directory to write normalized local artifacts.",
+        help="Directory where pages/ and manifest.json are written.",
     )
     local_files_parser.add_argument(
         "--dry-run",
         action="store_true",
         help=(
-            "Preview the same output paths and write summary a write run would use, "
-            "without writing files."
+            "Preview the resolved file path, artifact path, manifest path, and "
+            "normalized markdown without writing files."
         ),
     )
 
@@ -225,6 +283,16 @@ def main(argv: Sequence[str] | None = None) -> int:
             tree=args.tree,
             max_depth=args.max_depth,
         )
+        output_dir_input = Path(confluence_config.output_dir).expanduser()
+        output_dir = output_dir_input.resolve()
+        if output_dir_input.exists() and not output_dir_input.is_dir():
+            exit_with_cli_error(
+                (
+                    f"Output path is not a directory: {output_dir}. "
+                    "Verify --output-dir and use a directory path."
+                ),
+                command="confluence",
+            )
         if confluence_config.max_depth < 0:
             exit_with_cli_error(
                 "--max-depth must be greater than or equal to 0.",
@@ -310,24 +378,34 @@ def main(argv: Sequence[str] | None = None) -> int:
                 title=str(page["title"]) if page.get("title") else None,
             )
 
-        def _print_single_page_dry_run(
+        def _display_output_path(path: Path) -> Path:
+            """Return an absolute path for user-facing output."""
+            try:
+                relative_path = path.relative_to(output_dir_input)
+            except ValueError:
+                return path if path.is_absolute() else path.resolve()
+            return output_dir / relative_path
+
+        def _print_single_page_plan(
             *,
             page_id: str,
             source_url: str,
             output_path: Path,
             manifest_output_path: Path,
             action: str,
+            dry_run: bool,
             markdown: str | None = None,
         ) -> None:
-            write_count = 1 if action == "write" else 0
-            skip_count = 1 if action == "skip" else 0
             print("\nPlan: Confluence run")
             print(f"  resolved_page_id: {page_id}")
             print(f"  source_url: {source_url}")
-            print(f"  output_path: {output_path}")
-            print(f"  manifest_path: {manifest_output_path}")
-            print(f"  action: would {action}")
-            print(f"  Summary: would write {write_count}, would skip {skip_count}")
+            print(f"  artifact_path: {_display_output_path(output_path)}")
+            print(f"  manifest_path: {_display_output_path(manifest_output_path)}")
+            print(f"  action: {'would ' if dry_run else ''}{action}")
+            if dry_run:
+                write_count = 1 if action == "write" else 0
+                skip_count = 1 if action == "skip" else 0
+                print(f"  Summary: would write {write_count}, would skip {skip_count}")
             if markdown is not None:
                 print()
                 print(markdown)
@@ -376,17 +454,18 @@ def main(argv: Sequence[str] | None = None) -> int:
                 1 for _page, _output_path, action in page_records if action == "write"
             )
             skip_count = len(page_records) - write_count
+            manifest_output_path = manifest_path(confluence_config.output_dir)
+
+            print("\nPlan: Confluence run")
+            print(f"  resolved_root_page_id: {root_page_id}")
+            print(f"  max_depth: {confluence_config.max_depth}")
+            print(f"  manifest_path: {_display_output_path(manifest_output_path)}")
+            print(f"  unique_pages: {len(page_records)}")
 
             if confluence_config.dry_run:
-                manifest_output_path = manifest_path(confluence_config.output_dir)
-                print("\nPlan: Confluence run")
-                print(f"  resolved_root_page_id: {root_page_id}")
-                print(f"  max_depth: {confluence_config.max_depth}")
-                print(f"  manifest_path: {manifest_output_path}")
                 for _page, output_path, action in page_records:
-                    print(f"  would {action} {output_path}")
+                    print(f"  would {action} {_display_output_path(output_path)}")
                 print(f"  Summary: would write {write_count}, would skip {skip_count}")
-                print(f"  {len(page_records)} unique pages")
                 return 0
 
             files = [
@@ -394,27 +473,34 @@ def main(argv: Sequence[str] | None = None) -> int:
                 for page, output_path, _action in page_records
             ]
 
-            for page, output_path, action in page_records:
-                if action == "skip":
-                    print(f"\nSkipped: {output_path}")
-                    continue
+            try:
+                for page, output_path, action in page_records:
+                    if action == "skip":
+                        print(f"\nSkipped: {_display_output_path(output_path)}")
+                        continue
 
-                markdown = normalize_to_markdown(page)
-                write_markdown(
+                    markdown = normalize_to_markdown(page)
+                    write_markdown(
+                        confluence_config.output_dir,
+                        str(page.get("canonical_id") or ""),
+                        markdown,
+                    )
+                    print(f"\nWrote: {_display_output_path(output_path)}")
+
+                manifest = write_manifest_with_context(
                     confluence_config.output_dir,
-                    str(page.get("canonical_id") or ""),
-                    markdown,
+                    files,
+                    root_page_id=root_page_id,
+                    max_depth=confluence_config.max_depth,
                 )
-                print(f"\nWrote: {output_path}")
-
-            manifest = write_manifest_with_context(
-                confluence_config.output_dir,
-                files,
-                root_page_id=root_page_id,
-                max_depth=confluence_config.max_depth,
-            )
+            except OSError as exc:
+                exit_with_output_error(
+                    confluence_config.output_dir,
+                    command="confluence",
+                    exc=exc,
+                )
             print(f"\nSummary: wrote {write_count}, skipped {skip_count}")
-            print(f"\nManifest: {manifest}")
+            print(f"\nManifest: {_display_output_path(manifest)}")
             return 0
 
         try:
@@ -444,45 +530,59 @@ def main(argv: Sequence[str] | None = None) -> int:
 
         if confluence_config.dry_run:
             planned_markdown = normalize_to_markdown(page) if action == "write" else None
-            _print_single_page_dry_run(
+            _print_single_page_plan(
                 page_id=page_id,
                 source_url=str(page.get("source_url", "")),
                 output_path=output_path,
                 manifest_output_path=manifest_output_path,
                 action=action,
+                dry_run=True,
                 markdown=planned_markdown,
             )
             return 0
 
-        if action == "write":
-            markdown = normalize_to_markdown(page)
-            write_markdown(
-                confluence_config.output_dir,
-                page_id,
-                markdown,
-            )
-            print(f"\nWrote: {output_path}")
-        else:
-            print(f"\nSkipped: {output_path}")
-
-        manifest = write_manifest(
-            confluence_config.output_dir,
-            [
-                _build_manifest_entry_for_page(page, output_path),
-            ],
+        _print_single_page_plan(
+            page_id=page_id,
+            source_url=str(page.get("source_url", "")),
+            output_path=output_path,
+            manifest_output_path=manifest_output_path,
+            action=action,
+            dry_run=False,
         )
+
+        try:
+            if action == "write":
+                markdown = normalize_to_markdown(page)
+                write_markdown(
+                    confluence_config.output_dir,
+                    page_id,
+                    markdown,
+                )
+                print(f"\nWrote: {_display_output_path(output_path)}")
+            else:
+                print(f"\nSkipped: {_display_output_path(output_path)}")
+
+            manifest = write_manifest(
+                confluence_config.output_dir,
+                [
+                    _build_manifest_entry_for_page(page, output_path),
+                ],
+            )
+        except OSError as exc:
+            exit_with_output_error(
+                confluence_config.output_dir,
+                command="confluence",
+                exc=exc,
+            )
         write_count = 1 if action == "write" else 0
         skip_count = 1 if action == "skip" else 0
         print(f"\nSummary: wrote {write_count}, skipped {skip_count}")
-        print(f"Manifest: {manifest}")
+        print(f"Manifest: {_display_output_path(manifest)}")
         return 0
 
     if args.command == "local_files":
-        from pathlib import Path
-
         from knowledge_adapters.confluence.manifest import (
             build_manifest_entry,
-            manifest_path,
             write_manifest,
         )
         from knowledge_adapters.local_files.client import fetch_file
@@ -496,8 +596,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             dry_run=args.dry_run,
         )
 
-        output_dir = Path(local_files_config.output_dir).expanduser()
-        if output_dir.exists() and not output_dir.is_dir():
+        output_dir_input = Path(local_files_config.output_dir).expanduser()
+        output_dir = output_dir_input.resolve()
+        if output_dir_input.exists() and not output_dir_input.is_dir():
             exit_with_cli_error(
                 (
                     f"Output path is not a directory: {output_dir}. "
@@ -519,89 +620,50 @@ def main(argv: Sequence[str] | None = None) -> int:
 
         input_path = Path(local_files_config.file_path)
         output_name = input_path.stem or input_path.name
-        manifest_output_path = manifest_path(local_files_config.output_dir)
-        try:
-            output_path = write_markdown(
-                local_files_config.output_dir,
-                output_name,
-                markdown,
-                dry_run=local_files_config.dry_run,
-            )
-        except PermissionError:
-            exit_with_cli_error(
-                (
-                    f"Output directory is not writable: {output_dir}. "
-                    "Verify --output-dir and check the path permissions."
-                ),
-                command="local_files",
-            )
-        except NotADirectoryError:
-            exit_with_cli_error(
-                (
-                    f"Output path is not a directory: {output_dir}. "
-                    "Verify --output-dir and use a directory path."
-                ),
-                command="local_files",
-            )
-        except OSError:
-            exit_with_cli_error(
-                (
-                    f"Could not write output under {output_dir}. "
-                    "Verify --output-dir and try again."
-                ),
-                command="local_files",
-            )
+        resolved_input_path = input_path.resolve()
+        manifest_output_path = output_dir / "manifest.json"
+        output_path = output_dir / "pages" / f"{output_name}.md"
+        manifest_entry_output_path = output_dir_input / "pages" / f"{output_name}.md"
+
+        print("\nPlan: Local files run")
+        print(f"  resolved_file_path: {resolved_input_path}")
+        print(f"  source_url: {page.get('source_url', '')}")
+        print(f"  artifact_path: {output_path}")
+        print(f"  manifest_path: {manifest_output_path}")
+        print(f"  action: {'would write' if local_files_config.dry_run else 'write'}")
         if local_files_config.dry_run:
-            print("\nPlan: Local files run")
-            print(f"  source_path: {input_path.resolve()}")
-            print(f"  output_path: {output_path}")
-            print(f"  manifest_path: {manifest_output_path}")
-            print("  action: would write")
             print("  Summary: would write 1, would skip 0")
             print()
             print(markdown)
             return 0
 
         try:
+            write_markdown(
+                local_files_config.output_dir,
+                output_name,
+                markdown,
+            )
             manifest = write_manifest(
                 local_files_config.output_dir,
                 [
                     build_manifest_entry(
                         canonical_id=str(page["canonical_id"]),
                         source_url=str(page.get("source_url", "")),
-                        output_path=output_path,
+                        output_path=manifest_entry_output_path,
                         output_dir=local_files_config.output_dir,
                         title=str(page["title"]) if page.get("title") else None,
                     )
                 ],
             )
-        except PermissionError:
-            exit_with_cli_error(
-                (
-                    f"Output directory is not writable: {output_dir}. "
-                    "Verify --output-dir and check the path permissions."
-                ),
+        except OSError as exc:
+            exit_with_output_error(
+                local_files_config.output_dir,
                 command="local_files",
-            )
-        except NotADirectoryError:
-            exit_with_cli_error(
-                (
-                    f"Output path is not a directory: {output_dir}. "
-                    "Verify --output-dir and use a directory path."
-                ),
-                command="local_files",
-            )
-        except OSError:
-            exit_with_cli_error(
-                (
-                    f"Could not write output under {output_dir}. "
-                    "Verify --output-dir and try again."
-                ),
-                command="local_files",
+                exc=exc,
             )
         print(f"\nWrote: {output_path}")
         print("\nSummary: wrote 1, skipped 0")
-        print(f"Manifest: {manifest}")
+        print(f"Manifest: {output_dir / manifest.relative_to(output_dir_input)}")
         return 0
 
     parser.error("Unknown command")

--- a/src/knowledge_adapters/confluence/incremental.py
+++ b/src/knowledge_adapters/confluence/incremental.py
@@ -17,11 +17,16 @@ def load_previous_manifest_index(output_dir: str) -> dict[str, str] | None:
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
-        raise RuntimeError(f"Could not read prior manifest {path}.") from exc
+        raise RuntimeError(
+            f"Could not read prior manifest {path}. Fix or remove the manifest and try again."
+        ) from exc
 
     files = payload.get("files")
     if not isinstance(files, list):
-        raise RuntimeError(f"Prior manifest {path} is invalid: expected a files list.")
+        raise RuntimeError(
+            f"Prior manifest {path} is invalid: expected a files list. "
+            "Fix or remove the manifest and try again."
+        )
 
     entries_by_id: dict[str, str] = {}
     seen_output_paths: set[str] = set()
@@ -29,7 +34,8 @@ def load_previous_manifest_index(output_dir: str) -> dict[str, str] | None:
     for entry in files:
         if not isinstance(entry, dict):
             raise RuntimeError(
-                f"Prior manifest {path} is invalid: each files entry must be an object."
+                f"Prior manifest {path} is invalid: each files entry must be an object. "
+                "Fix or remove the manifest and try again."
             )
 
         canonical_id = entry.get("canonical_id")
@@ -37,16 +43,18 @@ def load_previous_manifest_index(output_dir: str) -> dict[str, str] | None:
         if not isinstance(canonical_id, str) or not isinstance(output_path, str):
             raise RuntimeError(
                 f"Prior manifest {path} is invalid: files entries must include string "
-                "canonical_id and output_path values."
+                "canonical_id and output_path values. Fix or remove the manifest and try again."
             )
 
         if canonical_id in entries_by_id:
             raise RuntimeError(
-                f"Prior manifest {path} is invalid: duplicate canonical_id {canonical_id!r}."
+                f"Prior manifest {path} is invalid: duplicate canonical_id {canonical_id!r}. "
+                "Fix or remove the manifest and try again."
             )
         if output_path in seen_output_paths:
             raise RuntimeError(
-                f"Prior manifest {path} is invalid: duplicate output_path {output_path!r}."
+                f"Prior manifest {path} is invalid: duplicate output_path {output_path!r}. "
+                "Fix or remove the manifest and try again."
             )
 
         entries_by_id[canonical_id] = output_path

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -28,6 +28,21 @@ def _run_cli(tmp_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
     )
 
 
+def test_top_level_help_introduces_shared_cli_flow(tmp_path: Path) -> None:
+    result = _run_cli(tmp_path, "--help")
+
+    assert result.returncode == 0, result.stderr
+    assert "Normalize knowledge sources into a shared local artifact layout." in result.stdout
+    assert "plans a markdown artifact under pages/ plus manifest.json" in result.stdout
+    assert "Normalize Confluence content into shared artifacts." in result.stdout
+    assert "Normalize a local text file into shared artifacts." in result.stdout
+    assert (
+        "Start with --dry-run to preview the source, artifact path, manifest path,"
+        in result.stdout
+    )
+    assert "Re-run without --dry-run to write the same artifact layout" in result.stdout
+
+
 def test_local_files_cli_smoke_uses_installed_entrypoint_with_readme_style_args(
     tmp_path: Path,
 ) -> None:
@@ -48,6 +63,10 @@ def test_local_files_cli_smoke_uses_installed_entrypoint_with_readme_style_args(
     assert result.returncode == 0, result.stderr
     assert "Local files adapter invoked" in result.stdout
     assert "run_mode: write" in result.stdout
+    assert "Plan: Local files run" in result.stdout
+    assert f"resolved_file_path: {source_file.resolve()}" in result.stdout
+    assert f"source_url: {source_file.resolve().as_uri()}" in result.stdout
+    assert f"artifact_path: {tmp_path / 'artifacts' / 'pages' / 'today.md'}" in result.stdout
     assert "Wrote:" in result.stdout
     assert "Summary: wrote 1, skipped 0" in result.stdout
     assert "Manifest:" in result.stdout
@@ -86,15 +105,12 @@ def test_local_files_cli_help_includes_first_run_guidance(tmp_path: Path) -> Non
     result = _run_cli(tmp_path, "local_files", "--help")
 
     assert result.returncode == 0, result.stderr
-    assert (
-        "Normalize a single local UTF-8 text file into local markdown artifacts."
-        in result.stdout
-    )
+    assert "Normalize one local UTF-8 text file into the shared artifact layout." in result.stdout
     assert "--file-path FILE" in result.stdout
-    assert "Local UTF-8 text file to normalize." in result.stdout
+    assert "Relative paths resolve" in result.stdout
     assert "--output-dir DIR" in result.stdout
-    assert "Directory to write normalized local artifacts." in result.stdout
-    assert "Preview the same output paths and write summary" in result.stdout
+    assert "Directory where pages/ and manifest.json are written." in result.stdout
+    assert "resolved file path, artifact path, manifest path" in result.stdout
     assert "without writing files." in result.stdout
     assert "knowledge-adapters local_files" in result.stdout
     assert "--dry-run" in result.stdout
@@ -120,6 +136,9 @@ def test_confluence_cli_smoke_uses_installed_entrypoint_with_default_stub_client
     assert "content_source: scaffolded page content" in result.stdout
     assert "fetch_scope: page" in result.stdout
     assert "run_mode: write" in result.stdout
+    assert "Plan: Confluence run" in result.stdout
+    assert "resolved_page_id: 12345" in result.stdout
+    assert "artifact_path:" in result.stdout
     assert "auth_method:" not in result.stdout
     assert "Wrote:" in result.stdout
     assert "Summary: wrote 1, skipped 0" in result.stdout
@@ -170,13 +189,14 @@ def test_confluence_help_lists_supported_auth_methods_and_examples(
     assert "client-cert-env" in result.stdout
     assert "--debug" in result.stdout
     assert "request debug details" in result.stdout
-    assert "real-client" in result.stdout
-    assert "same output paths and write/skip summary a write run would use" in result.stdout
+    assert "artifact layout and reporting" in result.stdout
+    assert "preview resolved page IDs, artifact paths, and write/skip decisions" in result.stdout
     assert "same resolve, plan, and write flow" in result.stdout
     assert "'real' fetches from" in result.stdout
     assert "using --auth-method" in result.stdout
-    assert "contract-tested live Confluence fetches" in result.stdout
-    assert "validated and normalized to canonical" in result.stdout
-    assert "pageId form for output and manifests" in result.stdout
+    assert "contract-tested live fetches" in result.stdout
+    assert "The CLI resolves either input into one canonical page" in result.stdout
+    assert "source URL for artifact and manifest reporting" in result.stdout
+    assert "artifact and manifest reporting" in result.stdout
     assert "CONFLUENCE_BEARER_TOKEN=... knowledge-adapters confluence" in result.stdout
     assert "--dry-run" in result.stdout

--- a/tests/test_confluence_incremental_contract.py
+++ b/tests/test_confluence_incremental_contract.py
@@ -683,4 +683,4 @@ def test_incremental_dry_run_summary_reports_mixed_write_and_skip_counts(
 
     captured = capsys.readouterr()
     assert "Summary: would write 2, would skip 2" in captured.out
-    assert "4 unique pages" in captured.out
+    assert "unique_pages: 4" in captured.out

--- a/tests/test_confluence_real_client_contract.py
+++ b/tests/test_confluence_real_client_contract.py
@@ -235,6 +235,11 @@ def test_stub_and_real_single_page_write_runs_share_the_same_cli_shape(
     assert "content_source: scaffolded page content" in stub_output
     assert "fetch_scope: page" in stub_output
     assert "run_mode: write" in stub_output
+    assert "Plan: Confluence run" in stub_output
+    assert "resolved_page_id: 12345" in stub_output
+    assert f"artifact_path: {stub_output_dir / 'pages' / '12345.md'}" in stub_output
+    assert f"manifest_path: {stub_output_dir / 'manifest.json'}" in stub_output
+    assert "action: write" in stub_output
     assert "auth_method:" not in stub_output
     assert f"Manifest: {stub_output_dir / 'manifest.json'}" in stub_output
     assert "Summary: wrote 1, skipped 0" in stub_output
@@ -263,6 +268,11 @@ def test_stub_and_real_single_page_write_runs_share_the_same_cli_shape(
     assert "content_source: live Confluence content" in real_output
     assert "fetch_scope: page" in real_output
     assert "run_mode: write" in real_output
+    assert "Plan: Confluence run" in real_output
+    assert "resolved_page_id: 12345" in real_output
+    assert f"artifact_path: {real_output_dir / 'pages' / '12345.md'}" in real_output
+    assert f"manifest_path: {real_output_dir / 'manifest.json'}" in real_output
+    assert "action: write" in real_output
     assert "auth_method: bearer-env" in real_output
     assert f"Manifest: {real_output_dir / 'manifest.json'}" in real_output
     assert "Summary: wrote 1, skipped 0" in real_output
@@ -286,6 +296,7 @@ def test_stub_and_real_single_page_dry_runs_share_the_same_plan_shape(
     assert "run_mode: dry-run" in stub_output
     assert "Plan: Confluence run" in stub_output
     assert "resolved_page_id: 12345" in stub_output
+    assert f"artifact_path: {stub_output_dir / 'pages' / '12345.md'}" in stub_output
     assert f"manifest_path: {stub_output_dir / 'manifest.json'}" in stub_output
     assert "action: would write" in stub_output
     assert "Summary: would write 1, would skip 0" in stub_output
@@ -316,6 +327,7 @@ def test_stub_and_real_single_page_dry_runs_share_the_same_plan_shape(
     assert "auth_method: bearer-env" in real_output
     assert "Plan: Confluence run" in real_output
     assert "resolved_page_id: 12345" in real_output
+    assert f"artifact_path: {real_output_dir / 'pages' / '12345.md'}" in real_output
     assert f"manifest_path: {real_output_dir / 'manifest.json'}" in real_output
     assert "action: would write" in real_output
     assert "Summary: would write 1, would skip 0" in real_output

--- a/tests/test_confluence_recursive_contract.py
+++ b/tests/test_confluence_recursive_contract.py
@@ -276,7 +276,7 @@ def test_recursive_dry_run_reports_unique_planned_outputs_without_writing(
 
     for page_id in ["100", "200", "300", "205", "210"]:
         assert output.count(f"{output_dir / 'pages' / f'{page_id}.md'}") == 1
-    assert output.count("5 unique pages") == 1
+    assert output.count("unique_pages: 5") == 1
 
 
 def test_recursive_deeper_tree_excludes_descendants_beyond_max_depth(

--- a/tests/test_local_files.py
+++ b/tests/test_local_files.py
@@ -121,8 +121,9 @@ def test_local_files_cli_dry_run_reports_output_without_writing(
     assert "Local files adapter invoked" in captured.out
     assert "run_mode: dry-run" in captured.out
     assert "Plan: Local files run" in captured.out
-    assert f"source_path: {source_file.resolve()}" in captured.out
-    assert f"output_path: {output_path}" in captured.out
+    assert f"resolved_file_path: {source_file.resolve()}" in captured.out
+    assert f"source_url: {source_file.resolve().as_uri()}" in captured.out
+    assert f"artifact_path: {output_path}" in captured.out
     assert f"manifest_path: {output_dir / 'manifest.json'}" in captured.out
     assert "action: would write" in captured.out
     assert "Summary: would write 1, would skip 0" in captured.out

--- a/tests/test_normalize_writer.py
+++ b/tests/test_normalize_writer.py
@@ -146,7 +146,7 @@ def test_confluence_cli_dry_run_reports_output_without_writing(
     assert "Plan: Confluence run" in captured.out
     assert "resolved_page_id: 12345" in captured.out
     assert "source_url: https://example.com/wiki/pages/viewpage.action?pageId=12345" in captured.out
-    assert f"output_path: {output_path}" in captured.out
+    assert f"artifact_path: {output_path}" in captured.out
     assert f"manifest_path: {output_dir / 'manifest.json'}" in captured.out
     assert "action: would write" in captured.out
     assert "Summary: would write 1, would skip 0" in captured.out
@@ -177,7 +177,7 @@ def test_confluence_cli_dry_run_reports_same_resolved_target_details_for_full_ur
     captured = capsys.readouterr()
     assert "resolved_page_id: 12345" in captured.out
     assert "source_url: https://example.com/wiki/pages/viewpage.action?pageId=12345" in captured.out
-    assert f"output_path: {output_dir / 'pages' / '12345.md'}" in captured.out
+    assert f"artifact_path: {output_dir / 'pages' / '12345.md'}" in captured.out
     assert (
         "- source_url: https://example.com/wiki/pages/viewpage.action?pageId=12345"
         in captured.out
@@ -248,7 +248,7 @@ def test_confluence_cli_full_flow_keeps_dry_run_and_write_artifacts_in_sync(
     assert "Plan: Confluence run" in dry_run_output
     assert "resolved_page_id: 12345" in dry_run_output
     assert f"source_url: {canonical_source_url}" in dry_run_output
-    assert f"output_path: {page_output_path}" in dry_run_output
+    assert f"artifact_path: {page_output_path}" in dry_run_output
     assert f"manifest_path: {manifest_output_path}" in dry_run_output
     assert "action: would write" in dry_run_output
     assert "Summary: would write 1, would skip 0" in dry_run_output
@@ -274,6 +274,11 @@ def test_confluence_cli_full_flow_keeps_dry_run_and_write_artifacts_in_sync(
     assert "content_source: scaffolded page content" in write_output
     assert "fetch_scope: page" in write_output
     assert "run_mode: write" in write_output
+    assert "Plan: Confluence run" in write_output
+    assert "resolved_page_id: 12345" in write_output
+    assert f"artifact_path: {page_output_path}" in write_output
+    assert f"manifest_path: {manifest_output_path}" in write_output
+    assert "action: write" in write_output
     assert f"Wrote: {page_output_path}" in write_output
     assert "Summary: wrote 1, skipped 0" in write_output
     assert f"Manifest: {manifest_output_path}" in write_output
@@ -343,6 +348,7 @@ def test_confluence_cli_tree_dry_run_reports_manifest_path(
     captured = capsys.readouterr()
     assert f"manifest_path: {output_dir / 'manifest.json'}" in captured.out
     assert "Plan: Confluence run" in captured.out
+    assert "unique_pages: 1" in captured.out
     assert "Summary: would write 1, would skip 0" in captured.out
 
 
@@ -519,3 +525,30 @@ def test_confluence_cli_rejects_negative_max_depth(
     assert (
         "knowledge-adapters confluence: error: --max-depth must be greater than or equal to 0.\n"
     ) in captured.err
+
+
+def test_confluence_cli_reports_invalid_output_dir(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    output_path = tmp_path / "artifacts.txt"
+    output_path.write_text("not a directory\n", encoding="utf-8")
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(
+            [
+                "confluence",
+                "--base-url",
+                "https://example.com/wiki",
+                "--target",
+                "12345",
+                "--output-dir",
+                str(output_path),
+            ]
+        )
+
+    assert exc_info.value.code == 2
+
+    captured = capsys.readouterr()
+    assert f"Output path is not a directory: {output_path}." in captured.err
+    assert "Verify --output-dir and use a directory path." in captured.err


### PR DESCRIPTION
Summary
- align top-level and adapter help text around one shared run model
- make single-page and local_files runs report the same invocation, plan, action, and summary shape with clearer artifact and manifest paths
- tighten README onboarding, Confluence adapter docs, and actionable output/manifest error guidance

Testing
- make check
- ran representative local_files dry-run and write commands
- ran representative confluence dry-run and write commands