### PR TITLE
chore: clarify confluence tree-mode first run

### DIFF
--- a/adapters/confluence/README.md
+++ b/adapters/confluence/README.md
@@ -20,6 +20,21 @@ The Confluence-specific difference is that dry runs and write runs may report
 `write` or `skip` for a page when an existing manifest entry and on-disk
 artifact already match the planned output.
 
+## Tree Mode First Run
+
+- `--tree` switches the run from one resolved page to the resolved root page
+  plus any discovered descendants.
+- `--max-depth` counts descendant depth from that root page: `0` includes only
+  the root page, `1` adds direct children, and `2` adds grandchildren.
+- In `--dry-run`, tree mode previews the resolved root page ID, planned
+  `manifest.json` path, unique page count, and one `would write` or `would skip`
+  line per planned page. It does not write files.
+- In write mode, tree mode performs the same planned writes and skips, then
+  writes `manifest.json`.
+- With the default `stub` client, tree mode still plans only the root page
+  because no child pages are discovered. Multi-page tree runs require
+  `--client-mode real` or a monkeypatched client that returns child page IDs.
+
 ## Current Behavior
 
 Out of the box, the default Confluence CLI:

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -30,6 +30,13 @@ CONFLUENCE_HELP_EXAMPLES = """Examples:
   knowledge-adapters confluence \\
     --base-url https://example.com/wiki \\
     --target 12345 \\
+    --output-dir ./artifacts \\
+    --tree \\
+    --max-depth 1 \\
+    --dry-run
+  knowledge-adapters confluence \\
+    --base-url https://example.com/wiki \\
+    --target 12345 \\
     --output-dir ./artifacts
   CONFLUENCE_BEARER_TOKEN=... knowledge-adapters confluence \\
     --client-mode real \\
@@ -113,12 +120,15 @@ def build_parser() -> argparse.ArgumentParser:
         "confluence",
         help="Normalize Confluence content into shared artifacts.",
         description=(
-            "Normalize a Confluence page or page tree into the shared artifact "
-            "layout. Stub and real modes keep the same resolve, plan, and write "
-            "flow. Use --dry-run to preview resolved page IDs, artifact paths, and "
-            "write/skip decisions before writing. The default stub mode uses "
-            "scaffolded content without contacting Confluence. Use --client-mode "
-            "real for contract-tested live fetches."
+            "Normalize a Confluence page or, with --tree, a page tree into the "
+            "shared artifact layout. Stub and real modes keep the same resolve, "
+            "plan, and write flow. Use --dry-run to preview resolved page IDs, "
+            "planned artifact paths, manifest path, and write/skip decisions "
+            "before writing. In tree mode, dry-run previews the root plus "
+            "discovered descendants up to --max-depth, and write mode applies that "
+            "same plan. The default stub mode uses scaffolded content without "
+            "contacting Confluence. Use --client-mode real for contract-tested "
+            "live fetches."
         ),
         epilog=CONFLUENCE_HELP_EXAMPLES,
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -183,13 +193,19 @@ def build_parser() -> argparse.ArgumentParser:
     confluence_parser.add_argument(
         "--tree",
         action="store_true",
-        help="Fetch a page tree instead of a single page.",
+        help=(
+            "Traverse the resolved root page plus discovered descendants instead "
+            "of only one page."
+        ),
     )
     confluence_parser.add_argument(
         "--max-depth",
         type=int,
         default=0,
-        help="Maximum recursion depth for tree mode. 0 means single page only.",
+        help=(
+            "Maximum descendant depth for --tree. 0 includes only the resolved "
+            "root page, 1 adds direct children. Ignored unless --tree is set."
+        ),
     )
 
     local_files_parser = subparsers.add_parser(

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -190,7 +190,10 @@ def test_confluence_help_lists_supported_auth_methods_and_examples(
     assert "--debug" in result.stdout
     assert "request debug details" in result.stdout
     assert "artifact layout and reporting" in result.stdout
-    assert "preview resolved page IDs, artifact paths, and write/skip decisions" in result.stdout
+    assert "page or, with --tree, a page tree" in result.stdout
+    assert "planned artifact paths, manifest path, and write/skip decisions" in result.stdout
+    assert "In tree mode, dry-run previews the root plus discovered descendants" in result.stdout
+    assert "write mode applies that same plan" in result.stdout
     assert "same resolve, plan, and write flow" in result.stdout
     assert "'real' fetches from" in result.stdout
     assert "using --auth-method" in result.stdout
@@ -198,5 +201,10 @@ def test_confluence_help_lists_supported_auth_methods_and_examples(
     assert "The CLI resolves either input into one canonical page" in result.stdout
     assert "source URL for artifact and manifest reporting" in result.stdout
     assert "artifact and manifest reporting" in result.stdout
+    assert "Traverse the resolved root page plus discovered" in result.stdout
+    assert "descendants instead of only one page." in result.stdout
+    assert "Maximum descendant depth for --tree." in result.stdout
+    assert "Ignored unless --tree is set." in result.stdout
     assert "CONFLUENCE_BEARER_TOKEN=... knowledge-adapters confluence" in result.stdout
+    assert "--max-depth 1" in result.stdout
     assert "--dry-run" in result.stdout

--- a/tests/test_normalize_writer.py
+++ b/tests/test_normalize_writer.py
@@ -318,6 +318,8 @@ def test_confluence_cli_tree_run_reports_manifest_path(
     assert exit_code == 0
 
     captured = capsys.readouterr()
+    assert "fetch_scope: tree" in captured.out
+    assert "max_depth: 0" in captured.out
     assert f"Manifest: {output_dir / 'manifest.json'}" in captured.out
 
 
@@ -346,6 +348,8 @@ def test_confluence_cli_tree_dry_run_reports_manifest_path(
     assert exit_code == 0
 
     captured = capsys.readouterr()
+    assert "fetch_scope: tree" in captured.out
+    assert "max_depth: 0" in captured.out
     assert f"manifest_path: {output_dir / 'manifest.json'}" in captured.out
     assert "Plan: Confluence run" in captured.out
     assert "unique_pages: 1" in captured.out


### PR DESCRIPTION
Summary
- tighten Confluence tree-mode help text so first-time users can understand what `--tree` does and how `--max-depth` is applied
- add a tree-mode dry-run example and clarify that dry-run previews the planned tree run while write mode applies that same plan
- add adapter-local documentation for tree-mode first runs and focused assertions for tree help and output wording

Testing
- make check
- ./.venv/bin/knowledge-adapters confluence --help