### PR TITLE
fix: clarify local_files empty and UTF-8 handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ This resolves the file path, previews `artifacts/pages/today.md`, previews
 `artifacts/manifest.json`, and prints the normalized markdown without writing
 files.
 
+`local_files` expects one UTF-8 text file at a time. Empty UTF-8 files are
+allowed and still produce metadata plus an empty `Content` section. Files that
+are not valid UTF-8 text fail fast with guidance to re-save the input as UTF-8.
+
 Minimal Confluence first run (default `stub` mode):
 
 ```bash

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -197,10 +197,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="Normalize a local text file into shared artifacts.",
         description=(
             "Normalize one local UTF-8 text file into the shared artifact layout. "
-            "Use --dry-run to preview the resolved file path, artifact path, "
-            "manifest path, and normalized markdown before writing. Unlike "
-            "Confluence, local_files always plans one write and does not use "
-            "manifest-based skip logic."
+            "Empty UTF-8 files are allowed and produce an empty content section. "
+            "Files that are not valid UTF-8 text are rejected. Use --dry-run to "
+            "preview the resolved file path, artifact path, manifest path, and "
+            "normalized markdown before writing. Unlike Confluence, local_files "
+            "always plans one write and does not use manifest-based skip logic."
         ),
         epilog=LOCAL_FILES_HELP_EXAMPLES,
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -209,7 +210,10 @@ def build_parser() -> argparse.ArgumentParser:
         "--file-path",
         required=True,
         metavar="FILE",
-        help="Local UTF-8 text file to normalize. Relative paths resolve from the cwd.",
+        help=(
+            "Single local UTF-8 text file to normalize. Empty files are allowed. "
+            "Relative paths resolve from the cwd."
+        ),
     )
     local_files_parser.add_argument(
         "--output-dir",
@@ -630,6 +634,14 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"  source_url: {page.get('source_url', '')}")
         print(f"  artifact_path: {output_path}")
         print(f"  manifest_path: {manifest_output_path}")
+        content = str(page.get("content", ""))
+        if content:
+            print("  content_status: UTF-8 text with content")
+        else:
+            print(
+                "  content_status: empty UTF-8 file; output will contain metadata "
+                "and an empty content section"
+            )
         print(f"  action: {'would write' if local_files_config.dry_run else 'write'}")
         if local_files_config.dry_run:
             print("  Summary: would write 1, would skip 0")

--- a/src/knowledge_adapters/local_files/client.py
+++ b/src/knowledge_adapters/local_files/client.py
@@ -11,7 +11,10 @@ def fetch_file(file_path: str) -> dict[str, object]:
     if not input_path.exists():
         raise ValueError(f"File does not exist: {input_path}. Verify --file-path and try again.")
     if not input_path.is_file():
-        raise ValueError(f"Path is not a regular file: {input_path}. Use a UTF-8 text file.")
+        raise ValueError(
+            f"Path is not a regular file: {input_path}. "
+            "local_files reads one UTF-8 text file at a time; directories are not supported."
+        )
 
     path = input_path.resolve()
     try:
@@ -22,7 +25,9 @@ def fetch_file(file_path: str) -> dict[str, object]:
         ) from exc
     except UnicodeDecodeError as exc:
         raise ValueError(
-            f"File is not readable as UTF-8 text: {path}. Use a UTF-8 text file."
+            f"File is not valid UTF-8 text: {path}. "
+            "local_files reads one UTF-8 text file at a time and does not support binary "
+            "or other encoded input. Re-save the file as UTF-8 text and try again."
         ) from exc
     except OSError as exc:
         raise ValueError(f"Could not read file: {path}. Verify --file-path and try again.") from exc

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -106,7 +106,12 @@ def test_local_files_cli_help_includes_first_run_guidance(tmp_path: Path) -> Non
 
     assert result.returncode == 0, result.stderr
     assert "Normalize one local UTF-8 text file into the shared artifact layout." in result.stdout
+    assert "Empty UTF-8 files are allowed" in result.stdout
+    assert "Files that are not valid UTF-8 text are rejected." in result.stdout
     assert "--file-path FILE" in result.stdout
+    assert "Single local UTF-8 text file to normalize." in result.stdout
+    assert "Empty files are" in result.stdout
+    assert "allowed. Relative paths resolve" in result.stdout
     assert "Relative paths resolve" in result.stdout
     assert "--output-dir DIR" in result.stdout
     assert "Directory where pages/ and manifest.json are written." in result.stdout

--- a/tests/test_local_files.py
+++ b/tests/test_local_files.py
@@ -125,6 +125,7 @@ def test_local_files_cli_dry_run_reports_output_without_writing(
     assert f"source_url: {source_file.resolve().as_uri()}" in captured.out
     assert f"artifact_path: {output_path}" in captured.out
     assert f"manifest_path: {output_dir / 'manifest.json'}" in captured.out
+    assert "content_status: UTF-8 text with content" in captured.out
     assert "action: would write" in captured.out
     assert "Summary: would write 1, would skip 0" in captured.out
     assert "Line one." in captured.out
@@ -195,7 +196,79 @@ def test_local_files_cli_reports_non_file_input_path(
     assert exc_info.value.code == 2
     captured = capsys.readouterr()
     assert f"Path is not a regular file: {source_dir}." in captured.err
-    assert "Use a UTF-8 text file." in captured.err
+    assert "local_files reads one UTF-8 text file at a time" in captured.err
+    assert "directories are not supported." in captured.err
+
+
+def test_local_files_cli_writes_empty_utf8_file_with_empty_content_section(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    source_file = tmp_path / "empty.txt"
+    source_file.write_text("", encoding="utf-8")
+    output_dir = tmp_path / "out"
+
+    exit_code = main(
+        [
+            "local_files",
+            "--file-path",
+            str(source_file),
+            "--output-dir",
+            str(output_dir),
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert (
+        "content_status: empty UTF-8 file; output will contain metadata and an empty "
+        "content section"
+    ) in captured.out
+
+    output_path = output_dir / "pages" / "empty.md"
+    assert output_path.read_text(encoding="utf-8") == (
+        f"""# empty.txt
+
+## Metadata
+- source: local_files
+- canonical_id: {source_file.resolve()}
+- parent_id:
+- source_url: {source_file.resolve().as_uri()}
+- fetched_at:
+- updated_at:
+- adapter: local_files
+
+## Content
+
+
+"""
+    )
+
+
+def test_local_files_cli_reports_non_utf8_input_with_actionable_error(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    source_file = tmp_path / "notes.txt"
+    source_file.write_bytes(b"\xff\xfe\x00not-utf8")
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(
+            [
+                "local_files",
+                "--file-path",
+                str(source_file),
+                "--output-dir",
+                str(tmp_path / "out"),
+            ]
+        )
+
+    assert exc_info.value.code == 2
+    captured = capsys.readouterr()
+    assert f"File is not valid UTF-8 text: {source_file.resolve()}." in captured.err
+    assert "local_files reads one UTF-8 text file at a time" in captured.err
+    assert "does not support binary or other encoded input." in captured.err
+    assert "Re-save the file as UTF-8 text and try again." in captured.err
 
 
 def test_local_files_cli_reports_invalid_output_dir(


### PR DESCRIPTION
Summary
- clarify local_files help and README wording so first-time users know empty UTF-8 files are allowed and non-UTF-8 input is rejected
- surface empty-file expectations in local_files plan output without broadening adapter scope
- improve non-file and invalid UTF-8 errors with local_files-specific guidance and add focused coverage for both cases

Testing
- make check
- .venv/bin/knowledge-adapters local_files --file-path /tmp/ka-empty-check/empty.txt --output-dir /tmp/ka-empty-check/out --dry-run
- .venv/bin/knowledge-adapters local_files --file-path /tmp/ka-nonutf8-check/not-utf8.txt --output-dir /tmp/ka-nonutf8-check/out

Objective
- Make empty-file and non-UTF-8 local_files behavior clearer for first-time users without expanding supported scope.

Scope
- local_files user-facing CLI/help/error clarity
- focused local_files tests
- minimal README wording for first-run expectations

Validation
- make check
- verified empty-file dry-run reports an empty content section
- verified non-UTF-8 input fails with actionable UTF-8 guidance

Risks
- user-facing local_files output now includes a new content_status line, so any downstream consumers that scrape exact CLI text may need to adjust

Recommendation
- Merge as-is; this improves clarity in the supported local_files path without changing adapter capabilities.