### PR TITLE
docs: clarify Confluence first-run onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,10 @@ files.
 allowed and still produce metadata plus an empty `Content` section. Files that
 are not valid UTF-8 text fail fast with guidance to re-save the input as UTF-8.
 
-Minimal Confluence first run (default `stub` mode):
+Recommended Confluence first run:
+
+1. Start with the default `stub` client plus `--dry-run` so you can confirm the
+   resolve and write plan without credentials or live Confluence access.
 
 ```bash
 knowledge-adapters confluence \
@@ -71,19 +74,15 @@ This resolves page `12345`, previews `artifacts/pages/12345.md`, previews
 `artifacts/manifest.json`, and prints the normalized markdown without
 contacting a live Confluence instance.
 
-For Confluence runs, `--target` accepts either a numeric page ID or a full page
-URL under `--base-url`. Full page URLs are validated and normalized to canonical
+`--target` accepts either a numeric page ID or a full page URL under
+`--base-url`. Full page URLs are validated and normalized to canonical
 `pageId` form for artifact and manifest reporting.
 
-Confluence is also the adapter that currently uses manifest-based skip logic, so
-its dry runs and write runs may report `write` or `skip` for a page when an
-existing artifact already matches the planned output. `local_files` always plans
-one write.
+2. If that dry run looks right, rerun the same command without `--dry-run` to
+   write the stub artifact and `manifest.json`.
 
-When the dry run looks right, rerun the same command without `--dry-run` to
-write the artifact and manifest.
-
-Next step for Confluence: opt into real mode with bearer auth:
+3. When you want live Confluence content, keep the same command shape and opt
+   into `--client-mode real` plus auth:
 
 - `bearer-env` -> `CONFLUENCE_BEARER_TOKEN`
 - `client-cert-env` -> `CONFLUENCE_CLIENT_CERT_FILE` and optional `CONFLUENCE_CLIENT_KEY_FILE`
@@ -94,8 +93,17 @@ CONFLUENCE_BEARER_TOKEN=... knowledge-adapters confluence \
   --auth-method bearer-env \
   --base-url https://example.com/wiki \
   --target 12345 \
-  --output-dir ./artifacts
+  --output-dir ./artifacts \
+  --dry-run
 ```
+
+If that real-mode dry run looks right, rerun it without `--dry-run` to write
+the live-fetched artifact and manifest.
+
+Confluence is also the adapter that currently uses manifest-based skip logic, so
+its dry runs and write runs may report `write` or `skip` for a page when an
+existing artifact already matches the planned output. `local_files` always plans
+one write.
 
 ---
 

--- a/adapters/confluence/README.md
+++ b/adapters/confluence/README.md
@@ -20,7 +20,42 @@ The Confluence-specific difference is that dry runs and write runs may report
 `write` or `skip` for a page when an existing manifest entry and on-disk
 artifact already match the planned output.
 
-## Tree Mode First Run
+## Recommended First Run
+
+Start with one page in the default `stub` mode before you try tree mode or live
+Confluence fetches:
+
+```bash
+knowledge-adapters confluence \
+  --base-url https://example.com/wiki \
+  --target 12345 \
+  --output-dir ./artifacts \
+  --dry-run
+```
+
+That first run resolves the target into a canonical page ID, previews
+`pages/12345.md`, previews `manifest.json`, and prints normalized markdown
+without contacting a live Confluence instance or requiring credentials.
+
+`--target` accepts either a numeric page ID or a full page URL under
+`--base-url`. Full page URLs are validated and normalized to canonical
+`pageId` form for dry-run and write reporting.
+
+If that dry run looks right, rerun the same command without `--dry-run` to
+write the stub artifact and `manifest.json`.
+
+When you want live Confluence content, keep the same CLI flow and add
+`--client-mode real` plus an auth method:
+
+- `bearer-env` via `CONFLUENCE_BEARER_TOKEN`
+- `client-cert-env` via `CONFLUENCE_CLIENT_CERT_FILE` plus optional
+  `CONFLUENCE_CLIENT_KEY_FILE`
+
+Tree mode is best treated as a follow-on step. With the default `stub` client,
+`--tree` still plans only the resolved root page because no child pages are
+discovered.
+
+## Tree Mode After First Run
 
 - `--tree` switches the run from one resolved page to the resolved root page
   plus any discovered descendants.


### PR DESCRIPTION
Summary
- make the shared README walk installed-CLI users through Confluence stub dry-run, stub write, and optional real mode in order
- add adapter-local first-run guidance that explains when to use page IDs or full URLs and when to move on to tree mode
- keep the wording aligned with current Confluence behavior, including stub-mode no-network runs and manifest-based write/skip reporting

Testing
- make check