### PR TITLE
docs: clarify local_files first-run wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,18 @@ knowledge-adapters local_files \
   --dry-run
 ```
 
+Use any existing UTF-8 text file for `--file-path`. Relative paths resolve from
+the directory where you run `knowledge-adapters`.
+
 This resolves the file path, previews `artifacts/pages/today.md`, previews
 `artifacts/manifest.json`, and prints the normalized markdown without writing
 files.
 
-`local_files` expects one UTF-8 text file at a time. Empty UTF-8 files are
-allowed and still produce metadata plus an empty `Content` section. Files that
-are not valid UTF-8 text fail fast with guidance to re-save the input as UTF-8.
+`local_files` expects one existing UTF-8 text file at a time; directories are
+not supported. Empty UTF-8 files are allowed and still produce metadata plus an
+empty `Content` section. Files that are not valid UTF-8 text, including binary
+files or files saved with another encoding, fail fast with guidance to re-save
+the input as UTF-8.
 
 Minimal Confluence first run (default `stub` mode):
 
@@ -294,6 +299,9 @@ knowledge-adapters local_files \
   --output-dir ./artifacts \
   --dry-run
 ```
+
+`--file-path` should point to one existing UTF-8 text file. Relative paths
+resolve from the current working directory, and directories are not supported.
 
 Write the same local file artifact after reviewing the plan:
 

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -212,12 +212,13 @@ def build_parser() -> argparse.ArgumentParser:
         "local_files",
         help="Normalize a local text file into shared artifacts.",
         description=(
-            "Normalize one local UTF-8 text file into the shared artifact layout. "
+            "Normalize one existing UTF-8 text file into the shared artifact layout. "
             "Empty UTF-8 files are allowed and produce an empty content section. "
-            "Files that are not valid UTF-8 text are rejected. Use --dry-run to "
-            "preview the resolved file path, artifact path, manifest path, and "
-            "normalized markdown before writing. Unlike Confluence, local_files "
-            "always plans one write and does not use manifest-based skip logic."
+            "Files that are not valid UTF-8 text are rejected. Directories are "
+            "not supported. Use --dry-run to preview the resolved file path, "
+            "artifact path, manifest path, and normalized markdown before "
+            "writing. Unlike Confluence, local_files always plans one write and "
+            "does not use manifest-based skip logic."
         ),
         epilog=LOCAL_FILES_HELP_EXAMPLES,
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -227,8 +228,9 @@ def build_parser() -> argparse.ArgumentParser:
         required=True,
         metavar="FILE",
         help=(
-            "Single local UTF-8 text file to normalize. Empty files are allowed. "
-            "Relative paths resolve from the cwd."
+            "Path to one existing local UTF-8 text file. Empty files are "
+            "allowed; directories are not supported. Relative paths resolve "
+            "from the cwd."
         ),
     )
     local_files_parser.add_argument(

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -105,14 +105,20 @@ def test_local_files_cli_help_includes_first_run_guidance(tmp_path: Path) -> Non
     result = _run_cli(tmp_path, "local_files", "--help")
 
     assert result.returncode == 0, result.stderr
-    assert "Normalize one local UTF-8 text file into the shared artifact layout." in result.stdout
+    assert (
+        "Normalize one existing UTF-8 text file into the shared artifact layout."
+        in result.stdout
+    )
     assert "Empty UTF-8 files are allowed" in result.stdout
     assert "Files that are not valid UTF-8 text are rejected." in result.stdout
+    assert "Directories are not supported." in result.stdout
     assert "--file-path FILE" in result.stdout
-    assert "Single local UTF-8 text file to normalize." in result.stdout
-    assert "Empty files are" in result.stdout
-    assert "allowed. Relative paths resolve" in result.stdout
-    assert "Relative paths resolve" in result.stdout
+    assert "Path to one existing local UTF-8 text file." in result.stdout
+    assert "Empty files" in result.stdout
+    assert "are allowed; directories are not supported." in result.stdout
+    assert "directories are not supported." in result.stdout
+    assert "Relative paths" in result.stdout
+    assert "resolve from the cwd." in result.stdout
     assert "--output-dir DIR" in result.stdout
     assert "Directory where pages/ and manifest.json are written." in result.stdout
     assert "resolved file path, artifact path, manifest path" in result.stdout


### PR DESCRIPTION
Summary
- clarify the installed-CLI README path for local_files by calling out existing UTF-8 files, cwd-relative paths, and directory limits
- align local_files help text with the current empty-file, UTF-8, and single-file scope
- update smoke coverage so the clarified onboarding copy stays truthful

Testing
- make check