### PR TITLE
docs: tighten local_files first-run copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,18 +49,22 @@ knowledge-adapters local_files \
   --dry-run
 ```
 
-Use any existing UTF-8 text file for `--file-path`. Relative paths resolve from
-the directory where you run `knowledge-adapters`.
+Use any existing UTF-8 text file for `--file-path`; relative paths resolve from
+your current working directory.
 
 This resolves the file path, previews `artifacts/pages/today.md`, previews
 `artifacts/manifest.json`, and prints the normalized markdown without writing
 files.
 
-`local_files` expects one existing UTF-8 text file at a time; directories are
-not supported. Empty UTF-8 files are allowed and still produce metadata plus an
-empty `Content` section. Files that are not valid UTF-8 text, including binary
-files or files saved with another encoding, fail fast with guidance to re-save
-the input as UTF-8.
+`local_files` accepts:
+
+- one existing UTF-8 text file per run
+- empty UTF-8 files, which still produce metadata plus an empty `Content`
+  section
+- directories are not supported
+
+Files that are not valid UTF-8 text, including binary files or files saved with
+another encoding, fail fast with guidance to re-save the input as UTF-8.
 
 Recommended Confluence first run:
 


### PR DESCRIPTION
Summary
- tighten the local_files --file-path wording in the shared installed-CLI first-run section
- reorder the local_files constraints into a short scan-friendly list while preserving current behavior and examples

Testing
- make check