### PR TITLE
docs: tighten confluence cli help wording

### DIFF
--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -118,17 +118,21 @@ def build_parser() -> argparse.ArgumentParser:
 
     confluence_parser = subparsers.add_parser(
         "confluence",
-        help="Normalize Confluence content into shared artifacts.",
+        help=(
+            "Normalize Confluence content into shared artifacts. "
+            "Start with one page or use --tree to include descendants."
+        ),
         description=(
             "Normalize a Confluence page or, with --tree, a page tree into the "
-            "shared artifact layout. Stub and real modes keep the same resolve, "
+            "shared artifact layout. Start with one page, then add --tree when "
+            "you want descendants. Stub and real modes keep the same resolve, "
             "plan, and write flow. Use --dry-run to preview resolved page IDs, "
             "planned artifact paths, manifest path, and write/skip decisions "
             "before writing. In tree mode, dry-run previews the root plus "
-            "discovered descendants up to --max-depth, and write mode applies that "
-            "same plan. The default stub mode uses scaffolded content without "
-            "contacting Confluence. Use --client-mode real for contract-tested "
-            "live fetches."
+            "discovered descendants up to --max-depth, and write mode applies "
+            "that same plan. The default stub mode uses scaffolded content "
+            "without contacting Confluence. Use --client-mode real for "
+            "contract-tested live fetches."
         ),
         epilog=CONFLUENCE_HELP_EXAMPLES,
         formatter_class=argparse.RawDescriptionHelpFormatter,


### PR DESCRIPTION
Summary
- tighten the shared Confluence help copy in the top-level CLI output so first-time users immediately see the one-page versus --tree path
- add one first-run sentence to the Confluence subcommand description without changing parser behavior, command structure, or examples

Testing
- make check
- verified .venv/bin/knowledge-adapters --help
- verified .venv/bin/knowledge-adapters confluence --help