### PR TITLE
docs: tighten first run recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,8 @@ Every adapter follows the same high-level shape:
 - plan `manifest.json` in the selected output directory
 - write only when `--dry-run` is not set
 
-Recommended first run: start with `--dry-run`, confirm the planned source,
-artifact path, and manifest path, then rerun the same command without
-`--dry-run`.
+Recommended first run: use `--dry-run`, confirm the planned source, artifact
+path, and manifest path, then rerun without `--dry-run`.
 
 Minimal local file first run:
 


### PR DESCRIPTION
Summary
- tighten the shared First Run recommendation sentence in README.md
- keep the wording-only change limited to the installed CLI section

Testing
- make check