### PR TITLE
docs: tighten confluence base-url help

### DIFF
--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -143,7 +143,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--base-url",
         required=True,
         help=(
-            "Base Confluence URL used to validate full page URLs and build "
+            "Base Confluence URL for validating full page URLs and building "
             "canonical source URLs."
         ),
     )


### PR DESCRIPTION
Summary
- tighten one Confluence-facing CLI help sentence to make the base URL path easier to scan for first-time users
- keep the change wording-only in src/knowledge_adapters/cli.py without changing behavior, parser structure, or examples

Testing
- make check