### PR TITLE
docs: clarify local_files edge-case help

### DIFF
--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -221,8 +221,8 @@ def build_parser() -> argparse.ArgumentParser:
             "Normalize one existing UTF-8 text file into the shared artifact layout. "
             "Use --dry-run to preview the resolved file path, artifact path, "
             "manifest path, and normalized markdown before writing. Empty UTF-8 "
-            "files are allowed and produce an empty content section. Files that "
-            "are not valid UTF-8 text are rejected. Directories are not "
+            "files are allowed; output includes an empty content section. Files "
+            "that are not valid UTF-8 text are rejected. Directories are not "
             "supported. Unlike Confluence, local_files always plans one write; "
             "it does not use manifest-based skip logic."
         ),


### PR DESCRIPTION
Summary
- tighten the local_files empty-file help wording for first-time users
- keep the UTF-8 rejection and directory rejection wording aligned with existing CLI help and tests

Testing
- make check