### PR TITLE
docs: tighten README install and local setup wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ them into one predictable local artifact layout.
 
 ## Install (without cloning)
 
-If you only want the CLI, install it directly from GitHub with `pipx`:
+For the CLI only, install directly from GitHub with `pipx`:
 
 ```bash
 pipx install git+https://github.com/ctrl-alt-keith/knowledge-adapters.git
 knowledge-adapters --help
 ```
 
-When installed this way, use `knowledge-adapters` in place of `.venv/bin/knowledge-adapters` in the examples below.
+With a `pipx` install, use `knowledge-adapters` instead of `.venv/bin/knowledge-adapters` in the examples below.
 
 ---
 
@@ -117,7 +117,7 @@ one write.
 
 ## Local Development Setup
 
-uv is recommended for faster environment setup, but standard pip workflows are also supported.
+Use `uv` for the fastest local setup. A standard `pip` workflow is also supported.
 
 ### Using uv (recommended)
 


### PR DESCRIPTION
Summary
- tighten the README install wording around the pipx flow
- tighten the local development setup lead-in for faster scanning
- keep the uv and pip setup paths clearly separated without changing behavior

Testing
- make check
- internal consistency review of the Install and Local Development Setup sections