### PR TITLE
docs: clarify local_files first-run help

### DIFF
--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -219,10 +219,10 @@ def build_parser() -> argparse.ArgumentParser:
 
     local_files_parser = subparsers.add_parser(
         "local_files",
-        help="Normalize a local text file into shared artifacts.",
+        help="Normalize one local UTF-8 text file into shared artifacts.",
         description=(
             "Normalize one existing UTF-8 text file into the shared artifact layout. "
-            "Use --dry-run to preview the resolved file path, artifact path, "
+            "Start with --dry-run to preview the resolved file path, artifact path, "
             "manifest path, and normalized markdown before writing. Empty UTF-8 "
             "files are allowed; output includes an empty content section. Files "
             "that are not valid UTF-8 text are rejected. Directories are not "

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -35,7 +35,10 @@ def test_top_level_help_introduces_shared_cli_flow(tmp_path: Path) -> None:
     assert "Normalize knowledge sources into a shared local artifact layout." in result.stdout
     assert "plans a markdown artifact under pages/ plus manifest.json" in result.stdout
     assert "Normalize Confluence content into shared artifacts." in result.stdout
-    assert "Normalize a local text file into shared artifacts." in result.stdout
+    assert (
+        "Normalize one local UTF-8 text file into shared\n"
+        "                        artifacts." in result.stdout
+    )
     assert (
         "Start with --dry-run to preview the source, artifact path, manifest path,"
         in result.stdout


### PR DESCRIPTION
Summary
- tighten the local_files help line to call out one-file UTF-8 usage
- make the local_files description point first-time users to start with --dry-run
- keep examples and behavior unchanged

Testing
- make check