### PR TITLE
docs: clarify Confluence tree-mode summaries

### DIFF
--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -130,9 +130,9 @@ def build_parser() -> argparse.ArgumentParser:
             "you want descendants. Stub and real modes keep the same resolve, "
             "plan, and write flow. Use --dry-run to preview resolved page IDs, "
             "planned artifact paths, manifest path, and write/skip decisions "
-            "before writing. In tree mode, dry-run previews the root plus "
-            "discovered descendants included by --max-depth and the paths that "
-            "would be written, and write mode applies that same plan. Use "
+            "before writing. In tree mode, dry-run previews the root page plus "
+            "discovered descendants included by --max-depth and the artifact "
+            "paths that write mode would use. Use "
             "--max-depth to limit descendant levels. Ignored unless --tree is "
             "set. The default stub mode uses scaffolded content "
             "without contacting Confluence. Use --client-mode real for "
@@ -487,10 +487,10 @@ def main(argv: Sequence[str] | None = None) -> int:
             manifest_output_path = manifest_path(confluence_config.output_dir)
 
             print("\nPlan: Confluence run")
-            print(f"  resolved_root_page_id: {root_page_id}")
+            print(f"  resolved_root_page_id: {root_page_id} (root page)")
             print(f"  max_depth: {confluence_config.max_depth}")
             print(f"  manifest_path: {_display_output_path(manifest_output_path)}")
-            print(f"  unique_pages: {len(page_records)}")
+            print(f"  unique_pages: {len(page_records)} (root + descendants)")
 
             if confluence_config.dry_run:
                 for _page, output_path, action in page_records:

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -203,8 +203,8 @@ def test_confluence_help_lists_supported_auth_methods_and_examples(
     assert "artifact layout and reporting" in result.stdout
     assert "page or, with --tree, a page tree" in result.stdout
     assert "planned artifact paths, manifest path, and write/skip decisions" in result.stdout
-    assert "In tree mode, dry-run previews the root plus discovered descendants" in result.stdout
-    assert "write mode applies that same plan" in result.stdout
+    assert "In tree mode, dry-run previews the root page plus" in result.stdout
+    assert "artifact paths that write mode would use" in result.stdout
     assert "same resolve, plan, and write flow" in result.stdout
     assert "'real' fetches from" in result.stdout
     assert "using --auth-method" in result.stdout


### PR DESCRIPTION
Summary
- clarify the Confluence tree-mode help text so dry-run more clearly previews the root page, descendants within `--max-depth`, and the artifact paths write mode would use
- label the tree plan output so `resolved_root_page_id` reads as the root page and `unique_pages` reads as the root plus descendants
- keep traversal behavior, command shape, and output structure unchanged

Testing
- make check