### PR TITLE
fix: tighten confluence tree-mode summary wording

### DIFF
--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -487,7 +487,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             manifest_output_path = manifest_path(confluence_config.output_dir)
 
             print("\nPlan: Confluence run")
-            print(f"  root_page_id: {root_page_id} (root page)")
+            print(f"  resolved_root_page_id: {root_page_id} (root page)")
             print(f"  max_depth: {confluence_config.max_depth}")
             print(f"  manifest_path: {_display_output_path(manifest_output_path)}")
             print(f"  pages_in_tree: {len(page_records)} (root + descendants)")

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -487,15 +487,17 @@ def main(argv: Sequence[str] | None = None) -> int:
             manifest_output_path = manifest_path(confluence_config.output_dir)
 
             print("\nPlan: Confluence run")
-            print(f"  resolved_root_page_id: {root_page_id} (root page)")
+            print(f"  root_page_id: {root_page_id} (root page)")
             print(f"  max_depth: {confluence_config.max_depth}")
             print(f"  manifest_path: {_display_output_path(manifest_output_path)}")
-            print(f"  unique_pages: {len(page_records)} (root + descendants)")
+            print(f"  pages_in_tree: {len(page_records)} (root + descendants)")
 
             if confluence_config.dry_run:
                 for _page, output_path, action in page_records:
                     print(f"  would {action} {_display_output_path(output_path)}")
-                print(f"  Summary: would write {write_count}, would skip {skip_count}")
+                print(
+                    f"  Summary: dry-run preview; write {write_count}, skip {skip_count}"
+                )
                 return 0
 
             files = [

--- a/tests/test_confluence_incremental_contract.py
+++ b/tests/test_confluence_incremental_contract.py
@@ -252,7 +252,7 @@ def test_incremental_dry_run_reports_both_would_write_and_would_skip_without_wri
     captured = capsys.readouterr()
     assert f"would skip {existing_page}" in captured.out
     assert f"would write {_page_path(output_dir, '200')}" in captured.out
-    assert "Summary: would write 1, would skip 1" in captured.out
+    assert "Summary: dry-run preview; write 1, skip 1" in captured.out
     assert existing_page.read_text(encoding="utf-8") == "already written\n"
     assert not _page_path(output_dir, "200").exists()
     assert _manifest_path(output_dir).read_text(encoding="utf-8") == original_manifest
@@ -514,7 +514,7 @@ def test_incremental_dry_run_ignores_non_identity_manifest_fields_for_skip(
 
     captured = capsys.readouterr()
     assert f"would skip {existing_page}" in captured.out
-    assert "Summary: would write 1, would skip 1" in captured.out
+    assert "Summary: dry-run preview; write 1, skip 1" in captured.out
 
 
 def test_incremental_run_fails_fast_for_duplicate_output_paths_in_prior_manifest(
@@ -682,5 +682,5 @@ def test_incremental_dry_run_summary_reports_mixed_write_and_skip_counts(
     assert not _page_path(output_dir, "400").exists()
 
     captured = capsys.readouterr()
-    assert "Summary: would write 2, would skip 2" in captured.out
-    assert "unique_pages: 4" in captured.out
+    assert "Summary: dry-run preview; write 2, skip 2" in captured.out
+    assert "pages_in_tree: 4" in captured.out

--- a/tests/test_confluence_recursive_contract.py
+++ b/tests/test_confluence_recursive_contract.py
@@ -276,7 +276,7 @@ def test_recursive_dry_run_reports_unique_planned_outputs_without_writing(
 
     for page_id in ["100", "200", "300", "205", "210"]:
         assert output.count(f"{output_dir / 'pages' / f'{page_id}.md'}") == 1
-    assert output.count("unique_pages: 5") == 1
+    assert output.count("pages_in_tree: 5") == 1
 
 
 def test_recursive_deeper_tree_excludes_descendants_beyond_max_depth(

--- a/tests/test_normalize_writer.py
+++ b/tests/test_normalize_writer.py
@@ -352,8 +352,8 @@ def test_confluence_cli_tree_dry_run_reports_manifest_path(
     assert "max_depth: 0" in captured.out
     assert f"manifest_path: {output_dir / 'manifest.json'}" in captured.out
     assert "Plan: Confluence run" in captured.out
-    assert "unique_pages: 1" in captured.out
-    assert "Summary: would write 1, would skip 0" in captured.out
+    assert "pages_in_tree: 1" in captured.out
+    assert "Summary: dry-run preview; write 1, skip 0" in captured.out
 
 
 def test_confluence_cli_invalid_target_reports_expected_shapes(


### PR DESCRIPTION
Summary
- tighten Confluence tree-mode CLI plan labels so the root page and total tree scope scan faster
- make the tree-mode dry-run summary explicitly read as a preview without changing traversal, manifest, or write behavior

Testing
- make check