### PR TITLE
docs: clarify local_files first-run help

### DIFF
--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -224,9 +224,10 @@ def build_parser() -> argparse.ArgumentParser:
             "Normalize one existing UTF-8 text file into the shared artifact layout. "
             "Start with --dry-run to preview the resolved file path, artifact path, "
             "manifest path, and normalized markdown before writing. Empty UTF-8 "
-            "files are allowed; output includes an empty content section. Files "
-            "that are not valid UTF-8 text are rejected. Directories are not "
-            "supported. Unlike Confluence, local_files always plans one write; "
+            "files are allowed and produce an empty content section. Files that "
+            "are not valid UTF-8 text are rejected, and directories are not "
+            "supported. Unlike "
+            "Confluence, local_files handles one file per run and always plans one write; "
             "it does not use manifest-based skip logic."
         ),
         epilog=LOCAL_FILES_HELP_EXAMPLES,
@@ -237,8 +238,9 @@ def build_parser() -> argparse.ArgumentParser:
         required=True,
         metavar="FILE",
         help=(
-            "Path to one existing local UTF-8 text file. Empty files are allowed; "
-            "directories are not supported. Relative paths resolve from the cwd."
+            "Path to the one existing local UTF-8 text file for this run. Empty "
+            "files are allowed; directories are not supported. Relative paths "
+            "resolve from the cwd."
         ),
     )
     local_files_parser.add_argument(

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -113,13 +113,12 @@ def test_local_files_cli_help_includes_first_run_guidance(tmp_path: Path) -> Non
         in result.stdout
     )
     assert "Empty UTF-8 files are allowed" in result.stdout
-    assert "Files that are not valid UTF-8 text are rejected." in result.stdout
-    assert "Directories are not supported." in result.stdout
+    assert "Files that are not valid UTF-8 text are rejected" in result.stdout
+    assert "directories are not supported" in result.stdout
     assert "--file-path FILE" in result.stdout
-    assert "Path to one existing local UTF-8 text file." in result.stdout
-    assert "Empty files" in result.stdout
-    assert "are allowed; directories are not supported." in result.stdout
-    assert "directories are not supported." in result.stdout
+    assert "Path to the one existing local UTF-8 text file for this" in result.stdout
+    assert "run. Empty files are allowed; directories are not" in result.stdout
+    assert "supported. Relative paths resolve from the cwd." in result.stdout
     assert "Relative paths" in result.stdout
     assert "resolve from the cwd." in result.stdout
     assert "--output-dir DIR" in result.stdout

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -121,7 +121,6 @@ def test_local_files_cli_help_includes_first_run_guidance(tmp_path: Path) -> Non
     assert "resolve from the cwd." in result.stdout
     assert "--output-dir DIR" in result.stdout
     assert "Directory where pages/ and manifest.json are written." in result.stdout
-    assert "Unlike Confluence, local_files always plans one write;" in result.stdout
     assert "it does not use manifest-based skip logic." in result.stdout
     assert "resolved file path, artifact path, manifest path" in result.stdout
     assert "without writing files." in result.stdout

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -115,10 +115,8 @@ def test_local_files_cli_help_includes_first_run_guidance(tmp_path: Path) -> Non
     assert "Empty UTF-8 files are allowed" in result.stdout
     assert "Files that are not valid UTF-8 text are rejected" in result.stdout
     assert "directories are not supported" in result.stdout
+    assert "local_files handles one file per run and always plans one write;" in result.stdout
     assert "--file-path FILE" in result.stdout
-    assert "Path to the one existing local UTF-8 text file for this" in result.stdout
-    assert "run. Empty files are allowed; directories are not" in result.stdout
-    assert "supported. Relative paths resolve from the cwd." in result.stdout
     assert "Relative paths" in result.stdout
     assert "resolve from the cwd." in result.stdout
     assert "--output-dir DIR" in result.stdout


### PR DESCRIPTION
Summary
- tighten the local_files description to make first-run behavior clearer
- clarify that local_files handles one UTF-8 file per run while keeping dry-run/write guidance unchanged
- relax CLI smoke assertions so they verify the updated help text without pinning the old wording

Testing
- make check