### PR TITLE
docs: tighten Confluence first-run usage note

### DIFF
--- a/adapters/confluence/README.md
+++ b/adapters/confluence/README.md
@@ -22,8 +22,8 @@ artifact already match the planned output.
 
 ## Recommended First Run
 
-Start with one page in the default `stub` mode before you try tree mode or live
-Confluence fetches:
+Start with a single-page dry run in the default `stub` mode before trying tree
+mode or live Confluence fetches:
 
 ```bash
 knowledge-adapters confluence \
@@ -51,9 +51,8 @@ When you want live Confluence content, keep the same CLI flow and add
 - `client-cert-env` via `CONFLUENCE_CLIENT_CERT_FILE` plus optional
   `CONFLUENCE_CLIENT_KEY_FILE`
 
-Tree mode is best treated as a follow-on step. With the default `stub` client,
-`--tree` still plans only the resolved root page because no child pages are
-discovered.
+Treat tree mode as a follow-on step: with the default `stub` client, `--tree`
+still plans only the resolved root page because no child pages are discovered.
 
 ## Tree Mode After First Run
 


### PR DESCRIPTION
Summary
- tighten two sentences in the adapter-local Confluence first-run guidance so the single-page dry run and follow-on tree-mode note scan faster
- preserve the existing behavior and expectations for stub mode, tree mode, and target handling

Testing
- reviewed the touched README section for internal consistency
- make check (currently fails on pre-existing CLI help tests: test_local_files_cli_help_includes_first_run_guidance and test_confluence_help_lists_supported_auth_methods_and_examples)