### PR TITLE
docs: tighten install wording in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ them into one predictable local artifact layout.
 
 ## Install (without cloning)
 
-For the CLI only, install directly from GitHub with `pipx`:
+To install only the CLI, use `pipx` directly from GitHub:
 
 ```bash
 pipx install git+https://github.com/ctrl-alt-keith/knowledge-adapters.git


### PR DESCRIPTION
Summary
- tighten one sentence in the install section of README.md to make first-time CLI setup easier to scan
- preserve the existing install command and surrounding guidance

Testing
- make check