### PR TITLE
test: stabilize CLI help smoke assertion

### DIFF
--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -36,8 +36,8 @@ def test_top_level_help_introduces_shared_cli_flow(tmp_path: Path) -> None:
     assert "plans a markdown artifact under pages/ plus manifest.json" in result.stdout
     assert "Normalize Confluence content into shared artifacts." in result.stdout
     assert (
-        "Normalize one local UTF-8 text file into shared\n"
-        "                        artifacts." in result.stdout
+        "Normalize one local UTF-8 text file into shared artifacts."
+        in " ".join(result.stdout.split())
     )
     assert (
         "Start with --dry-run to preview the source, artifact path, manifest path,"


### PR DESCRIPTION
Summary
- replace one top-level CLI help assertion that depended on wrapped output formatting
- assert the same help sentence after collapsing whitespace so line wrapping and indentation do not affect the test intent

Testing
- make check