### PR TITLE
docs: tighten Confluence first-run wording

### DIFF
--- a/adapters/confluence/README.md
+++ b/adapters/confluence/README.md
@@ -44,14 +44,14 @@ without contacting a live Confluence instance or requiring credentials.
 If that dry run looks right, rerun the same command without `--dry-run` to
 write the stub artifact and `manifest.json`.
 
-When you want live Confluence content, keep the same CLI flow and add
-`--client-mode real` plus an auth method:
+For live Confluence content, keep the same CLI flow and add `--client-mode
+real` plus an auth method:
 
 - `bearer-env` via `CONFLUENCE_BEARER_TOKEN`
 - `client-cert-env` via `CONFLUENCE_CLIENT_CERT_FILE` plus optional
   `CONFLUENCE_CLIENT_KEY_FILE`
 
-Treat tree mode as a follow-on step: with the default `stub` client, `--tree`
+Treat tree mode as a follow-on step. With the default `stub` client, `--tree`
 still plans only the resolved root page because no child pages are discovered.
 
 ## Tree Mode After First Run


### PR DESCRIPTION
Summary
- tighten two sentences in the Confluence adapter first-run guidance
- make the live-content and tree-mode usage notes easier to scan without changing behavior

Testing
- make check