### PR TITLE
fix: clarify confluence CLI wording

### DIFF
--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -130,9 +130,9 @@ def build_parser() -> argparse.ArgumentParser:
             "you want descendants. Stub and real modes keep the same resolve, "
             "plan, and write flow. Use --dry-run to preview resolved page IDs, "
             "planned artifact paths, manifest path, and write/skip decisions "
-            "before writing. In tree mode, dry-run previews the root page plus "
+            "before writing. In tree mode, dry-run previews the root page and "
             "discovered descendants included by --max-depth and the artifact "
-            "paths that write mode would use. Use "
+            "paths used in write mode. Use "
             "--max-depth to limit descendant levels. Ignored unless --tree is "
             "set. The default stub mode uses scaffolded content "
             "without contacting Confluence. Use --client-mode real for "
@@ -202,7 +202,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--tree",
         action="store_true",
         help=(
-            "Traverse the resolved root page plus discovered descendants "
+            "Traverse the resolved root page and discovered descendants "
             "instead of only one page. Use --max-depth to limit descendant "
             "levels."
         ),

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -208,8 +208,8 @@ def test_confluence_help_lists_supported_auth_methods_and_examples(
     assert "artifact layout and reporting" in result.stdout
     assert "page or, with --tree, a page tree" in result.stdout
     assert "planned artifact paths, manifest path, and write/skip decisions" in result.stdout
-    assert "In tree mode, dry-run previews the root page plus" in result.stdout
-    assert "artifact paths that write mode would use" in result.stdout
+    assert "In tree mode, dry-run previews the root page and" in result.stdout
+    assert "artifact paths used in write mode" in result.stdout
     assert "same resolve, plan, and write flow" in result.stdout
     assert "'real' fetches from" in result.stdout
     assert "using --auth-method" in result.stdout
@@ -217,7 +217,7 @@ def test_confluence_help_lists_supported_auth_methods_and_examples(
     assert "The CLI resolves either input into one canonical page" in result.stdout
     assert "source URL for artifact and manifest reporting" in result.stdout
     assert "artifact and manifest reporting" in result.stdout
-    assert "Traverse the resolved root page plus discovered" in result.stdout
+    assert "Traverse the resolved root page and discovered" in result.stdout
     assert "descendants instead of only one page." in result.stdout
     assert "Maximum descendant depth for --tree." in result.stdout
     assert "Ignored unless --tree is set." in result.stdout


### PR DESCRIPTION
Summary
- tighten two Confluence help phrases to make tree-mode dry-run and root/descendants wording clearer
- preserve the existing behavior and update the smoke test expectations for the revised help text

Testing
- make check