### PR TITLE
fix: add local_files write summary

### DIFF
--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -700,7 +700,8 @@ def main(argv: Sequence[str] | None = None) -> int:
                 exc=exc,
             )
         print(f"\nWrote: {output_path}")
-        print("\nSummary: wrote 1, skipped 0")
+        print("\nSummary: wrote 1 file")
+        print(f"Artifact: {output_path}")
         print(f"Manifest: {output_dir / manifest.relative_to(output_dir_input)}")
         return 0
 

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -71,8 +71,9 @@ def test_local_files_cli_smoke_uses_installed_entrypoint_with_readme_style_args(
     assert f"source_url: {source_file.resolve().as_uri()}" in result.stdout
     assert f"artifact_path: {tmp_path / 'artifacts' / 'pages' / 'today.md'}" in result.stdout
     assert "Wrote:" in result.stdout
-    assert "Summary: wrote 1, skipped 0" in result.stdout
-    assert "Manifest:" in result.stdout
+    assert "Summary: wrote 1 file" in result.stdout
+    assert f"Artifact: {tmp_path / 'artifacts' / 'pages' / 'today.md'}" in result.stdout
+    assert f"Manifest: {tmp_path / 'artifacts' / 'manifest.json'}" in result.stdout
 
     output_path = tmp_path / "artifacts" / "pages" / "today.md"
     assert output_path.read_text(encoding="utf-8") == (

--- a/tests/test_local_files.py
+++ b/tests/test_local_files.py
@@ -42,7 +42,10 @@ def test_local_files_reuses_shared_normalizer() -> None:
     assert markdown.endswith("Hello from disk.\n")
 
 
-def test_local_files_cli_writes_normalized_markdown(tmp_path: Path) -> None:
+def test_local_files_cli_writes_normalized_markdown(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
     source_file = tmp_path / "meeting-notes.txt"
     source_file.write_text("Line one.\nLine two.\n", encoding="utf-8")
     output_dir = tmp_path / "out"
@@ -58,6 +61,10 @@ def test_local_files_cli_writes_normalized_markdown(tmp_path: Path) -> None:
     )
 
     assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "Summary: wrote 1 file" in captured.out
+    assert f"Artifact: {output_dir / 'pages' / 'meeting-notes.md'}" in captured.out
+    assert f"Manifest: {output_dir / 'manifest.json'}" in captured.out
 
     output_path = output_dir / "pages" / "meeting-notes.md"
     assert output_path.exists()


### PR DESCRIPTION
Summary
- add a concise post-write summary for successful local_files runs
- report the written artifact path and manifest path in that footer
- keep dry-run and Confluence behavior unchanged

Testing
- make check