### PR TITLE
fix: clarify CLI completion messages

### DIFF
--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -275,6 +275,16 @@ def exit_with_cli_error(
     raise SystemExit(2)
 
 
+def print_dry_run_complete() -> None:
+    """Print a consistent dry-run completion message."""
+    print("\nDry run complete. No files written.")
+
+
+def print_write_complete(output_dir: Path) -> None:
+    """Print a consistent write completion message."""
+    print(f"\nWrite complete. Artifacts created under {output_dir}")
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     """Run the CLI."""
     parser = build_parser()
@@ -500,6 +510,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 print(
                     f"  Summary: dry-run preview; write {write_count}, skip {skip_count}"
                 )
+                print_dry_run_complete()
                 return 0
 
             files = [
@@ -535,6 +546,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 )
             print(f"\nSummary: wrote {write_count}, skipped {skip_count}")
             print(f"\nManifest: {_display_output_path(manifest)}")
+            print_write_complete(output_dir)
             return 0
 
         try:
@@ -573,6 +585,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 dry_run=True,
                 markdown=planned_markdown,
             )
+            print_dry_run_complete()
             return 0
 
         _print_single_page_plan(
@@ -612,6 +625,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         skip_count = 1 if action == "skip" else 0
         print(f"\nSummary: wrote {write_count}, skipped {skip_count}")
         print(f"Manifest: {_display_output_path(manifest)}")
+        print_write_complete(output_dir)
         return 0
 
     if args.command == "local_files":
@@ -677,6 +691,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             print("  Summary: would write 1, would skip 0")
             print()
             print(markdown)
+            print_dry_run_complete()
             return 0
 
         try:
@@ -706,6 +721,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"\nWrote: {output_path}")
         print("\nSummary: wrote 1, skipped 0")
         print(f"Manifest: {output_dir / manifest.relative_to(output_dir_input)}")
+        print_write_complete(output_dir)
         return 0
 
     parser.error("Unknown command")

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -73,6 +73,7 @@ def test_local_files_cli_smoke_uses_installed_entrypoint_with_readme_style_args(
     assert "Wrote:" in result.stdout
     assert "Summary: wrote 1, skipped 0" in result.stdout
     assert "Manifest:" in result.stdout
+    assert f"Write complete. Artifacts created under {tmp_path / 'artifacts'}" in result.stdout
 
     output_path = tmp_path / "artifacts" / "pages" / "today.md"
     assert output_path.read_text(encoding="utf-8") == (
@@ -155,6 +156,7 @@ def test_confluence_cli_smoke_uses_installed_entrypoint_with_default_stub_client
     assert "Wrote:" in result.stdout
     assert "Summary: wrote 1, skipped 0" in result.stdout
     assert "Manifest:" in result.stdout
+    assert f"Write complete. Artifacts created under {tmp_path / 'artifacts'}" in result.stdout
 
     output_path = tmp_path / "artifacts" / "pages" / "12345.md"
     assert output_path.read_text(encoding="utf-8") == (

--- a/tests/test_local_files.py
+++ b/tests/test_local_files.py
@@ -128,6 +128,7 @@ def test_local_files_cli_dry_run_reports_output_without_writing(
     assert "content_status: UTF-8 text with content" in captured.out
     assert "action: would write" in captured.out
     assert "Summary: would write 1, would skip 0" in captured.out
+    assert "Dry run complete. No files written." in captured.out
     assert "Line one." in captured.out
 
 

--- a/tests/test_normalize_writer.py
+++ b/tests/test_normalize_writer.py
@@ -150,6 +150,7 @@ def test_confluence_cli_dry_run_reports_output_without_writing(
     assert f"manifest_path: {output_dir / 'manifest.json'}" in captured.out
     assert "action: would write" in captured.out
     assert "Summary: would write 1, would skip 0" in captured.out
+    assert "Dry run complete. No files written." in captured.out
     assert "# stub-page-12345" in captured.out
 
 
@@ -252,6 +253,7 @@ def test_confluence_cli_full_flow_keeps_dry_run_and_write_artifacts_in_sync(
     assert f"manifest_path: {manifest_output_path}" in dry_run_output
     assert "action: would write" in dry_run_output
     assert "Summary: would write 1, would skip 0" in dry_run_output
+    assert "Dry run complete. No files written." in dry_run_output
 
     write_exit_code = main(
         [
@@ -282,6 +284,7 @@ def test_confluence_cli_full_flow_keeps_dry_run_and_write_artifacts_in_sync(
     assert f"Wrote: {page_output_path}" in write_output
     assert "Summary: wrote 1, skipped 0" in write_output
     assert f"Manifest: {manifest_output_path}" in write_output
+    assert f"Write complete. Artifacts created under {output_dir}" in write_output
 
     payload = json.loads(manifest_output_path.read_text(encoding="utf-8"))
     assert payload["files"] == [


### PR DESCRIPTION
Summary
- add explicit completion messages so dry-run and write execution are visually distinct
- print the same phrasing in both local_files and Confluence CLI flows
- extend CLI assertions to cover the new completion text

Testing
- make check