### PR TITLE
fix: clarify confluence dry-run summary

### DIFF
--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -437,10 +437,32 @@ def main(argv: Sequence[str] | None = None) -> int:
             if dry_run:
                 write_count = 1 if action == "write" else 0
                 skip_count = 1 if action == "skip" else 0
-                print(f"  Summary: would write {write_count}, would skip {skip_count}")
+                _print_confluence_dry_run_summary(
+                    mode="single",
+                    total_pages=1,
+                    write_count=write_count,
+                    skip_count=skip_count,
+                )
             if markdown is not None:
                 print()
                 print(markdown)
+
+        def _print_confluence_dry_run_summary(
+            *,
+            mode: str,
+            total_pages: int,
+            write_count: int,
+            skip_count: int,
+        ) -> None:
+            descendant_count = max(total_pages - 1, 0)
+            print("  Summary:")
+            print(f"    mode: {mode}")
+            print(
+                "    pages_in_plan: "
+                f"{total_pages} (root 1, descendants {descendant_count})"
+            )
+            print(f"    would_write: {write_count}")
+            print(f"    would_skip: {skip_count}")
 
         if confluence_config.tree:
             if confluence_config.client_mode == "real":
@@ -495,11 +517,14 @@ def main(argv: Sequence[str] | None = None) -> int:
             print(f"  pages_in_tree: {len(page_records)} (root + descendants)")
 
             if confluence_config.dry_run:
+                _print_confluence_dry_run_summary(
+                    mode="tree",
+                    total_pages=len(page_records),
+                    write_count=write_count,
+                    skip_count=skip_count,
+                )
                 for _page, output_path, action in page_records:
                     print(f"  would {action} {_display_output_path(output_path)}")
-                print(
-                    f"  Summary: dry-run preview; write {write_count}, skip {skip_count}"
-                )
                 return 0
 
             files = [

--- a/tests/test_confluence_incremental_contract.py
+++ b/tests/test_confluence_incremental_contract.py
@@ -252,7 +252,11 @@ def test_incremental_dry_run_reports_both_would_write_and_would_skip_without_wri
     captured = capsys.readouterr()
     assert f"would skip {existing_page}" in captured.out
     assert f"would write {_page_path(output_dir, '200')}" in captured.out
-    assert "Summary: dry-run preview; write 1, skip 1" in captured.out
+    assert "  Summary:" in captured.out
+    assert "    mode: tree" in captured.out
+    assert "    pages_in_plan: 2 (root 1, descendants 1)" in captured.out
+    assert "    would_write: 1" in captured.out
+    assert "    would_skip: 1" in captured.out
     assert existing_page.read_text(encoding="utf-8") == "already written\n"
     assert not _page_path(output_dir, "200").exists()
     assert _manifest_path(output_dir).read_text(encoding="utf-8") == original_manifest
@@ -514,7 +518,11 @@ def test_incremental_dry_run_ignores_non_identity_manifest_fields_for_skip(
 
     captured = capsys.readouterr()
     assert f"would skip {existing_page}" in captured.out
-    assert "Summary: dry-run preview; write 1, skip 1" in captured.out
+    assert "  Summary:" in captured.out
+    assert "    mode: tree" in captured.out
+    assert "    pages_in_plan: 2 (root 1, descendants 1)" in captured.out
+    assert "    would_write: 1" in captured.out
+    assert "    would_skip: 1" in captured.out
 
 
 def test_incremental_run_fails_fast_for_duplicate_output_paths_in_prior_manifest(
@@ -682,5 +690,9 @@ def test_incremental_dry_run_summary_reports_mixed_write_and_skip_counts(
     assert not _page_path(output_dir, "400").exists()
 
     captured = capsys.readouterr()
-    assert "Summary: dry-run preview; write 2, skip 2" in captured.out
+    assert "  Summary:" in captured.out
+    assert "    mode: tree" in captured.out
+    assert "    pages_in_plan: 4 (root 1, descendants 3)" in captured.out
+    assert "    would_write: 2" in captured.out
+    assert "    would_skip: 2" in captured.out
     assert "pages_in_tree: 4" in captured.out

--- a/tests/test_confluence_real_client_contract.py
+++ b/tests/test_confluence_real_client_contract.py
@@ -299,7 +299,11 @@ def test_stub_and_real_single_page_dry_runs_share_the_same_plan_shape(
     assert f"artifact_path: {stub_output_dir / 'pages' / '12345.md'}" in stub_output
     assert f"manifest_path: {stub_output_dir / 'manifest.json'}" in stub_output
     assert "action: would write" in stub_output
-    assert "Summary: would write 1, would skip 0" in stub_output
+    assert "  Summary:" in stub_output
+    assert "    mode: single" in stub_output
+    assert "    pages_in_plan: 1 (root 1, descendants 0)" in stub_output
+    assert "    would_write: 1" in stub_output
+    assert "    would_skip: 0" in stub_output
 
     def stub_real_fetch(*args: object, **kwargs: object) -> dict[str, object]:
         return {
@@ -330,7 +334,11 @@ def test_stub_and_real_single_page_dry_runs_share_the_same_plan_shape(
     assert f"artifact_path: {real_output_dir / 'pages' / '12345.md'}" in real_output
     assert f"manifest_path: {real_output_dir / 'manifest.json'}" in real_output
     assert "action: would write" in real_output
-    assert "Summary: would write 1, would skip 0" in real_output
+    assert "  Summary:" in real_output
+    assert "    mode: single" in real_output
+    assert "    pages_in_plan: 1 (root 1, descendants 0)" in real_output
+    assert "    would_write: 1" in real_output
+    assert "    would_skip: 0" in real_output
 
 
 @pytest.mark.parametrize(

--- a/tests/test_normalize_writer.py
+++ b/tests/test_normalize_writer.py
@@ -149,7 +149,11 @@ def test_confluence_cli_dry_run_reports_output_without_writing(
     assert f"artifact_path: {output_path}" in captured.out
     assert f"manifest_path: {output_dir / 'manifest.json'}" in captured.out
     assert "action: would write" in captured.out
-    assert "Summary: would write 1, would skip 0" in captured.out
+    assert "  Summary:" in captured.out
+    assert "    mode: single" in captured.out
+    assert "    pages_in_plan: 1 (root 1, descendants 0)" in captured.out
+    assert "    would_write: 1" in captured.out
+    assert "    would_skip: 0" in captured.out
     assert "# stub-page-12345" in captured.out
 
 
@@ -251,7 +255,11 @@ def test_confluence_cli_full_flow_keeps_dry_run_and_write_artifacts_in_sync(
     assert f"artifact_path: {page_output_path}" in dry_run_output
     assert f"manifest_path: {manifest_output_path}" in dry_run_output
     assert "action: would write" in dry_run_output
-    assert "Summary: would write 1, would skip 0" in dry_run_output
+    assert "  Summary:" in dry_run_output
+    assert "    mode: single" in dry_run_output
+    assert "    pages_in_plan: 1 (root 1, descendants 0)" in dry_run_output
+    assert "    would_write: 1" in dry_run_output
+    assert "    would_skip: 0" in dry_run_output
 
     write_exit_code = main(
         [
@@ -353,7 +361,11 @@ def test_confluence_cli_tree_dry_run_reports_manifest_path(
     assert f"manifest_path: {output_dir / 'manifest.json'}" in captured.out
     assert "Plan: Confluence run" in captured.out
     assert "pages_in_tree: 1" in captured.out
-    assert "Summary: dry-run preview; write 1, skip 0" in captured.out
+    assert "  Summary:" in captured.out
+    assert "    mode: tree" in captured.out
+    assert "    pages_in_plan: 1 (root 1, descendants 0)" in captured.out
+    assert "    would_write: 1" in captured.out
+    assert "    would_skip: 0" in captured.out
 
 
 def test_confluence_cli_invalid_target_reports_expected_shapes(


### PR DESCRIPTION
Summary
- add a structured Confluence dry-run summary for single-page and tree runs
- include mode, pages in plan, and root vs descendant counts in the summary block
- keep the existing per-path dry-run lines while making write vs skip totals easier to scan

Testing
- make check