### PR TITLE
refactor: standardize confluence dry-run summary order

### DIFF
--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -465,14 +465,16 @@ def main(argv: Sequence[str] | None = None) -> int:
             skip_count: int,
         ) -> None:
             descendant_count = max(total_pages - 1, 0)
-            print("  Summary:")
-            print(f"    mode: {mode}")
-            print(
+            summary_lines = (
+                f"    mode: {mode}",
                 "    pages_in_plan: "
-                f"{total_pages} (root 1, descendants {descendant_count})"
+                f"{total_pages} (root 1, descendants {descendant_count})",
+                f"    would_write: {write_count}",
+                f"    would_skip: {skip_count}",
             )
-            print(f"    would_write: {write_count}")
-            print(f"    would_skip: {skip_count}")
+            print("  Summary:")
+            for line in summary_lines:
+                print(line)
 
         if confluence_config.tree:
             if confluence_config.client_mode == "real":

--- a/tests/test_confluence_incremental_contract.py
+++ b/tests/test_confluence_incremental_contract.py
@@ -252,11 +252,13 @@ def test_incremental_dry_run_reports_both_would_write_and_would_skip_without_wri
     captured = capsys.readouterr()
     assert f"would skip {existing_page}" in captured.out
     assert f"would write {_page_path(output_dir, '200')}" in captured.out
-    assert "  Summary:" in captured.out
-    assert "    mode: tree" in captured.out
-    assert "    pages_in_plan: 2 (root 1, descendants 1)" in captured.out
-    assert "    would_write: 1" in captured.out
-    assert "    would_skip: 1" in captured.out
+    assert (
+        "  Summary:\n"
+        "    mode: tree\n"
+        "    pages_in_plan: 2 (root 1, descendants 1)\n"
+        "    would_write: 1\n"
+        "    would_skip: 1\n"
+    ) in captured.out
     assert existing_page.read_text(encoding="utf-8") == "already written\n"
     assert not _page_path(output_dir, "200").exists()
     assert _manifest_path(output_dir).read_text(encoding="utf-8") == original_manifest
@@ -518,11 +520,13 @@ def test_incremental_dry_run_ignores_non_identity_manifest_fields_for_skip(
 
     captured = capsys.readouterr()
     assert f"would skip {existing_page}" in captured.out
-    assert "  Summary:" in captured.out
-    assert "    mode: tree" in captured.out
-    assert "    pages_in_plan: 2 (root 1, descendants 1)" in captured.out
-    assert "    would_write: 1" in captured.out
-    assert "    would_skip: 1" in captured.out
+    assert (
+        "  Summary:\n"
+        "    mode: tree\n"
+        "    pages_in_plan: 2 (root 1, descendants 1)\n"
+        "    would_write: 1\n"
+        "    would_skip: 1\n"
+    ) in captured.out
 
 
 def test_incremental_run_fails_fast_for_duplicate_output_paths_in_prior_manifest(
@@ -690,9 +694,11 @@ def test_incremental_dry_run_summary_reports_mixed_write_and_skip_counts(
     assert not _page_path(output_dir, "400").exists()
 
     captured = capsys.readouterr()
-    assert "  Summary:" in captured.out
-    assert "    mode: tree" in captured.out
-    assert "    pages_in_plan: 4 (root 1, descendants 3)" in captured.out
-    assert "    would_write: 2" in captured.out
-    assert "    would_skip: 2" in captured.out
+    assert (
+        "  Summary:\n"
+        "    mode: tree\n"
+        "    pages_in_plan: 4 (root 1, descendants 3)\n"
+        "    would_write: 2\n"
+        "    would_skip: 2\n"
+    ) in captured.out
     assert "pages_in_tree: 4" in captured.out

--- a/tests/test_confluence_real_client_contract.py
+++ b/tests/test_confluence_real_client_contract.py
@@ -299,11 +299,13 @@ def test_stub_and_real_single_page_dry_runs_share_the_same_plan_shape(
     assert f"artifact_path: {stub_output_dir / 'pages' / '12345.md'}" in stub_output
     assert f"manifest_path: {stub_output_dir / 'manifest.json'}" in stub_output
     assert "action: would write" in stub_output
-    assert "  Summary:" in stub_output
-    assert "    mode: single" in stub_output
-    assert "    pages_in_plan: 1 (root 1, descendants 0)" in stub_output
-    assert "    would_write: 1" in stub_output
-    assert "    would_skip: 0" in stub_output
+    assert (
+        "  Summary:\n"
+        "    mode: single\n"
+        "    pages_in_plan: 1 (root 1, descendants 0)\n"
+        "    would_write: 1\n"
+        "    would_skip: 0\n"
+    ) in stub_output
 
     def stub_real_fetch(*args: object, **kwargs: object) -> dict[str, object]:
         return {
@@ -334,11 +336,13 @@ def test_stub_and_real_single_page_dry_runs_share_the_same_plan_shape(
     assert f"artifact_path: {real_output_dir / 'pages' / '12345.md'}" in real_output
     assert f"manifest_path: {real_output_dir / 'manifest.json'}" in real_output
     assert "action: would write" in real_output
-    assert "  Summary:" in real_output
-    assert "    mode: single" in real_output
-    assert "    pages_in_plan: 1 (root 1, descendants 0)" in real_output
-    assert "    would_write: 1" in real_output
-    assert "    would_skip: 0" in real_output
+    assert (
+        "  Summary:\n"
+        "    mode: single\n"
+        "    pages_in_plan: 1 (root 1, descendants 0)\n"
+        "    would_write: 1\n"
+        "    would_skip: 0\n"
+    ) in real_output
 
 
 @pytest.mark.parametrize(

--- a/tests/test_normalize_writer.py
+++ b/tests/test_normalize_writer.py
@@ -149,11 +149,13 @@ def test_confluence_cli_dry_run_reports_output_without_writing(
     assert f"artifact_path: {output_path}" in captured.out
     assert f"manifest_path: {output_dir / 'manifest.json'}" in captured.out
     assert "action: would write" in captured.out
-    assert "  Summary:" in captured.out
-    assert "    mode: single" in captured.out
-    assert "    pages_in_plan: 1 (root 1, descendants 0)" in captured.out
-    assert "    would_write: 1" in captured.out
-    assert "    would_skip: 0" in captured.out
+    assert (
+        "  Summary:\n"
+        "    mode: single\n"
+        "    pages_in_plan: 1 (root 1, descendants 0)\n"
+        "    would_write: 1\n"
+        "    would_skip: 0\n"
+    ) in captured.out
     assert "Dry run complete. No files written." in captured.out
     assert "# stub-page-12345" in captured.out
 
@@ -256,11 +258,13 @@ def test_confluence_cli_full_flow_keeps_dry_run_and_write_artifacts_in_sync(
     assert f"artifact_path: {page_output_path}" in dry_run_output
     assert f"manifest_path: {manifest_output_path}" in dry_run_output
     assert "action: would write" in dry_run_output
-    assert "  Summary:" in dry_run_output
-    assert "    mode: single" in dry_run_output
-    assert "    pages_in_plan: 1 (root 1, descendants 0)" in dry_run_output
-    assert "    would_write: 1" in dry_run_output
-    assert "    would_skip: 0" in dry_run_output
+    assert (
+        "  Summary:\n"
+        "    mode: single\n"
+        "    pages_in_plan: 1 (root 1, descendants 0)\n"
+        "    would_write: 1\n"
+        "    would_skip: 0\n"
+    ) in dry_run_output
     assert "Dry run complete. No files written." in dry_run_output
 
     write_exit_code = main(
@@ -364,11 +368,13 @@ def test_confluence_cli_tree_dry_run_reports_manifest_path(
     assert f"manifest_path: {output_dir / 'manifest.json'}" in captured.out
     assert "Plan: Confluence run" in captured.out
     assert "pages_in_tree: 1" in captured.out
-    assert "  Summary:" in captured.out
-    assert "    mode: tree" in captured.out
-    assert "    pages_in_plan: 1 (root 1, descendants 0)" in captured.out
-    assert "    would_write: 1" in captured.out
-    assert "    would_skip: 0" in captured.out
+    assert (
+        "  Summary:\n"
+        "    mode: tree\n"
+        "    pages_in_plan: 1 (root 1, descendants 0)\n"
+        "    would_write: 1\n"
+        "    would_skip: 0\n"
+    ) in captured.out
 
 
 def test_confluence_cli_invalid_target_reports_expected_shapes(


### PR DESCRIPTION
Summary
- make the Confluence dry-run summary helper emit its fields from an explicit ordered sequence
- update Confluence dry-run tests to assert the full summary block in deterministic order

Testing
- make check