### PR TITLE
fix: align CLI output labels

### DIFF
--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -441,8 +441,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             print("\nPlan: Confluence run")
             print(f"  resolved_page_id: {page_id}")
             print(f"  source_url: {source_url}")
-            print(f"  artifact_path: {_display_output_path(output_path)}")
-            print(f"  manifest_path: {_display_output_path(manifest_output_path)}")
+            print(f"  Artifact: {_display_output_path(output_path)}")
+            print(f"  Manifest: {_display_output_path(manifest_output_path)}")
             print(f"  action: {'would ' if dry_run else ''}{action}")
             if dry_run:
                 write_count = 1 if action == "write" else 0
@@ -501,7 +501,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             print("\nPlan: Confluence run")
             print(f"  resolved_root_page_id: {root_page_id} (root page)")
             print(f"  max_depth: {confluence_config.max_depth}")
-            print(f"  manifest_path: {_display_output_path(manifest_output_path)}")
+            print(f"  Manifest: {_display_output_path(manifest_output_path)}")
             print(f"  pages_in_tree: {len(page_records)} (root + descendants)")
 
             if confluence_config.dry_run:
@@ -545,7 +545,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     exc=exc,
                 )
             print(f"\nSummary: wrote {write_count}, skipped {skip_count}")
-            print(f"\nManifest: {_display_output_path(manifest)}")
+            print(f"Manifest: {_display_output_path(manifest)}")
             print_write_complete(output_dir)
             return 0
 
@@ -676,8 +676,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         print("\nPlan: Local files run")
         print(f"  resolved_file_path: {resolved_input_path}")
         print(f"  source_url: {page.get('source_url', '')}")
-        print(f"  artifact_path: {output_path}")
-        print(f"  manifest_path: {manifest_output_path}")
+        print(f"  Artifact: {output_path}")
+        print(f"  Manifest: {manifest_output_path}")
         content = str(page.get("content", ""))
         if content:
             print("  content_status: UTF-8 text with content")
@@ -719,7 +719,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 exc=exc,
             )
         print(f"\nWrote: {output_path}")
-        print("\nSummary: wrote 1 file")
+        print("\nSummary: wrote 1, skipped 0")
         print(f"Artifact: {output_path}")
         print(f"Manifest: {output_dir / manifest.relative_to(output_dir_input)}")
         print_write_complete(output_dir)

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -69,9 +69,9 @@ def test_local_files_cli_smoke_uses_installed_entrypoint_with_readme_style_args(
     assert "Plan: Local files run" in result.stdout
     assert f"resolved_file_path: {source_file.resolve()}" in result.stdout
     assert f"source_url: {source_file.resolve().as_uri()}" in result.stdout
-    assert f"artifact_path: {tmp_path / 'artifacts' / 'pages' / 'today.md'}" in result.stdout
+    assert f"Artifact: {tmp_path / 'artifacts' / 'pages' / 'today.md'}" in result.stdout
     assert "Wrote:" in result.stdout
-    assert "Summary: wrote 1 file" in result.stdout
+    assert "Summary: wrote 1, skipped 0" in result.stdout
     assert f"Artifact: {tmp_path / 'artifacts' / 'pages' / 'today.md'}" in result.stdout
     assert f"Manifest: {tmp_path / 'artifacts' / 'manifest.json'}" in result.stdout
     assert f"Write complete. Artifacts created under {tmp_path / 'artifacts'}" in result.stdout
@@ -152,7 +152,7 @@ def test_confluence_cli_smoke_uses_installed_entrypoint_with_default_stub_client
     assert "run_mode: write" in result.stdout
     assert "Plan: Confluence run" in result.stdout
     assert "resolved_page_id: 12345" in result.stdout
-    assert "artifact_path:" in result.stdout
+    assert "Artifact:" in result.stdout
     assert "auth_method:" not in result.stdout
     assert "Wrote:" in result.stdout
     assert "Summary: wrote 1, skipped 0" in result.stdout

--- a/tests/test_confluence_real_client_contract.py
+++ b/tests/test_confluence_real_client_contract.py
@@ -237,8 +237,8 @@ def test_stub_and_real_single_page_write_runs_share_the_same_cli_shape(
     assert "run_mode: write" in stub_output
     assert "Plan: Confluence run" in stub_output
     assert "resolved_page_id: 12345" in stub_output
-    assert f"artifact_path: {stub_output_dir / 'pages' / '12345.md'}" in stub_output
-    assert f"manifest_path: {stub_output_dir / 'manifest.json'}" in stub_output
+    assert f"Artifact: {stub_output_dir / 'pages' / '12345.md'}" in stub_output
+    assert f"Manifest: {stub_output_dir / 'manifest.json'}" in stub_output
     assert "action: write" in stub_output
     assert "auth_method:" not in stub_output
     assert f"Manifest: {stub_output_dir / 'manifest.json'}" in stub_output
@@ -270,8 +270,8 @@ def test_stub_and_real_single_page_write_runs_share_the_same_cli_shape(
     assert "run_mode: write" in real_output
     assert "Plan: Confluence run" in real_output
     assert "resolved_page_id: 12345" in real_output
-    assert f"artifact_path: {real_output_dir / 'pages' / '12345.md'}" in real_output
-    assert f"manifest_path: {real_output_dir / 'manifest.json'}" in real_output
+    assert f"Artifact: {real_output_dir / 'pages' / '12345.md'}" in real_output
+    assert f"Manifest: {real_output_dir / 'manifest.json'}" in real_output
     assert "action: write" in real_output
     assert "auth_method: bearer-env" in real_output
     assert f"Manifest: {real_output_dir / 'manifest.json'}" in real_output
@@ -296,8 +296,8 @@ def test_stub_and_real_single_page_dry_runs_share_the_same_plan_shape(
     assert "run_mode: dry-run" in stub_output
     assert "Plan: Confluence run" in stub_output
     assert "resolved_page_id: 12345" in stub_output
-    assert f"artifact_path: {stub_output_dir / 'pages' / '12345.md'}" in stub_output
-    assert f"manifest_path: {stub_output_dir / 'manifest.json'}" in stub_output
+    assert f"Artifact: {stub_output_dir / 'pages' / '12345.md'}" in stub_output
+    assert f"Manifest: {stub_output_dir / 'manifest.json'}" in stub_output
     assert "action: would write" in stub_output
     assert "Summary: would write 1, would skip 0" in stub_output
 
@@ -327,8 +327,8 @@ def test_stub_and_real_single_page_dry_runs_share_the_same_plan_shape(
     assert "auth_method: bearer-env" in real_output
     assert "Plan: Confluence run" in real_output
     assert "resolved_page_id: 12345" in real_output
-    assert f"artifact_path: {real_output_dir / 'pages' / '12345.md'}" in real_output
-    assert f"manifest_path: {real_output_dir / 'manifest.json'}" in real_output
+    assert f"Artifact: {real_output_dir / 'pages' / '12345.md'}" in real_output
+    assert f"Manifest: {real_output_dir / 'manifest.json'}" in real_output
     assert "action: would write" in real_output
     assert "Summary: would write 1, would skip 0" in real_output
 

--- a/tests/test_local_files.py
+++ b/tests/test_local_files.py
@@ -62,7 +62,7 @@ def test_local_files_cli_writes_normalized_markdown(
 
     assert exit_code == 0
     captured = capsys.readouterr()
-    assert "Summary: wrote 1 file" in captured.out
+    assert "Summary: wrote 1, skipped 0" in captured.out
     assert f"Artifact: {output_dir / 'pages' / 'meeting-notes.md'}" in captured.out
     assert f"Manifest: {output_dir / 'manifest.json'}" in captured.out
 
@@ -130,8 +130,8 @@ def test_local_files_cli_dry_run_reports_output_without_writing(
     assert "Plan: Local files run" in captured.out
     assert f"resolved_file_path: {source_file.resolve()}" in captured.out
     assert f"source_url: {source_file.resolve().as_uri()}" in captured.out
-    assert f"artifact_path: {output_path}" in captured.out
-    assert f"manifest_path: {output_dir / 'manifest.json'}" in captured.out
+    assert f"Artifact: {output_path}" in captured.out
+    assert f"Manifest: {output_dir / 'manifest.json'}" in captured.out
     assert "content_status: UTF-8 text with content" in captured.out
     assert "action: would write" in captured.out
     assert "Summary: would write 1, would skip 0" in captured.out

--- a/tests/test_normalize_writer.py
+++ b/tests/test_normalize_writer.py
@@ -146,8 +146,8 @@ def test_confluence_cli_dry_run_reports_output_without_writing(
     assert "Plan: Confluence run" in captured.out
     assert "resolved_page_id: 12345" in captured.out
     assert "source_url: https://example.com/wiki/pages/viewpage.action?pageId=12345" in captured.out
-    assert f"artifact_path: {output_path}" in captured.out
-    assert f"manifest_path: {output_dir / 'manifest.json'}" in captured.out
+    assert f"Artifact: {output_path}" in captured.out
+    assert f"Manifest: {output_dir / 'manifest.json'}" in captured.out
     assert "action: would write" in captured.out
     assert "Summary: would write 1, would skip 0" in captured.out
     assert "Dry run complete. No files written." in captured.out
@@ -178,7 +178,7 @@ def test_confluence_cli_dry_run_reports_same_resolved_target_details_for_full_ur
     captured = capsys.readouterr()
     assert "resolved_page_id: 12345" in captured.out
     assert "source_url: https://example.com/wiki/pages/viewpage.action?pageId=12345" in captured.out
-    assert f"artifact_path: {output_dir / 'pages' / '12345.md'}" in captured.out
+    assert f"Artifact: {output_dir / 'pages' / '12345.md'}" in captured.out
     assert (
         "- source_url: https://example.com/wiki/pages/viewpage.action?pageId=12345"
         in captured.out
@@ -249,8 +249,8 @@ def test_confluence_cli_full_flow_keeps_dry_run_and_write_artifacts_in_sync(
     assert "Plan: Confluence run" in dry_run_output
     assert "resolved_page_id: 12345" in dry_run_output
     assert f"source_url: {canonical_source_url}" in dry_run_output
-    assert f"artifact_path: {page_output_path}" in dry_run_output
-    assert f"manifest_path: {manifest_output_path}" in dry_run_output
+    assert f"Artifact: {page_output_path}" in dry_run_output
+    assert f"Manifest: {manifest_output_path}" in dry_run_output
     assert "action: would write" in dry_run_output
     assert "Summary: would write 1, would skip 0" in dry_run_output
     assert "Dry run complete. No files written." in dry_run_output
@@ -278,8 +278,8 @@ def test_confluence_cli_full_flow_keeps_dry_run_and_write_artifacts_in_sync(
     assert "run_mode: write" in write_output
     assert "Plan: Confluence run" in write_output
     assert "resolved_page_id: 12345" in write_output
-    assert f"artifact_path: {page_output_path}" in write_output
-    assert f"manifest_path: {manifest_output_path}" in write_output
+    assert f"Artifact: {page_output_path}" in write_output
+    assert f"Manifest: {manifest_output_path}" in write_output
     assert "action: write" in write_output
     assert f"Wrote: {page_output_path}" in write_output
     assert "Summary: wrote 1, skipped 0" in write_output
@@ -353,7 +353,7 @@ def test_confluence_cli_tree_dry_run_reports_manifest_path(
     captured = capsys.readouterr()
     assert "fetch_scope: tree" in captured.out
     assert "max_depth: 0" in captured.out
-    assert f"manifest_path: {output_dir / 'manifest.json'}" in captured.out
+    assert f"Manifest: {output_dir / 'manifest.json'}" in captured.out
     assert "Plan: Confluence run" in captured.out
     assert "pages_in_tree: 1" in captured.out
     assert "Summary: dry-run preview; write 1, skip 0" in captured.out


### PR DESCRIPTION
Summary
- normalize CLI label casing for artifact and manifest output in local_files and confluence
- align local_files write summary text with the shared count-based summary style
- remove the extra blank-line prefix before the confluence tree manifest line

Testing
- make check