### PR TITLE
docs: clarify Confluence dry-run tree labels

### DIFF
--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -362,13 +362,21 @@ def main(argv: Sequence[str] | None = None) -> int:
         else:
             selected_fetch_page = fetch_page
 
+        def _describe_tree_depth(max_depth: int) -> str:
+            if max_depth == 0:
+                return "root only"
+            if max_depth == 1:
+                return "root + children"
+            if max_depth == 2:
+                return "root + children + grandchildren"
+            return f"root + descendants through depth {max_depth}"
+
         def _print_confluence_invocation() -> None:
             content_source = (
                 "scaffolded page content"
                 if confluence_config.client_mode == "stub"
                 else "live Confluence content"
             )
-            fetch_scope = "tree" if confluence_config.tree else "page"
             run_mode = "dry-run" if confluence_config.dry_run else "write"
             print("Confluence adapter invoked")
             print(f"  base_url: {confluence_config.base_url}")
@@ -376,10 +384,18 @@ def main(argv: Sequence[str] | None = None) -> int:
             print(f"  output_dir: {confluence_config.output_dir}")
             print(f"  client_mode: {confluence_config.client_mode}")
             print(f"  content_source: {content_source}")
-            print(f"  fetch_scope: {fetch_scope}")
+            if confluence_config.dry_run:
+                mode = "tree" if confluence_config.tree else "single"
+                print(f"  mode: {mode}")
+            else:
+                fetch_scope = "tree" if confluence_config.tree else "page"
+                print(f"  fetch_scope: {fetch_scope}")
             print(f"  run_mode: {run_mode}")
             if confluence_config.tree:
-                print(f"  max_depth: {confluence_config.max_depth}")
+                max_depth = str(confluence_config.max_depth)
+                if confluence_config.dry_run:
+                    max_depth = f"{max_depth} ({_describe_tree_depth(confluence_config.max_depth)})"
+                print(f"  max_depth: {max_depth}")
             if confluence_config.client_mode == "real":
                 print(f"  auth_method: {confluence_config.auth_method}")
 

--- a/tests/test_confluence_real_client_contract.py
+++ b/tests/test_confluence_real_client_contract.py
@@ -292,7 +292,7 @@ def test_stub_and_real_single_page_dry_runs_share_the_same_plan_shape(
     stub_output = capsys.readouterr().out
     assert "client_mode: stub" in stub_output
     assert "content_source: scaffolded page content" in stub_output
-    assert "fetch_scope: page" in stub_output
+    assert "mode: single" in stub_output
     assert "run_mode: dry-run" in stub_output
     assert "Plan: Confluence run" in stub_output
     assert "resolved_page_id: 12345" in stub_output
@@ -322,7 +322,7 @@ def test_stub_and_real_single_page_dry_runs_share_the_same_plan_shape(
     real_output = capsys.readouterr().out
     assert "client_mode: real" in real_output
     assert "content_source: live Confluence content" in real_output
-    assert "fetch_scope: page" in real_output
+    assert "mode: single" in real_output
     assert "run_mode: dry-run" in real_output
     assert "auth_method: bearer-env" in real_output
     assert "Plan: Confluence run" in real_output

--- a/tests/test_confluence_recursive_contract.py
+++ b/tests/test_confluence_recursive_contract.py
@@ -274,6 +274,8 @@ def test_recursive_dry_run_reports_unique_planned_outputs_without_writing(
     captured = capsys.readouterr()
     output = captured.out
 
+    assert "mode: tree" in output
+    assert "max_depth: 2 (root + children + grandchildren)" in output
     for page_id in ["100", "200", "300", "205", "210"]:
         assert output.count(f"{output_dir / 'pages' / f'{page_id}.md'}") == 1
     assert output.count("unique_pages: 5") == 1

--- a/tests/test_normalize_writer.py
+++ b/tests/test_normalize_writer.py
@@ -141,7 +141,7 @@ def test_confluence_cli_dry_run_reports_output_without_writing(
     assert "Confluence adapter invoked" in captured.out
     assert "client_mode: stub" in captured.out
     assert "content_source: scaffolded page content" in captured.out
-    assert "fetch_scope: page" in captured.out
+    assert "mode: single" in captured.out
     assert "run_mode: dry-run" in captured.out
     assert "Plan: Confluence run" in captured.out
     assert "resolved_page_id: 12345" in captured.out
@@ -243,7 +243,7 @@ def test_confluence_cli_full_flow_keeps_dry_run_and_write_artifacts_in_sync(
     dry_run_output = capsys.readouterr().out
     assert "client_mode: stub" in dry_run_output
     assert "content_source: scaffolded page content" in dry_run_output
-    assert "fetch_scope: page" in dry_run_output
+    assert "mode: single" in dry_run_output
     assert "run_mode: dry-run" in dry_run_output
     assert "Plan: Confluence run" in dry_run_output
     assert "resolved_page_id: 12345" in dry_run_output
@@ -348,8 +348,8 @@ def test_confluence_cli_tree_dry_run_reports_manifest_path(
     assert exit_code == 0
 
     captured = capsys.readouterr()
-    assert "fetch_scope: tree" in captured.out
-    assert "max_depth: 0" in captured.out
+    assert "mode: tree" in captured.out
+    assert "max_depth: 0 (root only)" in captured.out
     assert f"manifest_path: {output_dir / 'manifest.json'}" in captured.out
     assert "Plan: Confluence run" in captured.out
     assert "unique_pages: 1" in captured.out


### PR DESCRIPTION
Summary
- clarify dry-run mode labels for Confluence single-page and tree runs
- append human-readable max-depth descriptions in tree dry-run output
- update dry-run assertions to cover the revised wording

Testing
- make check