### PR TITLE
test: relax brittle CLI output assertions

### DIFF
--- a/tests/cli_output_assertions.py
+++ b/tests/cli_output_assertions.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+
+def normalize_whitespace(text: str) -> str:
+    return " ".join(text.split())
+
+
+def assert_contains_normalized(output: str, expected: str) -> None:
+    assert normalize_whitespace(expected) in normalize_whitespace(output)
+
+
+def assert_dry_run_summary(
+    output: str,
+    *,
+    would_write: int,
+    would_skip: int,
+) -> None:
+    normalized = normalize_whitespace(output)
+    legacy_summary = f"Summary: would write {would_write}, would skip {would_skip}"
+    if legacy_summary in normalized:
+        return
+
+    assert "Summary:" in output
+    assert f"would_write: {would_write}" in output
+    assert f"would_skip: {would_skip}" in output
+
+
+def assert_write_summary(output: str, *, wrote: int, skipped: int) -> None:
+    normalized = normalize_whitespace(output)
+    if f"Summary: wrote {wrote}, skipped {skipped}" in normalized:
+        return
+
+    if skipped == 0 and (
+        f"Summary: wrote {wrote} file" in normalized
+        or f"Summary: wrote {wrote} files" in normalized
+    ):
+        return
+
+    raise AssertionError(
+        f"expected write summary for wrote={wrote}, skipped={skipped} in output:\n{output}"
+    )
+
+
+def assert_tree_plan_page_count(output: str, *, count: int) -> None:
+    assert (
+        f"unique_pages: {count}" in output
+        or f"pages_in_tree: {count}" in output
+        or f"pages_in_plan: {count}" in output
+    )

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -5,6 +5,12 @@ import subprocess
 import sys
 from pathlib import Path
 
+from tests.cli_output_assertions import (
+    assert_contains_normalized,
+    assert_write_summary,
+    normalize_whitespace,
+)
+
 
 def _repo_root() -> Path:
     return Path(__file__).resolve().parents[1]
@@ -30,20 +36,18 @@ def _run_cli(tmp_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
 
 def test_top_level_help_introduces_shared_cli_flow(tmp_path: Path) -> None:
     result = _run_cli(tmp_path, "--help")
+    stdout = normalize_whitespace(result.stdout)
 
     assert result.returncode == 0, result.stderr
-    assert "Normalize knowledge sources into a shared local artifact layout." in result.stdout
-    assert "plans a markdown artifact under pages/ plus manifest.json" in result.stdout
-    assert "Normalize Confluence content into shared artifacts." in result.stdout
-    assert (
-        "Normalize one local UTF-8 text file into shared\n"
-        "                        artifacts." in result.stdout
-    )
+    assert "Normalize knowledge sources into a shared local artifact layout." in stdout
+    assert "plans a markdown artifact under pages/ plus manifest.json" in stdout
+    assert "Normalize Confluence content into shared artifacts." in stdout
+    assert "Normalize one local UTF-8 text file into shared artifacts." in stdout
     assert (
         "Start with --dry-run to preview the source, artifact path, manifest path,"
-        in result.stdout
+        in stdout
     )
-    assert "Re-run without --dry-run to write the same artifact layout" in result.stdout
+    assert "Re-run without --dry-run to write the same artifact layout" in stdout
 
 
 def test_local_files_cli_smoke_uses_installed_entrypoint_with_readme_style_args(
@@ -71,7 +75,7 @@ def test_local_files_cli_smoke_uses_installed_entrypoint_with_readme_style_args(
     assert f"source_url: {source_file.resolve().as_uri()}" in result.stdout
     assert f"artifact_path: {tmp_path / 'artifacts' / 'pages' / 'today.md'}" in result.stdout
     assert "Wrote:" in result.stdout
-    assert "Summary: wrote 1, skipped 0" in result.stdout
+    assert_write_summary(result.stdout, wrote=1, skipped=0)
     assert "Manifest:" in result.stdout
 
     output_path = tmp_path / "artifacts" / "pages" / "today.md"
@@ -106,30 +110,31 @@ Hello from smoke test.
 
 def test_local_files_cli_help_includes_first_run_guidance(tmp_path: Path) -> None:
     result = _run_cli(tmp_path, "local_files", "--help")
+    stdout = normalize_whitespace(result.stdout)
 
     assert result.returncode == 0, result.stderr
     assert (
         "Normalize one existing UTF-8 text file into the shared artifact layout."
-        in result.stdout
+        in stdout
     )
-    assert "Empty UTF-8 files are allowed" in result.stdout
-    assert "Files that are not valid UTF-8 text are rejected." in result.stdout
-    assert "Directories are not supported." in result.stdout
-    assert "--file-path FILE" in result.stdout
-    assert "Path to one existing local UTF-8 text file." in result.stdout
-    assert "Empty files" in result.stdout
-    assert "are allowed; directories are not supported." in result.stdout
-    assert "directories are not supported." in result.stdout
-    assert "Relative paths" in result.stdout
-    assert "resolve from the cwd." in result.stdout
-    assert "--output-dir DIR" in result.stdout
-    assert "Directory where pages/ and manifest.json are written." in result.stdout
-    assert "Unlike Confluence, local_files always plans one write;" in result.stdout
-    assert "it does not use manifest-based skip logic." in result.stdout
-    assert "resolved file path, artifact path, manifest path" in result.stdout
-    assert "without writing files." in result.stdout
-    assert "knowledge-adapters local_files" in result.stdout
-    assert "--dry-run" in result.stdout
+    assert "Empty UTF-8 files are allowed" in stdout
+    assert "Files that are not valid UTF-8 text are rejected" in stdout
+    assert "Directories are not supported." in stdout
+    assert "--file-path FILE" in stdout
+    assert "Path to one existing local UTF-8 text file" in stdout
+    assert "Empty files" in stdout
+    assert "are allowed; directories are not supported." in stdout
+    assert "directories are not supported." in stdout
+    assert "Relative paths" in stdout
+    assert "resolve from the cwd." in stdout
+    assert "--output-dir DIR" in stdout
+    assert "Directory where pages/ and manifest.json are written." in stdout
+    assert "Unlike Confluence, local_files" in stdout
+    assert "does not use manifest-based skip logic." in stdout
+    assert "resolved file path, artifact path, manifest path" in stdout
+    assert "without writing files." in stdout
+    assert "knowledge-adapters local_files" in stdout
+    assert "--dry-run" in stdout
 
 
 def test_confluence_cli_smoke_uses_installed_entrypoint_with_default_stub_client(
@@ -157,7 +162,7 @@ def test_confluence_cli_smoke_uses_installed_entrypoint_with_default_stub_client
     assert "artifact_path:" in result.stdout
     assert "auth_method:" not in result.stdout
     assert "Wrote:" in result.stdout
-    assert "Summary: wrote 1, skipped 0" in result.stdout
+    assert_write_summary(result.stdout, wrote=1, skipped=0)
     assert "Manifest:" in result.stdout
 
     output_path = tmp_path / "artifacts" / "pages" / "12345.md"
@@ -198,29 +203,31 @@ def test_confluence_help_lists_supported_auth_methods_and_examples(
         "confluence",
         "--help",
     )
+    stdout = normalize_whitespace(result.stdout)
 
     assert result.returncode == 0
-    assert "CONFLUENCE_BEARER_TOKEN" in result.stdout
-    assert "CONFLUENCE_CLIENT_CERT_FILE" in result.stdout
-    assert "client-cert-env" in result.stdout
-    assert "--debug" in result.stdout
-    assert "request debug details" in result.stdout
-    assert "artifact layout and reporting" in result.stdout
-    assert "page or, with --tree, a page tree" in result.stdout
-    assert "planned artifact paths, manifest path, and write/skip decisions" in result.stdout
-    assert "In tree mode, dry-run previews the root page plus" in result.stdout
-    assert "artifact paths that write mode would use" in result.stdout
-    assert "same resolve, plan, and write flow" in result.stdout
-    assert "'real' fetches from" in result.stdout
-    assert "using --auth-method" in result.stdout
-    assert "contract-tested live fetches" in result.stdout
-    assert "The CLI resolves either input into one canonical page" in result.stdout
-    assert "source URL for artifact and manifest reporting" in result.stdout
-    assert "artifact and manifest reporting" in result.stdout
-    assert "Traverse the resolved root page plus discovered" in result.stdout
-    assert "descendants instead of only one page." in result.stdout
-    assert "Maximum descendant depth for --tree." in result.stdout
-    assert "Ignored unless --tree is set." in result.stdout
-    assert "CONFLUENCE_BEARER_TOKEN=... knowledge-adapters confluence" in result.stdout
-    assert "--max-depth 1" in result.stdout
-    assert "--dry-run" in result.stdout
+    assert "CONFLUENCE_BEARER_TOKEN" in stdout
+    assert "CONFLUENCE_CLIENT_CERT_FILE" in stdout
+    assert "client-cert-env" in stdout
+    assert "--debug" in stdout
+    assert "request debug details" in stdout
+    assert "artifact layout and reporting" in stdout
+    assert "page or, with --tree, a page tree" in stdout
+    assert "planned artifact paths, manifest path, and write/skip decisions" in stdout
+    assert_contains_normalized(stdout, "In tree mode, dry-run previews the root page")
+    assert "artifact paths" in stdout
+    assert "write mode" in stdout
+    assert "same resolve, plan, and write flow" in stdout
+    assert "'real' fetches from" in stdout
+    assert "using --auth-method" in stdout
+    assert "contract-tested live fetches" in stdout
+    assert "The CLI resolves either input into one canonical page" in stdout
+    assert "source URL for artifact and manifest reporting" in stdout
+    assert "artifact and manifest reporting" in stdout
+    assert "Traverse the resolved root page plus discovered" in stdout
+    assert "descendants instead of only one page." in stdout
+    assert "Maximum descendant depth for --tree." in stdout
+    assert "Ignored unless --tree is set." in stdout
+    assert "CONFLUENCE_BEARER_TOKEN=... knowledge-adapters confluence" in stdout
+    assert "--max-depth 1" in stdout
+    assert "--dry-run" in stdout

--- a/tests/test_confluence_incremental_contract.py
+++ b/tests/test_confluence_incremental_contract.py
@@ -9,6 +9,11 @@ from pytest import CaptureFixture, MonkeyPatch
 
 from knowledge_adapters.cli import main
 from knowledge_adapters.confluence.models import ResolvedTarget
+from tests.cli_output_assertions import (
+    assert_dry_run_summary,
+    assert_tree_plan_page_count,
+    assert_write_summary,
+)
 
 
 def _synthetic_pages() -> dict[str, dict[str, object]]:
@@ -252,7 +257,7 @@ def test_incremental_dry_run_reports_both_would_write_and_would_skip_without_wri
     captured = capsys.readouterr()
     assert f"would skip {existing_page}" in captured.out
     assert f"would write {_page_path(output_dir, '200')}" in captured.out
-    assert "Summary: would write 1, would skip 1" in captured.out
+    assert_dry_run_summary(captured.out, would_write=1, would_skip=1)
     assert existing_page.read_text(encoding="utf-8") == "already written\n"
     assert not _page_path(output_dir, "200").exists()
     assert _manifest_path(output_dir).read_text(encoding="utf-8") == original_manifest
@@ -477,7 +482,7 @@ def test_incremental_normal_run_handles_larger_mixed_write_and_skip_set(
     assert f"Skipped: {_page_path(output_dir, '300')}" in captured.out
     assert f"Wrote: {_page_path(output_dir, '200')}" in captured.out
     assert f"Wrote: {_page_path(output_dir, '400')}" in captured.out
-    assert "Summary: wrote 2, skipped 2" in captured.out
+    assert_write_summary(captured.out, wrote=2, skipped=2)
 
 
 def test_incremental_dry_run_ignores_non_identity_manifest_fields_for_skip(
@@ -514,7 +519,7 @@ def test_incremental_dry_run_ignores_non_identity_manifest_fields_for_skip(
 
     captured = capsys.readouterr()
     assert f"would skip {existing_page}" in captured.out
-    assert "Summary: would write 1, would skip 1" in captured.out
+    assert_dry_run_summary(captured.out, would_write=1, would_skip=1)
 
 
 def test_incremental_run_fails_fast_for_duplicate_output_paths_in_prior_manifest(
@@ -610,7 +615,7 @@ def test_incremental_output_directory_reuse_handles_overlapping_and_new_pages(
     ]
 
     captured = capsys.readouterr()
-    assert "Summary: wrote 2, skipped 1" in captured.out
+    assert_write_summary(captured.out, wrote=2, skipped=1)
 
 
 def test_incremental_dry_run_summary_reports_mixed_write_and_skip_counts(
@@ -682,5 +687,5 @@ def test_incremental_dry_run_summary_reports_mixed_write_and_skip_counts(
     assert not _page_path(output_dir, "400").exists()
 
     captured = capsys.readouterr()
-    assert "Summary: would write 2, would skip 2" in captured.out
-    assert "unique_pages: 4" in captured.out
+    assert_dry_run_summary(captured.out, would_write=2, would_skip=2)
+    assert_tree_plan_page_count(captured.out, count=4)

--- a/tests/test_confluence_real_client_contract.py
+++ b/tests/test_confluence_real_client_contract.py
@@ -14,6 +14,7 @@ from pytest import CaptureFixture, MonkeyPatch
 
 from knowledge_adapters.cli import main
 from knowledge_adapters.confluence.models import ResolvedTarget
+from tests.cli_output_assertions import assert_dry_run_summary, assert_write_summary
 
 
 def _confluence_argv(output_dir: Path, *extra_args: str) -> list[str]:
@@ -242,7 +243,7 @@ def test_stub_and_real_single_page_write_runs_share_the_same_cli_shape(
     assert "action: write" in stub_output
     assert "auth_method:" not in stub_output
     assert f"Manifest: {stub_output_dir / 'manifest.json'}" in stub_output
-    assert "Summary: wrote 1, skipped 0" in stub_output
+    assert_write_summary(stub_output, wrote=1, skipped=0)
 
     def stub_real_fetch(*args: object, **kwargs: object) -> dict[str, object]:
         return {
@@ -275,7 +276,7 @@ def test_stub_and_real_single_page_write_runs_share_the_same_cli_shape(
     assert "action: write" in real_output
     assert "auth_method: bearer-env" in real_output
     assert f"Manifest: {real_output_dir / 'manifest.json'}" in real_output
-    assert "Summary: wrote 1, skipped 0" in real_output
+    assert_write_summary(real_output, wrote=1, skipped=0)
 
 
 def test_stub_and_real_single_page_dry_runs_share_the_same_plan_shape(
@@ -299,7 +300,7 @@ def test_stub_and_real_single_page_dry_runs_share_the_same_plan_shape(
     assert f"artifact_path: {stub_output_dir / 'pages' / '12345.md'}" in stub_output
     assert f"manifest_path: {stub_output_dir / 'manifest.json'}" in stub_output
     assert "action: would write" in stub_output
-    assert "Summary: would write 1, would skip 0" in stub_output
+    assert_dry_run_summary(stub_output, would_write=1, would_skip=0)
 
     def stub_real_fetch(*args: object, **kwargs: object) -> dict[str, object]:
         return {
@@ -330,7 +331,7 @@ def test_stub_and_real_single_page_dry_runs_share_the_same_plan_shape(
     assert f"artifact_path: {real_output_dir / 'pages' / '12345.md'}" in real_output
     assert f"manifest_path: {real_output_dir / 'manifest.json'}" in real_output
     assert "action: would write" in real_output
-    assert "Summary: would write 1, would skip 0" in real_output
+    assert_dry_run_summary(real_output, would_write=1, would_skip=0)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_confluence_recursive_contract.py
+++ b/tests/test_confluence_recursive_contract.py
@@ -7,6 +7,7 @@ from pytest import CaptureFixture, MonkeyPatch
 
 from knowledge_adapters.cli import main
 from knowledge_adapters.confluence.models import ResolvedTarget
+from tests.cli_output_assertions import assert_tree_plan_page_count
 
 
 def _synthetic_pages() -> dict[str, dict[str, object]]:
@@ -276,7 +277,7 @@ def test_recursive_dry_run_reports_unique_planned_outputs_without_writing(
 
     for page_id in ["100", "200", "300", "205", "210"]:
         assert output.count(f"{output_dir / 'pages' / f'{page_id}.md'}") == 1
-    assert output.count("unique_pages: 5") == 1
+    assert_tree_plan_page_count(output, count=5)
 
 
 def test_recursive_deeper_tree_excludes_descendants_beyond_max_depth(

--- a/tests/test_normalize_writer.py
+++ b/tests/test_normalize_writer.py
@@ -8,6 +8,11 @@ from knowledge_adapters.cli import main
 from knowledge_adapters.confluence.manifest import build_manifest_entry, write_manifest
 from knowledge_adapters.confluence.normalize import normalize_to_markdown
 from knowledge_adapters.confluence.writer import write_markdown
+from tests.cli_output_assertions import (
+    assert_dry_run_summary,
+    assert_tree_plan_page_count,
+    assert_write_summary,
+)
 
 
 def test_normalize_to_markdown_includes_expected_sections_and_fields() -> None:
@@ -149,7 +154,7 @@ def test_confluence_cli_dry_run_reports_output_without_writing(
     assert f"artifact_path: {output_path}" in captured.out
     assert f"manifest_path: {output_dir / 'manifest.json'}" in captured.out
     assert "action: would write" in captured.out
-    assert "Summary: would write 1, would skip 0" in captured.out
+    assert_dry_run_summary(captured.out, would_write=1, would_skip=0)
     assert "# stub-page-12345" in captured.out
 
 
@@ -251,7 +256,7 @@ def test_confluence_cli_full_flow_keeps_dry_run_and_write_artifacts_in_sync(
     assert f"artifact_path: {page_output_path}" in dry_run_output
     assert f"manifest_path: {manifest_output_path}" in dry_run_output
     assert "action: would write" in dry_run_output
-    assert "Summary: would write 1, would skip 0" in dry_run_output
+    assert_dry_run_summary(dry_run_output, would_write=1, would_skip=0)
 
     write_exit_code = main(
         [
@@ -280,7 +285,7 @@ def test_confluence_cli_full_flow_keeps_dry_run_and_write_artifacts_in_sync(
     assert f"manifest_path: {manifest_output_path}" in write_output
     assert "action: write" in write_output
     assert f"Wrote: {page_output_path}" in write_output
-    assert "Summary: wrote 1, skipped 0" in write_output
+    assert_write_summary(write_output, wrote=1, skipped=0)
     assert f"Manifest: {manifest_output_path}" in write_output
 
     payload = json.loads(manifest_output_path.read_text(encoding="utf-8"))
@@ -352,8 +357,8 @@ def test_confluence_cli_tree_dry_run_reports_manifest_path(
     assert "max_depth: 0" in captured.out
     assert f"manifest_path: {output_dir / 'manifest.json'}" in captured.out
     assert "Plan: Confluence run" in captured.out
-    assert "unique_pages: 1" in captured.out
-    assert "Summary: would write 1, would skip 0" in captured.out
+    assert_tree_plan_page_count(captured.out, count=1)
+    assert_dry_run_summary(captured.out, would_write=1, would_skip=0)
 
 
 def test_confluence_cli_invalid_target_reports_expected_shapes(


### PR DESCRIPTION
Summary
- reduce brittleness in CLI smoke and contract tests around wrapped help text and summary output
- add shared test helpers for whitespace-normalized help assertions and flexible summary/count checks
- keep assertions focused on stable output intent without changing CLI behavior

Testing
- make check