### PR TITLE
test: align confluence dry-run summary assertions

### DIFF
--- a/tests/confluence_output_assertions.py
+++ b/tests/confluence_output_assertions.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+
+
+def assert_single_page_confluence_dry_run_summary(
+    output: str,
+    *,
+    client_mode: str,
+    content_source: str,
+    page_id: str,
+    source_url: str,
+    artifact_path: Path,
+    manifest_path: Path,
+    auth_method: str | None = None,
+    action: str = "write",
+    write_count: int = 1,
+    skip_count: int = 0,
+) -> None:
+    assert "Confluence adapter invoked" in output
+    assert f"client_mode: {client_mode}" in output
+    assert f"content_source: {content_source}" in output
+    assert "fetch_scope: page" in output
+    assert "run_mode: dry-run" in output
+    if auth_method is None:
+        assert "auth_method:" not in output
+    else:
+        assert f"auth_method: {auth_method}" in output
+
+    assert "Plan: Confluence run" in output
+    assert f"resolved_page_id: {page_id}" in output
+    assert f"source_url: {source_url}" in output
+    assert f"artifact_path: {artifact_path}" in output
+    assert f"manifest_path: {manifest_path}" in output
+    assert f"action: would {action}" in output
+    assert f"Summary: would write {write_count}, would skip {skip_count}" in output
+
+
+def assert_tree_confluence_dry_run_summary(
+    output: str,
+    *,
+    root_page_id: str,
+    manifest_path: Path,
+    max_depth: int,
+    unique_pages: int,
+    write_count: int,
+    skip_count: int,
+    client_mode: str = "stub",
+    content_source: str = "scaffolded page content",
+    auth_method: str | None = None,
+    planned_actions: Iterable[tuple[str, Path]] = (),
+) -> None:
+    assert "Confluence adapter invoked" in output
+    assert f"client_mode: {client_mode}" in output
+    assert f"content_source: {content_source}" in output
+    assert "fetch_scope: tree" in output
+    assert "run_mode: dry-run" in output
+    if auth_method is None:
+        assert "auth_method:" not in output
+    else:
+        assert f"auth_method: {auth_method}" in output
+
+    assert "Plan: Confluence run" in output
+    assert f"resolved_root_page_id: {root_page_id} (root page)" in output
+    assert f"max_depth: {max_depth}" in output
+    assert f"manifest_path: {manifest_path}" in output
+    assert f"unique_pages: {unique_pages} (root + descendants)" in output
+    for action, path in planned_actions:
+        assert f"would {action} {path}" in output
+    assert f"Summary: would write {write_count}, would skip {skip_count}" in output

--- a/tests/test_confluence_incremental_contract.py
+++ b/tests/test_confluence_incremental_contract.py
@@ -9,6 +9,7 @@ from pytest import CaptureFixture, MonkeyPatch
 
 from knowledge_adapters.cli import main
 from knowledge_adapters.confluence.models import ResolvedTarget
+from tests.confluence_output_assertions import assert_tree_confluence_dry_run_summary
 
 
 def _synthetic_pages() -> dict[str, dict[str, object]]:
@@ -133,8 +134,19 @@ def test_incremental_dry_run_without_manifest_marks_all_pages_as_write(
     assert exit_code == 0
 
     captured = capsys.readouterr()
-    assert f"would write {_page_path(output_dir, '100')}" in captured.out
-    assert f"would write {_page_path(output_dir, '200')}" in captured.out
+    assert_tree_confluence_dry_run_summary(
+        captured.out,
+        root_page_id="100",
+        manifest_path=_manifest_path(output_dir),
+        max_depth=1,
+        unique_pages=2,
+        write_count=2,
+        skip_count=0,
+        planned_actions=[
+            ("write", _page_path(output_dir, "100")),
+            ("write", _page_path(output_dir, "200")),
+        ],
+    )
     assert f"would skip {_page_path(output_dir, '100')}" not in captured.out
     assert f"would skip {_page_path(output_dir, '200')}" not in captured.out
     assert not _page_path(output_dir, "100").exists()
@@ -212,6 +224,17 @@ def test_incremental_dry_run_uses_manifest_identity_and_file_existence_for_skip(
     assert exit_code == 0
 
     captured = capsys.readouterr()
+    write_count = 1 if expected_phrase == "would skip" else 2
+    skip_count = 1 if expected_phrase == "would skip" else 0
+    assert_tree_confluence_dry_run_summary(
+        captured.out,
+        root_page_id="100",
+        manifest_path=_manifest_path(output_dir),
+        max_depth=1,
+        unique_pages=2,
+        write_count=write_count,
+        skip_count=skip_count,
+    )
     assert f"{expected_phrase} {_page_path(output_dir, '100')}" in captured.out
     if materialize_file and manifest_entry["output_path"] == "pages/100.md":
         assert _page_path(output_dir, "100").read_text(encoding="utf-8") == "existing artifact\n"
@@ -250,9 +273,19 @@ def test_incremental_dry_run_reports_both_would_write_and_would_skip_without_wri
     assert exit_code == 0
 
     captured = capsys.readouterr()
-    assert f"would skip {existing_page}" in captured.out
-    assert f"would write {_page_path(output_dir, '200')}" in captured.out
-    assert "Summary: would write 1, would skip 1" in captured.out
+    assert_tree_confluence_dry_run_summary(
+        captured.out,
+        root_page_id="100",
+        manifest_path=_manifest_path(output_dir),
+        max_depth=1,
+        unique_pages=2,
+        write_count=1,
+        skip_count=1,
+        planned_actions=[
+            ("skip", existing_page),
+            ("write", _page_path(output_dir, "200")),
+        ],
+    )
     assert existing_page.read_text(encoding="utf-8") == "already written\n"
     assert not _page_path(output_dir, "200").exists()
     assert _manifest_path(output_dir).read_text(encoding="utf-8") == original_manifest
@@ -513,8 +546,16 @@ def test_incremental_dry_run_ignores_non_identity_manifest_fields_for_skip(
     assert exit_code == 0
 
     captured = capsys.readouterr()
-    assert f"would skip {existing_page}" in captured.out
-    assert "Summary: would write 1, would skip 1" in captured.out
+    assert_tree_confluence_dry_run_summary(
+        captured.out,
+        root_page_id="100",
+        manifest_path=_manifest_path(output_dir),
+        max_depth=1,
+        unique_pages=2,
+        write_count=1,
+        skip_count=1,
+        planned_actions=[("skip", existing_page)],
+    )
 
 
 def test_incremental_run_fails_fast_for_duplicate_output_paths_in_prior_manifest(
@@ -682,5 +723,12 @@ def test_incremental_dry_run_summary_reports_mixed_write_and_skip_counts(
     assert not _page_path(output_dir, "400").exists()
 
     captured = capsys.readouterr()
-    assert "Summary: would write 2, would skip 2" in captured.out
-    assert "unique_pages: 4" in captured.out
+    assert_tree_confluence_dry_run_summary(
+        captured.out,
+        root_page_id="100",
+        manifest_path=_manifest_path(output_dir),
+        max_depth=1,
+        unique_pages=4,
+        write_count=2,
+        skip_count=2,
+    )

--- a/tests/test_confluence_real_client_contract.py
+++ b/tests/test_confluence_real_client_contract.py
@@ -14,6 +14,9 @@ from pytest import CaptureFixture, MonkeyPatch
 
 from knowledge_adapters.cli import main
 from knowledge_adapters.confluence.models import ResolvedTarget
+from tests.confluence_output_assertions import (
+    assert_single_page_confluence_dry_run_summary,
+)
 
 
 def _confluence_argv(output_dir: Path, *extra_args: str) -> list[str]:
@@ -290,16 +293,15 @@ def test_stub_and_real_single_page_dry_runs_share_the_same_plan_shape(
     assert stub_exit_code == 0
 
     stub_output = capsys.readouterr().out
-    assert "client_mode: stub" in stub_output
-    assert "content_source: scaffolded page content" in stub_output
-    assert "fetch_scope: page" in stub_output
-    assert "run_mode: dry-run" in stub_output
-    assert "Plan: Confluence run" in stub_output
-    assert "resolved_page_id: 12345" in stub_output
-    assert f"artifact_path: {stub_output_dir / 'pages' / '12345.md'}" in stub_output
-    assert f"manifest_path: {stub_output_dir / 'manifest.json'}" in stub_output
-    assert "action: would write" in stub_output
-    assert "Summary: would write 1, would skip 0" in stub_output
+    assert_single_page_confluence_dry_run_summary(
+        stub_output,
+        client_mode="stub",
+        content_source="scaffolded page content",
+        page_id="12345",
+        source_url="https://example.com/wiki/pages/viewpage.action?pageId=12345",
+        artifact_path=stub_output_dir / "pages" / "12345.md",
+        manifest_path=stub_output_dir / "manifest.json",
+    )
 
     def stub_real_fetch(*args: object, **kwargs: object) -> dict[str, object]:
         return {
@@ -320,17 +322,16 @@ def test_stub_and_real_single_page_dry_runs_share_the_same_plan_shape(
     assert real_exit_code == 0
 
     real_output = capsys.readouterr().out
-    assert "client_mode: real" in real_output
-    assert "content_source: live Confluence content" in real_output
-    assert "fetch_scope: page" in real_output
-    assert "run_mode: dry-run" in real_output
-    assert "auth_method: bearer-env" in real_output
-    assert "Plan: Confluence run" in real_output
-    assert "resolved_page_id: 12345" in real_output
-    assert f"artifact_path: {real_output_dir / 'pages' / '12345.md'}" in real_output
-    assert f"manifest_path: {real_output_dir / 'manifest.json'}" in real_output
-    assert "action: would write" in real_output
-    assert "Summary: would write 1, would skip 0" in real_output
+    assert_single_page_confluence_dry_run_summary(
+        real_output,
+        client_mode="real",
+        content_source="live Confluence content",
+        page_id="12345",
+        source_url="https://example.com/wiki/spaces/ENG/pages/12345",
+        artifact_path=real_output_dir / "pages" / "12345.md",
+        manifest_path=real_output_dir / "manifest.json",
+        auth_method="bearer-env",
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_normalize_writer.py
+++ b/tests/test_normalize_writer.py
@@ -8,6 +8,10 @@ from knowledge_adapters.cli import main
 from knowledge_adapters.confluence.manifest import build_manifest_entry, write_manifest
 from knowledge_adapters.confluence.normalize import normalize_to_markdown
 from knowledge_adapters.confluence.writer import write_markdown
+from tests.confluence_output_assertions import (
+    assert_single_page_confluence_dry_run_summary,
+    assert_tree_confluence_dry_run_summary,
+)
 
 
 def test_normalize_to_markdown_includes_expected_sections_and_fields() -> None:
@@ -138,18 +142,15 @@ def test_confluence_cli_dry_run_reports_output_without_writing(
     assert not (output_dir / "manifest.json").exists()
 
     captured = capsys.readouterr()
-    assert "Confluence adapter invoked" in captured.out
-    assert "client_mode: stub" in captured.out
-    assert "content_source: scaffolded page content" in captured.out
-    assert "fetch_scope: page" in captured.out
-    assert "run_mode: dry-run" in captured.out
-    assert "Plan: Confluence run" in captured.out
-    assert "resolved_page_id: 12345" in captured.out
-    assert "source_url: https://example.com/wiki/pages/viewpage.action?pageId=12345" in captured.out
-    assert f"artifact_path: {output_path}" in captured.out
-    assert f"manifest_path: {output_dir / 'manifest.json'}" in captured.out
-    assert "action: would write" in captured.out
-    assert "Summary: would write 1, would skip 0" in captured.out
+    assert_single_page_confluence_dry_run_summary(
+        captured.out,
+        client_mode="stub",
+        content_source="scaffolded page content",
+        page_id="12345",
+        source_url="https://example.com/wiki/pages/viewpage.action?pageId=12345",
+        artifact_path=output_path,
+        manifest_path=output_dir / "manifest.json",
+    )
     assert "# stub-page-12345" in captured.out
 
 
@@ -175,9 +176,15 @@ def test_confluence_cli_dry_run_reports_same_resolved_target_details_for_full_ur
     assert exit_code == 0
 
     captured = capsys.readouterr()
-    assert "resolved_page_id: 12345" in captured.out
-    assert "source_url: https://example.com/wiki/pages/viewpage.action?pageId=12345" in captured.out
-    assert f"artifact_path: {output_dir / 'pages' / '12345.md'}" in captured.out
+    assert_single_page_confluence_dry_run_summary(
+        captured.out,
+        client_mode="stub",
+        content_source="scaffolded page content",
+        page_id="12345",
+        source_url="https://example.com/wiki/pages/viewpage.action?pageId=12345",
+        artifact_path=output_dir / "pages" / "12345.md",
+        manifest_path=output_dir / "manifest.json",
+    )
     assert (
         "- source_url: https://example.com/wiki/pages/viewpage.action?pageId=12345"
         in captured.out
@@ -241,17 +248,15 @@ def test_confluence_cli_full_flow_keeps_dry_run_and_write_artifacts_in_sync(
     assert not manifest_output_path.exists()
 
     dry_run_output = capsys.readouterr().out
-    assert "client_mode: stub" in dry_run_output
-    assert "content_source: scaffolded page content" in dry_run_output
-    assert "fetch_scope: page" in dry_run_output
-    assert "run_mode: dry-run" in dry_run_output
-    assert "Plan: Confluence run" in dry_run_output
-    assert "resolved_page_id: 12345" in dry_run_output
-    assert f"source_url: {canonical_source_url}" in dry_run_output
-    assert f"artifact_path: {page_output_path}" in dry_run_output
-    assert f"manifest_path: {manifest_output_path}" in dry_run_output
-    assert "action: would write" in dry_run_output
-    assert "Summary: would write 1, would skip 0" in dry_run_output
+    assert_single_page_confluence_dry_run_summary(
+        dry_run_output,
+        client_mode="stub",
+        content_source="scaffolded page content",
+        page_id="12345",
+        source_url=canonical_source_url,
+        artifact_path=page_output_path,
+        manifest_path=manifest_output_path,
+    )
 
     write_exit_code = main(
         [
@@ -348,12 +353,16 @@ def test_confluence_cli_tree_dry_run_reports_manifest_path(
     assert exit_code == 0
 
     captured = capsys.readouterr()
-    assert "fetch_scope: tree" in captured.out
-    assert "max_depth: 0" in captured.out
-    assert f"manifest_path: {output_dir / 'manifest.json'}" in captured.out
-    assert "Plan: Confluence run" in captured.out
-    assert "unique_pages: 1" in captured.out
-    assert "Summary: would write 1, would skip 0" in captured.out
+    assert_tree_confluence_dry_run_summary(
+        captured.out,
+        root_page_id="12345",
+        manifest_path=output_dir / "manifest.json",
+        max_depth=0,
+        unique_pages=1,
+        write_count=1,
+        skip_count=0,
+        planned_actions=[("write", output_dir / "pages" / "12345.md")],
+    )
 
 
 def test_confluence_cli_invalid_target_reports_expected_shapes(


### PR DESCRIPTION
Summary
- centralize the Confluence dry-run summary expectations in a shared test helper
- align single-page and tree-mode dry-run assertions with the current CLI summary surface across the affected Confluence tests

Testing
- make check