### PR TITLE
fix: clarify local_files output paths

### DIFF
--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -719,8 +719,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         print("\nPlan: Local files run")
         print(f"  resolved_file_path: {resolved_input_path}")
         print(f"  source_url: {page.get('source_url', '')}")
-        print(f"  Artifact: {output_path}")
-        print(f"  Manifest: {manifest_output_path}")
+        print(f"  Artifact path: {output_path}")
+        print(f"  Manifest path: {manifest_output_path}")
         content = str(page.get("content", ""))
         if content:
             print("  content_status: UTF-8 text with content")
@@ -763,8 +763,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
         print(f"\nWrote: {output_path}")
         print("\nSummary: wrote 1, skipped 0")
-        print(f"Artifact: {output_path}")
-        print(f"Manifest: {output_dir / manifest.relative_to(output_dir_input)}")
+        print(f"Artifact path: {output_path}")
+        print(f"Manifest path: {output_dir / manifest.relative_to(output_dir_input)}")
         print_write_complete(output_dir)
         return 0
 

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -73,11 +73,11 @@ def test_local_files_cli_smoke_uses_installed_entrypoint_with_readme_style_args(
     assert "Plan: Local files run" in result.stdout
     assert f"resolved_file_path: {source_file.resolve()}" in result.stdout
     assert f"source_url: {source_file.resolve().as_uri()}" in result.stdout
-    assert f"Artifact: {tmp_path / 'artifacts' / 'pages' / 'today.md'}" in result.stdout
+    assert f"Artifact path: {tmp_path / 'artifacts' / 'pages' / 'today.md'}" in result.stdout
     assert "Wrote:" in result.stdout
     assert_write_summary(result.stdout, wrote=1, skipped=0)
-    assert f"Artifact: {tmp_path / 'artifacts' / 'pages' / 'today.md'}" in result.stdout
-    assert f"Manifest: {tmp_path / 'artifacts' / 'manifest.json'}" in result.stdout
+    assert f"Artifact path: {tmp_path / 'artifacts' / 'pages' / 'today.md'}" in result.stdout
+    assert f"Manifest path: {tmp_path / 'artifacts' / 'manifest.json'}" in result.stdout
     assert f"Write complete. Artifacts created under {tmp_path / 'artifacts'}" in result.stdout
 
     output_path = tmp_path / "artifacts" / "pages" / "today.md"

--- a/tests/test_local_files.py
+++ b/tests/test_local_files.py
@@ -63,8 +63,8 @@ def test_local_files_cli_writes_normalized_markdown(
     assert exit_code == 0
     captured = capsys.readouterr()
     assert "Summary: wrote 1, skipped 0" in captured.out
-    assert f"Artifact: {output_dir / 'pages' / 'meeting-notes.md'}" in captured.out
-    assert f"Manifest: {output_dir / 'manifest.json'}" in captured.out
+    assert f"Artifact path: {output_dir / 'pages' / 'meeting-notes.md'}" in captured.out
+    assert f"Manifest path: {output_dir / 'manifest.json'}" in captured.out
 
     output_path = output_dir / "pages" / "meeting-notes.md"
     assert output_path.exists()
@@ -130,8 +130,8 @@ def test_local_files_cli_dry_run_reports_output_without_writing(
     assert "Plan: Local files run" in captured.out
     assert f"resolved_file_path: {source_file.resolve()}" in captured.out
     assert f"source_url: {source_file.resolve().as_uri()}" in captured.out
-    assert f"Artifact: {output_path}" in captured.out
-    assert f"Manifest: {output_dir / 'manifest.json'}" in captured.out
+    assert f"Artifact path: {output_path}" in captured.out
+    assert f"Manifest path: {output_dir / 'manifest.json'}" in captured.out
     assert "content_status: UTF-8 text with content" in captured.out
     assert "action: would write" in captured.out
     assert "Summary: would write 1, would skip 0" in captured.out


### PR DESCRIPTION
Summary
- clarify the local_files artifact and manifest labels by calling them path output
- keep the dry-run and write behavior unchanged

Testing
- make check