### PR TITLE
fix: clarify confluence single-page planned action

### DIFF
--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -459,7 +459,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             print(f"  source_url: {source_url}")
             print(f"  Artifact: {_display_output_path(output_path)}")
             print(f"  Manifest: {_display_output_path(manifest_output_path)}")
-            print(f"  action: {'would ' if dry_run else ''}{action}")
+            print(f"  planned_action: {'would ' if dry_run else ''}{action}")
             if dry_run:
                 write_count = 1 if action == "write" else 0
                 skip_count = 1 if action == "skip" else 0

--- a/tests/test_confluence_real_client_contract.py
+++ b/tests/test_confluence_real_client_contract.py
@@ -240,7 +240,7 @@ def test_stub_and_real_single_page_write_runs_share_the_same_cli_shape(
     assert "resolved_page_id: 12345" in stub_output
     assert f"Artifact: {stub_output_dir / 'pages' / '12345.md'}" in stub_output
     assert f"Manifest: {stub_output_dir / 'manifest.json'}" in stub_output
-    assert "action: write" in stub_output
+    assert "planned_action: write" in stub_output
     assert "auth_method:" not in stub_output
     assert f"Manifest: {stub_output_dir / 'manifest.json'}" in stub_output
     assert_write_summary(stub_output, wrote=1, skipped=0)
@@ -273,7 +273,7 @@ def test_stub_and_real_single_page_write_runs_share_the_same_cli_shape(
     assert "resolved_page_id: 12345" in real_output
     assert f"Artifact: {real_output_dir / 'pages' / '12345.md'}" in real_output
     assert f"Manifest: {real_output_dir / 'manifest.json'}" in real_output
-    assert "action: write" in real_output
+    assert "planned_action: write" in real_output
     assert "auth_method: bearer-env" in real_output
     assert f"Manifest: {real_output_dir / 'manifest.json'}" in real_output
     assert_write_summary(real_output, wrote=1, skipped=0)
@@ -300,7 +300,7 @@ def test_stub_and_real_single_page_dry_runs_share_the_same_plan_shape(
     assert "source_url: https://example.com/wiki/pages/viewpage.action?pageId=12345" in stub_output
     assert f"Artifact: {stub_output_dir / 'pages' / '12345.md'}" in stub_output
     assert f"Manifest: {stub_output_dir / 'manifest.json'}" in stub_output
-    assert "action: would write" in stub_output
+    assert "planned_action: would write" in stub_output
     assert_dry_run_summary(stub_output, would_write=1, would_skip=0)
 
     def stub_real_fetch(*args: object, **kwargs: object) -> dict[str, object]:
@@ -332,7 +332,7 @@ def test_stub_and_real_single_page_dry_runs_share_the_same_plan_shape(
     assert "source_url: https://example.com/wiki/spaces/ENG/pages/12345" in real_output
     assert f"Artifact: {real_output_dir / 'pages' / '12345.md'}" in real_output
     assert f"Manifest: {real_output_dir / 'manifest.json'}" in real_output
-    assert "action: would write" in real_output
+    assert "planned_action: would write" in real_output
     assert_dry_run_summary(real_output, would_write=1, would_skip=0)
 
 

--- a/tests/test_normalize_writer.py
+++ b/tests/test_normalize_writer.py
@@ -153,7 +153,7 @@ def test_confluence_cli_dry_run_reports_output_without_writing(
     assert "source_url: https://example.com/wiki/pages/viewpage.action?pageId=12345" in captured.out
     assert f"Artifact: {output_path}" in captured.out
     assert f"Manifest: {output_dir / 'manifest.json'}" in captured.out
-    assert "action: would write" in captured.out
+    assert "planned_action: would write" in captured.out
     assert_dry_run_summary(captured.out, would_write=1, would_skip=0)
     assert "# stub-page-12345" in captured.out
 
@@ -255,7 +255,7 @@ def test_confluence_cli_full_flow_keeps_dry_run_and_write_artifacts_in_sync(
     assert f"source_url: {canonical_source_url}" in dry_run_output
     assert f"Artifact: {page_output_path}" in dry_run_output
     assert f"Manifest: {manifest_output_path}" in dry_run_output
-    assert "action: would write" in dry_run_output
+    assert "planned_action: would write" in dry_run_output
     assert_dry_run_summary(dry_run_output, would_write=1, would_skip=0)
 
     write_exit_code = main(
@@ -283,7 +283,7 @@ def test_confluence_cli_full_flow_keeps_dry_run_and_write_artifacts_in_sync(
     assert "resolved_page_id: 12345" in write_output
     assert f"Artifact: {page_output_path}" in write_output
     assert f"Manifest: {manifest_output_path}" in write_output
-    assert "action: write" in write_output
+    assert "planned_action: write" in write_output
     assert f"Wrote: {page_output_path}" in write_output
     assert_write_summary(write_output, wrote=1, skipped=0)
     assert f"Manifest: {manifest_output_path}" in write_output


### PR DESCRIPTION
Summary
- clarify the Confluence single-page plan line by renaming action to planned_action
- preserve behavior and update Confluence single-page wording assertions to match

Testing
- make check