### PR TITLE
fix: validate --base-url before Confluence planning

### DIFF
--- a/src/knowledge_adapters/confluence/resolve.py
+++ b/src/knowledge_adapters/confluence/resolve.py
@@ -18,6 +18,18 @@ def _parse_absolute_http_url(value: str) -> parse.ParseResult | None:
     return parsed
 
 
+def validate_base_url(base_url: str) -> str:
+    """Validate and normalize a CLI-facing Confluence base URL."""
+    normalized_base_url = base_url.strip()
+    if _parse_absolute_http_url(normalized_base_url) is None:
+        raise ValueError(
+            f"--base-url {base_url!r} is invalid. "
+            "Provide a full http:// or https:// Confluence base URL, "
+            "for example 'https://example.com/wiki'."
+        )
+    return normalized_base_url
+
+
 def _page_id_from_url(parsed_url: parse.ParseResult) -> str | None:
     query_page_ids = parse.parse_qs(parsed_url.query).get("pageId", [])
     if query_page_ids:
@@ -115,13 +127,17 @@ def resolve_target(target: str) -> ResolvedTarget:
 
 def resolve_target_for_base_url(target: str, *, base_url: str) -> ResolvedTarget:
     """Resolve and validate a target for CLI-facing Confluence usage."""
+    validated_base_url = validate_base_url(base_url)
     resolved = resolve_target(target)
 
     if resolved.input_kind == "page_id":
         return ResolvedTarget(
             raw_value=resolved.raw_value,
             page_id=resolved.page_id,
-            page_url=_canonical_page_url(base_url=base_url, page_id=resolved.page_id or ""),
+            page_url=_canonical_page_url(
+                base_url=validated_base_url,
+                page_id=resolved.page_id or "",
+            ),
             input_kind=resolved.input_kind,
         )
 
@@ -142,16 +158,17 @@ def resolve_target_for_base_url(target: str, *, base_url: str) -> ResolvedTarget
             )
         if resolved.page_url and not _url_matches_base_url(
             page_url=resolved.page_url,
-            base_url=base_url,
+            base_url=validated_base_url,
         ):
             raise ValueError(
-                f"Target URL {resolved.raw_value!r} does not match --base-url {base_url!r}. "
+                f"Target URL {resolved.raw_value!r} does not match "
+                f"--base-url {validated_base_url!r}. "
                 "Use a URL under that base URL or pass the page ID directly."
             )
         return ResolvedTarget(
             raw_value=resolved.raw_value,
             page_id=resolved.page_id,
-            page_url=_canonical_page_url(base_url=base_url, page_id=resolved.page_id),
+            page_url=_canonical_page_url(base_url=validated_base_url, page_id=resolved.page_id),
             input_kind=resolved.input_kind,
         )
 

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -232,3 +232,26 @@ def test_confluence_help_lists_supported_auth_methods_and_examples(
     assert "CONFLUENCE_BEARER_TOKEN=... knowledge-adapters confluence" in stdout
     assert "--max-depth 1" in stdout
     assert "--dry-run" in stdout
+
+
+def test_confluence_cli_rejects_invalid_base_url_before_planning(tmp_path: Path) -> None:
+    result = _run_cli(
+        tmp_path,
+        "confluence",
+        "--base-url",
+        "ftp://example.com/wiki",
+        "--target",
+        "12345",
+        "--output-dir",
+        "./artifacts",
+    )
+
+    assert result.returncode == 2
+    assert result.stdout == ""
+    assert "Plan: Confluence run" not in result.stdout
+    assert "Confluence adapter invoked" not in result.stdout
+    assert (
+        "knowledge-adapters confluence: error: --base-url 'ftp://example.com/wiki' "
+        "is invalid. Provide a full http:// or https:// Confluence base URL, for "
+        "example 'https://example.com/wiki'.\n"
+    ) == result.stderr

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -1,6 +1,10 @@
 import pytest
 
-from knowledge_adapters.confluence.resolve import resolve_target, resolve_target_for_base_url
+from knowledge_adapters.confluence.resolve import (
+    resolve_target,
+    resolve_target_for_base_url,
+    validate_base_url,
+)
 
 
 def test_resolve_numeric_page_id() -> None:
@@ -114,6 +118,25 @@ def test_resolve_target_for_base_url_builds_canonical_page_url_for_page_id_input
 
     assert target.page_id == "7890"
     assert target.page_url == "https://example.com/wiki/pages/viewpage.action?pageId=7890"
+
+
+def test_validate_base_url_rejects_non_http_scheme() -> None:
+    with pytest.raises(
+        ValueError,
+        match="--base-url 'ftp://example.com/wiki' is invalid",
+    ):
+        validate_base_url("ftp://example.com/wiki")
+
+
+def test_resolve_target_for_base_url_rejects_malformed_base_url_before_target_resolution() -> None:
+    with pytest.raises(
+        ValueError,
+        match="--base-url 'https:///wiki' is invalid",
+    ):
+        resolve_target_for_base_url(
+            "https://example.com/wiki/spaces/ENG/pages/7890/Team+Runbook",
+            base_url="https:///wiki",
+        )
 
 
 def test_resolve_target_for_base_url_rejects_url_without_page_id() -> None:


### PR DESCRIPTION
Summary
- validate `--base-url` before Confluence target resolution so malformed and non-HTTP(S) inputs fail immediately
- reuse the validated base URL for canonical page URL construction and base URL matching
- add resolver and CLI coverage to confirm invalid base URLs stop before any planning output

Testing
- `make check`

Closes #97