### PR TITLE
docs: separate installed-user and developer command docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,10 @@ This project is designed to be **public-safe, reproducible, and adapter-focused*
 
 ## Development Setup
 
+This document is for **repo-local development**. If you only want to install
+and run the CLI as an end user, use the installed-user workflow in
+`README.md` instead of the `make` commands below.
+
 Bootstrap your local development environment:
 
 ```bash
@@ -25,6 +29,9 @@ These commands will:
 ---
 
 ## Common Commands
+
+These commands are for contributors working from a clone of this repository.
+Installed CLI users should not need them.
 
 ```bash
 make check-env   # verify required GitHub tooling

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,11 +20,21 @@ make dev
 ```
 
 These commands will:
-- verify GitHub CLI (`gh`) is installed and authenticated
+- verify local development prerequisites
 - create a local `.venv`
 - install all development dependencies (`pytest`, `ruff`, `mypy`, etc.)
 
 > Note: You do not need to manually activate the virtual environment when using `make` targets.
+
+GitHub authentication is not required for local setup or `make check`.
+GitHub-specific workflows stay explicit through:
+
+```bash
+make check-gh-env
+```
+
+Use `make check-gh-env` before opening pull requests, cutting releases, or
+running any other workflow that depends on an authenticated GitHub CLI session.
 
 ---
 
@@ -34,7 +44,8 @@ These commands are for contributors working from a clone of this repository.
 Installed CLI users should not need them.
 
 ```bash
-make check-env   # verify required GitHub tooling
+make check-env      # verify local development prerequisites
+make check-gh-env   # verify GitHub CLI install + auth for PR/release workflows
 make test        # run tests
 make lint        # check linting (ruff)
 make fix         # auto-fix lint issues where possible

--- a/README.md
+++ b/README.md
@@ -5,7 +5,20 @@ them into one predictable local artifact layout.
 
 ---
 
-## Install (without cloning)
+## Choose Your Command Context
+
+This repository supports two different ways to run the CLI:
+
+- **Installed CLI user**: install the published tool and run `knowledge-adapters`
+- **Repo-local developer**: clone the repository, run `make` targets, and use `.venv/bin/knowledge-adapters`
+
+Keep those contexts separate when copying commands. Installed-user examples
+below use `knowledge-adapters`. Contributor and development examples use
+`.venv/bin/knowledge-adapters` plus `make`.
+
+---
+
+## Installed CLI Setup (without cloning)
 
 To install only the CLI, use `pipx` directly from GitHub:
 
@@ -14,11 +27,13 @@ pipx install git+https://github.com/ctrl-alt-keith/knowledge-adapters.git
 knowledge-adapters --help
 ```
 
-With a `pipx` install, use `knowledge-adapters` instead of `.venv/bin/knowledge-adapters` in the examples below.
+With a `pipx` install, use `knowledge-adapters` in the installed-user examples
+below. The repo-local developer workflow later in this README uses
+`.venv/bin/knowledge-adapters` instead.
 
 ---
 
-## First Run (installed CLI)
+## Installed CLI First Run
 
 Start with the built-in help so the shared flow is visible before you pick an
 adapter:
@@ -115,7 +130,11 @@ one write.
 
 ---
 
-## Local Development Setup
+## Repo-Local Development Setup
+
+These steps are for contributors working from a local clone of this repository.
+If you only want to use the CLI, stay in the installed-user sections above and
+skip the developer setup below.
 
 Use `uv` for the fastest local setup. A standard `pip` workflow is also supported.
 
@@ -137,7 +156,7 @@ pip install -e .[dev]
 
 ---
 
-## Developer Quickstart
+## Repo-Local Developer Quickstart
 
 ```bash
 git clone <repo>
@@ -148,7 +167,7 @@ make dev
 make check
 ```
 
-After `make dev`, the installed CLI entrypoint for this repo is:
+After `make dev`, the repo-local CLI entrypoint for this checkout is:
 
 ```bash
 .venv/bin/knowledge-adapters
@@ -324,6 +343,11 @@ that design surface.
 
 ## Examples
 
+### Installed CLI Examples
+
+These examples assume you installed the tool with `pipx` and are running the
+global `knowledge-adapters` command.
+
 Start with a dry run for the local files adapter:
 
 ```bash
@@ -343,6 +367,47 @@ knowledge-adapters local_files \
   --file-path ./notes/today.txt \
   --output-dir ./artifacts
 ```
+
+Start with a dry run for the default Confluence adapter:
+
+```bash
+knowledge-adapters confluence \
+  --base-url https://example.com/wiki \
+  --target 12345 \
+  --output-dir ./artifacts \
+  --dry-run
+```
+
+Out of the box, this resolves page `12345`, generates stub content for that
+page, previews `pages/12345.md`, previews `manifest.json`, and does not contact
+a live Confluence instance.
+
+Full page URL targets are also accepted under `--base-url` and are normalized to
+canonical `pageId` form for artifact and manifest reporting.
+
+Write the same Confluence artifact after reviewing the plan:
+
+```bash
+knowledge-adapters confluence \
+  --base-url https://example.com/wiki \
+  --target 12345 \
+  --output-dir ./artifacts
+```
+
+Run the opt-in real Confluence client for a single resolved page:
+
+```bash
+CONFLUENCE_BEARER_TOKEN=... knowledge-adapters confluence \
+  --client-mode real \
+  --base-url https://example.com/wiki \
+  --target 12345 \
+  --output-dir ./artifacts
+```
+
+### Repo-Local Developer Examples
+
+These examples assume you cloned the repository, ran `make dev`, and are using
+the local virtual environment entrypoint.
 
 Start with a dry run for the default Confluence adapter:
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,10 @@ make dev
 make check
 ```
 
+`make check-env` verifies only the local prerequisites for development. GitHub
+authentication is not required to create the virtualenv, install dependencies,
+or run local validation.
+
 After `make dev`, the repo-local CLI entrypoint for this checkout is:
 
 ```bash
@@ -176,7 +180,8 @@ After `make dev`, the repo-local CLI entrypoint for this checkout is:
 Common commands:
 
 ```bash
-make check-env
+make check-env      # verify local development prerequisites
+make check-gh-env   # verify GitHub CLI install + auth for PR/release workflows
 make test
 make smoke
 make lint
@@ -184,6 +189,10 @@ make fix
 make format
 make typecheck
 ```
+
+Run `make check-gh-env` before GitHub-dependent workflows such as opening pull
+requests or performing release steps that require an authenticated `gh`
+session.
 
 ---
 


### PR DESCRIPTION
Summary
- separate installed CLI guidance from repo-local contributor commands in README.md
- label installed-user versus repo-local example contexts so command snippets are not mixed
- clarify in CONTRIBUTING.md that make-based setup is for contributors working from a clone

Testing
- make check

Closes #102