### PR TITLE
fix: decouple GitHub auth checks from local development bootstrap

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,18 +16,29 @@ make dev
 ```
 
 These commands will:
-- verify GitHub CLI (`gh`) is installed and authenticated
+- verify local development prerequisites
 - create a local `.venv`
 - install all development dependencies (`pytest`, `ruff`, `mypy`, etc.)
 
 > Note: You do not need to manually activate the virtual environment when using `make` targets.
+
+GitHub authentication is not required for local setup or `make check`.
+GitHub-specific workflows stay explicit through:
+
+```bash
+make check-gh-env
+```
+
+Use `make check-gh-env` before opening pull requests, cutting releases, or
+running any other workflow that depends on an authenticated GitHub CLI session.
 
 ---
 
 ## Common Commands
 
 ```bash
-make check-env   # verify required GitHub tooling
+make check-env      # verify local development prerequisites
+make check-gh-env   # verify GitHub CLI install + auth for PR/release workflows
 make test        # run tests
 make lint        # check linting (ruff)
 make fix         # auto-fix lint issues where possible

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev test smoke lint fix format typecheck check check-env clean
+.PHONY: dev test smoke lint fix format typecheck check check-env check-gh-env clean
 
 VENV = .venv
 PYTHON = $(VENV)/bin/python
@@ -16,6 +16,9 @@ $(VENV)/bin/activate:
 dev: $(VENV)/bin/activate
 
 check-env:
+	@command -v python3 >/dev/null 2>&1 || { echo "Error: python3 is required for local development." >&2; exit 1; }
+
+check-gh-env:
 	@command -v gh >/dev/null 2>&1 || { echo "Error: GitHub CLI (gh) is required but is not installed." >&2; exit 1; }
 	@gh auth status >/dev/null 2>&1 || { echo "Error: GitHub CLI authentication is required. Run 'gh auth login' and try again." >&2; exit 1; }
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ make dev
 make check
 ```
 
+`make check-env` verifies only the local prerequisites for development. GitHub
+authentication is not required to create the virtualenv, install dependencies,
+or run local validation.
+
 After `make dev`, the installed CLI entrypoint for this repo is:
 
 ```bash
@@ -157,7 +161,8 @@ After `make dev`, the installed CLI entrypoint for this repo is:
 Common commands:
 
 ```bash
-make check-env
+make check-env      # verify local development prerequisites
+make check-gh-env   # verify GitHub CLI install + auth for PR/release workflows
 make test
 make smoke
 make lint
@@ -165,6 +170,10 @@ make fix
 make format
 make typecheck
 ```
+
+Run `make check-gh-env` before GitHub-dependent workflows such as opening pull
+requests or performing release steps that require an authenticated `gh`
+session.
 
 ---
 


### PR DESCRIPTION
Summary
- split GitHub authentication checks into a dedicated `make check-gh-env` target
- keep `make check-env` focused on local development prerequisites so local bootstrap and validation do not require `gh auth`
- update README and CONTRIBUTING guidance to keep PR and release workflows explicit about the GitHub CLI requirement

Testing
- make check
- make check-env check-gh-env

Closes #101