### PR TITLE
fix: make stub tree-mode limitation explicit in Confluence run output

### DIFF
--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -492,6 +492,15 @@ def main(argv: Sequence[str] | None = None) -> int:
             for line in summary_lines:
                 print(line)
 
+        def _print_stub_tree_mode_note() -> None:
+            if not (confluence_config.tree and confluence_config.client_mode == "stub"):
+                return
+
+            print(
+                "  note: stub mode does not support descendant discovery; "
+                "use --client-mode real to discover descendants from Confluence."
+            )
+
         if confluence_config.tree:
             if confluence_config.client_mode == "real":
                 try:
@@ -543,6 +552,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             print(f"  max_depth: {confluence_config.max_depth}")
             print(f"  Manifest: {_display_output_path(manifest_output_path)}")
             print(f"  pages_in_tree: {len(page_records)} (root + descendants)")
+            _print_stub_tree_mode_note()
 
             if confluence_config.dry_run:
                 _print_confluence_dry_run_summary(

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -197,6 +197,33 @@ Stub content for page 12345.
     ]
 
 
+def test_confluence_cli_tree_dry_run_with_stub_client_reports_discovery_limit(
+    tmp_path: Path,
+) -> None:
+    result = _run_cli(
+        tmp_path,
+        "confluence",
+        "--base-url",
+        "https://example.com/wiki",
+        "--target",
+        "12345",
+        "--output-dir",
+        "./artifacts",
+        "--tree",
+        "--max-depth",
+        "1",
+        "--dry-run",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "client_mode: stub" in result.stdout
+    assert "mode: tree" in result.stdout
+    assert (
+        "note: stub mode does not support descendant discovery; use --client-mode real "
+        "to discover descendants from Confluence."
+    ) in result.stdout
+
+
 def test_confluence_help_lists_supported_auth_methods_and_examples(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_confluence_real_traversal_contract.py
+++ b/tests/test_confluence_real_traversal_contract.py
@@ -246,6 +246,27 @@ def test_real_tree_depth_semantics_use_separate_page_fetch_and_child_discovery(
     assert child_list_calls == expected_child_calls
 
 
+def test_real_tree_run_does_not_report_stub_discovery_limit(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    exit_code, _output_dir, _page_fetch_counts, _child_list_calls = _run_real_recursive_cli(
+        tmp_path,
+        monkeypatch,
+        max_depth=1,
+    )
+
+    assert exit_code == 0
+
+    output = capsys.readouterr().out
+    assert "client_mode: real" in output
+    assert (
+        "note: stub mode does not support descendant discovery; use --client-mode real "
+        "to discover descendants from Confluence."
+    ) not in output
+
+
 def test_real_tree_orders_pages_breadth_first_then_lexical_without_parent_adjacency(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,

--- a/tests/test_confluence_recursive_contract.py
+++ b/tests/test_confluence_recursive_contract.py
@@ -277,6 +277,10 @@ def test_recursive_dry_run_reports_unique_planned_outputs_without_writing(
 
     assert "mode: tree" in output
     assert "max_depth: 2 (root + children + grandchildren)" in output
+    assert (
+        "note: stub mode does not support descendant discovery; use --client-mode real "
+        "to discover descendants from Confluence."
+    ) in output
     for page_id in ["100", "200", "300", "205", "210"]:
         assert output.count(f"{output_dir / 'pages' / f'{page_id}.md'}") == 1
     assert_tree_plan_page_count(output, count=5)


### PR DESCRIPTION
Summary
- add a stub-only note to Confluence tree-mode run output explaining that stub mode does not discover descendants from Confluence
- keep traversal behavior unchanged and leave real-client tree output untouched
- extend CLI and traversal tests to cover the new stub note and the unchanged real-tree output

Testing
- make check

Closes #100