### PR TITLE
fix: fail fast on local_files artifact-path collisions

### DIFF
--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -103,6 +103,25 @@ def exit_with_output_error(
     )
 
 
+def exit_with_local_files_artifact_collision(
+    *,
+    output_path: Path,
+    manifest_output_path: Path,
+    prior_source_path: str,
+    current_source_path: str,
+) -> None:
+    """Exit with a consistent artifact-collision error for local_files."""
+    exit_with_cli_error(
+        (
+            f"Artifact path collision: {output_path} is already mapped to source file "
+            f"{prior_source_path} in {manifest_output_path}, but this run resolves "
+            f"{current_source_path}. Remove or rename one of the source files, or clear "
+            "the stale artifact directory before retrying."
+        ),
+        command="local_files",
+    )
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Build the top-level CLI parser."""
     parser = argparse.ArgumentParser(
@@ -672,6 +691,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 0
 
     if args.command == "local_files":
+        from knowledge_adapters.confluence.incremental import (
+            load_previous_manifest_output_index,
+        )
         from knowledge_adapters.confluence.manifest import (
             build_manifest_entry,
             write_manifest,
@@ -715,6 +737,26 @@ def main(argv: Sequence[str] | None = None) -> int:
         manifest_output_path = output_dir / "manifest.json"
         output_path = output_dir / "pages" / f"{output_name}.md"
         manifest_entry_output_path = output_dir_input / "pages" / f"{output_name}.md"
+        planned_output_path = output_path.relative_to(output_dir).as_posix()
+
+        try:
+            previous_manifest_output_index = load_previous_manifest_output_index(
+                local_files_config.output_dir
+            )
+        except RuntimeError as exc:
+            exit_with_cli_error(str(exc), command="local_files")
+
+        prior_source_path = None
+        if previous_manifest_output_index is not None:
+            prior_source_path = previous_manifest_output_index.get(planned_output_path)
+        current_source_path = str(page["canonical_id"])
+        if prior_source_path is not None and prior_source_path != current_source_path:
+            exit_with_local_files_artifact_collision(
+                output_path=output_path,
+                manifest_output_path=manifest_output_path,
+                prior_source_path=prior_source_path,
+                current_source_path=current_source_path,
+            )
 
         print("\nPlan: Local files run")
         print(f"  resolved_file_path: {resolved_input_path}")

--- a/src/knowledge_adapters/confluence/incremental.py
+++ b/src/knowledge_adapters/confluence/incremental.py
@@ -8,7 +8,9 @@ from pathlib import Path
 from knowledge_adapters.confluence.manifest import manifest_path
 
 
-def load_previous_manifest_index(output_dir: str) -> dict[str, str] | None:
+def _load_previous_manifest_indexes(
+    output_dir: str,
+) -> tuple[dict[str, str], dict[str, str]] | None:
     """Load and validate the previous manifest for incremental comparisons."""
     path = manifest_path(output_dir)
     if not path.exists():
@@ -29,7 +31,7 @@ def load_previous_manifest_index(output_dir: str) -> dict[str, str] | None:
         )
 
     entries_by_id: dict[str, str] = {}
-    seen_output_paths: set[str] = set()
+    entries_by_output_path: dict[str, str] = {}
 
     for entry in files:
         if not isinstance(entry, dict):
@@ -51,16 +53,34 @@ def load_previous_manifest_index(output_dir: str) -> dict[str, str] | None:
                 f"Prior manifest {path} is invalid: duplicate canonical_id {canonical_id!r}. "
                 "Fix or remove the manifest and try again."
             )
-        if output_path in seen_output_paths:
+        if output_path in entries_by_output_path:
             raise RuntimeError(
                 f"Prior manifest {path} is invalid: duplicate output_path {output_path!r}. "
                 "Fix or remove the manifest and try again."
             )
 
         entries_by_id[canonical_id] = output_path
-        seen_output_paths.add(output_path)
+        entries_by_output_path[output_path] = canonical_id
 
-    return entries_by_id
+    return entries_by_id, entries_by_output_path
+
+
+def load_previous_manifest_index(output_dir: str) -> dict[str, str] | None:
+    """Load and validate the previous manifest keyed by canonical_id."""
+    indexes = _load_previous_manifest_indexes(output_dir)
+    if indexes is None:
+        return None
+
+    return indexes[0]
+
+
+def load_previous_manifest_output_index(output_dir: str) -> dict[str, str] | None:
+    """Load and validate the previous manifest keyed by output_path."""
+    indexes = _load_previous_manifest_indexes(output_dir)
+    if indexes is None:
+        return None
+
+    return indexes[1]
 
 
 def is_already_written(

--- a/tests/test_local_files.py
+++ b/tests/test_local_files.py
@@ -139,6 +139,101 @@ def test_local_files_cli_dry_run_reports_output_without_writing(
     assert "Line one." in captured.out
 
 
+def test_local_files_cli_fails_fast_for_same_stem_artifact_collision(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    first_source = tmp_path / "notes.txt"
+    first_source.write_text("First file.\n", encoding="utf-8")
+    second_source = tmp_path / "notes.md"
+    second_source.write_text("Second file.\n", encoding="utf-8")
+    output_dir = tmp_path / "out"
+
+    exit_code = main(
+        [
+            "local_files",
+            "--file-path",
+            str(first_source),
+            "--output-dir",
+            str(output_dir),
+        ]
+    )
+
+    assert exit_code == 0
+    capsys.readouterr()
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(
+            [
+                "local_files",
+                "--file-path",
+                str(second_source),
+                "--output-dir",
+                str(output_dir),
+                "--dry-run",
+            ]
+        )
+
+    assert exc_info.value.code == 2
+    captured = capsys.readouterr()
+    assert "knowledge-adapters local_files: error:" in captured.err
+    assert f"Artifact path collision: {output_dir / 'pages' / 'notes.md'}" in captured.err
+    assert f"source file {first_source.resolve()}" in captured.err
+    assert f"this run resolves {second_source.resolve()}." in captured.err
+    assert "Remove or rename one of the source files" in captured.err
+    manifest_payload = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest_payload["files"][0]["canonical_id"] == str(first_source.resolve())
+
+
+def test_local_files_cli_fails_fast_for_same_name_different_directory_collision(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    first_source = tmp_path / "a" / "notes.txt"
+    first_source.parent.mkdir(parents=True)
+    first_source.write_text("First file.\n", encoding="utf-8")
+    second_source = tmp_path / "b" / "notes.txt"
+    second_source.parent.mkdir(parents=True)
+    second_source.write_text("Second file.\n", encoding="utf-8")
+    output_dir = tmp_path / "out"
+
+    exit_code = main(
+        [
+            "local_files",
+            "--file-path",
+            str(first_source),
+            "--output-dir",
+            str(output_dir),
+        ]
+    )
+
+    assert exit_code == 0
+    first_artifact = output_dir / "pages" / "notes.md"
+    original_artifact = first_artifact.read_text(encoding="utf-8")
+    capsys.readouterr()
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(
+            [
+                "local_files",
+                "--file-path",
+                str(second_source),
+                "--output-dir",
+                str(output_dir),
+            ]
+        )
+
+    assert exc_info.value.code == 2
+    captured = capsys.readouterr()
+    assert "knowledge-adapters local_files: error:" in captured.err
+    assert f"Artifact path collision: {first_artifact}" in captured.err
+    assert f"source file {first_source.resolve()}" in captured.err
+    assert f"this run resolves {second_source.resolve()}." in captured.err
+    assert first_artifact.read_text(encoding="utf-8") == original_artifact
+    manifest_payload = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest_payload["files"][0]["canonical_id"] == str(first_source.resolve())
+
+
 def test_fetch_file_reports_permission_errors(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
Summary
- fail fast when a local_files run plans an artifact path that the prior manifest already maps to a different source file
- reuse manifest validation to build an output-path ownership index without changing the existing naming scheme
- add regression coverage for same-stem and same-name-different-directory collisions

Testing
- make check

Closes #98