### PR TITLE
fix: standardize CLI path rendering

### DIFF
--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -294,6 +294,11 @@ def exit_with_cli_error(
     raise SystemExit(2)
 
 
+def render_user_path(path: str | Path) -> str:
+    """Render user-facing paths with one consistent absolute form."""
+    return str(Path(path).expanduser().resolve())
+
+
 def print_dry_run_complete() -> None:
     """Print a consistent dry-run completion message."""
     print("\nDry run complete. No files written.")
@@ -301,7 +306,7 @@ def print_dry_run_complete() -> None:
 
 def print_write_complete(output_dir: Path) -> None:
     """Print a consistent write completion message."""
-    print(f"\nWrite complete. Artifacts created under {output_dir}")
+    print(f"\nWrite complete. Artifacts created under {render_user_path(output_dir)}")
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -412,7 +417,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             print("Confluence adapter invoked")
             print(f"  base_url: {confluence_config.base_url}")
             print(f"  target: {target.raw_value}")
-            print(f"  output_dir: {confluence_config.output_dir}")
+            print(f"  output_dir: {render_user_path(confluence_config.output_dir)}")
             print(f"  client_mode: {confluence_config.client_mode}")
             print(f"  content_source: {content_source}")
             if confluence_config.dry_run:
@@ -455,13 +460,9 @@ def main(argv: Sequence[str] | None = None) -> int:
                 title=str(page["title"]) if page.get("title") else None,
             )
 
-        def _display_output_path(path: Path) -> Path:
-            """Return an absolute path for user-facing output."""
-            try:
-                relative_path = path.relative_to(output_dir_input)
-            except ValueError:
-                return path if path.is_absolute() else path.resolve()
-            return output_dir / relative_path
+        def _display_output_path(path: Path) -> str:
+            """Return the consistent user-facing path form for CLI output."""
+            return render_user_path(path)
 
         def _print_single_page_plan(
             *,
@@ -737,13 +738,13 @@ def main(argv: Sequence[str] | None = None) -> int:
         markdown = normalize_to_markdown(page)
 
         print("Local files adapter invoked")
-        print(f"  file_path: {local_files_config.file_path}")
-        print(f"  output_dir: {local_files_config.output_dir}")
+        print(f"  file_path: {render_user_path(local_files_config.file_path)}")
+        print(f"  output_dir: {render_user_path(local_files_config.output_dir)}")
         print(f"  run_mode: {'dry-run' if local_files_config.dry_run else 'write'}")
 
         input_path = Path(local_files_config.file_path)
         output_name = input_path.stem or input_path.name
-        resolved_input_path = input_path.resolve()
+        resolved_input_path = render_user_path(input_path)
         manifest_output_path = output_dir / "manifest.json"
         output_path = output_dir / "pages" / f"{output_name}.md"
         manifest_entry_output_path = output_dir_input / "pages" / f"{output_name}.md"
@@ -771,8 +772,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         print("\nPlan: Local files run")
         print(f"  resolved_file_path: {resolved_input_path}")
         print(f"  source_url: {page.get('source_url', '')}")
-        print(f"  Artifact path: {output_path}")
-        print(f"  Manifest path: {manifest_output_path}")
+        print(f"  Artifact path: {render_user_path(output_path)}")
+        print(f"  Manifest path: {render_user_path(manifest_output_path)}")
         content = str(page.get("content", ""))
         if content:
             print("  content_status: UTF-8 text with content")
@@ -813,10 +814,10 @@ def main(argv: Sequence[str] | None = None) -> int:
                 command="local_files",
                 exc=exc,
             )
-        print(f"\nWrote: {output_path}")
+        print(f"\nWrote: {render_user_path(output_path)}")
         print("\nSummary: wrote 1, skipped 0")
-        print(f"Artifact path: {output_path}")
-        print(f"Manifest path: {output_dir / manifest.relative_to(output_dir_input)}")
+        print(f"Artifact path: {render_user_path(output_path)}")
+        print(f"Manifest path: {render_user_path(manifest)}")
         print_write_complete(output_dir)
         return 0
 

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -69,6 +69,8 @@ def test_local_files_cli_smoke_uses_installed_entrypoint_with_readme_style_args(
 
     assert result.returncode == 0, result.stderr
     assert "Local files adapter invoked" in result.stdout
+    assert f"file_path: {source_file.resolve()}" in result.stdout
+    assert f"output_dir: {(tmp_path / 'artifacts').resolve()}" in result.stdout
     assert "run_mode: write" in result.stdout
     assert "Plan: Local files run" in result.stdout
     assert f"resolved_file_path: {source_file.resolve()}" in result.stdout
@@ -154,6 +156,7 @@ def test_confluence_cli_smoke_uses_installed_entrypoint_with_default_stub_client
 
     assert result.returncode == 0, result.stderr
     assert "Confluence adapter invoked" in result.stdout
+    assert f"output_dir: {(tmp_path / 'artifacts').resolve()}" in result.stdout
     assert "client_mode: stub" in result.stdout
     assert "content_source: scaffolded page content" in result.stdout
     assert "fetch_scope: page" in result.stdout

--- a/tests/test_local_files.py
+++ b/tests/test_local_files.py
@@ -139,6 +139,45 @@ def test_local_files_cli_dry_run_reports_output_without_writing(
     assert "Line one." in captured.out
 
 
+def test_local_files_cli_renders_symlinked_paths_consistently(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    real_root = tmp_path / "real"
+    real_root.mkdir()
+    alias_root = tmp_path / "alias"
+    try:
+        alias_root.symlink_to(real_root, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"symlinks unavailable: {exc}")
+
+    source_file = real_root / "meeting-notes.txt"
+    source_file.write_text("Line one.\nLine two.\n", encoding="utf-8")
+    file_path_arg = alias_root / "meeting-notes.txt"
+    output_dir_arg = alias_root / "out"
+    resolved_output_dir = (real_root / "out").resolve()
+
+    exit_code = main(
+        [
+            "local_files",
+            "--file-path",
+            str(file_path_arg),
+            "--output-dir",
+            str(output_dir_arg),
+            "--dry-run",
+        ]
+    )
+
+    assert exit_code == 0
+
+    captured = capsys.readouterr()
+    assert f"file_path: {source_file.resolve()}" in captured.out
+    assert f"output_dir: {resolved_output_dir}" in captured.out
+    assert f"resolved_file_path: {source_file.resolve()}" in captured.out
+    assert f"Artifact path: {resolved_output_dir / 'pages' / 'meeting-notes.md'}" in captured.out
+    assert f"Manifest path: {resolved_output_dir / 'manifest.json'}" in captured.out
+
+
 def test_local_files_cli_fails_fast_for_same_stem_artifact_collision(
     tmp_path: Path,
     capsys: CaptureFixture[str],

--- a/tests/test_normalize_writer.py
+++ b/tests/test_normalize_writer.py
@@ -218,6 +218,43 @@ def test_confluence_cli_writes_manifest_for_normal_run(tmp_path: Path) -> None:
     assert isinstance(payload["generated_at"], str)
 
 
+def test_confluence_cli_renders_symlinked_output_paths_consistently(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    real_root = tmp_path / "real"
+    real_root.mkdir()
+    alias_root = tmp_path / "alias"
+    try:
+        alias_root.symlink_to(real_root, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"symlinks unavailable: {exc}")
+
+    output_dir_arg = alias_root / "out"
+    resolved_output_dir = (real_root / "out").resolve()
+
+    exit_code = main(
+        [
+            "confluence",
+            "--base-url",
+            "https://example.com/wiki",
+            "--target",
+            "12345",
+            "--output-dir",
+            str(output_dir_arg),
+        ]
+    )
+
+    assert exit_code == 0
+
+    captured = capsys.readouterr()
+    assert f"output_dir: {resolved_output_dir}" in captured.out
+    assert f"Artifact: {resolved_output_dir / 'pages' / '12345.md'}" in captured.out
+    assert f"Wrote: {resolved_output_dir / 'pages' / '12345.md'}" in captured.out
+    assert f"Manifest: {resolved_output_dir / 'manifest.json'}" in captured.out
+    assert f"Write complete. Artifacts created under {resolved_output_dir}" in captured.out
+
+
 def test_confluence_cli_full_flow_keeps_dry_run_and_write_artifacts_in_sync(
     tmp_path: Path,
     capsys: CaptureFixture[str],


### PR DESCRIPTION
Summary
- standardize user-facing CLI path rendering on one absolute, resolved display format
- apply the same display policy across confluence and local_files invocation, plan, summary, and completion output
- add focused regression coverage for symlinked path inputs so dry-run and write output stay aligned

Testing
- make check