### PR TITLE
test: replace literal fixtures with semantic helpers

### DIFF
--- a/tests/artifact_assertions.py
+++ b/tests/artifact_assertions.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+
+def assert_markdown_document(
+    markdown: str,
+    *,
+    title: str,
+    metadata: Mapping[str, str],
+    content: str,
+) -> None:
+    actual_title, actual_metadata, actual_content = _parse_markdown_document(markdown)
+
+    assert actual_title == title
+    assert actual_metadata == dict(metadata)
+    assert actual_content == content.rstrip("\n")
+
+
+def manifest_file(
+    *,
+    canonical_id: str,
+    source_url: str,
+    output_path: str,
+    title: str | None = None,
+) -> dict[str, str]:
+    entry = {
+        "canonical_id": canonical_id,
+        "source_url": source_url,
+        "output_path": output_path,
+    }
+    if title is not None:
+        entry["title"] = title
+    return entry
+
+
+def assert_manifest_entry(
+    entry: Mapping[str, object],
+    *,
+    canonical_id: str,
+    source_url: str,
+    output_path: str,
+    title: str | None = None,
+) -> None:
+    assert dict(entry) == manifest_file(
+        canonical_id=canonical_id,
+        source_url=source_url,
+        output_path=output_path,
+        title=title,
+    )
+
+
+def assert_manifest_entries(
+    manifest: Path | Mapping[str, object],
+    *,
+    files: Sequence[Mapping[str, str]],
+) -> None:
+    payload = _load_manifest(manifest) if isinstance(manifest, Path) else dict(manifest)
+
+    assert isinstance(payload.get("generated_at"), str)
+
+    actual_files = payload.get("files")
+    assert isinstance(actual_files, list)
+    assert len(actual_files) == len(files)
+
+    for actual_entry, expected_entry in zip(actual_files, files, strict=True):
+        assert isinstance(actual_entry, dict)
+        assert dict(actual_entry) == dict(expected_entry)
+
+
+def _load_manifest(manifest_path: Path) -> dict[str, Any]:
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def _parse_markdown_document(markdown: str) -> tuple[str, dict[str, str], str]:
+    title_block, metadata_marker, remainder = markdown.partition("\n## Metadata\n")
+    assert metadata_marker
+
+    title_lines = title_block.splitlines()
+    assert title_lines
+    assert title_lines[0].startswith("# ")
+    assert all(not line.strip() for line in title_lines[1:])
+
+    metadata_block, content_marker, content_block = remainder.partition("\n## Content\n")
+    assert content_marker
+
+    metadata: dict[str, str] = {}
+    for line in metadata_block.splitlines():
+        if not line:
+            continue
+
+        assert line.startswith("- ")
+        key, separator, value = line[2:].partition(":")
+        assert separator == ":"
+        assert key not in metadata
+        metadata[key] = value.lstrip()
+
+    if content_block.startswith("\n"):
+        content_block = content_block[1:]
+
+    return title_lines[0][2:], metadata, content_block.rstrip("\n")

--- a/tests/test_local_files.py
+++ b/tests/test_local_files.py
@@ -7,6 +7,11 @@ from pytest import CaptureFixture
 from knowledge_adapters.cli import main
 from knowledge_adapters.local_files.client import fetch_file
 from knowledge_adapters.local_files.normalize import normalize_to_markdown
+from tests.artifact_assertions import (
+    assert_manifest_entries,
+    assert_markdown_document,
+    manifest_file,
+)
 
 
 def test_fetch_file_reads_local_path_into_adapter_payload(tmp_path: Path) -> None:
@@ -37,9 +42,20 @@ def test_local_files_reuses_shared_normalizer() -> None:
         }
     )
 
-    assert "- source: local_files\n" in markdown
-    assert "- adapter: local_files\n" in markdown
-    assert markdown.endswith("Hello from disk.\n")
+    assert_markdown_document(
+        markdown,
+        title="notes.txt",
+        metadata={
+            "source": "local_files",
+            "canonical_id": "/tmp/notes.txt",
+            "parent_id": "",
+            "source_url": "file:///tmp/notes.txt",
+            "fetched_at": "",
+            "updated_at": "",
+            "adapter": "local_files",
+        },
+        content="Hello from disk.",
+    )
 
 
 def test_local_files_cli_writes_normalized_markdown(
@@ -68,35 +84,32 @@ def test_local_files_cli_writes_normalized_markdown(
 
     output_path = output_dir / "pages" / "meeting-notes.md"
     assert output_path.exists()
-    assert output_path.read_text(encoding="utf-8") == (
-        f"""# meeting-notes.txt
-
-## Metadata
-- source: local_files
-- canonical_id: {source_file.resolve()}
-- parent_id:
-- source_url: {source_file.resolve().as_uri()}
-- fetched_at:
-- updated_at:
-- adapter: local_files
-
-## Content
-
-Line one.
-Line two.
-"""
+    assert_markdown_document(
+        output_path.read_text(encoding="utf-8"),
+        title="meeting-notes.txt",
+        metadata={
+            "source": "local_files",
+            "canonical_id": str(source_file.resolve()),
+            "parent_id": "",
+            "source_url": source_file.resolve().as_uri(),
+            "fetched_at": "",
+            "updated_at": "",
+            "adapter": "local_files",
+        },
+        content="Line one.\nLine two.",
     )
 
-    payload = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
-    assert payload["files"] == [
-        {
-            "canonical_id": str(source_file.resolve()),
-            "source_url": source_file.resolve().as_uri(),
-            "output_path": "pages/meeting-notes.md",
-            "title": "meeting-notes.txt",
-        }
-    ]
-    assert isinstance(payload["generated_at"], str)
+    assert_manifest_entries(
+        output_dir / "manifest.json",
+        files=[
+            manifest_file(
+                canonical_id=str(source_file.resolve()),
+                source_url=source_file.resolve().as_uri(),
+                output_path="pages/meeting-notes.md",
+                title="meeting-notes.txt",
+            )
+        ],
+    )
 
 
 def test_local_files_cli_dry_run_reports_output_without_writing(
@@ -368,22 +381,19 @@ def test_local_files_cli_writes_empty_utf8_file_with_empty_content_section(
     ) in captured.out
 
     output_path = output_dir / "pages" / "empty.md"
-    assert output_path.read_text(encoding="utf-8") == (
-        f"""# empty.txt
-
-## Metadata
-- source: local_files
-- canonical_id: {source_file.resolve()}
-- parent_id:
-- source_url: {source_file.resolve().as_uri()}
-- fetched_at:
-- updated_at:
-- adapter: local_files
-
-## Content
-
-
-"""
+    assert_markdown_document(
+        output_path.read_text(encoding="utf-8"),
+        title="empty.txt",
+        metadata={
+            "source": "local_files",
+            "canonical_id": str(source_file.resolve()),
+            "parent_id": "",
+            "source_url": source_file.resolve().as_uri(),
+            "fetched_at": "",
+            "updated_at": "",
+            "adapter": "local_files",
+        },
+        content="",
     )
 
 

--- a/tests/test_normalize_writer.py
+++ b/tests/test_normalize_writer.py
@@ -1,4 +1,3 @@
-import json
 from pathlib import Path
 
 import pytest
@@ -8,6 +7,12 @@ from knowledge_adapters.cli import main
 from knowledge_adapters.confluence.manifest import build_manifest_entry, write_manifest
 from knowledge_adapters.confluence.normalize import normalize_to_markdown
 from knowledge_adapters.confluence.writer import write_markdown
+from tests.artifact_assertions import (
+    assert_manifest_entries,
+    assert_manifest_entry,
+    assert_markdown_document,
+    manifest_file,
+)
 from tests.cli_output_assertions import (
     assert_dry_run_summary,
     assert_tree_plan_page_count,
@@ -25,32 +30,39 @@ def test_normalize_to_markdown_includes_expected_sections_and_fields() -> None:
 
     markdown = normalize_to_markdown(page)
 
-    expected = """# Team Notes
-
-## Metadata
-- source: confluence
-- canonical_id: 12345
-- parent_id:
-- source_url: https://example.com/wiki/spaces/ENG/pages/12345
-- fetched_at:
-- updated_at:
-- adapter: confluence
-
-## Content
-
-Hello from Confluence.
-"""
-
-    assert markdown == expected
+    assert_markdown_document(
+        markdown,
+        title="Team Notes",
+        metadata={
+            "source": "confluence",
+            "canonical_id": "12345",
+            "parent_id": "",
+            "source_url": "https://example.com/wiki/spaces/ENG/pages/12345",
+            "fetched_at": "",
+            "updated_at": "",
+            "adapter": "confluence",
+        },
+        content="Hello from Confluence.",
+    )
 
 
 def test_normalize_to_markdown_uses_safe_defaults_for_missing_fields() -> None:
     markdown = normalize_to_markdown({})
 
-    assert markdown.startswith("# untitled\n")
-    assert "- canonical_id: \n" in markdown
-    assert "- source_url: \n" in markdown
-    assert markdown.endswith("\n\n")
+    assert_markdown_document(
+        markdown,
+        title="untitled",
+        metadata={
+            "source": "confluence",
+            "canonical_id": "",
+            "parent_id": "",
+            "source_url": "",
+            "fetched_at": "",
+            "updated_at": "",
+            "adapter": "confluence",
+        },
+        content="",
+    )
 
 
 def test_write_markdown_writes_to_pages_subdirectory(tmp_path: Path) -> None:
@@ -84,12 +96,13 @@ def test_build_manifest_entry_uses_relative_output_path_and_optional_title(
         title="Page 42",
     )
 
-    assert entry == {
-        "canonical_id": "page-42",
-        "source_url": "https://example.com/wiki/pages/42",
-        "output_path": "pages/page-42.md",
-        "title": "Page 42",
-    }
+    assert_manifest_entry(
+        entry,
+        canonical_id="page-42",
+        source_url="https://example.com/wiki/pages/42",
+        output_path="pages/page-42.md",
+        title="Page 42",
+    )
 
 
 def test_write_manifest_writes_minimal_payload_for_current_run(tmp_path: Path) -> None:
@@ -106,15 +119,16 @@ def test_write_manifest_writes_minimal_payload_for_current_run(tmp_path: Path) -
 
     assert manifest == tmp_path / "manifest.json"
 
-    payload = json.loads(manifest.read_text(encoding="utf-8"))
-    assert payload["files"] == [
-        {
-            "canonical_id": "page-42",
-            "source_url": "https://example.com/wiki/pages/42",
-            "output_path": "pages/page-42.md",
-        }
-    ]
-    assert isinstance(payload["generated_at"], str)
+    assert_manifest_entries(
+        manifest,
+        files=[
+            manifest_file(
+                canonical_id="page-42",
+                source_url="https://example.com/wiki/pages/42",
+                output_path="pages/page-42.md",
+            )
+        ],
+    )
 
 
 def test_confluence_cli_dry_run_reports_output_without_writing(
@@ -206,16 +220,17 @@ def test_confluence_cli_writes_manifest_for_normal_run(tmp_path: Path) -> None:
 
     assert exit_code == 0
 
-    payload = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
-    assert payload["files"] == [
-        {
-            "canonical_id": "12345",
-            "source_url": "https://example.com/wiki/pages/viewpage.action?pageId=12345",
-            "output_path": "pages/12345.md",
-            "title": "stub-page-12345",
-        }
-    ]
-    assert isinstance(payload["generated_at"], str)
+    assert_manifest_entries(
+        output_dir / "manifest.json",
+        files=[
+            manifest_file(
+                canonical_id="12345",
+                source_url="https://example.com/wiki/pages/viewpage.action?pageId=12345",
+                output_path="pages/12345.md",
+                title="stub-page-12345",
+            )
+        ],
+    )
 
 
 def test_confluence_cli_renders_symlinked_output_paths_consistently(
@@ -326,15 +341,17 @@ def test_confluence_cli_full_flow_keeps_dry_run_and_write_artifacts_in_sync(
     assert f"Manifest: {manifest_output_path}" in write_output
     assert f"Write complete. Artifacts created under {output_dir}" in write_output
 
-    payload = json.loads(manifest_output_path.read_text(encoding="utf-8"))
-    assert payload["files"] == [
-        {
-            "canonical_id": "12345",
-            "source_url": canonical_source_url,
-            "output_path": "pages/12345.md",
-            "title": "stub-page-12345",
-        }
-    ]
+    assert_manifest_entries(
+        manifest_output_path,
+        files=[
+            manifest_file(
+                canonical_id="12345",
+                source_url=canonical_source_url,
+                output_path="pages/12345.md",
+                title="stub-page-12345",
+            )
+        ],
+    )
 
 
 def test_confluence_cli_tree_run_reports_manifest_path(


### PR DESCRIPTION
Summary
- add a small shared helper module for semantic markdown structure and manifest entry validation
- migrate targeted local_files and confluence writer tests away from large exact-string fixtures
- keep CLI wording assertions unchanged while still validating metadata, paths, and content

Testing
- make check