### PR TITLE
docs: add PR template, issue templates, and release runbook

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name: Bug report
+about: Report a bug or regression.
+title: "bug: "
+labels: []
+assignees: []
+---
+
+## What happened
+
+-
+
+## Expected behavior
+
+-
+
+## Reproduction steps
+
+1.
+2.
+3.
+
+## Environment
+
+- Optional

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Propose a focused improvement.
+title: "feature: "
+labels: []
+assignees: []
+---
+
+## Problem or goal
+
+-
+
+## Proposed change
+
+-
+
+## Scope / constraints
+
+-

--- a/.github/ISSUE_TEMPLATE/workflow_or_process.md
+++ b/.github/ISSUE_TEMPLATE/workflow_or_process.md
@@ -1,0 +1,22 @@
+---
+name: Workflow or process
+about: Suggest a repo workflow or process improvement.
+title: "workflow: "
+labels: []
+assignees: []
+---
+
+## Current friction
+
+-
+
+## Proposed improvement
+
+-
+
+## Affected surfaces
+
+- [ ] cli
+- [ ] tests
+- [ ] docs
+- [ ] workflow

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Summary
+
+- high-level description
+- key changes
+
+## Scope check
+
+- [ ] This PR contains only one logical arc.
+
+## Testing
+
+- `make check`
+
+## Notes
+
+- Optional
+
+## Issue closure
+
+- Closes #<issue number> (required for issue-driven work)

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -1,0 +1,26 @@
+# Release Workflow
+
+## Purpose
+
+This document captures the lightweight release steps for
+`knowledge-adapters`.
+
+Keep the release arc focused on versioning and release metadata. Avoid mixing
+unrelated cleanup into the same PR.
+
+## Release Steps
+
+1. ensure `main` is clean and up to date
+2. confirm the version bump is present
+3. confirm `CHANGELOG.md` is updated
+4. run `make check`
+5. create a release branch if needed
+6. merge the release PR
+7. create a tag in the format `vX.Y.Z`
+8. push the tag
+9. create the GitHub release
+
+## Notes
+
+- Keep the tag format consistent as `vX.Y.Z`.
+- Ensure the version, `CHANGELOG.md`, and tag all align.


### PR DESCRIPTION
Summary
- add a repository pull request template with scope, testing, notes, and issue-closure prompts
- add short issue templates for bug reports, feature requests, and workflow or process improvements
- add a lightweight release workflow runbook under docs/

Testing
- make check