### PR TITLE
chore: add minimal .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,30 +1,12 @@
+# macOS
+.DS_Store
+
+# Local worktrees
+.worktrees/
+
 # Python
 __pycache__/
-*.py[cod]
+*.pyc
+
+# Virtual environments
 .venv/
-venv/
-dist/
-build/
-*.egg-info/
-
-# Testing / coverage
-.pytest_cache/
-.coverage
-htmlcov/
-
-# OS / editor
-.DS_Store
-.vscode/
-.idea/
-
-# Local config and secrets
-.env
-.env.*
-.python-version
-local/
-secrets/
-tmp/
-cache/
-
-# Generated outputs
-output/


### PR DESCRIPTION
Summary
- replace the existing root `.gitignore` with a minimal set of ignores for macOS metadata, local worktrees, Python bytecode caches, and `.venv`
- keep the ignore list intentionally narrow with no additional tool-specific entries

Testing
- `make check`