### PR TITLE
feat: add source-aware incremental sync for confluence

### DIFF
--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -319,11 +319,12 @@ def main(argv: Sequence[str] | None = None) -> int:
             ConfluenceRequestError,
             fetch_page,
             fetch_real_page,
+            fetch_real_page_summary,
             list_real_child_page_ids,
         )
         from knowledge_adapters.confluence.config import ConfluenceConfig
         from knowledge_adapters.confluence.incremental import (
-            is_already_written,
+            classify_page_sync,
             load_previous_manifest_index,
         )
         from knowledge_adapters.confluence.manifest import (
@@ -377,11 +378,21 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
 
         selected_fetch_page: Callable[[ResolvedTarget], dict[str, object]]
+        selected_fetch_page_summary: Callable[[ResolvedTarget], dict[str, object]]
         selected_list_child_page_ids: Callable[[ResolvedTarget], list[str]] | None = None
         if confluence_config.client_mode == "real":
 
             def selected_fetch_page(resolved_target: ResolvedTarget) -> dict[str, object]:
                 return fetch_real_page(
+                    resolved_target,
+                    base_url=confluence_config.base_url,
+                    auth_method=confluence_config.auth_method,
+                )
+
+            def selected_fetch_page_summary(
+                resolved_target: ResolvedTarget,
+            ) -> dict[str, object]:
+                return fetch_real_page_summary(
                     resolved_target,
                     base_url=confluence_config.base_url,
                     auth_method=confluence_config.auth_method,
@@ -397,6 +408,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 )
         else:
             selected_fetch_page = fetch_page
+            selected_fetch_page_summary = fetch_page
 
         def _describe_tree_depth(max_depth: int) -> str:
             if max_depth == 0:
@@ -451,13 +463,22 @@ def main(argv: Sequence[str] | None = None) -> int:
         def _build_manifest_entry_for_page(
             page: dict[str, object],
             output_path: Path,
-        ) -> dict[str, str]:
+        ) -> dict[str, object]:
+            page_version = page.get("page_version")
             return build_manifest_entry(
                 canonical_id=str(page.get("canonical_id") or ""),
                 source_url=str(page.get("source_url", "")),
                 output_path=output_path,
                 output_dir=confluence_config.output_dir,
                 title=str(page["title"]) if page.get("title") else None,
+                page_version=(
+                    page_version
+                    if isinstance(page_version, int) and not isinstance(page_version, bool)
+                    else None
+                ),
+                last_modified=(
+                    str(page["last_modified"]) if page.get("last_modified") else None
+                ),
             )
 
         def _display_output_path(path: Path) -> str:
@@ -470,6 +491,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             source_url: str,
             output_path: Path,
             manifest_output_path: Path,
+            page_status: str,
             action: str,
             dry_run: bool,
             markdown: str | None = None,
@@ -479,6 +501,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             print(f"  source_url: {source_url}")
             print(f"  Artifact: {_display_output_path(output_path)}")
             print(f"  Manifest: {_display_output_path(manifest_output_path)}")
+            print(f"  page_status: {page_status}")
             print(f"  planned_action: {'would ' if dry_run else ''}{action}")
             if dry_run:
                 write_count = 1 if action == "write" else 0
@@ -486,6 +509,9 @@ def main(argv: Sequence[str] | None = None) -> int:
                 _print_confluence_dry_run_summary(
                     mode="single",
                     total_pages=1,
+                    new_count=1 if page_status == "new" else 0,
+                    changed_count=1 if page_status == "changed" else 0,
+                    unchanged_count=1 if page_status == "unchanged" else 0,
                     write_count=write_count,
                     skip_count=skip_count,
                 )
@@ -497,6 +523,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             *,
             mode: str,
             total_pages: int,
+            new_count: int,
+            changed_count: int,
+            unchanged_count: int,
             write_count: int,
             skip_count: int,
         ) -> None:
@@ -505,12 +534,30 @@ def main(argv: Sequence[str] | None = None) -> int:
                 f"    mode: {mode}",
                 "    pages_in_plan: "
                 f"{total_pages} (root 1, descendants {descendant_count})",
+                f"    new_pages: {new_count}",
+                f"    changed_pages: {changed_count}",
+                f"    unchanged_pages: {unchanged_count}",
                 f"    would_write: {write_count}",
                 f"    would_skip: {skip_count}",
             )
             print("  Summary:")
             for line in summary_lines:
                 print(line)
+
+        def _print_confluence_write_summary(
+            *,
+            new_count: int,
+            changed_count: int,
+            unchanged_count: int,
+            write_count: int,
+            skip_count: int,
+        ) -> None:
+            print(f"\nSummary: wrote {write_count}, skipped {skip_count}")
+            print(f"  new_pages: {new_count}")
+            print(f"  changed_pages: {changed_count}")
+            print(f"  unchanged_pages: {unchanged_count}")
+            print(f"  pages_written: {write_count}")
+            print(f"  pages_skipped: {skip_count}")
 
         def _print_stub_tree_mode_note() -> None:
             if not (confluence_config.tree and confluence_config.client_mode == "stub"):
@@ -522,12 +569,18 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
 
         if confluence_config.tree:
+            previous_manifest_index = load_previous_manifest_index(confluence_config.output_dir)
+            tree_fetch_page = (
+                selected_fetch_page
+                if previous_manifest_index is None
+                else selected_fetch_page_summary
+            )
             if confluence_config.client_mode == "real":
                 try:
                     root_page_id, pages = walk_pages(
                         target,
                         max_depth=confluence_config.max_depth,
-                        fetch_page=selected_fetch_page,
+                        fetch_page=tree_fetch_page,
                         list_child_page_ids=selected_list_child_page_ids,
                     )
                 except (RuntimeError, ValueError) as exc:
@@ -540,31 +593,38 @@ def main(argv: Sequence[str] | None = None) -> int:
                 root_page_id, pages = walk_pages(
                     target,
                     max_depth=confluence_config.max_depth,
-                    fetch_page=selected_fetch_page,
+                    fetch_page=tree_fetch_page,
                     list_child_page_ids=selected_list_child_page_ids,
                 )
             _print_confluence_invocation()
-            previous_manifest_index = load_previous_manifest_index(confluence_config.output_dir)
-            page_records: list[tuple[dict[str, object], Path, str]] = []
+            page_records: list[tuple[dict[str, object], Path, str, str]] = []
             for page in pages:
                 canonical_id = str(page.get("canonical_id") or "")
                 output_path = markdown_path(confluence_config.output_dir, canonical_id)
-                action = (
-                    "skip"
-                    if is_already_written(
-                        confluence_config.output_dir,
-                        previous_manifest_index,
-                        canonical_id=canonical_id,
-                        output_path=output_path,
-                    )
-                    else "write"
+                page_status = classify_page_sync(
+                    confluence_config.output_dir,
+                    previous_manifest_index,
+                    page=page,
+                    output_path=output_path,
                 )
-                page_records.append((page, output_path, action))
+                action = "skip" if page_status == "unchanged" else "write"
+                page_records.append((page, output_path, page_status, action))
 
             write_count = sum(
-                1 for _page, _output_path, action in page_records if action == "write"
+                1 for _page, _output_path, _page_status, action in page_records if action == "write"
             )
             skip_count = len(page_records) - write_count
+            new_count = sum(
+                1
+                for _page, _output_path, page_status, _action in page_records
+                if page_status == "new"
+            )
+            changed_count = sum(
+                1
+                for _page, _output_path, page_status, _action in page_records
+                if page_status == "changed"
+            )
+            unchanged_count = len(page_records) - new_count - changed_count
             manifest_output_path = manifest_path(confluence_config.output_dir)
 
             print("\nPlan: Confluence run")
@@ -578,32 +638,63 @@ def main(argv: Sequence[str] | None = None) -> int:
                 _print_confluence_dry_run_summary(
                     mode="tree",
                     total_pages=len(page_records),
+                    new_count=new_count,
+                    changed_count=changed_count,
+                    unchanged_count=unchanged_count,
                     write_count=write_count,
                     skip_count=skip_count,
                 )
-                for _page, output_path, action in page_records:
-                    print(f"  would {action} {_display_output_path(output_path)}")
+                for _page, output_path, record_status, action in page_records:
+                    print(
+                        f"  would {action} {_display_output_path(output_path)} ({record_status})"
+                    )
                 print_dry_run_complete()
                 return 0
 
             files = [
                 _build_manifest_entry_for_page(page, output_path)
-                for page, output_path, _action in page_records
+                for page, output_path, _page_status, _action in page_records
             ]
 
+            pages_to_write: dict[str, dict[str, object]] = {}
             try:
-                for page, output_path, action in page_records:
+                for page, _output_path, _page_status, action in page_records:
                     if action == "skip":
-                        print(f"\nSkipped: {_display_output_path(output_path)}")
                         continue
 
-                    markdown = normalize_to_markdown(page)
+                    if page.get("content") is not None:
+                        pages_to_write[str(page.get("canonical_id") or "")] = page
+                        continue
+
+                    page_id = str(page.get("canonical_id") or "")
+                    pages_to_write[page_id] = selected_fetch_page(
+                        ResolvedTarget(
+                            raw_value=page_id,
+                            page_id=page_id,
+                            page_url=None,
+                        )
+                    )
+            except (RuntimeError, ValueError) as exc:
+                exit_with_cli_error(
+                    str(exc),
+                    command="confluence",
+                    debug_lines=_confluence_debug_lines(exc),
+                )
+
+            try:
+                for page, output_path, record_status, action in page_records:
+                    if action == "skip":
+                        print(f"\nSkipped: {_display_output_path(output_path)} ({record_status})")
+                        continue
+
+                    page_to_write = pages_to_write[str(page.get("canonical_id") or "")]
+                    markdown = normalize_to_markdown(page_to_write)
                     write_markdown(
                         confluence_config.output_dir,
-                        str(page.get("canonical_id") or ""),
+                        str(page_to_write.get("canonical_id") or ""),
                         markdown,
                     )
-                    print(f"\nWrote: {_display_output_path(output_path)}")
+                    print(f"\nWrote: {_display_output_path(output_path)} ({record_status})")
 
                 manifest = write_manifest_with_context(
                     confluence_config.output_dir,
@@ -617,13 +708,24 @@ def main(argv: Sequence[str] | None = None) -> int:
                     command="confluence",
                     exc=exc,
                 )
-            print(f"\nSummary: wrote {write_count}, skipped {skip_count}")
+            _print_confluence_write_summary(
+                new_count=new_count,
+                changed_count=changed_count,
+                unchanged_count=unchanged_count,
+                write_count=write_count,
+                skip_count=skip_count,
+            )
             print(f"Manifest: {_display_output_path(manifest)}")
             print_write_complete(output_dir)
             return 0
 
+        previous_manifest_index = load_previous_manifest_index(confluence_config.output_dir)
         try:
-            page = selected_fetch_page(target)
+            page = (
+                selected_fetch_page(target)
+                if previous_manifest_index is None
+                else selected_fetch_page_summary(target)
+            )
         except (RuntimeError, ValueError) as exc:
             exit_with_cli_error(
                 str(exc),
@@ -635,25 +737,32 @@ def main(argv: Sequence[str] | None = None) -> int:
         page_id = str(page["canonical_id"])
         output_path = markdown_path(confluence_config.output_dir, page_id)
         manifest_output_path = manifest_path(confluence_config.output_dir)
-        previous_manifest_index = load_previous_manifest_index(confluence_config.output_dir)
-        action = (
-            "skip"
-            if is_already_written(
-                confluence_config.output_dir,
-                previous_manifest_index,
-                canonical_id=page_id,
-                output_path=output_path,
-            )
-            else "write"
+        page_status = classify_page_sync(
+            confluence_config.output_dir,
+            previous_manifest_index,
+            page=page,
+            output_path=output_path,
         )
+        action = "skip" if page_status == "unchanged" else "write"
 
         if confluence_config.dry_run:
-            planned_markdown = normalize_to_markdown(page) if action == "write" else None
+            planned_page = page
+            if action == "write" and page.get("content") is None:
+                try:
+                    planned_page = selected_fetch_page(target)
+                except (RuntimeError, ValueError) as exc:
+                    exit_with_cli_error(
+                        str(exc),
+                        command="confluence",
+                        debug_lines=_confluence_debug_lines(exc),
+                    )
+            planned_markdown = normalize_to_markdown(planned_page) if action == "write" else None
             _print_single_page_plan(
                 page_id=page_id,
                 source_url=str(page.get("source_url", "")),
                 output_path=output_path,
                 manifest_output_path=manifest_output_path,
+                page_status=page_status,
                 action=action,
                 dry_run=True,
                 markdown=planned_markdown,
@@ -666,27 +775,37 @@ def main(argv: Sequence[str] | None = None) -> int:
             source_url=str(page.get("source_url", "")),
             output_path=output_path,
             manifest_output_path=manifest_output_path,
+            page_status=page_status,
             action=action,
             dry_run=False,
         )
 
         try:
             if action == "write":
-                markdown = normalize_to_markdown(page)
+                page_to_write = (
+                    page if page.get("content") is not None else selected_fetch_page(target)
+                )
+                markdown = normalize_to_markdown(page_to_write)
                 write_markdown(
                     confluence_config.output_dir,
                     page_id,
                     markdown,
                 )
-                print(f"\nWrote: {_display_output_path(output_path)}")
+                print(f"\nWrote: {_display_output_path(output_path)} ({page_status})")
             else:
-                print(f"\nSkipped: {_display_output_path(output_path)}")
+                print(f"\nSkipped: {_display_output_path(output_path)} ({page_status})")
 
             manifest = write_manifest(
                 confluence_config.output_dir,
                 [
                     _build_manifest_entry_for_page(page, output_path),
                 ],
+            )
+        except (RuntimeError, ValueError) as exc:
+            exit_with_cli_error(
+                str(exc),
+                command="confluence",
+                debug_lines=_confluence_debug_lines(exc),
             )
         except OSError as exc:
             exit_with_output_error(
@@ -696,7 +815,13 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
         write_count = 1 if action == "write" else 0
         skip_count = 1 if action == "skip" else 0
-        print(f"\nSummary: wrote {write_count}, skipped {skip_count}")
+        _print_confluence_write_summary(
+            new_count=1 if page_status == "new" else 0,
+            changed_count=1 if page_status == "changed" else 0,
+            unchanged_count=1 if page_status == "unchanged" else 0,
+            write_count=write_count,
+            skip_count=skip_count,
+        )
         print(f"Manifest: {_display_output_path(manifest)}")
         print_write_complete(output_dir)
         return 0

--- a/src/knowledge_adapters/confluence/client.py
+++ b/src/knowledge_adapters/confluence/client.py
@@ -42,13 +42,15 @@ def fetch_page(target: ResolvedTarget) -> dict[str, object]:
         "canonical_id": canonical_id,
         "source_url": target.page_url or "",
         "content": f"Stub content for page {canonical_id}.",
+        "page_version": 1,
+        "last_modified": "1970-01-01T00:00:00Z",
     }
 
 
-def _content_api_url(base_url: str, page_id: str) -> str:
+def _content_api_url(base_url: str, page_id: str, *, expand: str) -> str:
     normalized_base = base_url.rstrip("/")
     encoded_page_id = parse.quote(page_id, safe="")
-    return f"{normalized_base}/rest/api/content/{encoded_page_id}?expand=body.storage,_links"
+    return f"{normalized_base}/rest/api/content/{encoded_page_id}?expand={expand}"
 
 
 def _child_page_api_url(base_url: str, page_id: str) -> str:
@@ -62,6 +64,24 @@ def _require_string(payload: dict[str, object], key: str) -> str:
     if not isinstance(value, str) or not value:
         raise ValueError(f"Response error: missing or invalid {key}.")
     return value
+
+
+def _optional_string(payload: dict[str, object], key: str) -> str | None:
+    value = payload.get(key)
+    if isinstance(value, str) and value:
+        return value
+    return None
+
+
+def _source_metadata(payload: dict[str, object]) -> tuple[int | None, str | None]:
+    version = payload.get("version")
+    if not isinstance(version, dict):
+        return None, None
+
+    number = version.get("number")
+    page_version = number if isinstance(number, int) and not isinstance(number, bool) else None
+    last_modified = _optional_string(version, "when")
+    return page_version, last_modified
 
 
 def _storage_content(payload: dict[str, object]) -> str:
@@ -111,12 +131,33 @@ def _map_real_page(payload: dict[str, object], requested_page_id: str) -> dict[s
     title = _require_string(payload, "title")
     content = _storage_content(payload)
     source_url = _absolute_source_url(payload)
+    page_version, last_modified = _source_metadata(payload)
 
     return {
         "canonical_id": canonical_id,
         "title": title,
         "content": content,
         "source_url": source_url,
+        "page_version": page_version,
+        "last_modified": last_modified,
+    }
+
+
+def _map_real_page_summary(payload: dict[str, object], requested_page_id: str) -> dict[str, object]:
+    canonical_id = _require_string(payload, "id")
+    if canonical_id != requested_page_id:
+        raise ValueError("Response error: canonical_id mismatch.")
+
+    title = _require_string(payload, "title")
+    source_url = _absolute_source_url(payload)
+    page_version, last_modified = _source_metadata(payload)
+
+    return {
+        "canonical_id": canonical_id,
+        "title": title,
+        "source_url": source_url,
+        "page_version": page_version,
+        "last_modified": last_modified,
     }
 
 
@@ -264,10 +305,28 @@ def fetch_real_page(
         raise ValueError("Response error: canonical_id mismatch.")
 
     raw_payload = _request_json(
-        _content_api_url(base_url, page_id),
+        _content_api_url(base_url, page_id, expand="body.storage,_links,version"),
         auth_method=auth_method,
     )
     return _map_real_page(raw_payload, page_id)
+
+
+def fetch_real_page_summary(
+    target: ResolvedTarget,
+    *,
+    base_url: str,
+    auth_method: str,
+) -> dict[str, object]:
+    """Fetch Confluence page metadata used for incremental sync decisions."""
+    page_id = target.page_id
+    if not page_id:
+        raise ValueError("Response error: canonical_id mismatch.")
+
+    raw_payload = _request_json(
+        _content_api_url(base_url, page_id, expand="version,_links"),
+        auth_method=auth_method,
+    )
+    return _map_real_page_summary(raw_payload, page_id)
 
 
 def list_real_child_page_ids(

--- a/src/knowledge_adapters/confluence/incremental.py
+++ b/src/knowledge_adapters/confluence/incremental.py
@@ -3,14 +3,40 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal
 
 from knowledge_adapters.confluence.manifest import manifest_path
 
 
+@dataclass(frozen=True)
+class PreviousManifestEntry:
+    """Normalized prior-manifest entry used for incremental comparisons."""
+
+    canonical_id: str
+    output_path: str
+    page_version: str | None
+    last_modified: str | None
+
+
+PageSyncStatus = Literal["new", "changed", "unchanged"]
+
+
+def _normalize_metadata_value(value: object) -> str | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, str) and value:
+        return value
+    return None
+
+
 def _load_previous_manifest_indexes(
     output_dir: str,
-) -> tuple[dict[str, str], dict[str, str]] | None:
+) -> tuple[dict[str, PreviousManifestEntry], dict[str, str]] | None:
     """Load and validate the previous manifest for incremental comparisons."""
     path = manifest_path(output_dir)
     if not path.exists():
@@ -30,7 +56,7 @@ def _load_previous_manifest_indexes(
             "Fix or remove the manifest and try again."
         )
 
-    entries_by_id: dict[str, str] = {}
+    entries_by_id: dict[str, PreviousManifestEntry] = {}
     entries_by_output_path: dict[str, str] = {}
 
     for entry in files:
@@ -59,13 +85,18 @@ def _load_previous_manifest_indexes(
                 "Fix or remove the manifest and try again."
             )
 
-        entries_by_id[canonical_id] = output_path
+        entries_by_id[canonical_id] = PreviousManifestEntry(
+            canonical_id=canonical_id,
+            output_path=output_path,
+            page_version=_normalize_metadata_value(entry.get("page_version")),
+            last_modified=_normalize_metadata_value(entry.get("last_modified")),
+        )
         entries_by_output_path[output_path] = canonical_id
 
     return entries_by_id, entries_by_output_path
 
 
-def load_previous_manifest_index(output_dir: str) -> dict[str, str] | None:
+def load_previous_manifest_index(output_dir: str) -> dict[str, PreviousManifestEntry] | None:
     """Load and validate the previous manifest keyed by canonical_id."""
     indexes = _load_previous_manifest_indexes(output_dir)
     if indexes is None:
@@ -83,20 +114,35 @@ def load_previous_manifest_output_index(output_dir: str) -> dict[str, str] | Non
     return indexes[1]
 
 
-def is_already_written(
+def classify_page_sync(
     output_dir: str,
-    previous_manifest_index: dict[str, str] | None,
+    previous_manifest_index: dict[str, PreviousManifestEntry] | None,
     *,
-    canonical_id: str,
+    page: Mapping[str, object],
     output_path: Path,
-) -> bool:
-    """Return whether the candidate page is already written for v1 sync rules."""
+) -> PageSyncStatus:
+    """Classify a page as new, changed, or unchanged for incremental sync."""
+    canonical_id = str(page.get("canonical_id") or "")
     if previous_manifest_index is None:
-        return False
+        return "new"
+
+    prior_entry = previous_manifest_index.get(canonical_id)
+    if prior_entry is None:
+        return "new"
 
     expected_output_path = output_path.relative_to(Path(output_dir)).as_posix()
-    prior_output_path = previous_manifest_index.get(canonical_id)
-    if prior_output_path != expected_output_path:
-        return False
+    if prior_entry.output_path != expected_output_path:
+        return "changed"
 
-    return (Path(output_dir) / prior_output_path).exists()
+    if not (Path(output_dir) / prior_entry.output_path).exists():
+        return "changed"
+
+    current_page_version = _normalize_metadata_value(page.get("page_version"))
+    if current_page_version is not None and prior_entry.page_version is not None:
+        return "unchanged" if current_page_version == prior_entry.page_version else "changed"
+
+    current_last_modified = _normalize_metadata_value(page.get("last_modified"))
+    if current_last_modified is not None and prior_entry.last_modified is not None:
+        return "unchanged" if current_last_modified == prior_entry.last_modified else "changed"
+
+    return "changed"

--- a/src/knowledge_adapters/confluence/manifest.py
+++ b/src/knowledge_adapters/confluence/manifest.py
@@ -19,9 +19,11 @@ def build_manifest_entry(
     output_path: Path,
     output_dir: str,
     title: str | None = None,
-) -> dict[str, str]:
+    page_version: int | str | None = None,
+    last_modified: str | None = None,
+) -> dict[str, object]:
     """Build a minimal manifest entry for a generated file."""
-    entry = {
+    entry: dict[str, object] = {
         "canonical_id": canonical_id,
         "source_url": source_url,
         "output_path": output_path.relative_to(Path(output_dir)).as_posix(),
@@ -29,18 +31,22 @@ def build_manifest_entry(
 
     if title:
         entry["title"] = title
+    if page_version is not None:
+        entry["page_version"] = page_version
+    if last_modified:
+        entry["last_modified"] = last_modified
 
     return entry
 
 
-def write_manifest(output_dir: str, files: list[dict[str, str]]) -> Path:
+def write_manifest(output_dir: str, files: list[dict[str, object]]) -> Path:
     """Write a per-run manifest describing generated files."""
     return write_manifest_with_context(output_dir, files)
 
 
 def write_manifest_with_context(
     output_dir: str,
-    files: list[dict[str, str]],
+    files: list[dict[str, object]],
     *,
     root_page_id: str | None = None,
     max_depth: int | None = None,

--- a/tests/artifact_assertions.py
+++ b/tests/artifact_assertions.py
@@ -26,14 +26,20 @@ def manifest_file(
     source_url: str,
     output_path: str,
     title: str | None = None,
-) -> dict[str, str]:
-    entry = {
+    page_version: int | str | None = None,
+    last_modified: str | None = None,
+) -> dict[str, object]:
+    entry: dict[str, object] = {
         "canonical_id": canonical_id,
         "source_url": source_url,
         "output_path": output_path,
     }
     if title is not None:
         entry["title"] = title
+    if page_version is not None:
+        entry["page_version"] = page_version
+    if last_modified is not None:
+        entry["last_modified"] = last_modified
     return entry
 
 
@@ -44,19 +50,23 @@ def assert_manifest_entry(
     source_url: str,
     output_path: str,
     title: str | None = None,
+    page_version: int | str | None = None,
+    last_modified: str | None = None,
 ) -> None:
     assert dict(entry) == manifest_file(
         canonical_id=canonical_id,
         source_url=source_url,
         output_path=output_path,
         title=title,
+        page_version=page_version,
+        last_modified=last_modified,
     )
 
 
 def assert_manifest_entries(
     manifest: Path | Mapping[str, object],
     *,
-    files: Sequence[Mapping[str, str]],
+    files: Sequence[Mapping[str, object]],
 ) -> None:
     payload = _load_manifest(manifest) if isinstance(manifest, Path) else dict(manifest)
 

--- a/tests/cli_output_assertions.py
+++ b/tests/cli_output_assertions.py
@@ -14,6 +14,9 @@ def assert_dry_run_summary(
     *,
     would_write: int,
     would_skip: int,
+    new_pages: int | None = None,
+    changed_pages: int | None = None,
+    unchanged_pages: int | None = None,
 ) -> None:
     normalized = normalize_whitespace(output)
     legacy_summary = f"Summary: would write {would_write}, would skip {would_skip}"
@@ -23,22 +26,45 @@ def assert_dry_run_summary(
     assert "Summary:" in output
     assert f"would_write: {would_write}" in output
     assert f"would_skip: {would_skip}" in output
+    if new_pages is not None:
+        assert f"new_pages: {new_pages}" in output
+    if changed_pages is not None:
+        assert f"changed_pages: {changed_pages}" in output
+    if unchanged_pages is not None:
+        assert f"unchanged_pages: {unchanged_pages}" in output
 
 
-def assert_write_summary(output: str, *, wrote: int, skipped: int) -> None:
+def assert_write_summary(
+    output: str,
+    *,
+    wrote: int,
+    skipped: int,
+    new_pages: int | None = None,
+    changed_pages: int | None = None,
+    unchanged_pages: int | None = None,
+) -> None:
     normalized = normalize_whitespace(output)
     if f"Summary: wrote {wrote}, skipped {skipped}" in normalized:
-        return
-
-    if skipped == 0 and (
+        pass
+    elif skipped == 0 and (
         f"Summary: wrote {wrote} file" in normalized
         or f"Summary: wrote {wrote} files" in normalized
     ):
-        return
+        pass
+    else:
+        raise AssertionError(
+            f"expected write summary for wrote={wrote}, skipped={skipped} in output:\n{output}"
+        )
 
-    raise AssertionError(
-        f"expected write summary for wrote={wrote}, skipped={skipped} in output:\n{output}"
-    )
+    if new_pages is not None:
+        assert f"new_pages: {new_pages}" in output
+    if changed_pages is not None:
+        assert f"changed_pages: {changed_pages}" in output
+    if unchanged_pages is not None:
+        assert f"unchanged_pages: {unchanged_pages}" in output
+    if any(value is not None for value in (new_pages, changed_pages, unchanged_pages)):
+        assert f"pages_written: {wrote}" in output
+        assert f"pages_skipped: {skipped}" in output
 
 
 def assert_tree_plan_page_count(output: str, *, count: int) -> None:

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -196,6 +196,8 @@ Stub content for page 12345.
             "source_url": "https://example.com/wiki/pages/viewpage.action?pageId=12345",
             "output_path": "pages/12345.md",
             "title": "stub-page-12345",
+            "page_version": 1,
+            "last_modified": "1970-01-01T00:00:00Z",
         }
     ]
 

--- a/tests/test_confluence_incremental_contract.py
+++ b/tests/test_confluence_incremental_contract.py
@@ -24,6 +24,8 @@ def _synthetic_pages() -> dict[str, dict[str, object]]:
             "title": "Root A",
             "source_url": "https://example.com/wiki/pages/100",
             "content": "Root A content.",
+            "page_version": 1,
+            "last_modified": "2026-04-20T00:00:00Z",
             "children": ["200"],
         },
         "200": {
@@ -31,6 +33,8 @@ def _synthetic_pages() -> dict[str, dict[str, object]]:
             "title": "Shared Child",
             "source_url": "https://example.com/wiki/pages/200",
             "content": "Shared child content.",
+            "page_version": 2,
+            "last_modified": "2026-04-20T00:01:00Z",
             "children": [],
         },
         "900": {
@@ -38,6 +42,8 @@ def _synthetic_pages() -> dict[str, dict[str, object]]:
             "title": "Root B",
             "source_url": "https://example.com/wiki/pages/900",
             "content": "Root B content.",
+            "page_version": 9,
+            "last_modified": "2026-04-20T00:02:00Z",
             "children": ["200", "950"],
         },
         "950": {
@@ -45,6 +51,8 @@ def _synthetic_pages() -> dict[str, dict[str, object]]:
             "title": "Exclusive Child",
             "source_url": "https://example.com/wiki/pages/950",
             "content": "Exclusive child content.",
+            "page_version": 10,
+            "last_modified": "2026-04-20T00:03:00Z",
             "children": [],
         },
     }
@@ -93,9 +101,33 @@ def _page_path(output_dir: Path, page_id: str) -> Path:
     return output_dir / "pages" / f"{page_id}.md"
 
 
+def _manifest_entry_for_page(
+    page_id: str,
+    *,
+    pages: dict[str, dict[str, object]] | None = None,
+    output_path: str | None = None,
+    source_url: str | None = None,
+    title: str | None = None,
+    include_metadata: bool = True,
+) -> dict[str, object]:
+    pages = pages or _synthetic_pages()
+    page = pages[page_id]
+    entry: dict[str, object] = {
+        "canonical_id": page_id,
+        "source_url": source_url or str(page["source_url"]),
+        "output_path": output_path or f"pages/{page_id}.md",
+    }
+    if title is not None:
+        entry["title"] = title
+    if include_metadata:
+        entry["page_version"] = page["page_version"]
+        entry["last_modified"] = page["last_modified"]
+    return entry
+
+
 def _write_previous_manifest(
     output_dir: Path,
-    files: list[dict[str, str]],
+    files: list[dict[str, object]],
     *,
     generated_at: str = "2026-04-19T00:00:00Z",
     root_page_id: str | None = None,
@@ -121,8 +153,8 @@ def _load_manifest(output_dir: Path) -> dict[str, object]:
     return cast(dict[str, object], payload)
 
 
-def _manifest_files(payload: dict[str, object]) -> list[dict[str, str]]:
-    return cast(list[dict[str, str]], payload["files"])
+def _manifest_files(payload: dict[str, object]) -> list[dict[str, object]]:
+    return cast(list[dict[str, object]], payload["files"])
 
 
 def test_incremental_dry_run_without_manifest_marks_all_pages_as_write(
@@ -152,6 +184,14 @@ def test_incremental_dry_run_without_manifest_marks_all_pages_as_write(
             ("write", _page_path(output_dir, "200")),
         ],
     )
+    assert_dry_run_summary(
+        captured.out,
+        would_write=2,
+        would_skip=0,
+        new_pages=2,
+        changed_pages=0,
+        unchanged_pages=0,
+    )
     assert f"would skip {_page_path(output_dir, '100')}" not in captured.out
     assert f"would skip {_page_path(output_dir, '200')}" not in captured.out
     assert not _page_path(output_dir, "100").exists()
@@ -163,11 +203,7 @@ def test_incremental_dry_run_without_manifest_marks_all_pages_as_write(
     ("manifest_entry", "materialize_file", "expected_phrase"),
     [
         (
-            {
-                "canonical_id": "100",
-                "source_url": "https://example.com/wiki/pages/100",
-                "output_path": "pages/100.md",
-            },
+            _manifest_entry_for_page("100"),
             True,
             "would skip",
         ),
@@ -204,7 +240,7 @@ def test_incremental_dry_run_uses_manifest_identity_and_file_existence_for_skip(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
     capsys: CaptureFixture[str],
-    manifest_entry: dict[str, str],
+    manifest_entry: dict[str, object],
     materialize_file: bool,
     expected_phrase: str,
 ) -> None:
@@ -216,7 +252,7 @@ def test_incremental_dry_run_uses_manifest_identity_and_file_existence_for_skip(
     )
 
     if materialize_file:
-        prior_path = output_dir / manifest_entry["output_path"]
+        prior_path = output_dir / str(manifest_entry["output_path"])
         prior_path.parent.mkdir(parents=True, exist_ok=True)
         prior_path.write_text("existing artifact\n", encoding="utf-8")
 
@@ -256,13 +292,7 @@ def test_incremental_dry_run_reports_both_would_write_and_would_skip_without_wri
     output_dir = tmp_path / "out"
     original_manifest = _write_previous_manifest(
         output_dir,
-        [
-            {
-                "canonical_id": "100",
-                "source_url": "https://example.com/wiki/pages/100",
-                "output_path": "pages/100.md",
-            }
-        ],
+        [_manifest_entry_for_page("100")],
         root_page_id="100",
     )
     existing_page = _page_path(output_dir, "100")
@@ -280,7 +310,14 @@ def test_incremental_dry_run_reports_both_would_write_and_would_skip_without_wri
     captured = capsys.readouterr()
     assert f"would skip {existing_page}" in captured.out
     assert f"would write {_page_path(output_dir, '200')}" in captured.out
-    assert_dry_run_summary(captured.out, would_write=1, would_skip=1)
+    assert_dry_run_summary(
+        captured.out,
+        would_write=1,
+        would_skip=1,
+        new_pages=1,
+        changed_pages=0,
+        unchanged_pages=1,
+    )
     assert existing_page.read_text(encoding="utf-8") == "already written\n"
     assert not _page_path(output_dir, "200").exists()
     assert _manifest_path(output_dir).read_text(encoding="utf-8") == original_manifest
@@ -293,13 +330,7 @@ def test_incremental_normal_run_manifest_includes_written_and_skipped_pages(
     output_dir = tmp_path / "out"
     _write_previous_manifest(
         output_dir,
-        [
-            {
-                "canonical_id": "100",
-                "source_url": "https://example.com/wiki/pages/100",
-                "output_path": "pages/100.md",
-            }
-        ],
+        [_manifest_entry_for_page("100")],
         root_page_id="100",
     )
     existing_page = _page_path(output_dir, "100")
@@ -318,6 +349,58 @@ def test_incremental_normal_run_manifest_includes_written_and_skipped_pages(
 
     payload = _load_manifest(output_dir)
     assert [entry["canonical_id"] for entry in _manifest_files(payload)] == ["100", "200"]
+    assert _manifest_files(payload)[0]["page_version"] == 1
+    assert _manifest_files(payload)[0]["last_modified"] == "2026-04-20T00:00:00Z"
+    assert _manifest_files(payload)[1]["page_version"] == 2
+    assert _manifest_files(payload)[1]["last_modified"] == "2026-04-20T00:01:00Z"
+
+
+def test_incremental_normal_run_rewrites_pages_when_source_metadata_changes(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    output_dir = tmp_path / "out"
+    _write_previous_manifest(
+        output_dir,
+        [
+            {
+                "canonical_id": "100",
+                "source_url": "https://example.com/wiki/pages/100?old=1",
+                "output_path": "pages/100.md",
+                "page_version": 0,
+                "last_modified": "2026-04-19T23:59:59Z",
+            }
+        ],
+        root_page_id="100",
+    )
+    existing_page = _page_path(output_dir, "100")
+    existing_page.parent.mkdir(parents=True, exist_ok=True)
+    existing_page.write_text("stale root\n", encoding="utf-8")
+
+    exit_code, _ = _run_recursive_cli(
+        tmp_path,
+        monkeypatch,
+        dry_run=False,
+    )
+
+    assert exit_code == 0
+    assert existing_page.read_text(encoding="utf-8") != "stale root\n"
+
+    captured = capsys.readouterr()
+    assert f"Wrote: {_page_path(output_dir, '100')} (changed)" in captured.out
+    assert_write_summary(
+        captured.out,
+        wrote=2,
+        skipped=0,
+        new_pages=1,
+        changed_pages=1,
+        unchanged_pages=0,
+    )
+
+    payload = _load_manifest(output_dir)
+    assert _manifest_files(payload)[0]["page_version"] == 1
+    assert _manifest_files(payload)[0]["last_modified"] == "2026-04-20T00:00:00Z"
 
 
 def test_incremental_output_directory_reuse_skips_overlapping_pages_without_target_validation(
@@ -327,13 +410,7 @@ def test_incremental_output_directory_reuse_skips_overlapping_pages_without_targ
     output_dir = tmp_path / "out"
     _write_previous_manifest(
         output_dir,
-        [
-            {
-                "canonical_id": "200",
-                "source_url": "https://example.com/wiki/pages/200",
-                "output_path": "pages/200.md",
-            }
-        ],
+        [_manifest_entry_for_page("200")],
         root_page_id="100",
     )
     overlapping_page = _page_path(output_dir, "200")
@@ -417,6 +494,8 @@ def test_incremental_normal_run_handles_larger_mixed_write_and_skip_set(
             "title": "Root",
             "source_url": "https://example.com/wiki/pages/100",
             "content": "Root content.",
+            "page_version": 1,
+            "last_modified": "2026-04-20T00:00:00Z",
             "children": ["200", "300", "400"],
         },
         "200": {
@@ -424,6 +503,8 @@ def test_incremental_normal_run_handles_larger_mixed_write_and_skip_set(
             "title": "Write Child A",
             "source_url": "https://example.com/wiki/pages/200",
             "content": "Child A content.",
+            "page_version": 22,
+            "last_modified": "2026-04-20T00:01:00Z",
             "children": [],
         },
         "300": {
@@ -431,6 +512,8 @@ def test_incremental_normal_run_handles_larger_mixed_write_and_skip_set(
             "title": "Skip Child",
             "source_url": "https://example.com/wiki/pages/300",
             "content": "Child B content.",
+            "page_version": 3,
+            "last_modified": "2026-04-20T00:02:00Z",
             "children": [],
         },
         "400": {
@@ -438,6 +521,8 @@ def test_incremental_normal_run_handles_larger_mixed_write_and_skip_set(
             "title": "Write Child B",
             "source_url": "https://example.com/wiki/pages/400",
             "content": "Child C content.",
+            "page_version": 44,
+            "last_modified": "2026-04-20T00:03:00Z",
             "children": [],
         },
     }
@@ -445,18 +530,18 @@ def test_incremental_normal_run_handles_larger_mixed_write_and_skip_set(
     _write_previous_manifest(
         output_dir,
         [
-            {
-                "canonical_id": "100",
-                "source_url": "https://example.com/wiki/pages/100?old=1",
-                "output_path": "pages/100.md",
-                "title": "Old Root",
-            },
-            {
-                "canonical_id": "300",
-                "source_url": "https://example.com/wiki/pages/300?old=1",
-                "output_path": "pages/300.md",
-                "title": "Old Child",
-            },
+            _manifest_entry_for_page(
+                "100",
+                pages=pages,
+                source_url="https://example.com/wiki/pages/100?old=1",
+                title="Old Root",
+            ),
+            _manifest_entry_for_page(
+                "300",
+                pages=pages,
+                source_url="https://example.com/wiki/pages/300?old=1",
+                title="Old Child",
+            ),
             {
                 "canonical_id": "999",
                 "source_url": "https://example.com/wiki/pages/999",
@@ -505,10 +590,17 @@ def test_incremental_normal_run_handles_larger_mixed_write_and_skip_set(
     assert f"Skipped: {_page_path(output_dir, '300')}" in captured.out
     assert f"Wrote: {_page_path(output_dir, '200')}" in captured.out
     assert f"Wrote: {_page_path(output_dir, '400')}" in captured.out
-    assert_write_summary(captured.out, wrote=2, skipped=2)
+    assert_write_summary(
+        captured.out,
+        wrote=2,
+        skipped=2,
+        new_pages=2,
+        changed_pages=0,
+        unchanged_pages=2,
+    )
 
 
-def test_incremental_dry_run_ignores_non_identity_manifest_fields_for_skip(
+def test_incremental_dry_run_rewrites_pages_from_older_manifests_without_source_metadata(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
     capsys: CaptureFixture[str],
@@ -541,8 +633,15 @@ def test_incremental_dry_run_ignores_non_identity_manifest_fields_for_skip(
     assert exit_code == 0
 
     captured = capsys.readouterr()
-    assert f"would skip {existing_page}" in captured.out
-    assert_dry_run_summary(captured.out, would_write=1, would_skip=1)
+    assert f"would write {existing_page} (changed)" in captured.out
+    assert_dry_run_summary(
+        captured.out,
+        would_write=2,
+        would_skip=0,
+        new_pages=1,
+        changed_pages=1,
+        unchanged_pages=0,
+    )
 
 
 def test_incremental_run_fails_fast_for_duplicate_output_paths_in_prior_manifest(
@@ -592,11 +691,10 @@ def test_incremental_output_directory_reuse_handles_overlapping_and_new_pages(
     _write_previous_manifest(
         output_dir,
         [
-            {
-                "canonical_id": "200",
-                "source_url": "https://example.com/wiki/pages/200?old=1",
-                "output_path": "pages/200.md",
-            },
+            _manifest_entry_for_page(
+                "200",
+                source_url="https://example.com/wiki/pages/200?old=1",
+            ),
             {
                 "canonical_id": "777",
                 "source_url": "https://example.com/wiki/pages/777",
@@ -638,7 +736,14 @@ def test_incremental_output_directory_reuse_handles_overlapping_and_new_pages(
     ]
 
     captured = capsys.readouterr()
-    assert_write_summary(captured.out, wrote=2, skipped=1)
+    assert_write_summary(
+        captured.out,
+        wrote=2,
+        skipped=1,
+        new_pages=2,
+        changed_pages=0,
+        unchanged_pages=1,
+    )
 
 
 def test_incremental_dry_run_summary_reports_mixed_write_and_skip_counts(
@@ -652,6 +757,8 @@ def test_incremental_dry_run_summary_reports_mixed_write_and_skip_counts(
             "title": "Root",
             "source_url": "https://example.com/wiki/pages/100",
             "content": "Root content.",
+            "page_version": 1,
+            "last_modified": "2026-04-20T00:00:00Z",
             "children": ["200", "300", "400"],
         },
         "200": {
@@ -659,6 +766,8 @@ def test_incremental_dry_run_summary_reports_mixed_write_and_skip_counts(
             "title": "Skip Child",
             "source_url": "https://example.com/wiki/pages/200",
             "content": "Skip child content.",
+            "page_version": 2,
+            "last_modified": "2026-04-20T00:01:00Z",
             "children": [],
         },
         "300": {
@@ -666,6 +775,8 @@ def test_incremental_dry_run_summary_reports_mixed_write_and_skip_counts(
             "title": "Write Child A",
             "source_url": "https://example.com/wiki/pages/300",
             "content": "Write child A content.",
+            "page_version": 33,
+            "last_modified": "2026-04-20T00:02:00Z",
             "children": [],
         },
         "400": {
@@ -673,6 +784,8 @@ def test_incremental_dry_run_summary_reports_mixed_write_and_skip_counts(
             "title": "Write Child B",
             "source_url": "https://example.com/wiki/pages/400",
             "content": "Write child B content.",
+            "page_version": 44,
+            "last_modified": "2026-04-20T00:03:00Z",
             "children": [],
         },
     }
@@ -680,16 +793,8 @@ def test_incremental_dry_run_summary_reports_mixed_write_and_skip_counts(
     _write_previous_manifest(
         output_dir,
         [
-            {
-                "canonical_id": "100",
-                "source_url": "https://example.com/wiki/pages/100",
-                "output_path": "pages/100.md",
-            },
-            {
-                "canonical_id": "200",
-                "source_url": "https://example.com/wiki/pages/200",
-                "output_path": "pages/200.md",
-            },
+            _manifest_entry_for_page("100", pages=pages),
+            _manifest_entry_for_page("200", pages=pages),
         ],
         root_page_id="100",
     )
@@ -710,5 +815,12 @@ def test_incremental_dry_run_summary_reports_mixed_write_and_skip_counts(
     assert not _page_path(output_dir, "400").exists()
 
     captured = capsys.readouterr()
-    assert_dry_run_summary(captured.out, would_write=2, would_skip=2)
+    assert_dry_run_summary(
+        captured.out,
+        would_write=2,
+        would_skip=2,
+        new_pages=2,
+        changed_pages=0,
+        unchanged_pages=2,
+    )
     assert_tree_plan_page_count(captured.out, count=4)

--- a/tests/test_confluence_real_client_contract.py
+++ b/tests/test_confluence_real_client_contract.py
@@ -119,6 +119,10 @@ def _valid_confluence_payload(
             "base": "https://example.com/wiki",
             "webui": f"/spaces/ENG/pages/{page_id}",
         },
+        "version": {
+            "number": 7,
+            "when": "2026-04-20T12:34:56Z",
+        },
     }
 
 
@@ -183,6 +187,8 @@ Stub content for page 12345.
             "source_url": "https://example.com/wiki/pages/viewpage.action?pageId=12345",
             "output_path": "pages/12345.md",
             "title": "stub-page-12345",
+            "page_version": 1,
+            "last_modified": "1970-01-01T00:00:00Z",
         }
     ]
 
@@ -199,6 +205,8 @@ def test_explicit_real_client_mode_selects_real_fetch_path(
             "title": "Real Page",
             "content": "<p>Hello from Confluence.</p>",
             "source_url": "https://example.com/wiki/spaces/ENG/pages/12345",
+            "page_version": 7,
+            "last_modified": "2026-04-20T12:34:56Z",
         }
 
     def fail_if_stub_used(target: ResolvedTarget) -> dict[str, object]:
@@ -251,6 +259,8 @@ def test_stub_and_real_single_page_write_runs_share_the_same_cli_shape(
             "title": "Real Page",
             "content": "<p>Hello from Confluence.</p>",
             "source_url": "https://example.com/wiki/spaces/ENG/pages/12345",
+            "page_version": 7,
+            "last_modified": "2026-04-20T12:34:56Z",
         }
 
     def fail_if_stub_used(target: ResolvedTarget) -> dict[str, object]:
@@ -309,6 +319,8 @@ def test_stub_and_real_single_page_dry_runs_share_the_same_plan_shape(
             "title": "Real Page",
             "content": "<p>Hello from Confluence.</p>",
             "source_url": "https://example.com/wiki/spaces/ENG/pages/12345",
+            "page_version": 7,
+            "last_modified": "2026-04-20T12:34:56Z",
         }
 
     def fail_if_stub_used(target: ResolvedTarget) -> dict[str, object]:
@@ -389,6 +401,8 @@ def test_real_fetch_maps_valid_confluence_response_into_adapter_payload(
         "title": "Real Page",
         "content": "<p>Hello from Confluence.</p>",
         "source_url": "https://example.com/wiki/spaces/ENG/pages/12345",
+        "page_version": 7,
+        "last_modified": "2026-04-20T12:34:56Z",
     }
     assert str(page["source_url"]).startswith("https://")
 
@@ -652,7 +666,7 @@ def test_real_fetch_ignores_extra_irrelevant_fields_in_valid_response(
     monkeypatch: MonkeyPatch,
 ) -> None:
     payload = _valid_confluence_payload()
-    payload["version"] = {"number": 7}
+    payload["version"] = {"number": 7, "when": "2026-04-20T12:34:56Z"}
     payload["space"] = {"key": "ENG"}
     payload["ignored"] = ["extra", "fields"]
 
@@ -669,6 +683,8 @@ def test_real_fetch_ignores_extra_irrelevant_fields_in_valid_response(
         "title": "Real Page",
         "content": "<p>Hello from Confluence.</p>",
         "source_url": "https://example.com/wiki/spaces/ENG/pages/12345",
+        "page_version": 7,
+        "last_modified": "2026-04-20T12:34:56Z",
     }
 
 
@@ -1123,7 +1139,7 @@ def test_real_client_cli_debug_mode_surfaces_request_context_for_request_failure
         == "knowledge-adapters confluence: error: Confluence request failed. "
         "Verify --base-url and try again.\n"
         "  debug request_url: https://example.com/wiki/rest/api/content/12345"
-        "?expand=body.storage,_links\n"
+        "?expand=body.storage,_links,version\n"
         "  debug client_mode: real\n"
         "  debug auth_method: bearer-env\n"
         "  debug exception: synthetic transport failure\n"

--- a/tests/test_confluence_real_traversal_contract.py
+++ b/tests/test_confluence_real_traversal_contract.py
@@ -40,8 +40,23 @@ def _load_manifest(output_dir: Path) -> dict[str, object]:
     return cast(dict[str, object], payload)
 
 
-def _manifest_files(payload: dict[str, object]) -> list[dict[str, str]]:
-    return cast(list[dict[str, str]], payload["files"])
+def _manifest_files(payload: dict[str, object]) -> list[dict[str, object]]:
+    return cast(list[dict[str, object]], payload["files"])
+
+
+def _write_previous_manifest(output_dir: Path, files: list[dict[str, object]]) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "generated_at": "2026-04-19T00:00:00Z",
+                "files": files,
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
 
 
 def _real_pages() -> dict[str, dict[str, object]]:
@@ -51,48 +66,64 @@ def _real_pages() -> dict[str, dict[str, object]]:
             "title": "Root Page",
             "source_url": "https://example.com/wiki/pages/100",
             "content": "Root content.",
+            "page_version": 1,
+            "last_modified": "2026-04-20T00:00:00Z",
         },
         "200": {
             "canonical_id": "200",
             "title": "Shared Child",
             "source_url": "https://example.com/wiki/pages/200",
             "content": "Shared child content.",
+            "page_version": 2,
+            "last_modified": "2026-04-20T00:01:00Z",
         },
         "300": {
             "canonical_id": "300",
             "title": "Sibling Child",
             "source_url": "https://example.com/wiki/pages/300",
             "content": "Sibling child content.",
+            "page_version": 3,
+            "last_modified": "2026-04-20T00:02:00Z",
         },
         "205": {
             "canonical_id": "205",
             "title": "Grandchild A",
             "source_url": "https://example.com/wiki/pages/205",
             "content": "Grandchild A content.",
+            "page_version": 4,
+            "last_modified": "2026-04-20T00:03:00Z",
         },
         "210": {
             "canonical_id": "210",
             "title": "Grandchild B",
             "source_url": "https://example.com/wiki/pages/210",
             "content": "Grandchild B content.",
+            "page_version": 5,
+            "last_modified": "2026-04-20T00:04:00Z",
         },
         "400": {
             "canonical_id": "400",
             "title": "Branch B",
             "source_url": "https://example.com/wiki/pages/400",
             "content": "Branch B content.",
+            "page_version": 6,
+            "last_modified": "2026-04-20T00:05:00Z",
         },
         "500": {
             "canonical_id": "500",
             "title": "Leaf",
             "source_url": "https://example.com/wiki/pages/500",
             "content": "Leaf content.",
+            "page_version": 7,
+            "last_modified": "2026-04-20T00:06:00Z",
         },
         "900": {
             "canonical_id": "900",
             "title": "Later Grandchild",
             "source_url": "https://example.com/wiki/pages/900",
             "content": "Later grandchild content.",
+            "page_version": 8,
+            "last_modified": "2026-04-20T00:07:00Z",
         },
     }
 
@@ -244,6 +275,103 @@ def test_real_tree_depth_semantics_use_separate_page_fetch_and_child_discovery(
     assert [entry["canonical_id"] for entry in _manifest_files(payload)] == expected_ids
     assert page_fetch_counts == expected_fetch_counts
     assert child_list_calls == expected_child_calls
+
+
+def test_real_tree_incremental_run_skips_full_page_fetch_for_unchanged_pages(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    from knowledge_adapters.confluence import client as client_module
+
+    output_dir = tmp_path / "out"
+    pages = _real_pages()
+    _write_previous_manifest(
+        output_dir,
+        [
+            {
+                "canonical_id": "100",
+                "source_url": pages["100"]["source_url"],
+                "output_path": "pages/100.md",
+                "title": pages["100"]["title"],
+                "page_version": pages["100"]["page_version"],
+                "last_modified": pages["100"]["last_modified"],
+            },
+            {
+                "canonical_id": "200",
+                "source_url": pages["200"]["source_url"],
+                "output_path": "pages/200.md",
+                "title": pages["200"]["title"],
+                "page_version": pages["200"]["page_version"],
+                "last_modified": pages["200"]["last_modified"],
+            },
+        ],
+    )
+    for page_id in ("100", "200"):
+        page_path = output_dir / "pages" / f"{page_id}.md"
+        page_path.parent.mkdir(parents=True, exist_ok=True)
+        page_path.write_text(f"existing {page_id}\n", encoding="utf-8")
+
+    full_fetch_counts: dict[str, int] = {}
+    summary_fetch_counts: dict[str, int] = {}
+
+    def stub_real_fetch(
+        target: ResolvedTarget,
+        *,
+        base_url: str = "https://example.com/wiki",
+        auth_method: str = "bearer-env",
+    ) -> dict[str, object]:
+        del base_url, auth_method
+        page_id = str(target.page_id)
+        full_fetch_counts[page_id] = full_fetch_counts.get(page_id, 0) + 1
+        return dict(pages[page_id])
+
+    def stub_real_fetch_summary(
+        target: ResolvedTarget,
+        *,
+        base_url: str = "https://example.com/wiki",
+        auth_method: str = "bearer-env",
+    ) -> dict[str, object]:
+        del base_url, auth_method
+        page_id = str(target.page_id)
+        summary_fetch_counts[page_id] = summary_fetch_counts.get(page_id, 0) + 1
+        page = dict(pages[page_id])
+        page.pop("content", None)
+        return page
+
+    def stub_child_id_discovery(*args: object, **kwargs: object) -> list[str]:
+        parent_id = _called_page_id(args, kwargs)
+        result = _real_children()[parent_id]
+        if isinstance(result, Exception):
+            raise result
+        return [str(child_id) for child_id in result]
+
+    monkeypatch.setattr(client_module, "fetch_real_page", stub_real_fetch, raising=False)
+    monkeypatch.setattr(
+        client_module,
+        "fetch_real_page_summary",
+        stub_real_fetch_summary,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        client_module,
+        "list_real_child_page_ids",
+        stub_child_id_discovery,
+        raising=False,
+    )
+
+    exit_code = main(_real_tree_argv(output_dir, max_depth=1))
+
+    assert exit_code == 0
+    assert full_fetch_counts == {"300": 1}
+    assert summary_fetch_counts == {"100": 1, "200": 1, "300": 1}
+
+    captured = capsys.readouterr()
+    assert "Skipped: " in captured.out
+    assert "Wrote: " in captured.out
+    assert "new_pages: 1" in captured.out
+    assert "changed_pages: 0" in captured.out
+    assert "unchanged_pages: 2" in captured.out
 
 
 def test_real_tree_run_does_not_report_stub_discovery_limit(

--- a/tests/test_normalize_writer.py
+++ b/tests/test_normalize_writer.py
@@ -228,6 +228,8 @@ def test_confluence_cli_writes_manifest_for_normal_run(tmp_path: Path) -> None:
                 source_url="https://example.com/wiki/pages/viewpage.action?pageId=12345",
                 output_path="pages/12345.md",
                 title="stub-page-12345",
+                page_version=1,
+                last_modified="1970-01-01T00:00:00Z",
             )
         ],
     )
@@ -349,6 +351,8 @@ def test_confluence_cli_full_flow_keeps_dry_run_and_write_artifacts_in_sync(
                 source_url=canonical_source_url,
                 output_path="pages/12345.md",
                 title="stub-page-12345",
+                page_version=1,
+                last_modified="1970-01-01T00:00:00Z",
             )
         ],
     )


### PR DESCRIPTION
Summary
- add source-aware incremental sync for the Confluence adapter using per-page manifest metadata
- persist page_version and last_modified for each Confluence page and keep older manifests compatible by treating missing metadata as a safe rewrite
- report new, changed, unchanged, written, and skipped counts in dry-run and write output

Before
- repeated runs only used canonical_id, output path, and file existence to decide whether a page could be skipped
- unchanged pages could still be fully re-fetched and re-processed when source metadata was unavailable in the prior manifest

After
- repeated runs classify each discovered page as new, changed, or unchanged using page_version first and last_modified as a fallback
- unchanged pages skip full fetch, normalize, and write work while changed and new pages still run the full pipeline
- manifests persist the latest metadata for all pages in the run, including skipped unchanged pages

Testing
- make check

Backward compatibility
- older manifests without page_version and last_modified remain readable and trigger a one-time rewrite so later runs can safely use metadata-based skips