### PR TITLE
feat: support custom CA bundles for Confluence TLS

### DIFF
--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -183,6 +183,15 @@ def build_parser() -> argparse.ArgumentParser:
         help="Directory where pages/ and manifest.json are written.",
     )
     confluence_parser.add_argument(
+        "--ca-bundle",
+        metavar="FILE",
+        help=(
+            "PEM bundle to trust for TLS verification in --client-mode real. "
+            "When set, this overrides default certificate discovery for "
+            "Confluence HTTPS requests."
+        ),
+    )
+    confluence_parser.add_argument(
         "--client-mode",
         choices=("stub", "real"),
         default="stub",
@@ -343,6 +352,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             base_url=args.base_url,
             target=args.target,
             output_dir=args.output_dir,
+            ca_bundle=args.ca_bundle,
             client_mode=args.client_mode,
             auth_method=args.auth_method,
             debug=args.debug,
@@ -387,6 +397,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     resolved_target,
                     base_url=confluence_config.base_url,
                     auth_method=confluence_config.auth_method,
+                    ca_bundle=confluence_config.ca_bundle,
                 )
 
             def selected_fetch_page_summary(
@@ -396,6 +407,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     resolved_target,
                     base_url=confluence_config.base_url,
                     auth_method=confluence_config.auth_method,
+                    ca_bundle=confluence_config.ca_bundle,
                 )
 
             def selected_list_child_page_ids(
@@ -405,6 +417,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     resolved_target,
                     base_url=confluence_config.base_url,
                     auth_method=confluence_config.auth_method,
+                    ca_bundle=confluence_config.ca_bundle,
                 )
         else:
             selected_fetch_page = fetch_page

--- a/src/knowledge_adapters/confluence/auth.py
+++ b/src/knowledge_adapters/confluence/auth.py
@@ -17,7 +17,11 @@ class RequestAuth:
     ssl_context: ssl.SSLContext | None
 
 
-def build_request_auth(auth_method: str) -> RequestAuth:
+def build_request_auth(
+    auth_method: str,
+    *,
+    ca_bundle: str | None = None,
+) -> RequestAuth:
     """Build auth material for a supported auth method."""
     if auth_method == "bearer-env":
         headers = _bearer_env_headers()
@@ -31,7 +35,7 @@ def build_request_auth(auth_method: str) -> RequestAuth:
 
     return RequestAuth(
         headers=headers,
-        ssl_context=_client_cert_ssl_context(auth_method),
+        ssl_context=_client_cert_ssl_context(auth_method, ca_bundle=ca_bundle),
     )
 
 
@@ -46,7 +50,11 @@ def _bearer_env_headers() -> dict[str, str]:
     return {"Authorization": f"Bearer {token}"}
 
 
-def _client_cert_ssl_context(auth_method: str) -> ssl.SSLContext | None:
+def _client_cert_ssl_context(
+    auth_method: str,
+    *,
+    ca_bundle: str | None = None,
+) -> ssl.SSLContext | None:
     cert_file = os.getenv("CONFLUENCE_CLIENT_CERT_FILE", "").strip()
     key_file = os.getenv("CONFLUENCE_CLIENT_KEY_FILE", "").strip()
 
@@ -62,10 +70,17 @@ def _client_cert_ssl_context(auth_method: str) -> ssl.SSLContext | None:
             "CONFLUENCE_CLIENT_CERT_FILE for --client-mode real --auth-method "
             "client-cert-env."
         )
-    if not cert_file:
+    if not cert_file and not ca_bundle:
         return None
 
-    ssl_context = ssl.create_default_context()
+    try:
+        ssl_context = ssl.create_default_context(cafile=ca_bundle)
+    except (OSError, ssl.SSLError, ValueError) as exc:
+        raise ValueError("Invalid Confluence CA bundle. Check --ca-bundle.") from exc
+
+    if not cert_file:
+        return ssl_context
+
     try:
         ssl_context.load_cert_chain(
             certfile=cert_file,

--- a/src/knowledge_adapters/confluence/client.py
+++ b/src/knowledge_adapters/confluence/client.py
@@ -267,8 +267,13 @@ def _request_failure_message(exc: HTTPError | URLError, *, auth_method: str) -> 
     return "Confluence request failed. Verify --base-url and try again."
 
 
-def _request_json(api_url: str, *, auth_method: str) -> dict[str, object]:
-    request_auth = build_request_auth(auth_method)
+def _request_json(
+    api_url: str,
+    *,
+    auth_method: str,
+    ca_bundle: str | None = None,
+) -> dict[str, object]:
+    request_auth = build_request_auth(auth_method, ca_bundle=ca_bundle)
     api_request = request.Request(
         api_url,
         headers=dict(request_auth.headers),
@@ -298,6 +303,7 @@ def fetch_real_page(
     *,
     base_url: str,
     auth_method: str,
+    ca_bundle: str | None = None,
 ) -> dict[str, object]:
     """Fetch one Confluence page through the opt-in real client path."""
     page_id = target.page_id
@@ -307,6 +313,7 @@ def fetch_real_page(
     raw_payload = _request_json(
         _content_api_url(base_url, page_id, expand="body.storage,_links,version"),
         auth_method=auth_method,
+        ca_bundle=ca_bundle,
     )
     return _map_real_page(raw_payload, page_id)
 
@@ -316,6 +323,7 @@ def fetch_real_page_summary(
     *,
     base_url: str,
     auth_method: str,
+    ca_bundle: str | None = None,
 ) -> dict[str, object]:
     """Fetch Confluence page metadata used for incremental sync decisions."""
     page_id = target.page_id
@@ -325,6 +333,7 @@ def fetch_real_page_summary(
     raw_payload = _request_json(
         _content_api_url(base_url, page_id, expand="version,_links"),
         auth_method=auth_method,
+        ca_bundle=ca_bundle,
     )
     return _map_real_page_summary(raw_payload, page_id)
 
@@ -334,6 +343,7 @@ def list_real_child_page_ids(
     *,
     base_url: str,
     auth_method: str,
+    ca_bundle: str | None = None,
 ) -> list[str]:
     """List direct child page IDs for one Confluence page in real mode."""
     page_id = target.page_id
@@ -343,5 +353,6 @@ def list_real_child_page_ids(
     raw_payload = _request_json(
         _child_page_api_url(base_url, page_id),
         auth_method=auth_method,
+        ca_bundle=ca_bundle,
     )
     return _map_child_page_ids(raw_payload)

--- a/src/knowledge_adapters/confluence/config.py
+++ b/src/knowledge_adapters/confluence/config.py
@@ -12,6 +12,7 @@ class ConfluenceConfig:
     base_url: str
     target: str
     output_dir: str
+    ca_bundle: str | None = None
     client_mode: str = "stub"
     auth_method: str = "bearer-env"
     debug: bool = False

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -243,6 +243,8 @@ def test_confluence_help_lists_supported_auth_methods_and_examples(
     assert "CONFLUENCE_BEARER_TOKEN" in stdout
     assert "CONFLUENCE_CLIENT_CERT_FILE" in stdout
     assert "client-cert-env" in stdout
+    assert "--ca-bundle FILE" in stdout
+    assert "overrides default certificate discovery" in stdout
     assert "--debug" in stdout
     assert "request debug details" in stdout
     assert "artifact layout and reporting" in stdout

--- a/tests/test_confluence_real_client_contract.py
+++ b/tests/test_confluence_real_client_contract.py
@@ -48,6 +48,7 @@ def _fetch_real_page(
     *,
     base_url: str = "https://example.com/wiki",
     auth_method: str = "bearer-env",
+    ca_bundle: str | None = None,
 ) -> dict[str, object]:
     from knowledge_adapters.confluence import client as client_module
 
@@ -56,6 +57,26 @@ def _fetch_real_page(
         target,
         base_url=base_url,
         auth_method=auth_method,
+        ca_bundle=ca_bundle,
+    )
+    return cast(dict[str, object], page)
+
+
+def _fetch_real_page_summary(
+    target: ResolvedTarget,
+    *,
+    base_url: str = "https://example.com/wiki",
+    auth_method: str = "bearer-env",
+    ca_bundle: str | None = None,
+) -> dict[str, object]:
+    from knowledge_adapters.confluence import client as client_module
+
+    client_module_any = cast(Any, client_module)
+    page = client_module_any.fetch_real_page_summary(
+        target,
+        base_url=base_url,
+        auth_method=auth_method,
+        ca_bundle=ca_bundle,
     )
     return cast(dict[str, object], page)
 
@@ -65,6 +86,7 @@ def _list_real_child_page_ids(
     *,
     base_url: str = "https://example.com/wiki",
     auth_method: str = "bearer-env",
+    ca_bundle: str | None = None,
 ) -> list[str]:
     from knowledge_adapters.confluence import client as client_module
 
@@ -73,6 +95,7 @@ def _list_real_child_page_ids(
         target,
         base_url=base_url,
         auth_method=auth_method,
+        ca_bundle=ca_bundle,
     )
     return cast(list[str], child_page_ids)
 
@@ -428,6 +451,66 @@ def test_real_fetch_passes_no_client_cert_context_by_default(
     assert observed_contexts == [None]
 
 
+def test_real_fetch_uses_ca_bundle_for_tls_verification(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    ssl_context = _FakeSSLContext()
+    observed_contexts: list[object | None] = []
+    observed_cafiles: list[str | None] = []
+
+    def fake_create_default_context(*, cafile: str | None = None) -> _FakeSSLContext:
+        observed_cafiles.append(cafile)
+        return ssl_context
+
+    def fake_urlopen(*args: object, **kwargs: object) -> _FakeHTTPResponse:
+        del args
+        observed_contexts.append(kwargs.get("context"))
+        return _FakeHTTPResponse(_valid_confluence_payload())
+
+    monkeypatch.setattr(
+        "knowledge_adapters.confluence.auth.ssl.create_default_context",
+        fake_create_default_context,
+    )
+    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    page = _fetch_real_page(_real_target(), ca_bundle="/tmp/internal-ca.pem")
+
+    assert page["canonical_id"] == "12345"
+    assert observed_cafiles == ["/tmp/internal-ca.pem"]
+    assert observed_contexts == [ssl_context]
+
+
+def test_real_fetch_summary_uses_ca_bundle_for_tls_verification(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    ssl_context = _FakeSSLContext()
+    observed_contexts: list[object | None] = []
+    observed_cafiles: list[str | None] = []
+
+    def fake_create_default_context(*, cafile: str | None = None) -> _FakeSSLContext:
+        observed_cafiles.append(cafile)
+        return ssl_context
+
+    def fake_urlopen(*args: object, **kwargs: object) -> _FakeHTTPResponse:
+        del args
+        observed_contexts.append(kwargs.get("context"))
+        return _FakeHTTPResponse(_valid_confluence_payload())
+
+    monkeypatch.setattr(
+        "knowledge_adapters.confluence.auth.ssl.create_default_context",
+        fake_create_default_context,
+    )
+    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    page = _fetch_real_page_summary(_real_target(), ca_bundle="/tmp/internal-ca.pem")
+
+    assert page["canonical_id"] == "12345"
+    assert observed_cafiles == ["/tmp/internal-ca.pem"]
+    assert observed_contexts == [ssl_context]
+
+
 def test_real_fetch_uses_combined_client_cert_pem_when_configured(
     monkeypatch: MonkeyPatch,
 ) -> None:
@@ -443,7 +526,7 @@ def test_real_fetch_uses_combined_client_cert_pem_when_configured(
 
     monkeypatch.setattr(
         "knowledge_adapters.confluence.auth.ssl.create_default_context",
-        lambda: ssl_context,
+        lambda *, cafile=None: ssl_context,
     )
     monkeypatch.setenv("CONFLUENCE_CLIENT_CERT_FILE", "/tmp/confluence-client.pem")
     monkeypatch.delenv("CONFLUENCE_CLIENT_KEY_FILE", raising=False)
@@ -472,7 +555,7 @@ def test_real_fetch_uses_split_client_cert_and_key_for_client_cert_auth(
 
     monkeypatch.setattr(
         "knowledge_adapters.confluence.auth.ssl.create_default_context",
-        lambda: ssl_context,
+        lambda *, cafile=None: ssl_context,
     )
     monkeypatch.setenv("CONFLUENCE_CLIENT_CERT_FILE", "/tmp/confluence-client.crt")
     monkeypatch.setenv("CONFLUENCE_CLIENT_KEY_FILE", "/tmp/confluence-client.key")
@@ -504,7 +587,7 @@ def test_real_fetch_uses_split_client_cert_and_key_with_bearer_auth(
 
     monkeypatch.setattr(
         "knowledge_adapters.confluence.auth.ssl.create_default_context",
-        lambda: ssl_context,
+        lambda *, cafile=None: ssl_context,
     )
     monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
     monkeypatch.setenv("CONFLUENCE_CLIENT_CERT_FILE", "/tmp/confluence-client.crt")
@@ -535,7 +618,7 @@ def test_real_fetch_treats_empty_client_key_env_as_omitted_for_combined_pem(
 
     monkeypatch.setattr(
         "knowledge_adapters.confluence.auth.ssl.create_default_context",
-        lambda: ssl_context,
+        lambda *, cafile=None: ssl_context,
     )
     monkeypatch.setenv("CONFLUENCE_CLIENT_CERT_FILE", " /tmp/confluence-client.pem ")
     monkeypatch.setenv("CONFLUENCE_CLIENT_KEY_FILE", "   ")
@@ -567,6 +650,39 @@ def test_real_fetch_ignores_empty_optional_client_cert_env_for_bearer_auth(
 
     assert page["canonical_id"] == "12345"
     assert observed_contexts == [None]
+
+
+def test_real_child_list_uses_ca_bundle_for_tls_verification(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    ssl_context = _FakeSSLContext()
+    observed_contexts: list[object | None] = []
+    observed_cafiles: list[str | None] = []
+
+    def fake_create_default_context(*, cafile: str | None = None) -> _FakeSSLContext:
+        observed_cafiles.append(cafile)
+        return ssl_context
+
+    def fake_urlopen(*args: object, **kwargs: object) -> _FakeHTTPResponse:
+        del args
+        observed_contexts.append(kwargs.get("context"))
+        return _FakeHTTPResponse(_valid_child_list_payload(child_page_ids=["200"]))
+
+    monkeypatch.setattr(
+        "knowledge_adapters.confluence.auth.ssl.create_default_context",
+        fake_create_default_context,
+    )
+    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    child_page_ids = _list_real_child_page_ids(
+        _real_target(),
+        ca_bundle="/tmp/internal-ca.pem",
+    )
+
+    assert child_page_ids == ["200"]
+    assert observed_cafiles == ["/tmp/internal-ca.pem"]
+    assert observed_contexts == [ssl_context]
 
 
 def test_real_child_list_maps_valid_confluence_response_into_child_page_ids(
@@ -723,7 +839,7 @@ def test_real_fetch_maps_http_status_failures(
     if auth_method == "client-cert-env":
         monkeypatch.setattr(
             "knowledge_adapters.confluence.auth.ssl.create_default_context",
-            lambda: _FakeSSLContext(),
+            lambda *, cafile=None: _FakeSSLContext(),
         )
         monkeypatch.setenv("CONFLUENCE_CLIENT_CERT_FILE", "/tmp/confluence-client.crt")
         monkeypatch.setenv("CONFLUENCE_CLIENT_KEY_FILE", "/tmp/confluence-client.key")
@@ -767,7 +883,7 @@ def test_real_fetch_maps_url_failures_to_clear_categories(
     if auth_method == "client-cert-env":
         monkeypatch.setattr(
             "knowledge_adapters.confluence.auth.ssl.create_default_context",
-            lambda: _FakeSSLContext(),
+            lambda *, cafile=None: _FakeSSLContext(),
         )
         monkeypatch.setenv("CONFLUENCE_CLIENT_CERT_FILE", "/tmp/confluence-client.crt")
         monkeypatch.setenv("CONFLUENCE_CLIENT_KEY_FILE", "/tmp/confluence-client.key")
@@ -775,6 +891,37 @@ def test_real_fetch_maps_url_failures_to_clear_categories(
 
     with pytest.raises(RuntimeError, match=f"^{re.escape(expected_message)}$"):
         _fetch_real_page(_real_target(), auth_method=auth_method)
+
+
+def test_real_fetch_rejects_invalid_ca_bundle_before_request(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    request_count = 0
+
+    def fail_if_requested(*args: object, **kwargs: object) -> object:
+        nonlocal request_count
+        del args, kwargs
+        request_count += 1
+        raise AssertionError("network request should not be attempted with invalid CA bundle")
+
+    def raise_invalid_ca_bundle(*, cafile: str | None = None) -> object:
+        del cafile
+        raise ssl.SSLError("synthetic CA bundle load failure")
+
+    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
+    monkeypatch.setattr(
+        "knowledge_adapters.confluence.auth.ssl.create_default_context",
+        raise_invalid_ca_bundle,
+    )
+    monkeypatch.setattr("urllib.request.urlopen", fail_if_requested)
+
+    with pytest.raises(
+        ValueError,
+        match=r"Invalid Confluence CA bundle\. Check --ca-bundle\.",
+    ):
+        _fetch_real_page(_real_target(), ca_bundle="/tmp/missing-ca.pem")
+
+    assert request_count == 0
 
 
 def test_real_fetch_requires_client_cert_file_for_client_cert_auth_before_request(
@@ -880,7 +1027,7 @@ def test_real_fetch_surfaces_clear_invalid_client_cert_configuration(
 
     monkeypatch.setattr(
         "knowledge_adapters.confluence.auth.ssl.create_default_context",
-        lambda: _BrokenSSLContext(),
+        lambda *, cafile=None: _BrokenSSLContext(),
     )
     monkeypatch.setenv("CONFLUENCE_CLIENT_CERT_FILE", "/tmp/confluence-client.crt")
     monkeypatch.setenv("CONFLUENCE_CLIENT_KEY_FILE", "/tmp/confluence-client.key")
@@ -1173,3 +1320,39 @@ def test_real_client_cli_default_mode_hides_debug_request_context(
     )
     assert "synthetic transport failure" not in captured.err
     assert "rest/api/content/12345" not in captured.err
+
+
+def test_real_client_cli_passes_ca_bundle_to_real_fetch(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    from knowledge_adapters.confluence import client as client_module
+
+    observed_ca_bundles: list[str | None] = []
+
+    def stub_real_fetch(*args: object, **kwargs: object) -> dict[str, object]:
+        del args
+        observed_ca_bundles.append(cast(str | None, kwargs.get("ca_bundle")))
+        return {
+            "canonical_id": "12345",
+            "title": "Real Page",
+            "content": "<p>Hello from Confluence.</p>",
+            "source_url": "https://example.com/wiki/spaces/ENG/pages/12345",
+            "page_version": 7,
+            "last_modified": "2026-04-20T12:34:56Z",
+        }
+
+    monkeypatch.setattr(client_module, "fetch_real_page", stub_real_fetch, raising=False)
+
+    exit_code = main(
+        _confluence_argv(
+            tmp_path / "out",
+            "--client-mode",
+            "real",
+            "--ca-bundle",
+            "/tmp/internal-ca.pem",
+        )
+    )
+
+    assert exit_code == 0
+    assert observed_ca_bundles == ["/tmp/internal-ca.pem"]

--- a/tests/test_confluence_real_traversal_contract.py
+++ b/tests/test_confluence_real_traversal_contract.py
@@ -201,8 +201,9 @@ def _run_real_recursive_cli(
         *,
         base_url: str = "https://example.com/wiki",
         auth_method: str = "bearer-env",
+        ca_bundle: str | None = None,
     ) -> dict[str, object]:
-        del base_url, auth_method
+        del base_url, auth_method, ca_bundle
 
         page_id = str(target.page_id)
         page_fetch_counts[page_id] = page_fetch_counts.get(page_id, 0) + 1
@@ -320,8 +321,9 @@ def test_real_tree_incremental_run_skips_full_page_fetch_for_unchanged_pages(
         *,
         base_url: str = "https://example.com/wiki",
         auth_method: str = "bearer-env",
+        ca_bundle: str | None = None,
     ) -> dict[str, object]:
-        del base_url, auth_method
+        del base_url, auth_method, ca_bundle
         page_id = str(target.page_id)
         full_fetch_counts[page_id] = full_fetch_counts.get(page_id, 0) + 1
         return dict(pages[page_id])
@@ -331,8 +333,9 @@ def test_real_tree_incremental_run_skips_full_page_fetch_for_unchanged_pages(
         *,
         base_url: str = "https://example.com/wiki",
         auth_method: str = "bearer-env",
+        ca_bundle: str | None = None,
     ) -> dict[str, object]:
-        del base_url, auth_method
+        del base_url, auth_method, ca_bundle
         page_id = str(target.page_id)
         summary_fetch_counts[page_id] = summary_fetch_counts.get(page_id, 0) + 1
         page = dict(pages[page_id])
@@ -660,8 +663,9 @@ def test_real_tree_stops_without_writes_when_later_child_list_fails_after_partia
         *,
         base_url: str = "https://example.com/wiki",
         auth_method: str = "bearer-env",
+        ca_bundle: str | None = None,
     ) -> dict[str, object]:
-        del base_url, auth_method
+        del base_url, auth_method, ca_bundle
 
         page_id = str(target.page_id)
         page_fetch_counts[page_id] = page_fetch_counts.get(page_id, 0) + 1
@@ -741,8 +745,9 @@ def test_real_tree_stops_without_writes_when_later_page_fetch_fails_after_partia
         *,
         base_url: str = "https://example.com/wiki",
         auth_method: str = "bearer-env",
+        ca_bundle: str | None = None,
     ) -> dict[str, object]:
-        del base_url, auth_method
+        del base_url, auth_method, ca_bundle
 
         page_id = str(target.page_id)
         page_fetch_counts[page_id] = page_fetch_counts.get(page_id, 0) + 1


### PR DESCRIPTION
Summary
- add a --ca-bundle CLI flag for the Confluence adapter real client
- thread the CA bundle path through page fetch, summary fetch, and child discovery requests
- load the custom bundle into the shared TLS context while preserving default verification when the flag is omitted

Testing
- make check