### PR TITLE
feat: add config-driven multi-run execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # Local worktrees
 .worktrees/
+runs.yaml
 
 # Python
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -128,6 +128,26 @@ its dry runs and write runs may report `write` or `skip` for a page when an
 existing artifact already matches the planned output. `local_files` always plans
 one write.
 
+## Run Multiple Sources from One Config File
+
+For sequential multi-source refreshes, copy the committed example config and
+edit the local working file:
+
+```bash
+cp runs.example.yaml runs.yaml
+```
+
+Update `runs.yaml` with the sources and output directories you want, then run:
+
+```bash
+knowledge-adapters run runs.yaml
+```
+
+The config uses a top-level `runs:` list. Each run includes a `name`, a `type`,
+adapter-specific inputs such as `base_url`/`target` or `file_path`, and its own
+`output_dir`. `runs.example.yaml` is committed for reference, while `runs.yaml`
+is gitignored for local use.
+
 ---
 
 ## Repo-Local Development Setup

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,9 @@ license = { text = "Apache-2.0" }
 authors = [
   { name = "Keith Minnig" }
 ]
-dependencies = []
+dependencies = [
+  "PyYAML>=6.0",
+]
 
 [project.optional-dependencies]
 dev = [

--- a/runs.example.yaml
+++ b/runs.example.yaml
@@ -1,0 +1,25 @@
+# Copy this file to runs.yaml, then replace the sample values with your own.
+# Relative file paths and output directories resolve from this config file.
+
+runs:
+  # Minimal local file example.
+  - name: team-notes
+    type: local_files
+    file_path: ./example-inputs/team-notes.txt
+    output_dir: ./artifacts/local/team-notes
+
+  # Minimal Confluence example using the default stub client.
+  - name: docs-home
+    type: confluence
+    base_url: https://example.atlassian.net/wiki
+    target: "12345"
+    output_dir: ./artifacts/confluence/docs-home
+
+  # Tree mode example. Switch to client_mode: real and set auth when ready.
+  - name: eng-space-tree
+    type: confluence
+    base_url: https://example.atlassian.net/wiki
+    target: "67890"
+    output_dir: ./artifacts/confluence/eng-space-tree
+    tree: true
+    max_depth: 1

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -3,14 +3,20 @@
 from __future__ import annotations
 
 import argparse
+import io
+import re
+import shlex
 import sys
 from collections.abc import Callable, Sequence
+from contextlib import redirect_stdout
+from dataclasses import dataclass
 from pathlib import Path
 
 from knowledge_adapters.confluence.auth import SUPPORTED_AUTH_METHODS
 
 TOP_LEVEL_HELP_EXAMPLES = """First steps:
   knowledge-adapters --help
+  knowledge-adapters run runs.yaml
   knowledge-adapters local_files --help
   knowledge-adapters confluence --help
 
@@ -21,6 +27,7 @@ Typical flow:
      and action.
   3. Re-run without --dry-run to write the same artifact layout under
      ./artifacts.
+  4. Use knowledge-adapters run runs.yaml to refresh multiple sources in order.
 """
 
 CONFLUENCE_HELP_EXAMPLES = """Examples:
@@ -57,6 +64,27 @@ LOCAL_FILES_HELP_EXAMPLES = """Examples:
     --file-path ./notes/today.txt \\
     --output-dir ./artifacts
 """
+
+RUN_HELP_EXAMPLES = """Examples:
+  knowledge-adapters run runs.yaml
+  knowledge-adapters run ./configs/runs.yaml
+"""
+
+_WRITE_SUMMARY_RE = re.compile(r"Summary: wrote (?P<wrote>\d+), skipped (?P<skipped>\d+)")
+_DRY_RUN_SUMMARY_RE = re.compile(
+    r"Summary: would write (?P<wrote>\d+), would skip (?P<skipped>\d+)"
+)
+_DRY_RUN_BLOCK_WRITE_RE = re.compile(r"would_write: (?P<wrote>\d+)")
+_DRY_RUN_BLOCK_SKIP_RE = re.compile(r"would_skip: (?P<skipped>\d+)")
+
+
+@dataclass(frozen=True)
+class MultiRunSummary:
+    """Summary parsed from one adapter CLI execution."""
+
+    dry_run: bool
+    wrote: int
+    skipped: int
 
 
 def _parse_confluence_auth_method(value: str) -> str:
@@ -286,6 +314,24 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
 
+    run_parser = subparsers.add_parser(
+        "run",
+        help="Execute multiple configured adapter runs from one YAML file.",
+        description=(
+            "Load a YAML config with a top-level runs: list and execute each "
+            "configured adapter run sequentially in file order. Each run reuses "
+            "the existing adapter CLI behavior, output directory, and manifest "
+            "handling."
+        ),
+        epilog=RUN_HELP_EXAMPLES,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    run_parser.add_argument(
+        "config_path",
+        metavar="RUNS_YAML",
+        help="Path to a YAML config file containing a top-level runs: list.",
+    )
+
     return parser
 
 
@@ -318,10 +364,130 @@ def print_write_complete(output_dir: Path) -> None:
     print(f"\nWrite complete. Artifacts created under {render_user_path(output_dir)}")
 
 
+def _parse_multi_run_summary(output: str) -> MultiRunSummary:
+    """Parse the existing adapter summary lines into one normalized shape."""
+    if match := _WRITE_SUMMARY_RE.search(output):
+        return MultiRunSummary(
+            dry_run=False,
+            wrote=int(match.group("wrote")),
+            skipped=int(match.group("skipped")),
+        )
+
+    if match := _DRY_RUN_SUMMARY_RE.search(output):
+        return MultiRunSummary(
+            dry_run=True,
+            wrote=int(match.group("wrote")),
+            skipped=int(match.group("skipped")),
+        )
+
+    dry_run_write_match = _DRY_RUN_BLOCK_WRITE_RE.search(output)
+    dry_run_skip_match = _DRY_RUN_BLOCK_SKIP_RE.search(output)
+    if dry_run_write_match and dry_run_skip_match:
+        return MultiRunSummary(
+            dry_run=True,
+            wrote=int(dry_run_write_match.group("wrote")),
+            skipped=int(dry_run_skip_match.group("skipped")),
+        )
+
+    raise RuntimeError(f"Could not parse adapter summary from output:\n{output}")
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     """Run the CLI."""
     parser = build_parser()
     args = parser.parse_args(argv)
+
+    if args.command == "run":
+        from knowledge_adapters.run_config import load_run_config
+
+        try:
+            run_config = load_run_config(args.config_path)
+        except ValueError as exc:
+            exit_with_cli_error(str(exc), command="run")
+
+        print("Config-driven run invoked")
+        print(f"  config_path: {render_user_path(run_config.config_path)}")
+        print(f"  runs_in_config: {len(run_config.runs)}")
+
+        completed_runs = 0
+        write_runs = 0
+        dry_run_runs = 0
+        total_wrote = 0
+        total_skipped = 0
+        total_would_write = 0
+        total_would_skip = 0
+
+        for index, configured_run in enumerate(run_config.runs, start=1):
+            display_command = shlex.join(("knowledge-adapters", *configured_run.argv))
+            print(
+                f"\nRun {index}/{len(run_config.runs)}: "
+                f"{configured_run.name} ({configured_run.run_type})"
+            )
+            print(f"  command: {display_command}")
+
+            captured_stdout = io.StringIO()
+            try:
+                with redirect_stdout(captured_stdout):
+                    exit_code = main(configured_run.argv)
+            except SystemExit:
+                output = captured_stdout.getvalue()
+                if output:
+                    print(output, end="" if output.endswith("\n") else "\n")
+                exit_with_cli_error(
+                    (
+                        f"Run {configured_run.name!r} ({configured_run.run_type}) failed "
+                        f"while executing {display_command}."
+                    ),
+                    command="run",
+                )
+
+            if exit_code != 0:
+                exit_with_cli_error(
+                    (
+                        f"Run {configured_run.name!r} ({configured_run.run_type}) returned "
+                        f"exit code {exit_code} while executing {display_command}."
+                    ),
+                    command="run",
+                )
+
+            output = captured_stdout.getvalue()
+            if output:
+                print(output, end="" if output.endswith("\n") else "\n")
+
+            try:
+                summary = _parse_multi_run_summary(output)
+            except RuntimeError as exc:
+                exit_with_cli_error(str(exc), command="run")
+
+            completed_runs += 1
+            if summary.dry_run:
+                dry_run_runs += 1
+                total_would_write += summary.wrote
+                total_would_skip += summary.skipped
+                print(
+                    f"Run summary: would write {summary.wrote}, "
+                    f"would skip {summary.skipped}"
+                )
+            else:
+                write_runs += 1
+                total_wrote += summary.wrote
+                total_skipped += summary.skipped
+                print(f"Run summary: wrote {summary.wrote}, skipped {summary.skipped}")
+
+        print("\nAggregate summary:")
+        print(f"  runs_completed: {completed_runs}")
+        print(f"  write_runs: {write_runs}")
+        print(f"  dry_run_runs: {dry_run_runs}")
+        print(f"  wrote: {total_wrote}")
+        print(f"  skipped: {total_skipped}")
+        if dry_run_runs > 0:
+            print(f"  would_write: {total_would_write}")
+            print(f"  would_skip: {total_would_skip}")
+        print(
+            "Config run complete. "
+            f"Processed {completed_runs} run(s) from {render_user_path(run_config.config_path)}"
+        )
+        return 0
 
     if args.command == "confluence":
         from knowledge_adapters.confluence.client import (

--- a/src/knowledge_adapters/run_config.py
+++ b/src/knowledge_adapters/run_config.py
@@ -1,0 +1,283 @@
+"""Config loading for sequential multi-run execution."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml  # type: ignore[import-untyped]
+
+SUPPORTED_RUN_TYPES = frozenset({"confluence", "local_files"})
+
+_COMMON_REQUIRED_KEYS = frozenset({"name", "type", "output_dir"})
+_CONFLUENCE_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
+    {
+        "auth_method",
+        "base_url",
+        "client_mode",
+        "debug",
+        "dry_run",
+        "max_depth",
+        "target",
+        "tree",
+    }
+)
+_LOCAL_FILES_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset({"dry_run", "file_path"})
+
+
+@dataclass(frozen=True)
+class ConfiguredRun:
+    """One adapter execution described in a config file."""
+
+    name: str
+    run_type: str
+    argv: tuple[str, ...]
+    dry_run: bool
+
+
+@dataclass(frozen=True)
+class RunConfig:
+    """Validated multi-run config."""
+
+    config_path: Path
+    runs: tuple[ConfiguredRun, ...]
+
+
+def load_run_config(config_path: str | Path) -> RunConfig:
+    """Load and validate a config-driven run file."""
+    resolved_config_path = Path(config_path).expanduser().resolve()
+    try:
+        raw_config = yaml.safe_load(resolved_config_path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValueError(f"Config file not found: {resolved_config_path}.") from exc
+    except OSError as exc:
+        raise ValueError(f"Could not read config file {resolved_config_path}: {exc}.") from exc
+    except yaml.YAMLError as exc:
+        raise ValueError(f"Could not parse YAML config {resolved_config_path}: {exc}.") from exc
+
+    if raw_config is None:
+        raise ValueError(
+            f"Config file is empty: {resolved_config_path}. Add a top-level 'runs:' list."
+        )
+    if not isinstance(raw_config, dict):
+        raise ValueError(
+            f"Config file {resolved_config_path} must contain a top-level 'runs:' list."
+        )
+
+    runs = raw_config.get("runs")
+    if not isinstance(runs, list) or not runs:
+        raise ValueError(
+            f"Config file {resolved_config_path} must define a non-empty top-level 'runs:' list."
+        )
+
+    return RunConfig(
+        config_path=resolved_config_path,
+        runs=tuple(
+            _parse_run(run_config, index=index, config_path=resolved_config_path)
+            for index, run_config in enumerate(runs, start=1)
+        ),
+    )
+
+
+def _parse_run(
+    run_config: object,
+    *,
+    index: int,
+    config_path: Path,
+) -> ConfiguredRun:
+    if not isinstance(run_config, dict):
+        raise ValueError(
+            f"Run #{index} in {config_path} must be a mapping with name, type, and inputs."
+        )
+
+    name = _require_string(run_config, "name", index=index, config_path=config_path)
+    run_type = _require_string(run_config, "type", index=index, config_path=config_path)
+    if run_type not in SUPPORTED_RUN_TYPES:
+        supported_types = ", ".join(sorted(SUPPORTED_RUN_TYPES))
+        raise ValueError(
+            f"Run {name!r} in {config_path} uses unsupported type {run_type!r}. "
+            f"Supported types: {supported_types}."
+        )
+
+    if run_type == "confluence":
+        argv = _build_confluence_argv(run_config, name=name, config_path=config_path)
+        dry_run = _optional_bool(
+            run_config,
+            "dry_run",
+            index=index,
+            config_path=config_path,
+            default=False,
+        )
+        return ConfiguredRun(name=name, run_type=run_type, argv=argv, dry_run=dry_run)
+
+    argv = _build_local_files_argv(run_config, name=name, config_path=config_path)
+    dry_run = _optional_bool(
+        run_config,
+        "dry_run",
+        index=index,
+        config_path=config_path,
+        default=False,
+    )
+    return ConfiguredRun(name=name, run_type=run_type, argv=argv, dry_run=dry_run)
+
+
+def _build_confluence_argv(
+    run_config: dict[str, object],
+    *,
+    name: str,
+    config_path: Path,
+) -> tuple[str, ...]:
+    _reject_unknown_keys(
+        run_config,
+        allowed_keys=_CONFLUENCE_ALLOWED_KEYS,
+        name=name,
+        config_path=config_path,
+    )
+    index = _run_index(name=name, config_path=config_path)
+    base_url = _require_string(run_config, "base_url", index=index, config_path=config_path)
+    target = _require_string(run_config, "target", index=index, config_path=config_path)
+    output_dir = _resolve_path_string(
+        _require_string(run_config, "output_dir", index=index, config_path=config_path),
+        config_path=config_path,
+    )
+    argv: list[str] = [
+        "confluence",
+        "--base-url",
+        base_url,
+        "--target",
+        target,
+        "--output-dir",
+        output_dir,
+    ]
+
+    client_mode = _optional_string(run_config, "client_mode", index=index, config_path=config_path)
+    if client_mode is not None:
+        argv.extend(["--client-mode", client_mode])
+
+    auth_method = _optional_string(run_config, "auth_method", index=index, config_path=config_path)
+    if auth_method is not None:
+        argv.extend(["--auth-method", auth_method])
+
+    if _optional_bool(run_config, "debug", index=index, config_path=config_path, default=False):
+        argv.append("--debug")
+    if _optional_bool(run_config, "dry_run", index=index, config_path=config_path, default=False):
+        argv.append("--dry-run")
+    if _optional_bool(run_config, "tree", index=index, config_path=config_path, default=False):
+        argv.append("--tree")
+
+    max_depth = run_config.get("max_depth")
+    if max_depth is not None:
+        if isinstance(max_depth, bool) or not isinstance(max_depth, int):
+            raise ValueError(
+                f"Run {name!r} in {config_path} must set 'max_depth' to an integer."
+            )
+        argv.extend(["--max-depth", str(max_depth)])
+
+    return tuple(argv)
+
+
+def _build_local_files_argv(
+    run_config: dict[str, object],
+    *,
+    name: str,
+    config_path: Path,
+) -> tuple[str, ...]:
+    _reject_unknown_keys(
+        run_config,
+        allowed_keys=_LOCAL_FILES_ALLOWED_KEYS,
+        name=name,
+        config_path=config_path,
+    )
+    index = _run_index(name=name, config_path=config_path)
+    file_path = _resolve_path_string(
+        _require_string(run_config, "file_path", index=index, config_path=config_path),
+        config_path=config_path,
+    )
+    output_dir = _resolve_path_string(
+        _require_string(run_config, "output_dir", index=index, config_path=config_path),
+        config_path=config_path,
+    )
+    argv: list[str] = [
+        "local_files",
+        "--file-path",
+        file_path,
+        "--output-dir",
+        output_dir,
+    ]
+    if _optional_bool(run_config, "dry_run", index=index, config_path=config_path, default=False):
+        argv.append("--dry-run")
+    return tuple(argv)
+
+
+def _reject_unknown_keys(
+    run_config: dict[str, object],
+    *,
+    allowed_keys: frozenset[str],
+    name: str,
+    config_path: Path,
+) -> None:
+    unknown_keys = sorted(set(run_config) - allowed_keys)
+    if unknown_keys:
+        unknown_key_list = ", ".join(repr(key) for key in unknown_keys)
+        raise ValueError(
+            f"Run {name!r} in {config_path} contains unsupported keys: {unknown_key_list}."
+        )
+
+
+def _require_string(
+    run_config: dict[str, object],
+    key: str,
+    *,
+    index: int | str,
+    config_path: Path,
+) -> str:
+    value = run_config.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(
+            f"Run {index!r} in {config_path} must define a non-empty string for {key!r}."
+        )
+    return value.strip()
+
+
+def _optional_string(
+    run_config: dict[str, object],
+    key: str,
+    *,
+    index: int | str,
+    config_path: Path,
+) -> str | None:
+    if key not in run_config:
+        return None
+    value = run_config.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(
+            f"Run {index!r} in {config_path} must define a non-empty string for {key!r}."
+        )
+    return value.strip()
+
+
+def _optional_bool(
+    run_config: dict[str, object],
+    key: str,
+    *,
+    index: int | str,
+    config_path: Path,
+    default: bool,
+) -> bool:
+    if key not in run_config:
+        return default
+    value = run_config.get(key)
+    if not isinstance(value, bool):
+        raise ValueError(f"Run {index!r} in {config_path} must set {key!r} to true or false.")
+    return value
+
+
+def _resolve_path_string(value: str, *, config_path: Path) -> str:
+    path = Path(value).expanduser()
+    if path.is_absolute():
+        return str(path)
+    return str((config_path.parent / path).resolve())
+
+
+def _run_index(*, name: str, config_path: Path) -> str:
+    return f"{name} in {config_path}"

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -41,6 +41,7 @@ def test_top_level_help_introduces_shared_cli_flow(tmp_path: Path) -> None:
     assert result.returncode == 0, result.stderr
     assert "Normalize knowledge sources into a shared local artifact layout." in stdout
     assert "plans a markdown artifact under pages/ plus manifest.json" in stdout
+    assert "Execute multiple configured adapter runs from one YAML file." in stdout
     assert "Normalize Confluence content into shared artifacts." in stdout
     assert "Normalize one local UTF-8 text file into shared artifacts." in stdout
     assert (
@@ -48,6 +49,7 @@ def test_top_level_help_introduces_shared_cli_flow(tmp_path: Path) -> None:
         in stdout
     )
     assert "Re-run without --dry-run to write the same artifact layout" in stdout
+    assert "knowledge-adapters run runs.yaml" in stdout
 
 
 def test_local_files_cli_smoke_uses_installed_entrypoint_with_readme_style_args(
@@ -138,6 +140,47 @@ def test_local_files_cli_help_includes_first_run_guidance(tmp_path: Path) -> Non
     assert "without writing files." in stdout
     assert "knowledge-adapters local_files" in stdout
     assert "--dry-run" in stdout
+
+
+def test_run_cli_smoke_executes_multiple_sources_from_yaml(tmp_path: Path) -> None:
+    inputs_dir = tmp_path / "inputs"
+    inputs_dir.mkdir()
+    source_file = inputs_dir / "today.txt"
+    source_file.write_text("Hello from config run.\n", encoding="utf-8")
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: team-notes
+    type: local_files
+    file_path: ./inputs/today.txt
+    output_dir: ./artifacts/local/team-notes
+  - name: docs-home
+    type: confluence
+    base_url: https://example.com/wiki
+    target: "12345"
+    output_dir: ./artifacts/confluence/docs-home
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = _run_cli(tmp_path, "run", "./runs.yaml")
+
+    assert result.returncode == 0, result.stderr
+    assert "Config-driven run invoked" in result.stdout
+    assert "Run 1/2: team-notes (local_files)" in result.stdout
+    assert "Run 2/2: docs-home (confluence)" in result.stdout
+    assert "Aggregate summary:" in result.stdout
+    assert "runs_completed: 2" in result.stdout
+    assert "write_runs: 2" in result.stdout
+    assert "dry_run_runs: 0" in result.stdout
+    assert "wrote: 2" in result.stdout
+    assert "skipped: 0" in result.stdout
+
+    local_output_path = tmp_path / "artifacts" / "local" / "team-notes" / "pages" / "today.md"
+    assert local_output_path.exists()
+    assert "Hello from config run." in local_output_path.read_text(encoding="utf-8")
 
 
 def test_confluence_cli_smoke_uses_installed_entrypoint_with_default_stub_client(

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pytest import CaptureFixture
+
+from knowledge_adapters.cli import main
+from knowledge_adapters.run_config import ConfiguredRun, load_run_config
+
+
+def test_load_run_config_resolves_relative_paths_from_config_location(tmp_path: Path) -> None:
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: docs-home
+    type: confluence
+    base_url: https://example.com/wiki
+    target: "12345"
+    output_dir: ./artifacts/confluence/docs-home
+  - name: team-notes
+    type: local_files
+    file_path: ./inputs/team-notes.txt
+    output_dir: ./artifacts/local/team-notes
+    dry_run: true
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    run_config = load_run_config(config_path)
+
+    assert run_config.config_path == config_path.resolve()
+    assert run_config.runs == (
+        ConfiguredRun(
+            name="docs-home",
+            run_type="confluence",
+            argv=(
+                "confluence",
+                "--base-url",
+                "https://example.com/wiki",
+                "--target",
+                "12345",
+                "--output-dir",
+                str((tmp_path / "artifacts" / "confluence" / "docs-home").resolve()),
+            ),
+            dry_run=False,
+        ),
+        ConfiguredRun(
+            name="team-notes",
+            run_type="local_files",
+            argv=(
+                "local_files",
+                "--file-path",
+                str((tmp_path / "inputs" / "team-notes.txt").resolve()),
+                "--output-dir",
+                str((tmp_path / "artifacts" / "local" / "team-notes").resolve()),
+                "--dry-run",
+            ),
+            dry_run=True,
+        ),
+    )
+
+
+def test_load_run_config_rejects_unsupported_keys(tmp_path: Path) -> None:
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: team-notes
+    type: local_files
+    file_path: ./notes.txt
+    output_dir: ./artifacts
+    unexpected: true
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="unsupported keys"):
+        load_run_config(config_path)
+
+
+def test_run_command_executes_multiple_runs_in_sequence(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    source_file = tmp_path / "inputs" / "team-notes.txt"
+    source_file.parent.mkdir(parents=True)
+    source_file.write_text("Ship it.\n", encoding="utf-8")
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: team-notes
+    type: local_files
+    file_path: ./inputs/team-notes.txt
+    output_dir: ./artifacts/local/team-notes
+  - name: docs-home
+    type: confluence
+    base_url: https://example.com/wiki
+    target: "12345"
+    output_dir: ./artifacts/confluence/docs-home
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    exit_code = main(["run", str(config_path)])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "Config-driven run invoked" in captured.out
+    assert "Run 1/2: team-notes (local_files)" in captured.out
+    assert "Run 2/2: docs-home (confluence)" in captured.out
+    assert captured.out.index("Run 1/2: team-notes (local_files)") < captured.out.index(
+        "Run 2/2: docs-home (confluence)"
+    )
+    assert "Run summary: wrote 1, skipped 0" in captured.out
+    assert "Aggregate summary:" in captured.out
+    assert "runs_completed: 2" in captured.out
+    assert "write_runs: 2" in captured.out
+    assert "dry_run_runs: 0" in captured.out
+    assert "wrote: 2" in captured.out
+    assert "skipped: 0" in captured.out
+
+    local_output_dir = tmp_path / "artifacts" / "local" / "team-notes"
+    local_output_path = local_output_dir / "pages" / "team-notes.md"
+    assert local_output_path.exists()
+    assert "Ship it." in local_output_path.read_text(encoding="utf-8")
+    local_manifest = json.loads((local_output_dir / "manifest.json").read_text(encoding="utf-8"))
+    assert local_manifest["files"] == [
+        {
+            "canonical_id": str(source_file.resolve()),
+            "source_url": source_file.resolve().as_uri(),
+            "output_path": "pages/team-notes.md",
+            "title": "team-notes.txt",
+        }
+    ]
+
+    confluence_output_dir = tmp_path / "artifacts" / "confluence" / "docs-home"
+    confluence_output_path = confluence_output_dir / "pages" / "12345.md"
+    assert confluence_output_path.exists()
+    assert "Stub content for page 12345." in confluence_output_path.read_text(encoding="utf-8")
+    confluence_manifest = json.loads(
+        (confluence_output_dir / "manifest.json").read_text(encoding="utf-8")
+    )
+    assert confluence_manifest["files"] == [
+        {
+            "canonical_id": "12345",
+            "source_url": "https://example.com/wiki/pages/viewpage.action?pageId=12345",
+            "output_path": "pages/12345.md",
+            "title": "stub-page-12345",
+            "page_version": 1,
+            "last_modified": "1970-01-01T00:00:00Z",
+        }
+    ]
+
+
+def test_run_command_reports_dry_run_counts(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: docs-tree
+    type: confluence
+    base_url: https://example.com/wiki
+    target: "12345"
+    output_dir: ./artifacts/confluence/docs-tree
+    tree: true
+    max_depth: 1
+    dry_run: true
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    exit_code = main(["run", str(config_path)])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "Run summary: would write 1, would skip 0" in captured.out
+    assert "Aggregate summary:" in captured.out
+    assert "write_runs: 0" in captured.out
+    assert "dry_run_runs: 1" in captured.out
+    assert "would_write: 1" in captured.out
+    assert "would_skip: 0" in captured.out
+    assert not (tmp_path / "artifacts").exists()


### PR DESCRIPTION
Summary
- add a YAML-backed knowledge-adapters run command that executes configured adapter runs sequentially
- commit runs.example.yaml, ignore local runs.yaml, and document the copy/edit/run workflow
- keep existing per-adapter output and manifest behavior intact while adding per-run and aggregate summaries

Testing
- make check

Notes
- example config is committed and runs.yaml is gitignored for local working copies
- v1 executes runs sequentially and stops on the first failing run