### PR TITLE
feat: add Confluence run TLS config parity

### DIFF
--- a/runs.example.yaml
+++ b/runs.example.yaml
@@ -14,6 +14,9 @@ runs:
     base_url: https://example.atlassian.net/wiki
     target: "12345"
     output_dir: ./artifacts/confluence/docs-home
+    # ca_bundle: ./certs/internal-ca.pem
+    # client_cert_file: ./certs/confluence-client.crt
+    # client_key_file: ./certs/confluence-client.key
 
   # Tree mode example. Switch to client_mode: real and set auth when ready.
   - name: eng-space-tree
@@ -23,3 +26,5 @@ runs:
     output_dir: ./artifacts/confluence/eng-space-tree
     tree: true
     max_depth: 1
+    # ca_bundle: ./certs/internal-ca.pem
+    # client_cert_file: ./certs/confluence-client.pem

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -220,6 +220,14 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     confluence_parser.add_argument(
+        "--client-cert-file",
+        help=argparse.SUPPRESS,
+    )
+    confluence_parser.add_argument(
+        "--client-key-file",
+        help=argparse.SUPPRESS,
+    )
+    confluence_parser.add_argument(
         "--client-mode",
         choices=("stub", "real"),
         default="stub",
@@ -519,6 +527,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             target=args.target,
             output_dir=args.output_dir,
             ca_bundle=args.ca_bundle,
+            client_cert_file=args.client_cert_file,
+            client_key_file=args.client_key_file,
             client_mode=args.client_mode,
             auth_method=args.auth_method,
             debug=args.debug,
@@ -564,6 +574,8 @@ def main(argv: Sequence[str] | None = None) -> int:
                     base_url=confluence_config.base_url,
                     auth_method=confluence_config.auth_method,
                     ca_bundle=confluence_config.ca_bundle,
+                    client_cert_file=confluence_config.client_cert_file,
+                    client_key_file=confluence_config.client_key_file,
                 )
 
             def selected_fetch_page_summary(
@@ -574,6 +586,8 @@ def main(argv: Sequence[str] | None = None) -> int:
                     base_url=confluence_config.base_url,
                     auth_method=confluence_config.auth_method,
                     ca_bundle=confluence_config.ca_bundle,
+                    client_cert_file=confluence_config.client_cert_file,
+                    client_key_file=confluence_config.client_key_file,
                 )
 
             def selected_list_child_page_ids(
@@ -584,6 +598,8 @@ def main(argv: Sequence[str] | None = None) -> int:
                     base_url=confluence_config.base_url,
                     auth_method=confluence_config.auth_method,
                     ca_bundle=confluence_config.ca_bundle,
+                    client_cert_file=confluence_config.client_cert_file,
+                    client_key_file=confluence_config.client_key_file,
                 )
         else:
             selected_fetch_page = fetch_page

--- a/src/knowledge_adapters/confluence/auth.py
+++ b/src/knowledge_adapters/confluence/auth.py
@@ -21,6 +21,8 @@ def build_request_auth(
     auth_method: str,
     *,
     ca_bundle: str | None = None,
+    client_cert_file: str | None = None,
+    client_key_file: str | None = None,
 ) -> RequestAuth:
     """Build auth material for a supported auth method."""
     if auth_method == "bearer-env":
@@ -35,7 +37,12 @@ def build_request_auth(
 
     return RequestAuth(
         headers=headers,
-        ssl_context=_client_cert_ssl_context(auth_method, ca_bundle=ca_bundle),
+        ssl_context=_client_cert_ssl_context(
+            auth_method,
+            ca_bundle=ca_bundle,
+            client_cert_file=client_cert_file,
+            client_key_file=client_key_file,
+        ),
     )
 
 
@@ -54,9 +61,16 @@ def _client_cert_ssl_context(
     auth_method: str,
     *,
     ca_bundle: str | None = None,
+    client_cert_file: str | None = None,
+    client_key_file: str | None = None,
 ) -> ssl.SSLContext | None:
-    cert_file = os.getenv("CONFLUENCE_CLIENT_CERT_FILE", "").strip()
-    key_file = os.getenv("CONFLUENCE_CLIENT_KEY_FILE", "").strip()
+    cert_file = _first_non_empty(client_cert_file, os.getenv("CONFLUENCE_CLIENT_CERT_FILE"))
+    key_file = _first_non_empty(client_key_file, os.getenv("CONFLUENCE_CLIENT_KEY_FILE"))
+    resolved_ca_bundle = _first_non_empty(
+        ca_bundle,
+        os.getenv("REQUESTS_CA_BUNDLE"),
+        os.getenv("SSL_CERT_FILE"),
+    )
 
     if key_file and not cert_file:
         raise ValueError(
@@ -70,11 +84,11 @@ def _client_cert_ssl_context(
             "CONFLUENCE_CLIENT_CERT_FILE for --client-mode real --auth-method "
             "client-cert-env."
         )
-    if not cert_file and not ca_bundle:
+    if not cert_file and not resolved_ca_bundle:
         return None
 
     try:
-        ssl_context = ssl.create_default_context(cafile=ca_bundle)
+        ssl_context = ssl.create_default_context(cafile=resolved_ca_bundle)
     except (OSError, ssl.SSLError, ValueError) as exc:
         raise ValueError("Invalid Confluence CA bundle. Check --ca-bundle.") from exc
 
@@ -94,3 +108,13 @@ def _client_cert_ssl_context(
         ) from exc
 
     return ssl_context
+
+
+def _first_non_empty(*values: str | None) -> str | None:
+    for value in values:
+        if value is None:
+            continue
+        normalized_value = value.strip()
+        if normalized_value:
+            return normalized_value
+    return None

--- a/src/knowledge_adapters/confluence/client.py
+++ b/src/knowledge_adapters/confluence/client.py
@@ -272,8 +272,15 @@ def _request_json(
     *,
     auth_method: str,
     ca_bundle: str | None = None,
+    client_cert_file: str | None = None,
+    client_key_file: str | None = None,
 ) -> dict[str, object]:
-    request_auth = build_request_auth(auth_method, ca_bundle=ca_bundle)
+    request_auth = build_request_auth(
+        auth_method,
+        ca_bundle=ca_bundle,
+        client_cert_file=client_cert_file,
+        client_key_file=client_key_file,
+    )
     api_request = request.Request(
         api_url,
         headers=dict(request_auth.headers),
@@ -304,6 +311,8 @@ def fetch_real_page(
     base_url: str,
     auth_method: str,
     ca_bundle: str | None = None,
+    client_cert_file: str | None = None,
+    client_key_file: str | None = None,
 ) -> dict[str, object]:
     """Fetch one Confluence page through the opt-in real client path."""
     page_id = target.page_id
@@ -314,6 +323,8 @@ def fetch_real_page(
         _content_api_url(base_url, page_id, expand="body.storage,_links,version"),
         auth_method=auth_method,
         ca_bundle=ca_bundle,
+        client_cert_file=client_cert_file,
+        client_key_file=client_key_file,
     )
     return _map_real_page(raw_payload, page_id)
 
@@ -324,6 +335,8 @@ def fetch_real_page_summary(
     base_url: str,
     auth_method: str,
     ca_bundle: str | None = None,
+    client_cert_file: str | None = None,
+    client_key_file: str | None = None,
 ) -> dict[str, object]:
     """Fetch Confluence page metadata used for incremental sync decisions."""
     page_id = target.page_id
@@ -334,6 +347,8 @@ def fetch_real_page_summary(
         _content_api_url(base_url, page_id, expand="version,_links"),
         auth_method=auth_method,
         ca_bundle=ca_bundle,
+        client_cert_file=client_cert_file,
+        client_key_file=client_key_file,
     )
     return _map_real_page_summary(raw_payload, page_id)
 
@@ -344,6 +359,8 @@ def list_real_child_page_ids(
     base_url: str,
     auth_method: str,
     ca_bundle: str | None = None,
+    client_cert_file: str | None = None,
+    client_key_file: str | None = None,
 ) -> list[str]:
     """List direct child page IDs for one Confluence page in real mode."""
     page_id = target.page_id
@@ -354,5 +371,7 @@ def list_real_child_page_ids(
         _child_page_api_url(base_url, page_id),
         auth_method=auth_method,
         ca_bundle=ca_bundle,
+        client_cert_file=client_cert_file,
+        client_key_file=client_key_file,
     )
     return _map_child_page_ids(raw_payload)

--- a/src/knowledge_adapters/confluence/config.py
+++ b/src/knowledge_adapters/confluence/config.py
@@ -13,6 +13,8 @@ class ConfluenceConfig:
     target: str
     output_dir: str
     ca_bundle: str | None = None
+    client_cert_file: str | None = None
+    client_key_file: str | None = None
     client_mode: str = "stub"
     auth_method: str = "bearer-env"
     debug: bool = False

--- a/src/knowledge_adapters/run_config.py
+++ b/src/knowledge_adapters/run_config.py
@@ -14,7 +14,10 @@ _CONFLUENCE_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
     {
         "auth_method",
         "base_url",
+        "ca_bundle",
         "client_mode",
+        "client_cert_file",
+        "client_key_file",
         "debug",
         "dry_run",
         "max_depth",
@@ -157,6 +160,47 @@ def _build_confluence_argv(
     auth_method = _optional_string(run_config, "auth_method", index=index, config_path=config_path)
     if auth_method is not None:
         argv.extend(["--auth-method", auth_method])
+
+    ca_bundle = _optional_string(run_config, "ca_bundle", index=index, config_path=config_path)
+    if ca_bundle is not None:
+        argv.extend(
+            [
+                "--ca-bundle",
+                _resolve_path_string(ca_bundle, config_path=config_path),
+            ]
+        )
+
+    client_cert_file = _optional_string(
+        run_config,
+        "client_cert_file",
+        index=index,
+        config_path=config_path,
+    )
+    client_key_file = _optional_string(
+        run_config,
+        "client_key_file",
+        index=index,
+        config_path=config_path,
+    )
+    if client_key_file is not None and client_cert_file is None:
+        raise ValueError(
+            f"Run {name!r} in {config_path} must set 'client_cert_file' when "
+            "'client_key_file' is provided."
+        )
+    if client_cert_file is not None:
+        argv.extend(
+            [
+                "--client-cert-file",
+                _resolve_path_string(client_cert_file, config_path=config_path),
+            ]
+        )
+    if client_key_file is not None:
+        argv.extend(
+            [
+                "--client-key-file",
+                _resolve_path_string(client_key_file, config_path=config_path),
+            ]
+        )
 
     if _optional_bool(run_config, "debug", index=index, config_path=config_path, default=False):
         argv.append("--debug")

--- a/tests/test_confluence_real_client_contract.py
+++ b/tests/test_confluence_real_client_contract.py
@@ -49,6 +49,8 @@ def _fetch_real_page(
     base_url: str = "https://example.com/wiki",
     auth_method: str = "bearer-env",
     ca_bundle: str | None = None,
+    client_cert_file: str | None = None,
+    client_key_file: str | None = None,
 ) -> dict[str, object]:
     from knowledge_adapters.confluence import client as client_module
 
@@ -58,6 +60,8 @@ def _fetch_real_page(
         base_url=base_url,
         auth_method=auth_method,
         ca_bundle=ca_bundle,
+        client_cert_file=client_cert_file,
+        client_key_file=client_key_file,
     )
     return cast(dict[str, object], page)
 
@@ -68,6 +72,8 @@ def _fetch_real_page_summary(
     base_url: str = "https://example.com/wiki",
     auth_method: str = "bearer-env",
     ca_bundle: str | None = None,
+    client_cert_file: str | None = None,
+    client_key_file: str | None = None,
 ) -> dict[str, object]:
     from knowledge_adapters.confluence import client as client_module
 
@@ -77,6 +83,8 @@ def _fetch_real_page_summary(
         base_url=base_url,
         auth_method=auth_method,
         ca_bundle=ca_bundle,
+        client_cert_file=client_cert_file,
+        client_key_file=client_key_file,
     )
     return cast(dict[str, object], page)
 
@@ -87,6 +95,8 @@ def _list_real_child_page_ids(
     base_url: str = "https://example.com/wiki",
     auth_method: str = "bearer-env",
     ca_bundle: str | None = None,
+    client_cert_file: str | None = None,
+    client_key_file: str | None = None,
 ) -> list[str]:
     from knowledge_adapters.confluence import client as client_module
 
@@ -96,6 +106,8 @@ def _list_real_child_page_ids(
         base_url=base_url,
         auth_method=auth_method,
         ca_bundle=ca_bundle,
+        client_cert_file=client_cert_file,
+        client_key_file=client_key_file,
     )
     return cast(list[str], child_page_ids)
 
@@ -481,6 +493,90 @@ def test_real_fetch_uses_ca_bundle_for_tls_verification(
     assert observed_contexts == [ssl_context]
 
 
+def test_real_fetch_prefers_explicit_ca_bundle_over_env_fallback(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    ssl_context = _FakeSSLContext()
+    observed_cafiles: list[str | None] = []
+
+    def fake_create_default_context(*, cafile: str | None = None) -> _FakeSSLContext:
+        observed_cafiles.append(cafile)
+        return ssl_context
+
+    monkeypatch.setattr(
+        "knowledge_adapters.confluence.auth.ssl.create_default_context",
+        fake_create_default_context,
+    )
+    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", "/tmp/env-requests-ca.pem")
+    monkeypatch.setenv("SSL_CERT_FILE", "/tmp/env-ssl-ca.pem")
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *args, **kwargs: _FakeHTTPResponse(_valid_confluence_payload()),
+    )
+
+    page = _fetch_real_page(_real_target(), ca_bundle="/tmp/config-ca.pem")
+
+    assert page["canonical_id"] == "12345"
+    assert observed_cafiles == ["/tmp/config-ca.pem"]
+
+
+def test_real_fetch_uses_requests_ca_bundle_env_when_explicit_ca_bundle_omitted(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    ssl_context = _FakeSSLContext()
+    observed_cafiles: list[str | None] = []
+
+    def fake_create_default_context(*, cafile: str | None = None) -> _FakeSSLContext:
+        observed_cafiles.append(cafile)
+        return ssl_context
+
+    monkeypatch.setattr(
+        "knowledge_adapters.confluence.auth.ssl.create_default_context",
+        fake_create_default_context,
+    )
+    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", "/tmp/env-requests-ca.pem")
+    monkeypatch.setenv("SSL_CERT_FILE", "/tmp/env-ssl-ca.pem")
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *args, **kwargs: _FakeHTTPResponse(_valid_confluence_payload()),
+    )
+
+    page = _fetch_real_page(_real_target())
+
+    assert page["canonical_id"] == "12345"
+    assert observed_cafiles == ["/tmp/env-requests-ca.pem"]
+
+
+def test_real_fetch_uses_ssl_cert_file_env_when_requests_ca_bundle_is_absent(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    ssl_context = _FakeSSLContext()
+    observed_cafiles: list[str | None] = []
+
+    def fake_create_default_context(*, cafile: str | None = None) -> _FakeSSLContext:
+        observed_cafiles.append(cafile)
+        return ssl_context
+
+    monkeypatch.setattr(
+        "knowledge_adapters.confluence.auth.ssl.create_default_context",
+        fake_create_default_context,
+    )
+    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
+    monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
+    monkeypatch.setenv("SSL_CERT_FILE", "/tmp/env-ssl-ca.pem")
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *args, **kwargs: _FakeHTTPResponse(_valid_confluence_payload()),
+    )
+
+    page = _fetch_real_page(_real_target())
+
+    assert page["canonical_id"] == "12345"
+    assert observed_cafiles == ["/tmp/env-ssl-ca.pem"]
+
+
 def test_real_fetch_summary_uses_ca_bundle_for_tls_verification(
     monkeypatch: MonkeyPatch,
 ) -> None:
@@ -603,6 +699,40 @@ def test_real_fetch_uses_split_client_cert_and_key_with_bearer_auth(
     )
     assert observed_contexts == [ssl_context]
     assert observed_request_headers == [{"Authorization": "Bearer test-token"}]
+
+
+def test_real_fetch_prefers_explicit_client_cert_and_key_over_env_fallback(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    ssl_context = _FakeSSLContext()
+    observed_contexts: list[object | None] = []
+
+    def fake_urlopen(*args: object, **kwargs: object) -> _FakeHTTPResponse:
+        del args
+        observed_contexts.append(kwargs.get("context"))
+        return _FakeHTTPResponse(_valid_confluence_payload())
+
+    monkeypatch.setattr(
+        "knowledge_adapters.confluence.auth.ssl.create_default_context",
+        lambda *, cafile=None: ssl_context,
+    )
+    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
+    monkeypatch.setenv("CONFLUENCE_CLIENT_CERT_FILE", "/tmp/env-client.crt")
+    monkeypatch.setenv("CONFLUENCE_CLIENT_KEY_FILE", "/tmp/env-client.key")
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    page = _fetch_real_page(
+        _real_target(),
+        client_cert_file="/tmp/config-client.crt",
+        client_key_file="/tmp/config-client.key",
+    )
+
+    assert page["canonical_id"] == "12345"
+    assert ssl_context.loaded_cert_chain == (
+        "/tmp/config-client.crt",
+        "/tmp/config-client.key",
+    )
+    assert observed_contexts == [ssl_context]
 
 
 def test_real_fetch_treats_empty_client_key_env_as_omitted_for_combined_pem(

--- a/tests/test_confluence_real_traversal_contract.py
+++ b/tests/test_confluence_real_traversal_contract.py
@@ -202,8 +202,10 @@ def _run_real_recursive_cli(
         base_url: str = "https://example.com/wiki",
         auth_method: str = "bearer-env",
         ca_bundle: str | None = None,
+        client_cert_file: str | None = None,
+        client_key_file: str | None = None,
     ) -> dict[str, object]:
-        del base_url, auth_method, ca_bundle
+        del base_url, auth_method, ca_bundle, client_cert_file, client_key_file
 
         page_id = str(target.page_id)
         page_fetch_counts[page_id] = page_fetch_counts.get(page_id, 0) + 1
@@ -322,8 +324,10 @@ def test_real_tree_incremental_run_skips_full_page_fetch_for_unchanged_pages(
         base_url: str = "https://example.com/wiki",
         auth_method: str = "bearer-env",
         ca_bundle: str | None = None,
+        client_cert_file: str | None = None,
+        client_key_file: str | None = None,
     ) -> dict[str, object]:
-        del base_url, auth_method, ca_bundle
+        del base_url, auth_method, ca_bundle, client_cert_file, client_key_file
         page_id = str(target.page_id)
         full_fetch_counts[page_id] = full_fetch_counts.get(page_id, 0) + 1
         return dict(pages[page_id])
@@ -334,8 +338,10 @@ def test_real_tree_incremental_run_skips_full_page_fetch_for_unchanged_pages(
         base_url: str = "https://example.com/wiki",
         auth_method: str = "bearer-env",
         ca_bundle: str | None = None,
+        client_cert_file: str | None = None,
+        client_key_file: str | None = None,
     ) -> dict[str, object]:
-        del base_url, auth_method, ca_bundle
+        del base_url, auth_method, ca_bundle, client_cert_file, client_key_file
         page_id = str(target.page_id)
         summary_fetch_counts[page_id] = summary_fetch_counts.get(page_id, 0) + 1
         page = dict(pages[page_id])
@@ -664,8 +670,10 @@ def test_real_tree_stops_without_writes_when_later_child_list_fails_after_partia
         base_url: str = "https://example.com/wiki",
         auth_method: str = "bearer-env",
         ca_bundle: str | None = None,
+        client_cert_file: str | None = None,
+        client_key_file: str | None = None,
     ) -> dict[str, object]:
-        del base_url, auth_method, ca_bundle
+        del base_url, auth_method, ca_bundle, client_cert_file, client_key_file
 
         page_id = str(target.page_id)
         page_fetch_counts[page_id] = page_fetch_counts.get(page_id, 0) + 1
@@ -746,8 +754,10 @@ def test_real_tree_stops_without_writes_when_later_page_fetch_fails_after_partia
         base_url: str = "https://example.com/wiki",
         auth_method: str = "bearer-env",
         ca_bundle: str | None = None,
+        client_cert_file: str | None = None,
+        client_key_file: str | None = None,
     ) -> dict[str, object]:
-        del base_url, auth_method, ca_bundle
+        del base_url, auth_method, ca_bundle, client_cert_file, client_key_file
 
         page_id = str(target.page_id)
         page_fetch_counts[page_id] = page_fetch_counts.get(page_id, 0) + 1

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 
 import pytest
-from pytest import CaptureFixture
+from pytest import CaptureFixture, MonkeyPatch
 
 from knowledge_adapters.cli import main
 from knowledge_adapters.run_config import ConfiguredRun, load_run_config
@@ -191,3 +191,122 @@ runs:
     assert "would_write: 1" in captured.out
     assert "would_skip: 0" in captured.out
     assert not (tmp_path / "artifacts").exists()
+
+
+def test_load_run_config_includes_confluence_tls_and_client_cert_paths(tmp_path: Path) -> None:
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: docs-home
+    type: confluence
+    base_url: https://example.com/wiki
+    target: "12345"
+    output_dir: ./artifacts/confluence/docs-home
+    ca_bundle: ./certs/internal-ca.pem
+    client_cert_file: ./certs/confluence-client.crt
+    client_key_file: ./certs/confluence-client.key
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    run_config = load_run_config(config_path)
+
+    assert run_config.runs == (
+        ConfiguredRun(
+            name="docs-home",
+            run_type="confluence",
+            argv=(
+                "confluence",
+                "--base-url",
+                "https://example.com/wiki",
+                "--target",
+                "12345",
+                "--output-dir",
+                str((tmp_path / "artifacts" / "confluence" / "docs-home").resolve()),
+                "--ca-bundle",
+                str((tmp_path / "certs" / "internal-ca.pem").resolve()),
+                "--client-cert-file",
+                str((tmp_path / "certs" / "confluence-client.crt").resolve()),
+                "--client-key-file",
+                str((tmp_path / "certs" / "confluence-client.key").resolve()),
+            ),
+            dry_run=False,
+        ),
+    )
+
+
+def test_load_run_config_rejects_confluence_client_key_without_client_cert(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: docs-home
+    type: confluence
+    base_url: https://example.com/wiki
+    target: "12345"
+    output_dir: ./artifacts/confluence/docs-home
+    client_key_file: ./certs/confluence-client.key
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="must set 'client_cert_file' when 'client_key_file'"):
+        load_run_config(config_path)
+
+
+def test_run_command_passes_confluence_tls_config_to_real_client(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    from knowledge_adapters.confluence import client as client_module
+
+    observed_kwargs: list[dict[str, object]] = []
+
+    def stub_real_fetch(*args: object, **kwargs: object) -> dict[str, object]:
+        del args
+        observed_kwargs.append(dict(kwargs))
+        return {
+            "canonical_id": "12345",
+            "title": "Real Page",
+            "content": "<p>Hello from Confluence.</p>",
+            "source_url": "https://example.com/wiki/spaces/ENG/pages/12345",
+            "page_version": 7,
+            "last_modified": "2026-04-20T12:34:56Z",
+        }
+
+    monkeypatch.setattr(client_module, "fetch_real_page", stub_real_fetch, raising=False)
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: docs-home
+    type: confluence
+    client_mode: real
+    base_url: https://example.com/wiki
+    target: "12345"
+    output_dir: ./artifacts/confluence/docs-home
+    ca_bundle: ./certs/internal-ca.pem
+    client_cert_file: ./certs/confluence-client.crt
+    client_key_file: ./certs/confluence-client.key
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    exit_code = main(["run", str(config_path)])
+
+    assert exit_code == 0
+    assert observed_kwargs == [
+        {
+            "base_url": "https://example.com/wiki",
+            "auth_method": "bearer-env",
+            "ca_bundle": str((tmp_path / "certs" / "internal-ca.pem").resolve()),
+            "client_cert_file": str((tmp_path / "certs" / "confluence-client.crt").resolve()),
+            "client_key_file": str((tmp_path / "certs" / "confluence-client.key").resolve()),
+        }
+    ]


### PR DESCRIPTION
Summary
- add per-run Confluence TLS and client certificate fields to runs.yaml parsing and example config
- thread ca_bundle, client_cert_file, and client_key_file through the Confluence config and real-client auth path
- preserve config > env > default precedence with contract coverage for CA bundle and client certificate fallback behavior

Testing
- make check