### PR TITLE
fix: validate confluence runs and preserve run errors

### DIFF
--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -8,7 +8,7 @@ import re
 import shlex
 import sys
 from collections.abc import Callable, Sequence
-from contextlib import redirect_stdout
+from contextlib import redirect_stderr, redirect_stdout
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -76,6 +76,7 @@ _DRY_RUN_SUMMARY_RE = re.compile(
 )
 _DRY_RUN_BLOCK_WRITE_RE = re.compile(r"would_write: (?P<wrote>\d+)")
 _DRY_RUN_BLOCK_SKIP_RE = re.compile(r"would_skip: (?P<skipped>\d+)")
+_CLI_ERROR_RE = re.compile(r"^knowledge-adapters (?P<command>\S+): error: (?P<message>.+)$")
 
 
 @dataclass(frozen=True)
@@ -392,6 +393,20 @@ def _parse_multi_run_summary(output: str) -> MultiRunSummary:
     raise RuntimeError(f"Could not parse adapter summary from output:\n{output}")
 
 
+def _parse_nested_cli_error(stderr_output: str) -> tuple[str | None, tuple[str, ...]]:
+    """Extract the actionable message from a nested CLI failure."""
+    lines = tuple(line for line in stderr_output.splitlines() if line.strip())
+    if not lines:
+        return None, ()
+
+    for index, line in enumerate(lines):
+        match = _CLI_ERROR_RE.match(line)
+        if match is not None:
+            return match.group("message"), lines[index + 1 :]
+
+    return lines[-1], ()
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     """Run the CLI."""
     parser = build_parser()
@@ -426,28 +441,41 @@ def main(argv: Sequence[str] | None = None) -> int:
             print(f"  command: {display_command}")
 
             captured_stdout = io.StringIO()
+            captured_stderr = io.StringIO()
             try:
-                with redirect_stdout(captured_stdout):
+                with redirect_stdout(captured_stdout), redirect_stderr(captured_stderr):
                     exit_code = main(configured_run.argv)
             except SystemExit:
                 output = captured_stdout.getvalue()
                 if output:
                     print(output, end="" if output.endswith("\n") else "\n")
+                nested_error, nested_details = _parse_nested_cli_error(
+                    captured_stderr.getvalue()
+                )
+                message = (
+                    f"Run {configured_run.name!r} ({configured_run.run_type}) failed "
+                    f"while executing {display_command}."
+                )
+                if nested_error is not None:
+                    message = f"{message} {nested_error}"
                 exit_with_cli_error(
-                    (
-                        f"Run {configured_run.name!r} ({configured_run.run_type}) failed "
-                        f"while executing {display_command}."
-                    ),
+                    message,
                     command="run",
+                    debug_lines=nested_details or None,
                 )
 
             if exit_code != 0:
+                nested_error, nested_details = _parse_nested_cli_error(captured_stderr.getvalue())
+                message = (
+                    f"Run {configured_run.name!r} ({configured_run.run_type}) returned "
+                    f"exit code {exit_code} while executing {display_command}."
+                )
+                if nested_error is not None:
+                    message = f"{message} {nested_error}"
                 exit_with_cli_error(
-                    (
-                        f"Run {configured_run.name!r} ({configured_run.run_type}) returned "
-                        f"exit code {exit_code} while executing {display_command}."
-                    ),
+                    message,
                     command="run",
+                    debug_lines=nested_details or None,
                 )
 
             output = captured_stdout.getvalue()

--- a/src/knowledge_adapters/run_config.py
+++ b/src/knowledge_adapters/run_config.py
@@ -7,7 +7,11 @@ from pathlib import Path
 
 import yaml  # type: ignore[import-untyped]
 
+from knowledge_adapters.confluence.auth import SUPPORTED_AUTH_METHODS
+from knowledge_adapters.confluence.resolve import resolve_target_for_base_url, validate_base_url
+
 SUPPORTED_RUN_TYPES = frozenset({"confluence", "local_files"})
+_SUPPORTED_CONFLUENCE_CLIENT_MODES = frozenset({"real", "stub"})
 
 _COMMON_REQUIRED_KEYS = frozenset({"name", "type", "output_dir"})
 _CONFLUENCE_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
@@ -135,7 +139,21 @@ def _build_confluence_argv(
     )
     index = _run_index(name=name, config_path=config_path)
     base_url = _require_string(run_config, "base_url", index=index, config_path=config_path)
+    try:
+        validate_base_url(base_url)
+    except ValueError as exc:
+        raise ValueError(
+            f"Run {name!r} in {config_path} has invalid 'base_url': {exc}"
+        ) from exc
+
     target = _require_string(run_config, "target", index=index, config_path=config_path)
+    try:
+        resolve_target_for_base_url(target, base_url=base_url)
+    except ValueError as exc:
+        raise ValueError(
+            f"Run {name!r} in {config_path} has invalid 'target': {exc}"
+        ) from exc
+
     output_dir = _resolve_path_string(
         _require_string(run_config, "output_dir", index=index, config_path=config_path),
         config_path=config_path,
@@ -152,10 +170,24 @@ def _build_confluence_argv(
 
     client_mode = _optional_string(run_config, "client_mode", index=index, config_path=config_path)
     if client_mode is not None:
+        if client_mode not in _SUPPORTED_CONFLUENCE_CLIENT_MODES:
+            supported_values = " or ".join(
+                repr(mode) for mode in sorted(_SUPPORTED_CONFLUENCE_CLIENT_MODES)
+            )
+            raise ValueError(
+                f"Run {name!r} in {config_path} has unsupported 'client_mode' value "
+                f"{client_mode!r}. Use {supported_values}."
+            )
         argv.extend(["--client-mode", client_mode])
 
     auth_method = _optional_string(run_config, "auth_method", index=index, config_path=config_path)
     if auth_method is not None:
+        if auth_method not in SUPPORTED_AUTH_METHODS:
+            supported_values = " or ".join(repr(method) for method in SUPPORTED_AUTH_METHODS)
+            raise ValueError(
+                f"Run {name!r} in {config_path} has unsupported 'auth_method' value "
+                f"{auth_method!r}. Use {supported_values}."
+            )
         argv.extend(["--auth-method", auth_method])
 
     if _optional_bool(run_config, "debug", index=index, config_path=config_path, default=False):
@@ -170,6 +202,11 @@ def _build_confluence_argv(
         if isinstance(max_depth, bool) or not isinstance(max_depth, int):
             raise ValueError(
                 f"Run {name!r} in {config_path} must set 'max_depth' to an integer."
+            )
+        if max_depth < 0:
+            raise ValueError(
+                f"Run {name!r} in {config_path} must set 'max_depth' to an integer "
+                "greater than or equal to 0."
             )
         argv.extend(["--max-depth", str(max_depth)])
 

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -183,6 +183,37 @@ runs:
     assert "Hello from config run." in local_output_path.read_text(encoding="utf-8")
 
 
+def test_run_cli_smoke_rejects_invalid_confluence_config_before_execution(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: docs-home
+    type: confluence
+    base_url: https://example.com/wiki
+    target: "12345"
+    output_dir: ./artifacts/confluence/docs-home
+    client_mode: preview
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = _run_cli(tmp_path, "run", "./runs.yaml")
+
+    assert result.returncode == 2
+    assert result.stdout == ""
+    assert "Config-driven run invoked" not in result.stdout
+    assert "Run 1/1:" not in result.stdout
+    assert (
+        "knowledge-adapters run: error: Run 'docs-home' in "
+        f"{config_path.resolve()} has unsupported 'client_mode' value 'preview'. "
+        "Use 'real' or 'stub'.\n"
+    ) == result.stderr
+
+
 def test_confluence_cli_smoke_uses_installed_entrypoint_with_default_stub_client(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -83,6 +83,89 @@ runs:
         load_run_config(config_path)
 
 
+@pytest.mark.parametrize(
+    ("field_name", "field_block", "expected_fragment"),
+    [
+        (
+            "client_mode",
+            "client_mode: preview",
+            "unsupported 'client_mode' value 'preview'",
+        ),
+        (
+            "auth_method",
+            "auth_method: oauth",
+            "unsupported 'auth_method' value 'oauth'",
+        ),
+    ],
+)
+def test_load_run_config_rejects_invalid_confluence_enum_values(
+    tmp_path: Path,
+    field_name: str,
+    field_block: str,
+    expected_fragment: str,
+) -> None:
+    del field_name
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        f"""
+runs:
+  - name: docs-home
+    type: confluence
+    base_url: https://example.com/wiki
+    target: "12345"
+    output_dir: ./artifacts/confluence/docs-home
+    {field_block}
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match=expected_fragment):
+        load_run_config(config_path)
+
+
+def test_load_run_config_rejects_invalid_confluence_target_before_execution(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: docs-home
+    type: confluence
+    base_url: https://example.com/wiki
+    target: https://other.example.com/wiki/pages/viewpage.action?pageId=12345
+    output_dir: ./artifacts/confluence/docs-home
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="has invalid 'target'"):
+        load_run_config(config_path)
+
+
+def test_load_run_config_rejects_negative_confluence_max_depth(tmp_path: Path) -> None:
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: docs-tree
+    type: confluence
+    base_url: https://example.com/wiki
+    target: "12345"
+    output_dir: ./artifacts/confluence/docs-tree
+    tree: true
+    max_depth: -1
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="'max_depth'"):
+        load_run_config(config_path)
+
+
 def test_run_command_executes_multiple_runs_in_sequence(
     tmp_path: Path,
     capsys: CaptureFixture[str],
@@ -191,3 +274,44 @@ runs:
     assert "would_write: 1" in captured.out
     assert "would_skip: 0" in captured.out
     assert not (tmp_path / "artifacts").exists()
+
+
+def test_run_command_preserves_nested_adapter_error_details(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    monkeypatch.delenv("CONFLUENCE_BEARER_TOKEN", raising=False)
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: docs-home
+    type: confluence
+    base_url: https://example.com/wiki
+    target: "12345"
+    output_dir: ./artifacts/confluence/docs-home
+    client_mode: real
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(["run", str(config_path)])
+
+    assert exc_info.value.code == 2
+    captured = capsys.readouterr()
+    assert "Config-driven run invoked" in captured.out
+    assert f"config_path: {config_path.resolve()}" in captured.out
+    assert "runs_in_config: 1" in captured.out
+    assert "Run 1/1: docs-home (confluence)" in captured.out
+    assert (
+        "knowledge-adapters run: error: Run 'docs-home' (confluence) failed while "
+        "executing knowledge-adapters confluence --base-url https://example.com/wiki "
+        "--target 12345 --output-dir "
+    ) in captured.err
+    assert (
+        "Missing Confluence bearer token. Set CONFLUENCE_BEARER_TOKEN for "
+        "--client-mode real --auth-method bearer-env."
+    ) in captured.err


### PR DESCRIPTION
Summary
- validate Confluence-specific `runs.yaml` fields during config load so bad values fail before any configured adapter starts
- preserve the nested adapter error detail when `knowledge-adapters run` fails while still identifying the configured run and rendered command
- add focused coverage for early config validation failures and preserved nested runtime errors

Testing
- `make check`

Closes #123
Closes #121