### PR TITLE
feat: add opt-in continue-on-error for config runs

### DIFF
--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -68,6 +68,7 @@ LOCAL_FILES_HELP_EXAMPLES = """Examples:
 RUN_HELP_EXAMPLES = """Examples:
   knowledge-adapters run runs.yaml
   knowledge-adapters run ./configs/runs.yaml
+  knowledge-adapters run runs.yaml --continue-on-error
 """
 
 _WRITE_SUMMARY_RE = re.compile(r"Summary: wrote (?P<wrote>\d+), skipped (?P<skipped>\d+)")
@@ -340,8 +341,29 @@ def build_parser() -> argparse.ArgumentParser:
         metavar="RUNS_YAML",
         help="Path to a YAML config file containing a top-level runs: list.",
     )
+    run_parser.add_argument(
+        "--continue-on-error",
+        action="store_true",
+        help=(
+            "Keep executing later configured runs after one run fails. "
+            "Returns non-zero if any configured run fails."
+        ),
+    )
 
     return parser
+
+
+def print_cli_error(
+    message: str,
+    *,
+    command: str,
+    debug_lines: Sequence[str] | None = None,
+) -> None:
+    """Print a stable user-facing CLI error message."""
+    print(f"knowledge-adapters {command}: error: {message}", file=sys.stderr)
+    if debug_lines:
+        for line in debug_lines:
+            print(f"  {line}", file=sys.stderr)
 
 
 def exit_with_cli_error(
@@ -351,10 +373,7 @@ def exit_with_cli_error(
     debug_lines: Sequence[str] | None = None,
 ) -> None:
     """Exit the CLI with a stable user-facing error message."""
-    print(f"knowledge-adapters {command}: error: {message}", file=sys.stderr)
-    if debug_lines:
-        for line in debug_lines:
-            print(f"  {line}", file=sys.stderr)
+    print_cli_error(message, command=command, debug_lines=debug_lines)
     raise SystemExit(2)
 
 
@@ -415,6 +434,31 @@ def _parse_nested_cli_error(stderr_output: str) -> tuple[str | None, tuple[str, 
     return lines[-1], ()
 
 
+def _build_configured_run_failure(
+    *,
+    configured_run_name: str,
+    configured_run_type: str,
+    display_command: str,
+    stderr_output: str,
+    exit_code: int | None = None,
+) -> tuple[str, tuple[str, ...]]:
+    """Build one stable configured-run failure message."""
+    nested_error, nested_details = _parse_nested_cli_error(stderr_output)
+    if exit_code is None:
+        message = (
+            f"Run {configured_run_name!r} ({configured_run_type}) failed while "
+            f"executing {display_command}."
+        )
+    else:
+        message = (
+            f"Run {configured_run_name!r} ({configured_run_type}) returned "
+            f"exit code {exit_code} while executing {display_command}."
+        )
+    if nested_error is not None:
+        message = f"{message} {nested_error}"
+    return message, nested_details
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     """Run the CLI."""
     parser = build_parser()
@@ -433,6 +477,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"  runs_in_config: {len(run_config.runs)}")
 
         completed_runs = 0
+        failed_runs = 0
         write_runs = 0
         dry_run_runs = 0
         total_wrote = 0
@@ -457,34 +502,39 @@ def main(argv: Sequence[str] | None = None) -> int:
                 output = captured_stdout.getvalue()
                 if output:
                     print(output, end="" if output.endswith("\n") else "\n")
-                nested_error, nested_details = _parse_nested_cli_error(
-                    captured_stderr.getvalue()
+                message, nested_details = _build_configured_run_failure(
+                    configured_run_name=configured_run.name,
+                    configured_run_type=configured_run.run_type,
+                    display_command=display_command,
+                    stderr_output=captured_stderr.getvalue(),
                 )
-                message = (
-                    f"Run {configured_run.name!r} ({configured_run.run_type}) failed "
-                    f"while executing {display_command}."
-                )
-                if nested_error is not None:
-                    message = f"{message} {nested_error}"
-                exit_with_cli_error(
-                    message,
-                    command="run",
-                    debug_lines=nested_details or None,
-                )
+                if not args.continue_on_error:
+                    exit_with_cli_error(
+                        message,
+                        command="run",
+                        debug_lines=nested_details or None,
+                    )
+                print_cli_error(message, command="run", debug_lines=nested_details or None)
+                failed_runs += 1
+                continue
 
             if exit_code != 0:
-                nested_error, nested_details = _parse_nested_cli_error(captured_stderr.getvalue())
-                message = (
-                    f"Run {configured_run.name!r} ({configured_run.run_type}) returned "
-                    f"exit code {exit_code} while executing {display_command}."
+                message, nested_details = _build_configured_run_failure(
+                    configured_run_name=configured_run.name,
+                    configured_run_type=configured_run.run_type,
+                    display_command=display_command,
+                    stderr_output=captured_stderr.getvalue(),
+                    exit_code=exit_code,
                 )
-                if nested_error is not None:
-                    message = f"{message} {nested_error}"
-                exit_with_cli_error(
-                    message,
-                    command="run",
-                    debug_lines=nested_details or None,
-                )
+                if not args.continue_on_error:
+                    exit_with_cli_error(
+                        message,
+                        command="run",
+                        debug_lines=nested_details or None,
+                    )
+                print_cli_error(message, command="run", debug_lines=nested_details or None)
+                failed_runs += 1
+                continue
 
             output = captured_stdout.getvalue()
             if output:
@@ -512,6 +562,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 
         print("\nAggregate summary:")
         print(f"  runs_completed: {completed_runs}")
+        print(f"  runs_failed: {failed_runs}")
         print(f"  write_runs: {write_runs}")
         print(f"  dry_run_runs: {dry_run_runs}")
         print(f"  wrote: {total_wrote}")
@@ -519,6 +570,14 @@ def main(argv: Sequence[str] | None = None) -> int:
         if dry_run_runs > 0:
             print(f"  would_write: {total_would_write}")
             print(f"  would_skip: {total_would_skip}")
+        if failed_runs > 0:
+            print(
+                "Config run completed with failures. "
+                f"Processed {completed_runs} successful run(s) and {failed_runs} failed "
+                f"run(s) from {render_user_path(run_config.config_path)}"
+            )
+            return 1
+
         print(
             "Config run complete. "
             f"Processed {completed_runs} run(s) from {render_user_path(run_config.config_path)}"

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -214,6 +214,53 @@ runs:
     ) == result.stderr
 
 
+def test_run_cli_smoke_continue_on_error_executes_later_runs_and_returns_non_zero(
+    tmp_path: Path,
+) -> None:
+    inputs_dir = tmp_path / "inputs"
+    inputs_dir.mkdir()
+    source_file = inputs_dir / "today.txt"
+    source_file.write_text("Hello from config run.\n", encoding="utf-8")
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: docs-home
+    type: confluence
+    base_url: https://example.com/wiki
+    target: "12345"
+    output_dir: ./artifacts/confluence/docs-home
+    client_mode: real
+  - name: team-notes
+    type: local_files
+    file_path: ./inputs/today.txt
+    output_dir: ./artifacts/local/team-notes
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = _run_cli(tmp_path, "run", "./runs.yaml", "--continue-on-error")
+
+    assert result.returncode == 1
+    assert "Run 1/2: docs-home (confluence)" in result.stdout
+    assert "Run 2/2: team-notes (local_files)" in result.stdout
+    assert "Aggregate summary:" in result.stdout
+    assert "runs_completed: 1" in result.stdout
+    assert "runs_failed: 1" in result.stdout
+    assert "wrote: 1" in result.stdout
+    assert "skipped: 0" in result.stdout
+    assert "Config run completed with failures." in result.stdout
+    assert "knowledge-adapters run: error: Run 'docs-home' (confluence) failed while " in (
+        result.stderr
+    )
+    assert "Missing Confluence bearer token." in result.stderr
+
+    local_output_path = tmp_path / "artifacts" / "local" / "team-notes" / "pages" / "today.md"
+    assert local_output_path.exists()
+    assert "Hello from config run." in local_output_path.read_text(encoding="utf-8")
+
+
 def test_confluence_cli_smoke_uses_installed_entrypoint_with_default_stub_client(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -317,6 +317,101 @@ runs:
     ) in captured.err
 
 
+def test_run_command_stops_on_first_failed_run_by_default(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    monkeypatch.delenv("CONFLUENCE_BEARER_TOKEN", raising=False)
+    source_file = tmp_path / "inputs" / "team-notes.txt"
+    source_file.parent.mkdir(parents=True)
+    source_file.write_text("Ship it.\n", encoding="utf-8")
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: docs-home
+    type: confluence
+    base_url: https://example.com/wiki
+    target: "12345"
+    output_dir: ./artifacts/confluence/docs-home
+    client_mode: real
+  - name: team-notes
+    type: local_files
+    file_path: ./inputs/team-notes.txt
+    output_dir: ./artifacts/local/team-notes
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(["run", str(config_path)])
+
+    assert exc_info.value.code == 2
+    captured = capsys.readouterr()
+    assert "Run 1/2: docs-home (confluence)" in captured.out
+    assert "Run 2/2: team-notes (local_files)" not in captured.out
+    assert "Aggregate summary:" not in captured.out
+    assert "knowledge-adapters run: error: Run 'docs-home' (confluence) failed while " in (
+        captured.err
+    )
+    assert "Missing Confluence bearer token." in captured.err
+    assert not (tmp_path / "artifacts" / "local" / "team-notes").exists()
+
+
+def test_run_command_continue_on_error_executes_later_runs_and_reports_failures(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    monkeypatch.delenv("CONFLUENCE_BEARER_TOKEN", raising=False)
+    source_file = tmp_path / "inputs" / "team-notes.txt"
+    source_file.parent.mkdir(parents=True)
+    source_file.write_text("Ship it.\n", encoding="utf-8")
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: docs-home
+    type: confluence
+    base_url: https://example.com/wiki
+    target: "12345"
+    output_dir: ./artifacts/confluence/docs-home
+    client_mode: real
+  - name: team-notes
+    type: local_files
+    file_path: ./inputs/team-notes.txt
+    output_dir: ./artifacts/local/team-notes
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    exit_code = main(["run", str(config_path), "--continue-on-error"])
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "Run 1/2: docs-home (confluence)" in captured.out
+    assert "Run 2/2: team-notes (local_files)" in captured.out
+    assert "Aggregate summary:" in captured.out
+    assert "runs_completed: 1" in captured.out
+    assert "runs_failed: 1" in captured.out
+    assert "write_runs: 1" in captured.out
+    assert "dry_run_runs: 0" in captured.out
+    assert "wrote: 1" in captured.out
+    assert "skipped: 0" in captured.out
+    assert "Config run completed with failures." in captured.out
+    assert "knowledge-adapters run: error: Run 'docs-home' (confluence) failed while " in (
+        captured.err
+    )
+    assert "Missing Confluence bearer token." in captured.err
+
+    local_output_path = tmp_path / "artifacts" / "local" / "team-notes" / "pages" / "team-notes.md"
+    assert local_output_path.exists()
+    assert "Ship it." in local_output_path.read_text(encoding="utf-8")
+
+
 def test_load_run_config_includes_confluence_tls_and_client_cert_paths(tmp_path: Path) -> None:
     config_path = tmp_path / "runs.yaml"
     config_path.write_text(


### PR DESCRIPTION
Summary
- add opt-in --continue-on-error handling for config-driven runs while preserving default fail-fast behavior
- keep nested adapter failure details visible and continue later configured runs only when explicitly requested
- report aggregate completed/failed and write/skip counts, and return non-zero when any configured run fails

Testing
- make check

Closes #122