### PR TITLE
fix: explain Confluence incremental rewrite reasons

### DIFF
--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -594,6 +594,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         from knowledge_adapters.confluence.config import ConfluenceConfig
         from knowledge_adapters.confluence.incremental import (
+            PageSyncDecision,
             classify_page_sync,
             load_previous_manifest_index,
         )
@@ -767,13 +768,18 @@ def main(argv: Sequence[str] | None = None) -> int:
             """Return the consistent user-facing path form for CLI output."""
             return render_user_path(path)
 
+        def _format_page_sync_decision(page_decision: PageSyncDecision) -> str:
+            if page_decision.rewrite_reason is None:
+                return page_decision.status
+            return f"{page_decision.status}: {page_decision.rewrite_reason}"
+
         def _print_single_page_plan(
             *,
             page_id: str,
             source_url: str,
             output_path: Path,
             manifest_output_path: Path,
-            page_status: str,
+            page_decision: PageSyncDecision,
             action: str,
             dry_run: bool,
             markdown: str | None = None,
@@ -783,7 +789,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             print(f"  source_url: {source_url}")
             print(f"  Artifact: {_display_output_path(output_path)}")
             print(f"  Manifest: {_display_output_path(manifest_output_path)}")
-            print(f"  page_status: {page_status}")
+            print(f"  page_status: {page_decision.status}")
+            if page_decision.rewrite_reason is not None:
+                print(f"  rewrite_reason: {page_decision.rewrite_reason}")
             print(f"  planned_action: {'would ' if dry_run else ''}{action}")
             if dry_run:
                 write_count = 1 if action == "write" else 0
@@ -791,9 +799,9 @@ def main(argv: Sequence[str] | None = None) -> int:
                 _print_confluence_dry_run_summary(
                     mode="single",
                     total_pages=1,
-                    new_count=1 if page_status == "new" else 0,
-                    changed_count=1 if page_status == "changed" else 0,
-                    unchanged_count=1 if page_status == "unchanged" else 0,
+                    new_count=1 if page_decision.status == "new" else 0,
+                    changed_count=1 if page_decision.status == "changed" else 0,
+                    unchanged_count=1 if page_decision.status == "unchanged" else 0,
                     write_count=write_count,
                     skip_count=skip_count,
                 )
@@ -879,32 +887,34 @@ def main(argv: Sequence[str] | None = None) -> int:
                     list_child_page_ids=selected_list_child_page_ids,
                 )
             _print_confluence_invocation()
-            page_records: list[tuple[dict[str, object], Path, str, str]] = []
+            page_records: list[tuple[dict[str, object], Path, PageSyncDecision, str]] = []
             for page in pages:
                 canonical_id = str(page.get("canonical_id") or "")
                 output_path = markdown_path(confluence_config.output_dir, canonical_id)
-                page_status = classify_page_sync(
+                page_decision = classify_page_sync(
                     confluence_config.output_dir,
                     previous_manifest_index,
                     page=page,
                     output_path=output_path,
                 )
-                action = "skip" if page_status == "unchanged" else "write"
-                page_records.append((page, output_path, page_status, action))
+                action = "skip" if page_decision.status == "unchanged" else "write"
+                page_records.append((page, output_path, page_decision, action))
 
             write_count = sum(
-                1 for _page, _output_path, _page_status, action in page_records if action == "write"
+                1
+                for _page, _output_path, _page_decision, action in page_records
+                if action == "write"
             )
             skip_count = len(page_records) - write_count
             new_count = sum(
                 1
-                for _page, _output_path, page_status, _action in page_records
-                if page_status == "new"
+                for _page, _output_path, page_decision, _action in page_records
+                if page_decision.status == "new"
             )
             changed_count = sum(
                 1
-                for _page, _output_path, page_status, _action in page_records
-                if page_status == "changed"
+                for _page, _output_path, page_decision, _action in page_records
+                if page_decision.status == "changed"
             )
             unchanged_count = len(page_records) - new_count - changed_count
             manifest_output_path = manifest_path(confluence_config.output_dir)
@@ -926,21 +936,23 @@ def main(argv: Sequence[str] | None = None) -> int:
                     write_count=write_count,
                     skip_count=skip_count,
                 )
-                for _page, output_path, record_status, action in page_records:
+                for _page, output_path, page_decision, action in page_records:
                     print(
-                        f"  would {action} {_display_output_path(output_path)} ({record_status})"
+                        "  would "
+                        f"{action} {_display_output_path(output_path)} "
+                        f"({_format_page_sync_decision(page_decision)})"
                     )
                 print_dry_run_complete()
                 return 0
 
             files = [
                 _build_manifest_entry_for_page(page, output_path)
-                for page, output_path, _page_status, _action in page_records
+                for page, output_path, _page_decision, _action in page_records
             ]
 
             pages_to_write: dict[str, dict[str, object]] = {}
             try:
-                for page, _output_path, _page_status, action in page_records:
+                for page, _output_path, _page_decision, action in page_records:
                     if action == "skip":
                         continue
 
@@ -964,9 +976,13 @@ def main(argv: Sequence[str] | None = None) -> int:
                 )
 
             try:
-                for page, output_path, record_status, action in page_records:
+                for page, output_path, page_decision, action in page_records:
                     if action == "skip":
-                        print(f"\nSkipped: {_display_output_path(output_path)} ({record_status})")
+                        print(
+                            "\nSkipped: "
+                            f"{_display_output_path(output_path)} "
+                            f"({_format_page_sync_decision(page_decision)})"
+                        )
                         continue
 
                     page_to_write = pages_to_write[str(page.get("canonical_id") or "")]
@@ -976,7 +992,11 @@ def main(argv: Sequence[str] | None = None) -> int:
                         str(page_to_write.get("canonical_id") or ""),
                         markdown,
                     )
-                    print(f"\nWrote: {_display_output_path(output_path)} ({record_status})")
+                    print(
+                        "\nWrote: "
+                        f"{_display_output_path(output_path)} "
+                        f"({_format_page_sync_decision(page_decision)})"
+                    )
 
                 manifest = write_manifest_with_context(
                     confluence_config.output_dir,
@@ -1019,13 +1039,13 @@ def main(argv: Sequence[str] | None = None) -> int:
         page_id = str(page["canonical_id"])
         output_path = markdown_path(confluence_config.output_dir, page_id)
         manifest_output_path = manifest_path(confluence_config.output_dir)
-        page_status = classify_page_sync(
+        page_decision = classify_page_sync(
             confluence_config.output_dir,
             previous_manifest_index,
             page=page,
             output_path=output_path,
         )
-        action = "skip" if page_status == "unchanged" else "write"
+        action = "skip" if page_decision.status == "unchanged" else "write"
 
         if confluence_config.dry_run:
             planned_page = page
@@ -1044,7 +1064,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 source_url=str(page.get("source_url", "")),
                 output_path=output_path,
                 manifest_output_path=manifest_output_path,
-                page_status=page_status,
+                page_decision=page_decision,
                 action=action,
                 dry_run=True,
                 markdown=planned_markdown,
@@ -1057,7 +1077,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             source_url=str(page.get("source_url", "")),
             output_path=output_path,
             manifest_output_path=manifest_output_path,
-            page_status=page_status,
+            page_decision=page_decision,
             action=action,
             dry_run=False,
         )
@@ -1073,9 +1093,17 @@ def main(argv: Sequence[str] | None = None) -> int:
                     page_id,
                     markdown,
                 )
-                print(f"\nWrote: {_display_output_path(output_path)} ({page_status})")
+                print(
+                    "\nWrote: "
+                    f"{_display_output_path(output_path)} "
+                    f"({_format_page_sync_decision(page_decision)})"
+                )
             else:
-                print(f"\nSkipped: {_display_output_path(output_path)} ({page_status})")
+                print(
+                    "\nSkipped: "
+                    f"{_display_output_path(output_path)} "
+                    f"({_format_page_sync_decision(page_decision)})"
+                )
 
             manifest = write_manifest(
                 confluence_config.output_dir,
@@ -1098,9 +1126,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         write_count = 1 if action == "write" else 0
         skip_count = 1 if action == "skip" else 0
         _print_confluence_write_summary(
-            new_count=1 if page_status == "new" else 0,
-            changed_count=1 if page_status == "changed" else 0,
-            unchanged_count=1 if page_status == "unchanged" else 0,
+            new_count=1 if page_decision.status == "new" else 0,
+            changed_count=1 if page_decision.status == "changed" else 0,
+            unchanged_count=1 if page_decision.status == "unchanged" else 0,
             write_count=write_count,
             skip_count=skip_count,
         )

--- a/src/knowledge_adapters/confluence/incremental.py
+++ b/src/knowledge_adapters/confluence/incremental.py
@@ -24,6 +24,14 @@ class PreviousManifestEntry:
 PageSyncStatus = Literal["new", "changed", "unchanged"]
 
 
+@dataclass(frozen=True)
+class PageSyncDecision:
+    """Incremental sync decision plus an operator-facing rewrite reason."""
+
+    status: PageSyncStatus
+    rewrite_reason: str | None = None
+
+
 def _normalize_metadata_value(value: object) -> str | None:
     if isinstance(value, bool):
         return None
@@ -120,29 +128,42 @@ def classify_page_sync(
     *,
     page: Mapping[str, object],
     output_path: Path,
-) -> PageSyncStatus:
+) -> PageSyncDecision:
     """Classify a page as new, changed, or unchanged for incremental sync."""
     canonical_id = str(page.get("canonical_id") or "")
     if previous_manifest_index is None:
-        return "new"
+        return PageSyncDecision(status="new", rewrite_reason="new page")
 
     prior_entry = previous_manifest_index.get(canonical_id)
     if prior_entry is None:
-        return "new"
+        return PageSyncDecision(
+            status="new",
+            rewrite_reason="prior manifest entry missing entirely",
+        )
 
     expected_output_path = output_path.relative_to(Path(output_dir)).as_posix()
     if prior_entry.output_path != expected_output_path:
-        return "changed"
+        return PageSyncDecision(status="changed", rewrite_reason="output_path changed")
 
     if not (Path(output_dir) / prior_entry.output_path).exists():
-        return "changed"
+        return PageSyncDecision(
+            status="changed",
+            rewrite_reason="prior artifact missing, so safe rewrite",
+        )
 
     current_page_version = _normalize_metadata_value(page.get("page_version"))
     if current_page_version is not None and prior_entry.page_version is not None:
-        return "unchanged" if current_page_version == prior_entry.page_version else "changed"
+        if current_page_version == prior_entry.page_version:
+            return PageSyncDecision(status="unchanged")
+        return PageSyncDecision(status="changed", rewrite_reason="page_version changed")
 
     current_last_modified = _normalize_metadata_value(page.get("last_modified"))
     if current_last_modified is not None and prior_entry.last_modified is not None:
-        return "unchanged" if current_last_modified == prior_entry.last_modified else "changed"
+        if current_last_modified == prior_entry.last_modified:
+            return PageSyncDecision(status="unchanged")
+        return PageSyncDecision(status="changed", rewrite_reason="last_modified changed")
 
-    return "changed"
+    return PageSyncDecision(
+        status="changed",
+        rewrite_reason="prior manifest entry missing metadata, so safe rewrite",
+    )

--- a/tests/test_confluence_incremental_contract.py
+++ b/tests/test_confluence_incremental_contract.py
@@ -200,12 +200,12 @@ def test_incremental_dry_run_without_manifest_marks_all_pages_as_write(
 
 
 @pytest.mark.parametrize(
-    ("manifest_entry", "materialize_file", "expected_phrase"),
+    ("manifest_entry", "materialize_file", "expected_output"),
     [
         (
             _manifest_entry_for_page("100"),
             True,
-            "would skip",
+            "would skip {path} (unchanged)",
         ),
         (
             {
@@ -214,7 +214,7 @@ def test_incremental_dry_run_without_manifest_marks_all_pages_as_write(
                 "output_path": "pages/100.md",
             },
             True,
-            "would write",
+            "would write {path} (new: prior manifest entry missing entirely)",
         ),
         (
             {
@@ -223,7 +223,7 @@ def test_incremental_dry_run_without_manifest_marks_all_pages_as_write(
                 "output_path": "pages/custom-name.md",
             },
             True,
-            "would write",
+            "would write {path} (changed: output_path changed)",
         ),
         (
             {
@@ -232,7 +232,7 @@ def test_incremental_dry_run_without_manifest_marks_all_pages_as_write(
                 "output_path": "pages/100.md",
             },
             False,
-            "would write",
+            "would write {path} (changed: prior artifact missing, so safe rewrite)",
         ),
     ],
 )
@@ -242,7 +242,7 @@ def test_incremental_dry_run_uses_manifest_identity_and_file_existence_for_skip(
     capsys: CaptureFixture[str],
     manifest_entry: dict[str, object],
     materialize_file: bool,
-    expected_phrase: str,
+    expected_output: str,
 ) -> None:
     output_dir = tmp_path / "out"
     original_manifest = _write_previous_manifest(
@@ -265,8 +265,10 @@ def test_incremental_dry_run_uses_manifest_identity_and_file_existence_for_skip(
     assert exit_code == 0
 
     captured = capsys.readouterr()
-    write_count = 1 if expected_phrase == "would skip" else 2
-    skip_count = 1 if expected_phrase == "would skip" else 0
+    expected_line = expected_output.format(path=_page_path(output_dir, "100"))
+    is_skip = "would skip" in expected_line
+    write_count = 1 if is_skip else 2
+    skip_count = 1 if is_skip else 0
     assert_tree_confluence_dry_run_summary(
         captured.out,
         root_page_id="100",
@@ -276,7 +278,7 @@ def test_incremental_dry_run_uses_manifest_identity_and_file_existence_for_skip(
         write_count=write_count,
         skip_count=skip_count,
     )
-    assert f"{expected_phrase} {_page_path(output_dir, '100')}" in captured.out
+    assert expected_line in captured.out
     if materialize_file and manifest_entry["output_path"] == "pages/100.md":
         assert _page_path(output_dir, "100").read_text(encoding="utf-8") == "existing artifact\n"
     else:
@@ -308,8 +310,11 @@ def test_incremental_dry_run_reports_both_would_write_and_would_skip_without_wri
     assert exit_code == 0
 
     captured = capsys.readouterr()
-    assert f"would skip {existing_page}" in captured.out
-    assert f"would write {_page_path(output_dir, '200')}" in captured.out
+    assert f"would skip {existing_page} (unchanged)" in captured.out
+    assert (
+        f"would write {_page_path(output_dir, '200')} "
+        "(new: prior manifest entry missing entirely)"
+    ) in captured.out
     assert_dry_run_summary(
         captured.out,
         would_write=1,
@@ -388,7 +393,10 @@ def test_incremental_normal_run_rewrites_pages_when_source_metadata_changes(
     assert existing_page.read_text(encoding="utf-8") != "stale root\n"
 
     captured = capsys.readouterr()
-    assert f"Wrote: {_page_path(output_dir, '100')} (changed)" in captured.out
+    assert (
+        f"Wrote: {_page_path(output_dir, '100')} "
+        "(changed: page_version changed)"
+    ) in captured.out
     assert_write_summary(
         captured.out,
         wrote=2,
@@ -586,10 +594,16 @@ def test_incremental_normal_run_handles_larger_mixed_write_and_skip_set(
     ]
 
     captured = capsys.readouterr()
-    assert f"Skipped: {_page_path(output_dir, '100')}" in captured.out
-    assert f"Skipped: {_page_path(output_dir, '300')}" in captured.out
-    assert f"Wrote: {_page_path(output_dir, '200')}" in captured.out
-    assert f"Wrote: {_page_path(output_dir, '400')}" in captured.out
+    assert f"Skipped: {_page_path(output_dir, '100')} (unchanged)" in captured.out
+    assert f"Skipped: {_page_path(output_dir, '300')} (unchanged)" in captured.out
+    assert (
+        f"Wrote: {_page_path(output_dir, '200')} "
+        "(new: prior manifest entry missing entirely)"
+    ) in captured.out
+    assert (
+        f"Wrote: {_page_path(output_dir, '400')} "
+        "(new: prior manifest entry missing entirely)"
+    ) in captured.out
     assert_write_summary(
         captured.out,
         wrote=2,
@@ -633,7 +647,10 @@ def test_incremental_dry_run_rewrites_pages_from_older_manifests_without_source_
     assert exit_code == 0
 
     captured = capsys.readouterr()
-    assert f"would write {existing_page} (changed)" in captured.out
+    assert (
+        f"would write {existing_page} "
+        "(changed: prior manifest entry missing metadata, so safe rewrite)"
+    ) in captured.out
     assert_dry_run_summary(
         captured.out,
         would_write=2,
@@ -744,6 +761,43 @@ def test_incremental_output_directory_reuse_handles_overlapping_and_new_pages(
         changed_pages=0,
         unchanged_pages=1,
     )
+
+
+def test_incremental_dry_run_reports_last_modified_rewrite_reason(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    output_dir = tmp_path / "out"
+    _write_previous_manifest(
+        output_dir,
+        [
+            {
+                "canonical_id": "100",
+                "source_url": "https://example.com/wiki/pages/100?old=1",
+                "output_path": "pages/100.md",
+                "last_modified": "2026-04-19T23:59:59Z",
+            }
+        ],
+        root_page_id="100",
+    )
+    existing_page = _page_path(output_dir, "100")
+    existing_page.parent.mkdir(parents=True, exist_ok=True)
+    existing_page.write_text("already written\n", encoding="utf-8")
+
+    exit_code, _ = _run_recursive_cli(
+        tmp_path,
+        monkeypatch,
+        dry_run=True,
+    )
+
+    assert exit_code == 0
+
+    captured = capsys.readouterr()
+    assert (
+        f"would write {existing_page} "
+        "(changed: last_modified changed)"
+    ) in captured.out
 
 
 def test_incremental_dry_run_summary_reports_mixed_write_and_skip_counts(


### PR DESCRIPTION
Summary
- explain why Confluence incremental sync rewrites a page
- surface concise rewrite reasons in dry-run and write output without changing sync behavior
- add contract coverage for new, changed, and metadata-missing rewrite reasons

Testing
- make check

Closes #124