### PR TITLE
fix: surface active tls inputs in Confluence real-mode plan output

### DIFF
--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -12,7 +12,7 @@ from contextlib import redirect_stderr, redirect_stdout
 from dataclasses import dataclass
 from pathlib import Path
 
-from knowledge_adapters.confluence.auth import SUPPORTED_AUTH_METHODS
+from knowledge_adapters.confluence.auth import SUPPORTED_AUTH_METHODS, resolve_tls_inputs
 
 TOP_LEVEL_HELP_EXAMPLES = """First steps:
   knowledge-adapters --help
@@ -728,7 +728,31 @@ def main(argv: Sequence[str] | None = None) -> int:
                     max_depth = f"{max_depth} ({_describe_tree_depth(confluence_config.max_depth)})"
                 print(f"  max_depth: {max_depth}")
             if confluence_config.client_mode == "real":
+                resolved_tls_inputs = resolve_tls_inputs(
+                    ca_bundle=confluence_config.ca_bundle,
+                    client_cert_file=confluence_config.client_cert_file,
+                    client_key_file=confluence_config.client_key_file,
+                )
+                tls_inputs: list[str] = []
+                if resolved_tls_inputs.ca_bundle:
+                    tls_inputs.append(
+                        f"ca_bundle={render_user_path(resolved_tls_inputs.ca_bundle)}"
+                    )
+                if resolved_tls_inputs.client_cert_file:
+                    tls_inputs.append(
+                        "client_cert_file="
+                        f"{render_user_path(resolved_tls_inputs.client_cert_file)}"
+                    )
+                if resolved_tls_inputs.client_key_file:
+                    tls_inputs.append(
+                        "client_key_file="
+                        f"{render_user_path(resolved_tls_inputs.client_key_file)}"
+                    )
                 print(f"  auth_method: {confluence_config.auth_method}")
+                print(
+                    "  tls_inputs: "
+                    f"{', '.join(tls_inputs) if tls_inputs else 'defaults/environment'}"
+                )
 
         def _confluence_debug_lines(
             exc: RuntimeError | ValueError,

--- a/src/knowledge_adapters/confluence/auth.py
+++ b/src/knowledge_adapters/confluence/auth.py
@@ -17,6 +17,15 @@ class RequestAuth:
     ssl_context: ssl.SSLContext | None
 
 
+@dataclass(frozen=True)
+class ResolvedTLSInputs:
+    """Effective TLS/client-certificate inputs after env fallback resolution."""
+
+    ca_bundle: str | None
+    client_cert_file: str | None
+    client_key_file: str | None
+
+
 def build_request_auth(
     auth_method: str,
     *,
@@ -46,6 +55,30 @@ def build_request_auth(
     )
 
 
+def resolve_tls_inputs(
+    *,
+    ca_bundle: str | None = None,
+    client_cert_file: str | None = None,
+    client_key_file: str | None = None,
+) -> ResolvedTLSInputs:
+    """Resolve the effective TLS/client-certificate file inputs."""
+    return ResolvedTLSInputs(
+        ca_bundle=_first_non_empty(
+            ca_bundle,
+            os.getenv("REQUESTS_CA_BUNDLE"),
+            os.getenv("SSL_CERT_FILE"),
+        ),
+        client_cert_file=_first_non_empty(
+            client_cert_file,
+            os.getenv("CONFLUENCE_CLIENT_CERT_FILE"),
+        ),
+        client_key_file=_first_non_empty(
+            client_key_file,
+            os.getenv("CONFLUENCE_CLIENT_KEY_FILE"),
+        ),
+    )
+
+
 def _bearer_env_headers() -> dict[str, str]:
     token = os.getenv("CONFLUENCE_BEARER_TOKEN", "").strip()
     if not token:
@@ -64,13 +97,14 @@ def _client_cert_ssl_context(
     client_cert_file: str | None = None,
     client_key_file: str | None = None,
 ) -> ssl.SSLContext | None:
-    cert_file = _first_non_empty(client_cert_file, os.getenv("CONFLUENCE_CLIENT_CERT_FILE"))
-    key_file = _first_non_empty(client_key_file, os.getenv("CONFLUENCE_CLIENT_KEY_FILE"))
-    resolved_ca_bundle = _first_non_empty(
-        ca_bundle,
-        os.getenv("REQUESTS_CA_BUNDLE"),
-        os.getenv("SSL_CERT_FILE"),
+    resolved_tls_inputs = resolve_tls_inputs(
+        ca_bundle=ca_bundle,
+        client_cert_file=client_cert_file,
+        client_key_file=client_key_file,
     )
+    cert_file = resolved_tls_inputs.client_cert_file
+    key_file = resolved_tls_inputs.client_key_file
+    resolved_ca_bundle = resolved_tls_inputs.ca_bundle
 
     if key_file and not cert_file:
         raise ValueError(

--- a/tests/test_confluence_real_client_contract.py
+++ b/tests/test_confluence_real_client_contract.py
@@ -320,6 +320,7 @@ def test_stub_and_real_single_page_write_runs_share_the_same_cli_shape(
     assert f"Manifest: {real_output_dir / 'manifest.json'}" in real_output
     assert "planned_action: write" in real_output
     assert "auth_method: bearer-env" in real_output
+    assert "tls_inputs: defaults/environment" in real_output
     assert f"Manifest: {real_output_dir / 'manifest.json'}" in real_output
     assert_write_summary(real_output, wrote=1, skipped=0)
 
@@ -374,6 +375,7 @@ def test_stub_and_real_single_page_dry_runs_share_the_same_plan_shape(
     assert "mode: single" in real_output
     assert "run_mode: dry-run" in real_output
     assert "auth_method: bearer-env" in real_output
+    assert "tls_inputs: defaults/environment" in real_output
     assert "Plan: Confluence run" in real_output
     assert "resolved_page_id: 12345" in real_output
     assert "source_url: https://example.com/wiki/spaces/ENG/pages/12345" in real_output
@@ -381,6 +383,90 @@ def test_stub_and_real_single_page_dry_runs_share_the_same_plan_shape(
     assert f"Manifest: {real_output_dir / 'manifest.json'}" in real_output
     assert "planned_action: would write" in real_output
     assert_dry_run_summary(real_output, would_write=1, would_skip=0)
+
+
+def test_real_single_page_dry_run_surfaces_active_tls_input_paths(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    from knowledge_adapters.confluence import client as client_module
+
+    def stub_real_fetch(*args: object, **kwargs: object) -> dict[str, object]:
+        del args, kwargs
+        return {
+            "canonical_id": "12345",
+            "title": "Real Page",
+            "content": "<p>Hello from Confluence.</p>",
+            "source_url": "https://example.com/wiki/spaces/ENG/pages/12345",
+            "page_version": 7,
+            "last_modified": "2026-04-20T12:34:56Z",
+        }
+
+    monkeypatch.setattr(client_module, "fetch_real_page", stub_real_fetch, raising=False)
+
+    exit_code = main(
+        _confluence_argv(
+            tmp_path / "out",
+            "--client-mode",
+            "real",
+            "--dry-run",
+            "--ca-bundle",
+            "/tmp/internal-ca.pem",
+            "--client-cert-file",
+            "/tmp/confluence-client.crt",
+            "--client-key-file",
+            "/tmp/confluence-client.key",
+        )
+    )
+
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    expected_ca_bundle = str(Path("/tmp/internal-ca.pem").resolve())
+    expected_client_cert = str(Path("/tmp/confluence-client.crt").resolve())
+    expected_client_key = str(Path("/tmp/confluence-client.key").resolve())
+    assert (
+        f"tls_inputs: ca_bundle={expected_ca_bundle}, "
+        f"client_cert_file={expected_client_cert}, "
+        f"client_key_file={expected_client_key}"
+    ) in output
+
+
+def test_real_single_page_dry_run_surfaces_env_tls_input_paths(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    from knowledge_adapters.confluence import client as client_module
+
+    def stub_real_fetch(*args: object, **kwargs: object) -> dict[str, object]:
+        del args, kwargs
+        return {
+            "canonical_id": "12345",
+            "title": "Real Page",
+            "content": "<p>Hello from Confluence.</p>",
+            "source_url": "https://example.com/wiki/spaces/ENG/pages/12345",
+            "page_version": 7,
+            "last_modified": "2026-04-20T12:34:56Z",
+        }
+
+    monkeypatch.setattr(client_module, "fetch_real_page", stub_real_fetch, raising=False)
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", "/tmp/env-ca.pem")
+    monkeypatch.setenv("CONFLUENCE_CLIENT_CERT_FILE", "/tmp/env-client.crt")
+    monkeypatch.setenv("CONFLUENCE_CLIENT_KEY_FILE", "/tmp/env-client.key")
+
+    exit_code = main(_confluence_argv(tmp_path / "out", "--client-mode", "real", "--dry-run"))
+
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    expected_ca_bundle = str(Path("/tmp/env-ca.pem").resolve())
+    expected_client_cert = str(Path("/tmp/env-client.crt").resolve())
+    expected_client_key = str(Path("/tmp/env-client.key").resolve())
+    assert (
+        f"tls_inputs: ca_bundle={expected_ca_bundle}, "
+        f"client_cert_file={expected_client_cert}, "
+        f"client_key_file={expected_client_key}"
+    ) in output
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Summary
- surface effective TLS input paths in Confluence real-mode plan output
- reuse the auth-layer fallback resolution so CLI visibility matches the active CA bundle and client cert inputs
- cover explicit-path, env-fallback, and default/env output in the real-mode contract tests

Closes #125

Testing
- make check