### PR TITLE
fix: support run selection ergonomics in runs.yaml

### DIFF
--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -68,6 +68,7 @@ LOCAL_FILES_HELP_EXAMPLES = """Examples:
 RUN_HELP_EXAMPLES = """Examples:
   knowledge-adapters run runs.yaml
   knowledge-adapters run ./configs/runs.yaml
+  knowledge-adapters run runs.yaml --only team-notes,docs-home
   knowledge-adapters run runs.yaml --continue-on-error
 """
 
@@ -97,6 +98,25 @@ def _parse_confluence_auth_method(value: str) -> str:
 
     supported_values = " or ".join(repr(method) for method in SUPPORTED_AUTH_METHODS)
     raise argparse.ArgumentTypeError(f"unsupported value {value!r}. Choose {supported_values}.")
+
+
+def _parse_only_run_names(value: str) -> tuple[str, ...]:
+    """Parse a comma-separated run selection list."""
+    parsed_names: list[str] = []
+    seen_names: set[str] = set()
+    for raw_name in value.split(","):
+        name = raw_name.strip()
+        if not name or name in seen_names:
+            continue
+        parsed_names.append(name)
+        seen_names.add(name)
+
+    if not parsed_names:
+        raise argparse.ArgumentTypeError(
+            "expected one or more comma-separated run names."
+        )
+
+    return tuple(parsed_names)
 
 
 def exit_with_output_error(
@@ -342,6 +362,16 @@ def build_parser() -> argparse.ArgumentParser:
         help="Path to a YAML config file containing a top-level runs: list.",
     )
     run_parser.add_argument(
+        "--only",
+        type=_parse_only_run_names,
+        metavar="RUN_NAMES",
+        help=(
+            "Run only the named config entries from runs.yaml, matched by run name "
+            "and still executed in config order. Explicit selection overrides "
+            "enabled: false for those named runs."
+        ),
+    )
+    run_parser.add_argument(
         "--continue-on-error",
         action="store_true",
         help=(
@@ -465,16 +495,34 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     if args.command == "run":
-        from knowledge_adapters.run_config import load_run_config
+        from knowledge_adapters.run_config import load_run_config, select_runs
 
         try:
             run_config = load_run_config(args.config_path)
+            selected_runs = select_runs(run_config, only_names=args.only)
         except ValueError as exc:
             exit_with_cli_error(str(exc), command="run")
+
+        skipped_disabled_runs = (
+            ()
+            if args.only is not None
+            else tuple(
+                configured_run
+                for configured_run in run_config.runs
+                if not configured_run.enabled
+            )
+        )
 
         print("Config-driven run invoked")
         print(f"  config_path: {render_user_path(run_config.config_path)}")
         print(f"  runs_in_config: {len(run_config.runs)}")
+        if args.only is not None:
+            print(f"  only: {', '.join(args.only)}")
+            print(f"  runs_selected: {len(selected_runs)}")
+        if skipped_disabled_runs:
+            print(f"  runs_skipped_disabled: {len(skipped_disabled_runs)}")
+            for configured_run in skipped_disabled_runs:
+                print(f"  skipped_disabled: {configured_run.name} ({configured_run.run_type})")
 
         completed_runs = 0
         failed_runs = 0
@@ -485,10 +533,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         total_would_write = 0
         total_would_skip = 0
 
-        for index, configured_run in enumerate(run_config.runs, start=1):
+        for index, configured_run in enumerate(selected_runs, start=1):
             display_command = shlex.join(("knowledge-adapters", *configured_run.argv))
             print(
-                f"\nRun {index}/{len(run_config.runs)}: "
+                f"\nRun {index}/{len(selected_runs)}: "
                 f"{configured_run.name} ({configured_run.run_type})"
             )
             print(f"  command: {display_command}")
@@ -563,6 +611,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         print("\nAggregate summary:")
         print(f"  runs_completed: {completed_runs}")
         print(f"  runs_failed: {failed_runs}")
+        print(f"  runs_skipped_disabled: {len(skipped_disabled_runs)}")
         print(f"  write_runs: {write_runs}")
         print(f"  dry_run_runs: {dry_run_runs}")
         print(f"  wrote: {total_wrote}")

--- a/src/knowledge_adapters/run_config.py
+++ b/src/knowledge_adapters/run_config.py
@@ -24,12 +24,15 @@ _CONFLUENCE_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
         "client_key_file",
         "debug",
         "dry_run",
+        "enabled",
         "max_depth",
         "target",
         "tree",
     }
 )
-_LOCAL_FILES_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset({"dry_run", "file_path"})
+_LOCAL_FILES_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
+    {"dry_run", "enabled", "file_path"}
+)
 
 
 @dataclass(frozen=True)
@@ -40,6 +43,7 @@ class ConfiguredRun:
     run_type: str
     argv: tuple[str, ...]
     dry_run: bool
+    enabled: bool = True
 
 
 @dataclass(frozen=True)
@@ -86,6 +90,33 @@ def load_run_config(config_path: str | Path) -> RunConfig:
     )
 
 
+def select_runs(
+    run_config: RunConfig,
+    *,
+    only_names: tuple[str, ...] | None = None,
+) -> tuple[ConfiguredRun, ...]:
+    """Select runs for execution, preserving config order."""
+    if only_names is None:
+        return tuple(configured_run for configured_run in run_config.runs if configured_run.enabled)
+
+    available_names = {configured_run.name for configured_run in run_config.runs}
+    missing_names = tuple(name for name in only_names if name not in available_names)
+    if missing_names:
+        missing = ", ".join(repr(name) for name in missing_names)
+        available = ", ".join(repr(configured_run.name) for configured_run in run_config.runs)
+        raise ValueError(
+            f"Unknown run name(s) for --only in {run_config.config_path}: {missing}. "
+            f"Available run names: {available}."
+        )
+
+    selected_names = frozenset(only_names)
+    return tuple(
+        configured_run
+        for configured_run in run_config.runs
+        if configured_run.name in selected_names
+    )
+
+
 def _parse_run(
     run_config: object,
     *,
@@ -115,7 +146,20 @@ def _parse_run(
             config_path=config_path,
             default=False,
         )
-        return ConfiguredRun(name=name, run_type=run_type, argv=argv, dry_run=dry_run)
+        enabled = _optional_bool(
+            run_config,
+            "enabled",
+            index=index,
+            config_path=config_path,
+            default=True,
+        )
+        return ConfiguredRun(
+            name=name,
+            run_type=run_type,
+            argv=argv,
+            dry_run=dry_run,
+            enabled=enabled,
+        )
 
     argv = _build_local_files_argv(run_config, name=name, config_path=config_path)
     dry_run = _optional_bool(
@@ -125,7 +169,20 @@ def _parse_run(
         config_path=config_path,
         default=False,
     )
-    return ConfiguredRun(name=name, run_type=run_type, argv=argv, dry_run=dry_run)
+    enabled = _optional_bool(
+        run_config,
+        "enabled",
+        index=index,
+        config_path=config_path,
+        default=True,
+    )
+    return ConfiguredRun(
+        name=name,
+        run_type=run_type,
+        argv=argv,
+        dry_run=dry_run,
+        enabled=enabled,
+    )
 
 
 def _build_confluence_argv(

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -183,6 +183,71 @@ runs:
     assert "Hello from config run." in local_output_path.read_text(encoding="utf-8")
 
 
+def test_run_cli_smoke_supports_only_and_disabled_runs(tmp_path: Path) -> None:
+    inputs_dir = tmp_path / "inputs"
+    inputs_dir.mkdir()
+    source_file = inputs_dir / "today.txt"
+    source_file.write_text("Hello from config run.\n", encoding="utf-8")
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: docs-home
+    type: confluence
+    base_url: https://example.com/wiki
+    target: "12345"
+    output_dir: ./artifacts/confluence/docs-home
+    enabled: false
+  - name: team-notes
+    type: local_files
+    file_path: ./inputs/today.txt
+    output_dir: ./artifacts/local/team-notes
+  - name: docs-tree
+    type: confluence
+    base_url: https://example.com/wiki
+    target: "67890"
+    output_dir: ./artifacts/confluence/docs-tree
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = _run_cli(tmp_path, "run", "./runs.yaml", "--only", "docs-tree,docs-home")
+
+    assert result.returncode == 0, result.stderr
+    assert "only: docs-tree, docs-home" in result.stdout
+    assert "runs_selected: 2" in result.stdout
+    assert "runs_skipped_disabled: 0" in result.stdout
+    assert "Run 1/2: docs-home (confluence)" in result.stdout
+    assert "Run 2/2: docs-tree (confluence)" in result.stdout
+    assert "Run 1/2: team-notes (local_files)" not in result.stdout
+    assert not (tmp_path / "artifacts" / "local" / "team-notes" / "pages" / "today.md").exists()
+
+
+def test_run_cli_smoke_rejects_unknown_only_name(tmp_path: Path) -> None:
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: team-notes
+    type: local_files
+    file_path: ./inputs/today.txt
+    output_dir: ./artifacts/local/team-notes
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = _run_cli(tmp_path, "run", "./runs.yaml", "--only", "missing-run")
+
+    assert result.returncode == 2
+    assert result.stdout == ""
+    assert (
+        "knowledge-adapters run: error: Unknown run name(s) for --only in "
+        f"{config_path.resolve()}: 'missing-run'. Available run names: 'team-notes'.\n"
+    ) == result.stderr
+
+
 def test_run_cli_smoke_rejects_invalid_confluence_config_before_execution(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -7,7 +7,7 @@ import pytest
 from pytest import CaptureFixture, MonkeyPatch
 
 from knowledge_adapters.cli import main
-from knowledge_adapters.run_config import ConfiguredRun, load_run_config
+from knowledge_adapters.run_config import ConfiguredRun, load_run_config, select_runs
 
 
 def test_load_run_config_resolves_relative_paths_from_config_location(tmp_path: Path) -> None:
@@ -81,6 +81,128 @@ runs:
 
     with pytest.raises(ValueError, match="unsupported keys"):
         load_run_config(config_path)
+
+
+def test_load_run_config_parses_enabled_flag(tmp_path: Path) -> None:
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: team-notes
+    type: local_files
+    file_path: ./notes.txt
+    output_dir: ./artifacts
+    enabled: false
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    run_config = load_run_config(config_path)
+
+    assert run_config.runs == (
+        ConfiguredRun(
+            name="team-notes",
+            run_type="local_files",
+            argv=(
+                "local_files",
+                "--file-path",
+                str((tmp_path / "notes.txt").resolve()),
+                "--output-dir",
+                str((tmp_path / "artifacts").resolve()),
+            ),
+            dry_run=False,
+            enabled=False,
+        ),
+    )
+
+
+def test_select_runs_skips_disabled_runs_by_default(tmp_path: Path) -> None:
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: docs-home
+    type: confluence
+    base_url: https://example.com/wiki
+    target: "12345"
+    output_dir: ./artifacts/confluence/docs-home
+    enabled: false
+  - name: team-notes
+    type: local_files
+    file_path: ./notes.txt
+    output_dir: ./artifacts/local/team-notes
+  - name: docs-tree
+    type: confluence
+    base_url: https://example.com/wiki
+    target: "67890"
+    output_dir: ./artifacts/confluence/docs-tree
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    run_config = load_run_config(config_path)
+
+    assert tuple(run.name for run in select_runs(run_config)) == ("team-notes", "docs-tree")
+
+
+def test_select_runs_only_named_runs_preserves_config_order_and_overrides_disabled(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: docs-home
+    type: confluence
+    base_url: https://example.com/wiki
+    target: "12345"
+    output_dir: ./artifacts/confluence/docs-home
+    enabled: false
+  - name: team-notes
+    type: local_files
+    file_path: ./notes.txt
+    output_dir: ./artifacts/local/team-notes
+  - name: docs-tree
+    type: confluence
+    base_url: https://example.com/wiki
+    target: "67890"
+    output_dir: ./artifacts/confluence/docs-tree
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    run_config = load_run_config(config_path)
+
+    assert tuple(
+        run.name
+        for run in select_runs(run_config, only_names=("docs-tree", "docs-home"))
+    ) == (
+        "docs-home",
+        "docs-tree",
+    )
+
+
+def test_select_runs_rejects_unknown_only_names(tmp_path: Path) -> None:
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: team-notes
+    type: local_files
+    file_path: ./notes.txt
+    output_dir: ./artifacts
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    run_config = load_run_config(config_path)
+
+    with pytest.raises(ValueError, match="Unknown run name\\(s\\) for --only"):
+        select_runs(run_config, only_names=("missing-run",))
 
 
 @pytest.mark.parametrize(
@@ -240,6 +362,104 @@ runs:
             "last_modified": "1970-01-01T00:00:00Z",
         }
     ]
+
+
+def test_run_command_skips_disabled_runs_by_default(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    source_file = tmp_path / "inputs" / "team-notes.txt"
+    source_file.parent.mkdir(parents=True)
+    source_file.write_text("Ship it.\n", encoding="utf-8")
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: docs-home
+    type: confluence
+    base_url: https://example.com/wiki
+    target: "12345"
+    output_dir: ./artifacts/confluence/docs-home
+    enabled: false
+  - name: team-notes
+    type: local_files
+    file_path: ./inputs/team-notes.txt
+    output_dir: ./artifacts/local/team-notes
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    exit_code = main(["run", str(config_path)])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "runs_skipped_disabled: 1" in captured.out
+    assert "skipped_disabled: docs-home (confluence)" in captured.out
+    assert "Run 1/1: team-notes (local_files)" in captured.out
+    assert "Run 1/1: docs-home (confluence)" not in captured.out
+    assert "runs_completed: 1" in captured.out
+
+    local_output_path = (
+        tmp_path / "artifacts" / "local" / "team-notes" / "pages" / "team-notes.md"
+    )
+    assert local_output_path.exists()
+    disabled_output_path = (
+        tmp_path / "artifacts" / "confluence" / "docs-home" / "pages" / "12345.md"
+    )
+    assert not disabled_output_path.exists()
+
+
+def test_run_command_only_runs_selected_names_in_config_order_and_overrides_disabled(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    source_file = tmp_path / "inputs" / "team-notes.txt"
+    source_file.parent.mkdir(parents=True)
+    source_file.write_text("Ship it.\n", encoding="utf-8")
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: docs-home
+    type: confluence
+    base_url: https://example.com/wiki
+    target: "12345"
+    output_dir: ./artifacts/confluence/docs-home
+    enabled: false
+  - name: team-notes
+    type: local_files
+    file_path: ./inputs/team-notes.txt
+    output_dir: ./artifacts/local/team-notes
+  - name: docs-tree
+    type: confluence
+    base_url: https://example.com/wiki
+    target: "67890"
+    output_dir: ./artifacts/confluence/docs-tree
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    exit_code = main(["run", str(config_path), "--only", "docs-tree,docs-home"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "only: docs-tree, docs-home" in captured.out
+    assert "runs_selected: 2" in captured.out
+    assert "runs_skipped_disabled: 0" in captured.out
+    assert "Run 1/2: docs-home (confluence)" in captured.out
+    assert "Run 2/2: docs-tree (confluence)" in captured.out
+    assert "Run 1/2: team-notes (local_files)" not in captured.out
+
+    disabled_output_path = (
+        tmp_path / "artifacts" / "confluence" / "docs-home" / "pages" / "12345.md"
+    )
+    assert disabled_output_path.exists()
+    non_selected_output_path = (
+        tmp_path / "artifacts" / "local" / "team-notes" / "pages" / "team-notes.md"
+    )
+    assert not non_selected_output_path.exists()
 
 
 def test_run_command_reports_dry_run_counts(


### PR DESCRIPTION
Summary
- add --only run selection by config name
- support enabled: false with explicit selection override and skip reporting
- cover selection, disabled, and unknown-name behavior in unit and smoke tests

Testing
- make check

Closes #132
Closes #133