### PR TITLE
fix: harden Confluence TLS preflight and stub warnings

### DIFF
--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -79,6 +79,12 @@ _DRY_RUN_SUMMARY_RE = re.compile(
 _DRY_RUN_BLOCK_WRITE_RE = re.compile(r"would_write: (?P<wrote>\d+)")
 _DRY_RUN_BLOCK_SKIP_RE = re.compile(r"would_skip: (?P<skipped>\d+)")
 _CLI_ERROR_RE = re.compile(r"^knowledge-adapters (?P<command>\S+): error: (?P<message>.+)$")
+_CONFLUENCE_REAL_ONLY_INPUT_FLAGS = (
+    "--auth-method",
+    "--ca-bundle",
+    "--client-cert-file",
+    "--client-key-file",
+)
 
 
 @dataclass(frozen=True)
@@ -491,8 +497,9 @@ def _build_configured_run_failure(
 
 def main(argv: Sequence[str] | None = None) -> int:
     """Run the CLI."""
+    raw_argv = tuple(sys.argv[1:] if argv is None else argv)
     parser = build_parser()
-    args = parser.parse_args(argv)
+    args = parser.parse_args(raw_argv)
 
     if args.command == "run":
         from knowledge_adapters.run_config import load_run_config, select_runs
@@ -641,7 +648,11 @@ def main(argv: Sequence[str] | None = None) -> int:
             fetch_real_page_summary,
             list_real_child_page_ids,
         )
-        from knowledge_adapters.confluence.config import ConfluenceConfig
+        from knowledge_adapters.confluence.config import (
+            ConfluenceConfig,
+            validate_explicit_tls_paths,
+            validate_selected_real_tls_paths,
+        )
         from knowledge_adapters.confluence.incremental import (
             PageSyncDecision,
             classify_page_sync,
@@ -688,6 +699,16 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "--max-depth must be greater than or equal to 0.",
                 command="confluence",
             )
+        try:
+            validate_explicit_tls_paths(
+                ca_bundle=confluence_config.ca_bundle,
+                client_cert_file=confluence_config.client_cert_file,
+                client_key_file=confluence_config.client_key_file,
+            )
+            if confluence_config.client_mode == "real":
+                validate_selected_real_tls_paths(confluence_config)
+        except ValueError as exc:
+            exit_with_cli_error(str(exc), command="confluence")
 
         try:
             target = resolve_target_for_base_url(
@@ -752,6 +773,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             return f"root + descendants through depth {max_depth}"
 
         def _print_confluence_invocation() -> None:
+            ignored_inputs = tuple(
+                flag for flag in _CONFLUENCE_REAL_ONLY_INPUT_FLAGS if flag in raw_argv
+            )
             content_source = (
                 "scaffolded page content"
                 if confluence_config.client_mode == "stub"
@@ -776,6 +800,11 @@ def main(argv: Sequence[str] | None = None) -> int:
                 if confluence_config.dry_run:
                     max_depth = f"{max_depth} ({_describe_tree_depth(confluence_config.max_depth)})"
                 print(f"  max_depth: {max_depth}")
+            if confluence_config.client_mode == "stub" and ignored_inputs:
+                print(
+                    "  warning: stub mode ignores real-mode Confluence inputs: "
+                    f"{', '.join(ignored_inputs)}. Use --client-mode real to apply them."
+                )
             if confluence_config.client_mode == "real":
                 resolved_tls_inputs = resolve_tls_inputs(
                     ca_bundle=confluence_config.ca_bundle,

--- a/src/knowledge_adapters/confluence/config.py
+++ b/src/knowledge_adapters/confluence/config.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
+
+from knowledge_adapters.confluence.auth import resolve_tls_inputs
 
 
 @dataclass(frozen=True)
@@ -21,3 +24,78 @@ class ConfluenceConfig:
     dry_run: bool = False
     tree: bool = False
     max_depth: int = 0
+
+
+_TLS_INPUT_OPTION_NAMES = {
+    "ca_bundle": "--ca-bundle",
+    "client_cert_file": "--client-cert-file",
+    "client_key_file": "--client-key-file",
+}
+
+_TLS_INPUT_ENV_NAMES = {
+    "ca_bundle": ("REQUESTS_CA_BUNDLE", "SSL_CERT_FILE"),
+    "client_cert_file": ("CONFLUENCE_CLIENT_CERT_FILE",),
+    "client_key_file": ("CONFLUENCE_CLIENT_KEY_FILE",),
+}
+
+
+def validate_explicit_tls_paths(
+    *,
+    ca_bundle: str | None = None,
+    client_cert_file: str | None = None,
+    client_key_file: str | None = None,
+) -> None:
+    """Fail fast when explicit TLS/client-certificate file paths do not exist."""
+    for field_name, path_value in (
+        ("ca_bundle", ca_bundle),
+        ("client_cert_file", client_cert_file),
+        ("client_key_file", client_key_file),
+    ):
+        if path_value is None:
+            continue
+        _validate_path_exists(
+            field_name=field_name,
+            path_value=path_value,
+            source_hint=_TLS_INPUT_OPTION_NAMES[field_name],
+        )
+
+
+def validate_selected_real_tls_paths(config: ConfluenceConfig) -> None:
+    """Fail fast when real-mode TLS/client-certificate file paths do not exist."""
+    resolved_tls_inputs = resolve_tls_inputs(
+        ca_bundle=config.ca_bundle,
+        client_cert_file=config.client_cert_file,
+        client_key_file=config.client_key_file,
+    )
+    for field_name in _TLS_INPUT_OPTION_NAMES:
+        path_value = getattr(resolved_tls_inputs, field_name)
+        if path_value is None:
+            continue
+
+        explicit_value = getattr(config, field_name)
+        source_hint = (
+            _TLS_INPUT_OPTION_NAMES[field_name]
+            if explicit_value is not None
+            else " or ".join(_TLS_INPUT_ENV_NAMES[field_name])
+        )
+        _validate_path_exists(
+            field_name=field_name,
+            path_value=path_value,
+            source_hint=source_hint,
+        )
+
+
+def _validate_path_exists(
+    *,
+    field_name: str,
+    path_value: str,
+    source_hint: str,
+) -> None:
+    resolved_path = Path(path_value).expanduser().resolve()
+    if resolved_path.exists():
+        return
+
+    raise ValueError(
+        f"Confluence TLS/client-certificate path for {field_name!r} does not exist: "
+        f"{resolved_path}. Check {source_hint}."
+    )

--- a/src/knowledge_adapters/run_config.py
+++ b/src/knowledge_adapters/run_config.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import yaml  # type: ignore[import-untyped]
 
 from knowledge_adapters.confluence.auth import SUPPORTED_AUTH_METHODS
+from knowledge_adapters.confluence.config import validate_explicit_tls_paths
 from knowledge_adapters.confluence.resolve import resolve_target_for_base_url, validate_base_url
 
 SUPPORTED_RUN_TYPES = frozenset({"confluence", "local_files"})
@@ -251,19 +252,19 @@ def _build_confluence_argv(
         argv.extend(["--auth-method", auth_method])
 
     ca_bundle = _optional_string(run_config, "ca_bundle", index=index, config_path=config_path)
-    if ca_bundle is not None:
-        argv.extend(
-            [
-                "--ca-bundle",
-                _resolve_path_string(ca_bundle, config_path=config_path),
-            ]
-        )
-
+    resolved_ca_bundle = (
+        _resolve_path_string(ca_bundle, config_path=config_path) if ca_bundle is not None else None
+    )
     client_cert_file = _optional_string(
         run_config,
         "client_cert_file",
         index=index,
         config_path=config_path,
+    )
+    resolved_client_cert_file = (
+        _resolve_path_string(client_cert_file, config_path=config_path)
+        if client_cert_file is not None
+        else None
     )
     client_key_file = _optional_string(
         run_config,
@@ -271,23 +272,44 @@ def _build_confluence_argv(
         index=index,
         config_path=config_path,
     )
+    resolved_client_key_file = (
+        _resolve_path_string(client_key_file, config_path=config_path)
+        if client_key_file is not None
+        else None
+    )
     if client_key_file is not None and client_cert_file is None:
         raise ValueError(
             f"Run {name!r} in {config_path} must set 'client_cert_file' when "
             "'client_key_file' is provided."
         )
-    if client_cert_file is not None:
+    try:
+        validate_explicit_tls_paths(
+            ca_bundle=resolved_ca_bundle,
+            client_cert_file=resolved_client_cert_file,
+            client_key_file=resolved_client_key_file,
+        )
+    except ValueError as exc:
+        raise ValueError(f"Run {name!r} in {config_path}: {exc}") from exc
+
+    if resolved_ca_bundle is not None:
+        argv.extend(
+            [
+                "--ca-bundle",
+                resolved_ca_bundle,
+            ]
+        )
+    if resolved_client_cert_file is not None:
         argv.extend(
             [
                 "--client-cert-file",
-                _resolve_path_string(client_cert_file, config_path=config_path),
+                resolved_client_cert_file,
             ]
         )
-    if client_key_file is not None:
+    if resolved_client_key_file is not None:
         argv.extend(
             [
                 "--client-key-file",
-                _resolve_path_string(client_key_file, config_path=config_path),
+                resolved_client_key_file,
             ]
         )
 

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -347,6 +347,7 @@ def test_confluence_cli_smoke_uses_installed_entrypoint_with_default_stub_client
     assert "content_source: scaffolded page content" in result.stdout
     assert "fetch_scope: page" in result.stdout
     assert "run_mode: write" in result.stdout
+    assert "warning: stub mode ignores real-mode Confluence inputs:" not in result.stdout
     assert "Plan: Confluence run" in result.stdout
     assert "resolved_page_id: 12345" in result.stdout
     assert "Artifact:" in result.stdout
@@ -413,6 +414,89 @@ def test_confluence_cli_tree_dry_run_with_stub_client_reports_discovery_limit(
         "note: stub mode does not support descendant discovery; use --client-mode real "
         "to discover descendants from Confluence."
     ) in result.stdout
+
+
+def test_confluence_cli_stub_mode_warns_when_real_only_inputs_are_ignored(
+    tmp_path: Path,
+) -> None:
+    ca_bundle = tmp_path / "internal-ca.pem"
+    ca_bundle.write_text("ca\n", encoding="utf-8")
+
+    result = _run_cli(
+        tmp_path,
+        "confluence",
+        "--base-url",
+        "https://example.com/wiki",
+        "--target",
+        "12345",
+        "--output-dir",
+        "./artifacts",
+        "--auth-method",
+        "client-cert-env",
+        "--ca-bundle",
+        str(ca_bundle),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (
+        "warning: stub mode ignores real-mode Confluence inputs: --auth-method, "
+        "--ca-bundle. Use --client-mode real to apply them."
+    ) in result.stdout
+
+
+def test_run_cli_smoke_surfaces_stub_mode_warning_for_ignored_confluence_real_inputs(
+    tmp_path: Path,
+) -> None:
+    certs_dir = tmp_path / "certs"
+    certs_dir.mkdir()
+    (certs_dir / "internal-ca.pem").write_text("ca\n", encoding="utf-8")
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: docs-home
+    type: confluence
+    base_url: https://example.com/wiki
+    target: "12345"
+    output_dir: ./artifacts/confluence/docs-home
+    auth_method: client-cert-env
+    ca_bundle: ./certs/internal-ca.pem
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = _run_cli(tmp_path, "run", "./runs.yaml")
+
+    assert result.returncode == 0, result.stderr
+    assert (
+        "warning: stub mode ignores real-mode Confluence inputs: --auth-method, "
+        "--ca-bundle. Use --client-mode real to apply them."
+    ) in result.stdout
+
+
+def test_confluence_cli_rejects_missing_tls_path_before_execution(
+    tmp_path: Path,
+) -> None:
+    missing_ca_bundle = tmp_path / "missing-ca.pem"
+
+    result = _run_cli(
+        tmp_path,
+        "confluence",
+        "--base-url",
+        "https://example.com/wiki",
+        "--target",
+        "12345",
+        "--output-dir",
+        "./artifacts",
+        "--ca-bundle",
+        str(missing_ca_bundle),
+    )
+
+    assert result.returncode == 2
+    assert result.stdout == ""
+    assert "does not exist" in result.stderr
+    assert str(missing_ca_bundle.resolve()) in result.stderr
 
 
 def test_confluence_help_lists_supported_auth_methods_and_examples(

--- a/tests/test_confluence_real_client_contract.py
+++ b/tests/test_confluence_real_client_contract.py
@@ -404,6 +404,12 @@ def test_real_single_page_dry_run_surfaces_active_tls_input_paths(
         }
 
     monkeypatch.setattr(client_module, "fetch_real_page", stub_real_fetch, raising=False)
+    ca_bundle = tmp_path / "internal-ca.pem"
+    client_cert = tmp_path / "confluence-client.crt"
+    client_key = tmp_path / "confluence-client.key"
+    ca_bundle.write_text("ca\n", encoding="utf-8")
+    client_cert.write_text("cert\n", encoding="utf-8")
+    client_key.write_text("key\n", encoding="utf-8")
 
     exit_code = main(
         _confluence_argv(
@@ -412,19 +418,19 @@ def test_real_single_page_dry_run_surfaces_active_tls_input_paths(
             "real",
             "--dry-run",
             "--ca-bundle",
-            "/tmp/internal-ca.pem",
+            str(ca_bundle),
             "--client-cert-file",
-            "/tmp/confluence-client.crt",
+            str(client_cert),
             "--client-key-file",
-            "/tmp/confluence-client.key",
+            str(client_key),
         )
     )
 
     assert exit_code == 0
     output = capsys.readouterr().out
-    expected_ca_bundle = str(Path("/tmp/internal-ca.pem").resolve())
-    expected_client_cert = str(Path("/tmp/confluence-client.crt").resolve())
-    expected_client_key = str(Path("/tmp/confluence-client.key").resolve())
+    expected_ca_bundle = str(ca_bundle.resolve())
+    expected_client_cert = str(client_cert.resolve())
+    expected_client_key = str(client_key.resolve())
     assert (
         f"tls_inputs: ca_bundle={expected_ca_bundle}, "
         f"client_cert_file={expected_client_cert}, "
@@ -451,22 +457,49 @@ def test_real_single_page_dry_run_surfaces_env_tls_input_paths(
         }
 
     monkeypatch.setattr(client_module, "fetch_real_page", stub_real_fetch, raising=False)
-    monkeypatch.setenv("REQUESTS_CA_BUNDLE", "/tmp/env-ca.pem")
-    monkeypatch.setenv("CONFLUENCE_CLIENT_CERT_FILE", "/tmp/env-client.crt")
-    monkeypatch.setenv("CONFLUENCE_CLIENT_KEY_FILE", "/tmp/env-client.key")
+    env_ca_bundle = tmp_path / "env-ca.pem"
+    env_client_cert = tmp_path / "env-client.crt"
+    env_client_key = tmp_path / "env-client.key"
+    env_ca_bundle.write_text("ca\n", encoding="utf-8")
+    env_client_cert.write_text("cert\n", encoding="utf-8")
+    env_client_key.write_text("key\n", encoding="utf-8")
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", str(env_ca_bundle))
+    monkeypatch.setenv("CONFLUENCE_CLIENT_CERT_FILE", str(env_client_cert))
+    monkeypatch.setenv("CONFLUENCE_CLIENT_KEY_FILE", str(env_client_key))
 
     exit_code = main(_confluence_argv(tmp_path / "out", "--client-mode", "real", "--dry-run"))
 
     assert exit_code == 0
     output = capsys.readouterr().out
-    expected_ca_bundle = str(Path("/tmp/env-ca.pem").resolve())
-    expected_client_cert = str(Path("/tmp/env-client.crt").resolve())
-    expected_client_key = str(Path("/tmp/env-client.key").resolve())
+    expected_ca_bundle = str(env_ca_bundle.resolve())
+    expected_client_cert = str(env_client_cert.resolve())
+    expected_client_key = str(env_client_key.resolve())
     assert (
         f"tls_inputs: ca_bundle={expected_ca_bundle}, "
         f"client_cert_file={expected_client_cert}, "
         f"client_key_file={expected_client_key}"
     ) in output
+
+
+def test_real_client_cli_rejects_missing_env_selected_ca_bundle_before_request(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    from knowledge_adapters.confluence import client as client_module
+
+    def fail_if_real_fetch_runs(*args: object, **kwargs: object) -> dict[str, object]:
+        raise AssertionError("real fetch should not run when the selected CA bundle is missing")
+
+    monkeypatch.setattr(client_module, "fetch_real_page", fail_if_real_fetch_runs, raising=False)
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", str(tmp_path / "missing-env-ca.pem"))
+
+    with pytest.raises(SystemExit, match="2"):
+        main(_confluence_argv(tmp_path / "out", "--client-mode", "real"))
+
+    captured = capsys.readouterr()
+    assert "does not exist" in captured.err
+    assert "REQUESTS_CA_BUNDLE or SSL_CERT_FILE" in captured.err
 
 
 @pytest.mark.parametrize(
@@ -1545,6 +1578,8 @@ def test_real_client_cli_passes_ca_bundle_to_real_fetch(
     from knowledge_adapters.confluence import client as client_module
 
     observed_ca_bundles: list[str | None] = []
+    ca_bundle = tmp_path / "internal-ca.pem"
+    ca_bundle.write_text("ca\n", encoding="utf-8")
 
     def stub_real_fetch(*args: object, **kwargs: object) -> dict[str, object]:
         del args
@@ -1566,9 +1601,9 @@ def test_real_client_cli_passes_ca_bundle_to_real_fetch(
             "--client-mode",
             "real",
             "--ca-bundle",
-            "/tmp/internal-ca.pem",
+            str(ca_bundle),
         )
     )
 
     assert exit_code == 0
-    assert observed_ca_bundles == ["/tmp/internal-ca.pem"]
+    assert observed_ca_bundles == [str(ca_bundle)]

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -633,6 +633,11 @@ runs:
 
 
 def test_load_run_config_includes_confluence_tls_and_client_cert_paths(tmp_path: Path) -> None:
+    certs_dir = tmp_path / "certs"
+    certs_dir.mkdir()
+    (certs_dir / "internal-ca.pem").write_text("ca\n", encoding="utf-8")
+    (certs_dir / "confluence-client.crt").write_text("cert\n", encoding="utf-8")
+    (certs_dir / "confluence-client.key").write_text("key\n", encoding="utf-8")
     config_path = tmp_path / "runs.yaml"
     config_path.write_text(
         """
@@ -698,6 +703,28 @@ runs:
         load_run_config(config_path)
 
 
+def test_load_run_config_rejects_missing_confluence_tls_path_before_execution(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: docs-home
+    type: confluence
+    base_url: https://example.com/wiki
+    target: "12345"
+    output_dir: ./artifacts/confluence/docs-home
+    ca_bundle: ./certs/missing-ca.pem
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="ca_bundle"):
+        load_run_config(config_path)
+
+
 def test_run_command_passes_confluence_tls_config_to_real_client(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -719,6 +746,11 @@ def test_run_command_passes_confluence_tls_config_to_real_client(
         }
 
     monkeypatch.setattr(client_module, "fetch_real_page", stub_real_fetch, raising=False)
+    certs_dir = tmp_path / "certs"
+    certs_dir.mkdir()
+    (certs_dir / "internal-ca.pem").write_text("ca\n", encoding="utf-8")
+    (certs_dir / "confluence-client.crt").write_text("cert\n", encoding="utf-8")
+    (certs_dir / "confluence-client.key").write_text("key\n", encoding="utf-8")
     config_path = tmp_path / "runs.yaml"
     config_path.write_text(
         """


### PR DESCRIPTION
Summary
- fail early when explicit or selected Confluence TLS/client-certificate paths do not exist
- warn once when stub mode ignores explicit real-mode auth or TLS inputs
- cover run-config loading, direct CLI preflight, and config-driven runs with targeted tests

Testing
- make check

Closes #136
Closes #134