### PR TITLE
fix: report stale artifacts after Confluence tree sync

### DIFF
--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -656,6 +656,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         from knowledge_adapters.confluence.incremental import (
             PageSyncDecision,
             classify_page_sync,
+            find_stale_artifacts,
             load_previous_manifest_index,
         )
         from knowledge_adapters.confluence.manifest import (
@@ -920,9 +921,10 @@ def main(argv: Sequence[str] | None = None) -> int:
             unchanged_count: int,
             write_count: int,
             skip_count: int,
+            stale_count: int | None = None,
         ) -> None:
             descendant_count = max(total_pages - 1, 0)
-            summary_lines = (
+            summary_lines = [
                 f"    mode: {mode}",
                 "    pages_in_plan: "
                 f"{total_pages} (root 1, descendants {descendant_count})",
@@ -931,7 +933,9 @@ def main(argv: Sequence[str] | None = None) -> int:
                 f"    unchanged_pages: {unchanged_count}",
                 f"    would_write: {write_count}",
                 f"    would_skip: {skip_count}",
-            )
+            ]
+            if stale_count is not None:
+                summary_lines.append(f"    stale_artifacts: {stale_count}")
             print("  Summary:")
             for line in summary_lines:
                 print(line)
@@ -943,13 +947,34 @@ def main(argv: Sequence[str] | None = None) -> int:
             unchanged_count: int,
             write_count: int,
             skip_count: int,
+            stale_count: int | None = None,
         ) -> None:
             print(f"\nSummary: wrote {write_count}, skipped {skip_count}")
             print(f"  new_pages: {new_count}")
             print(f"  changed_pages: {changed_count}")
             print(f"  unchanged_pages: {unchanged_count}")
+            if stale_count is not None:
+                print(f"  stale_artifacts: {stale_count}")
             print(f"  pages_written: {write_count}")
             print(f"  pages_skipped: {skip_count}")
+
+        def _print_stale_artifacts(
+            stale_artifacts: list[tuple[str, str]],
+        ) -> None:
+            if not stale_artifacts:
+                return
+
+            stale_preview_limit = 5
+            print("  Stale artifacts:")
+            for canonical_id, relative_output_path in stale_artifacts[:stale_preview_limit]:
+                print(
+                    "    "
+                    f"{_display_output_path(output_dir / relative_output_path)} "
+                    f"(canonical_id: {canonical_id})"
+                )
+            remaining_count = len(stale_artifacts) - stale_preview_limit
+            if remaining_count > 0:
+                print(f"    ... and {remaining_count} more")
 
         def _print_stub_tree_mode_note() -> None:
             if not (confluence_config.tree and confluence_config.client_mode == "stub"):
@@ -1001,6 +1026,21 @@ def main(argv: Sequence[str] | None = None) -> int:
                 )
                 action = "skip" if page_decision.status == "unchanged" else "write"
                 page_records.append((page, output_path, page_decision, action))
+            stale_artifacts = [
+                (artifact.canonical_id, artifact.output_path)
+                for artifact in find_stale_artifacts(
+                    confluence_config.output_dir,
+                    previous_manifest_index,
+                    current_page_ids=[
+                        str(page.get("canonical_id") or "")
+                        for page, _output_path, _page_decision, _action in page_records
+                    ],
+                    current_output_paths=[
+                        output_path.relative_to(Path(confluence_config.output_dir)).as_posix()
+                        for _page, output_path, _page_decision, _action in page_records
+                    ],
+                )
+            ]
 
             write_count = sum(
                 1
@@ -1037,7 +1077,9 @@ def main(argv: Sequence[str] | None = None) -> int:
                     unchanged_count=unchanged_count,
                     write_count=write_count,
                     skip_count=skip_count,
+                    stale_count=len(stale_artifacts),
                 )
+                _print_stale_artifacts(stale_artifacts)
                 for _page, output_path, page_decision, action in page_records:
                     print(
                         "  would "
@@ -1118,7 +1160,9 @@ def main(argv: Sequence[str] | None = None) -> int:
                 unchanged_count=unchanged_count,
                 write_count=write_count,
                 skip_count=skip_count,
+                stale_count=len(stale_artifacts),
             )
+            _print_stale_artifacts(stale_artifacts)
             print(f"Manifest: {_display_output_path(manifest)}")
             print_write_complete(output_dir)
             return 0

--- a/src/knowledge_adapters/confluence/incremental.py
+++ b/src/knowledge_adapters/confluence/incremental.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Mapping
+from collections.abc import Collection, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
@@ -30,6 +30,14 @@ class PageSyncDecision:
 
     status: PageSyncStatus
     rewrite_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class StaleArtifact:
+    """Previously written artifact no longer discovered in the current tree run."""
+
+    canonical_id: str
+    output_path: str
 
 
 def _normalize_metadata_value(value: object) -> str | None:
@@ -120,6 +128,45 @@ def load_previous_manifest_output_index(output_dir: str) -> dict[str, str] | Non
         return None
 
     return indexes[1]
+
+
+def find_stale_artifacts(
+    output_dir: str,
+    previous_manifest_index: dict[str, PreviousManifestEntry] | None,
+    *,
+    current_page_ids: Collection[str],
+    current_output_paths: Collection[str],
+) -> list[StaleArtifact]:
+    """Return prior manifest artifacts no longer discovered and still present on disk."""
+    if previous_manifest_index is None:
+        return []
+
+    discovered_ids = frozenset(current_page_ids)
+    current_paths = frozenset(current_output_paths)
+    output_dir_path = Path(output_dir)
+    stale_artifacts: list[StaleArtifact] = []
+
+    for canonical_id, prior_entry in sorted(
+        previous_manifest_index.items(),
+        key=lambda item: (item[1].output_path, item[0]),
+    ):
+        if canonical_id in discovered_ids:
+            continue
+        if prior_entry.output_path in current_paths:
+            continue
+
+        artifact_path = output_dir_path / prior_entry.output_path
+        if not artifact_path.exists():
+            continue
+
+        stale_artifacts.append(
+            StaleArtifact(
+                canonical_id=canonical_id,
+                output_path=prior_entry.output_path,
+            )
+        )
+
+    return stale_artifacts
 
 
 def classify_page_sync(

--- a/tests/cli_output_assertions.py
+++ b/tests/cli_output_assertions.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
+from pathlib import Path
+
 
 def normalize_whitespace(text: str) -> str:
     return " ".join(text.split())
@@ -7,6 +10,22 @@ def normalize_whitespace(text: str) -> str:
 
 def assert_contains_normalized(output: str, expected: str) -> None:
     assert normalize_whitespace(expected) in normalize_whitespace(output)
+
+
+def assert_stale_artifacts(
+    output: str,
+    *,
+    count: int,
+    artifact_paths: Iterable[Path] = (),
+) -> None:
+    assert f"stale_artifacts: {count}" in output
+    if count == 0:
+        assert "Stale artifacts:" not in output
+        return
+
+    assert "Stale artifacts:" in output
+    for path in artifact_paths:
+        assert_contains_normalized(output, str(path))
 
 
 def assert_dry_run_summary(
@@ -42,6 +61,7 @@ def assert_write_summary(
     new_pages: int | None = None,
     changed_pages: int | None = None,
     unchanged_pages: int | None = None,
+    stale_artifacts: int | None = None,
 ) -> None:
     normalized = normalize_whitespace(output)
     if f"Summary: wrote {wrote}, skipped {skipped}" in normalized:
@@ -62,6 +82,8 @@ def assert_write_summary(
         assert f"changed_pages: {changed_pages}" in output
     if unchanged_pages is not None:
         assert f"unchanged_pages: {unchanged_pages}" in output
+    if stale_artifacts is not None:
+        assert f"stale_artifacts: {stale_artifacts}" in output
     if any(value is not None for value in (new_pages, changed_pages, unchanged_pages)):
         assert f"pages_written: {wrote}" in output
         assert f"pages_skipped: {skipped}" in output

--- a/tests/confluence_output_assertions.py
+++ b/tests/confluence_output_assertions.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from tests.cli_output_assertions import (
     assert_contains_normalized,
     assert_dry_run_summary,
+    assert_stale_artifacts,
     assert_tree_plan_page_count,
 )
 
@@ -58,6 +59,8 @@ def assert_tree_confluence_dry_run_summary(
     content_source: str = "scaffolded page content",
     auth_method: str | None = None,
     planned_actions: Iterable[tuple[str, Path]] = (),
+    stale_count: int = 0,
+    stale_artifact_paths: Iterable[Path] = (),
 ) -> None:
     assert "Confluence adapter invoked" in output
     assert f"client_mode: {client_mode}" in output
@@ -75,6 +78,11 @@ def assert_tree_confluence_dry_run_summary(
     assert_contains_normalized(output, f"Manifest: {manifest_path}")
     assert_tree_plan_page_count(output, count=unique_pages)
     assert_dry_run_summary(output, would_write=write_count, would_skip=skip_count)
+    assert_stale_artifacts(
+        output,
+        count=stale_count,
+        artifact_paths=stale_artifact_paths,
+    )
     for action, path in planned_actions:
         assert_contains_normalized(output, f"would {action} {path}")
     assert "Dry run complete. No files written." in output

--- a/tests/test_confluence_incremental_contract.py
+++ b/tests/test_confluence_incremental_contract.py
@@ -11,6 +11,7 @@ from knowledge_adapters.cli import main
 from knowledge_adapters.confluence.models import ResolvedTarget
 from tests.cli_output_assertions import (
     assert_dry_run_summary,
+    assert_stale_artifacts,
     assert_tree_plan_page_count,
     assert_write_summary,
 )
@@ -328,6 +329,64 @@ def test_incremental_dry_run_reports_both_would_write_and_would_skip_without_wri
     assert _manifest_path(output_dir).read_text(encoding="utf-8") == original_manifest
 
 
+def test_incremental_dry_run_reports_stale_artifacts_without_modifying_them(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    output_dir = tmp_path / "out"
+    original_manifest = _write_previous_manifest(
+        output_dir,
+        [
+            _manifest_entry_for_page("100"),
+            {
+                "canonical_id": "777",
+                "source_url": "https://example.com/wiki/pages/777",
+                "output_path": "pages/legacy-child.md",
+            },
+        ],
+        root_page_id="100",
+    )
+    existing_page = _page_path(output_dir, "100")
+    stale_page = output_dir / "pages" / "legacy-child.md"
+    for path, contents in [
+        (existing_page, "already written\n"),
+        (stale_page, "legacy artifact\n"),
+    ]:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(contents, encoding="utf-8")
+
+    exit_code, _ = _run_recursive_cli(
+        tmp_path,
+        monkeypatch,
+        dry_run=True,
+    )
+
+    assert exit_code == 0
+
+    captured = capsys.readouterr()
+    assert_tree_confluence_dry_run_summary(
+        captured.out,
+        root_page_id="100",
+        manifest_path=_manifest_path(output_dir),
+        max_depth=1,
+        unique_pages=2,
+        write_count=1,
+        skip_count=1,
+        stale_count=1,
+        stale_artifact_paths=[stale_page],
+    )
+    assert_stale_artifacts(
+        captured.out,
+        count=1,
+        artifact_paths=[stale_page],
+    )
+    assert stale_page.read_text(encoding="utf-8") == "legacy artifact\n"
+    assert existing_page.read_text(encoding="utf-8") == "already written\n"
+    assert not _page_path(output_dir, "200").exists()
+    assert _manifest_path(output_dir).read_text(encoding="utf-8") == original_manifest
+
+
 def test_incremental_normal_run_manifest_includes_written_and_skipped_pages(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -611,6 +670,12 @@ def test_incremental_normal_run_handles_larger_mixed_write_and_skip_set(
         new_pages=2,
         changed_pages=0,
         unchanged_pages=2,
+        stale_artifacts=1,
+    )
+    assert_stale_artifacts(
+        captured.out,
+        count=1,
+        artifact_paths=[_page_path(output_dir, "999")],
     )
 
 
@@ -760,6 +825,12 @@ def test_incremental_output_directory_reuse_handles_overlapping_and_new_pages(
         new_pages=2,
         changed_pages=0,
         unchanged_pages=1,
+        stale_artifacts=1,
+    )
+    assert_stale_artifacts(
+        captured.out,
+        count=1,
+        artifact_paths=[unrelated_page],
     )
 
 


### PR DESCRIPTION
Summary
- report stale Confluence tree artifacts when prior manifest entries are no longer discovered and the old artifact still exists on disk
- keep stale reporting concise by adding a count to tree summaries and listing only a short preview of stale artifact paths
- preserve existing write, skip, and single-page behavior while covering the new contract in incremental tests

Testing
- make check

Closes #135