### PR TITLE
feat: add progress output for long-running runs

### DIFF
--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -11,6 +11,7 @@ from collections.abc import Callable, Sequence
 from contextlib import redirect_stderr, redirect_stdout
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TextIO
 
 from knowledge_adapters.confluence.auth import SUPPORTED_AUTH_METHODS, resolve_tls_inputs
 
@@ -94,6 +95,22 @@ class MultiRunSummary:
     dry_run: bool
     wrote: int
     skipped: int
+
+
+class _TeeStream:
+    """Write nested CLI stdout both live and into an in-memory buffer."""
+
+    def __init__(self, *streams: TextIO) -> None:
+        self._streams = streams
+
+    def write(self, text: str) -> int:
+        for stream in self._streams:
+            stream.write(text)
+        return len(text)
+
+    def flush(self) -> None:
+        for stream in self._streams:
+            stream.flush()
 
 
 def _parse_confluence_auth_method(value: str) -> str:
@@ -569,7 +586,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
             display_command = shlex.join(("knowledge-adapters", *effective_argv))
             print(
-                f"\nRun {index}/{len(selected_runs)}: "
+                f"\nRun {index}/{len(selected_runs)} started: "
                 f"{configured_run.name} ({configured_run.run_type})"
             )
             print(f"  command: {display_command}")
@@ -577,12 +594,15 @@ def main(argv: Sequence[str] | None = None) -> int:
             captured_stdout = io.StringIO()
             captured_stderr = io.StringIO()
             try:
-                with redirect_stdout(captured_stdout), redirect_stderr(captured_stderr):
+                with redirect_stdout(_TeeStream(sys.stdout, captured_stdout)), redirect_stderr(
+                    captured_stderr
+                ):
                     exit_code = main(effective_argv)
             except SystemExit:
-                output = captured_stdout.getvalue()
-                if output:
-                    print(output, end="" if output.endswith("\n") else "\n")
+                print(
+                    f"Run {index}/{len(selected_runs)} failed: "
+                    f"{configured_run.name} ({configured_run.run_type})"
+                )
                 message, nested_details = _build_configured_run_failure(
                     configured_run_name=configured_run.name,
                     configured_run_type=configured_run.run_type,
@@ -600,6 +620,10 @@ def main(argv: Sequence[str] | None = None) -> int:
                 continue
 
             if exit_code != 0:
+                print(
+                    f"Run {index}/{len(selected_runs)} failed: "
+                    f"{configured_run.name} ({configured_run.run_type})"
+                )
                 message, nested_details = _build_configured_run_failure(
                     configured_run_name=configured_run.name,
                     configured_run_type=configured_run.run_type,
@@ -618,14 +642,16 @@ def main(argv: Sequence[str] | None = None) -> int:
                 continue
 
             output = captured_stdout.getvalue()
-            if output:
-                print(output, end="" if output.endswith("\n") else "\n")
 
             try:
                 summary = _parse_multi_run_summary(output)
             except RuntimeError as exc:
                 exit_with_cli_error(str(exc), command="run")
 
+            print(
+                f"Run {index}/{len(selected_runs)} completed: "
+                f"{configured_run.name} ({configured_run.run_type})"
+            )
             completed_runs += 1
             if summary.dry_run:
                 dry_run_runs += 1
@@ -694,7 +720,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         from knowledge_adapters.confluence.models import ResolvedTarget
         from knowledge_adapters.confluence.normalize import normalize_to_markdown
         from knowledge_adapters.confluence.resolve import resolve_target_for_base_url
-        from knowledge_adapters.confluence.traversal import walk_pages
+        from knowledge_adapters.confluence.traversal import TreeWalkProgress, walk_pages
         from knowledge_adapters.confluence.writer import markdown_path, write_markdown
 
         confluence_config = ConfluenceConfig(
@@ -1011,12 +1037,28 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "use --client-mode real to discover descendants from Confluence."
             )
 
+        def _print_tree_walk_progress(progress: TreeWalkProgress) -> None:
+            print(
+                "Tree progress: "
+                f"depth {progress.depth}, "
+                f"discovered {progress.discovered_pages}, "
+                f"fetched {progress.fetched_pages}, "
+                f"planned {progress.discovered_pages}"
+            )
+
+        def _should_report_fetch_progress(*, fetched_count: int, total_count: int) -> bool:
+            return total_count <= 5 or fetched_count == total_count or fetched_count % 10 == 0
+
         if confluence_config.tree:
             previous_manifest_index = load_previous_manifest_index(confluence_config.output_dir)
             tree_fetch_page = (
                 selected_fetch_page
                 if previous_manifest_index is None
                 else selected_fetch_page_summary
+            )
+            print(
+                "Tree progress: "
+                f"traversal started, max_depth {confluence_config.max_depth}"
             )
             if confluence_config.client_mode == "real":
                 try:
@@ -1025,6 +1067,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                         max_depth=confluence_config.max_depth,
                         fetch_page=tree_fetch_page,
                         list_child_page_ids=selected_list_child_page_ids,
+                        progress_callback=_print_tree_walk_progress,
                     )
                 except (RuntimeError, ValueError) as exc:
                     exit_with_cli_error(
@@ -1038,6 +1081,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     max_depth=confluence_config.max_depth,
                     fetch_page=tree_fetch_page,
                     list_child_page_ids=selected_list_child_page_ids,
+                    progress_callback=_print_tree_walk_progress,
                 )
             _print_confluence_invocation()
             page_records: list[tuple[dict[str, object], Path, PageSyncDecision, str]] = []
@@ -1121,6 +1165,19 @@ def main(argv: Sequence[str] | None = None) -> int:
             ]
 
             pages_to_write: dict[str, dict[str, object]] = {}
+            pages_needing_fetch = sum(
+                1
+                for page, _output_path, _page_decision, action in page_records
+                if action == "write" and page.get("content") is None
+            )
+            fetched_write_pages = 0
+            if pages_needing_fetch > 0:
+                print(
+                    "Tree fetch progress: "
+                    f"fetched 0/{pages_needing_fetch}, "
+                    f"skipped {skip_count}, "
+                    f"planned {len(page_records)}"
+                )
             try:
                 for page, _output_path, _page_decision, action in page_records:
                     if action == "skip":
@@ -1138,6 +1195,17 @@ def main(argv: Sequence[str] | None = None) -> int:
                             page_url=None,
                         )
                     )
+                    fetched_write_pages += 1
+                    if _should_report_fetch_progress(
+                        fetched_count=fetched_write_pages,
+                        total_count=pages_needing_fetch,
+                    ):
+                        print(
+                            "Tree fetch progress: "
+                            f"fetched {fetched_write_pages}/{pages_needing_fetch}, "
+                            f"skipped {skip_count}, "
+                            f"planned {len(page_records)}"
+                        )
             except (RuntimeError, ValueError) as exc:
                 exit_with_cli_error(
                     str(exc),

--- a/src/knowledge_adapters/confluence/traversal.py
+++ b/src/knowledge_adapters/confluence/traversal.py
@@ -3,12 +3,25 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping
+from dataclasses import dataclass
 
 from knowledge_adapters.confluence.models import ResolvedTarget
 
 PagePayload = Mapping[str, object]
 FetchPage = Callable[[ResolvedTarget], dict[str, object]]
 ListChildPageIds = Callable[[ResolvedTarget], list[str]]
+
+
+@dataclass(frozen=True)
+class TreeWalkProgress:
+    """Operator-facing progress snapshot for one tree traversal step."""
+
+    depth: int
+    discovered_pages: int
+    fetched_pages: int
+
+
+TreeWalkProgressCallback = Callable[[TreeWalkProgress], None]
 
 
 def _canonical_id(page: PagePayload, fallback_page_id: str) -> str:
@@ -43,6 +56,7 @@ def walk_pages(
     max_depth: int,
     fetch_page: FetchPage,
     list_child_page_ids: ListChildPageIds | None = None,
+    progress_callback: TreeWalkProgressCallback | None = None,
 ) -> tuple[str, list[dict[str, object]]]:
     """Fetch pages breadth-first up to the requested depth."""
     root_page = fetch_page(root_target)
@@ -51,6 +65,14 @@ def walk_pages(
     ordered_pages = [root_page]
     fetched_pages = {root_page_id: root_page}
     current_level = [root_page]
+    if progress_callback is not None:
+        progress_callback(
+            TreeWalkProgress(
+                depth=0,
+                discovered_pages=len(ordered_pages),
+                fetched_pages=len(fetched_pages),
+            )
+        )
 
     for _depth in range(max_depth):
         child_ids: set[str] = set()
@@ -85,5 +107,13 @@ def walk_pages(
             key=lambda page: _canonical_id(page, ""),
         )
         ordered_pages.extend(current_level)
+        if progress_callback is not None and current_level:
+            progress_callback(
+                TreeWalkProgress(
+                    depth=_depth + 1,
+                    discovered_pages=len(ordered_pages),
+                    fetched_pages=len(fetched_pages),
+                )
+            )
 
     return root_page_id, ordered_pages

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -169,8 +169,15 @@ runs:
 
     assert result.returncode == 0, result.stderr
     assert "Config-driven run invoked" in result.stdout
-    assert "Run 1/2: team-notes (local_files)" in result.stdout
-    assert "Run 2/2: docs-home (confluence)" in result.stdout
+    assert "Run 1/2 started: team-notes (local_files)" in result.stdout
+    assert "Run 1/2 completed: team-notes (local_files)" in result.stdout
+    assert "Run 2/2 started: docs-home (confluence)" in result.stdout
+    assert "Run 2/2 completed: docs-home (confluence)" in result.stdout
+    assert (
+        result.stdout.index("Run 1/2 started: team-notes (local_files)")
+        < result.stdout.index("Local files adapter invoked")
+        < result.stdout.index("Run 1/2 completed: team-notes (local_files)")
+    )
     assert "Aggregate summary:" in result.stdout
     assert "runs_completed: 2" in result.stdout
     assert "write_runs: 2" in result.stdout
@@ -218,9 +225,9 @@ runs:
     assert "only: docs-tree, docs-home" in result.stdout
     assert "runs_selected: 2" in result.stdout
     assert "runs_skipped_disabled: 0" in result.stdout
-    assert "Run 1/2: docs-home (confluence)" in result.stdout
-    assert "Run 2/2: docs-tree (confluence)" in result.stdout
-    assert "Run 1/2: team-notes (local_files)" not in result.stdout
+    assert "Run 1/2 started: docs-home (confluence)" in result.stdout
+    assert "Run 2/2 started: docs-tree (confluence)" in result.stdout
+    assert "Run 1/2 started: team-notes (local_files)" not in result.stdout
     assert not (tmp_path / "artifacts" / "local" / "team-notes" / "pages" / "today.md").exists()
 
 
@@ -308,8 +315,10 @@ runs:
     result = _run_cli(tmp_path, "run", "./runs.yaml", "--continue-on-error")
 
     assert result.returncode == 1
-    assert "Run 1/2: docs-home (confluence)" in result.stdout
-    assert "Run 2/2: team-notes (local_files)" in result.stdout
+    assert "Run 1/2 started: docs-home (confluence)" in result.stdout
+    assert "Run 1/2 failed: docs-home (confluence)" in result.stdout
+    assert "Run 2/2 started: team-notes (local_files)" in result.stdout
+    assert "Run 2/2 completed: team-notes (local_files)" in result.stdout
     assert "Aggregate summary:" in result.stdout
     assert "runs_completed: 1" in result.stdout
     assert "runs_failed: 1" in result.stdout

--- a/tests/test_confluence_real_traversal_contract.py
+++ b/tests/test_confluence_real_traversal_contract.py
@@ -381,6 +381,8 @@ def test_real_tree_incremental_run_skips_full_page_fetch_for_unchanged_pages(
     assert "new_pages: 1" in captured.out
     assert "changed_pages: 0" in captured.out
     assert "unchanged_pages: 2" in captured.out
+    assert "Tree fetch progress: fetched 0/1, skipped 2, planned 3" in captured.out
+    assert "Tree fetch progress: fetched 1/1, skipped 2, planned 3" in captured.out
 
 
 def test_real_tree_run_does_not_report_stub_discovery_limit(
@@ -402,6 +404,26 @@ def test_real_tree_run_does_not_report_stub_discovery_limit(
         "note: stub mode does not support descendant discovery; use --client-mode real "
         "to discover descendants from Confluence."
     ) not in output
+
+
+def test_real_tree_reports_depth_progress_during_traversal(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    exit_code, _output_dir, _page_fetch_counts, _child_list_calls = _run_real_recursive_cli(
+        tmp_path,
+        monkeypatch,
+        max_depth=2,
+    )
+
+    assert exit_code == 0
+
+    output = capsys.readouterr().out
+    assert "Tree progress: traversal started, max_depth 2" in output
+    assert "Tree progress: depth 0, discovered 1, fetched 1, planned 1" in output
+    assert "Tree progress: depth 1, discovered 3, fetched 3, planned 3" in output
+    assert "Tree progress: depth 2, discovered 5, fetched 5, planned 5" in output
 
 
 def test_real_tree_orders_pages_breadth_first_then_lexical_without_parent_adjacency(

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -333,10 +333,12 @@ runs:
     assert exit_code == 0
     captured = capsys.readouterr()
     assert "Config-driven run invoked" in captured.out
-    assert "Run 1/2: team-notes (local_files)" in captured.out
-    assert "Run 2/2: docs-home (confluence)" in captured.out
-    assert captured.out.index("Run 1/2: team-notes (local_files)") < captured.out.index(
-        "Run 2/2: docs-home (confluence)"
+    assert "Run 1/2 started: team-notes (local_files)" in captured.out
+    assert "Run 1/2 completed: team-notes (local_files)" in captured.out
+    assert "Run 2/2 started: docs-home (confluence)" in captured.out
+    assert "Run 2/2 completed: docs-home (confluence)" in captured.out
+    assert captured.out.index("Run 1/2 started: team-notes (local_files)") < captured.out.index(
+        "Run 2/2 started: docs-home (confluence)"
     )
     assert "Run summary: wrote 1, skipped 0" in captured.out
     assert "Aggregate summary:" in captured.out
@@ -411,8 +413,8 @@ runs:
     captured = capsys.readouterr()
     assert "runs_skipped_disabled: 1" in captured.out
     assert "skipped_disabled: docs-home (confluence)" in captured.out
-    assert "Run 1/1: team-notes (local_files)" in captured.out
-    assert "Run 1/1: docs-home (confluence)" not in captured.out
+    assert "Run 1/1 started: team-notes (local_files)" in captured.out
+    assert "Run 1/1 started: docs-home (confluence)" not in captured.out
     assert "runs_completed: 1" in captured.out
 
     local_output_path = (
@@ -463,9 +465,9 @@ runs:
     assert "only: docs-tree, docs-home" in captured.out
     assert "runs_selected: 2" in captured.out
     assert "runs_skipped_disabled: 0" in captured.out
-    assert "Run 1/2: docs-home (confluence)" in captured.out
-    assert "Run 2/2: docs-tree (confluence)" in captured.out
-    assert "Run 1/2: team-notes (local_files)" not in captured.out
+    assert "Run 1/2 started: docs-home (confluence)" in captured.out
+    assert "Run 2/2 started: docs-tree (confluence)" in captured.out
+    assert "Run 1/2 started: team-notes (local_files)" not in captured.out
 
     disabled_output_path = (
         tmp_path / "artifacts" / "confluence" / "docs-home" / "pages" / "12345.md"
@@ -540,7 +542,8 @@ runs:
     assert "Config-driven run invoked" in captured.out
     assert f"config_path: {config_path.resolve()}" in captured.out
     assert "runs_in_config: 1" in captured.out
-    assert "Run 1/1: docs-home (confluence)" in captured.out
+    assert "Run 1/1 started: docs-home (confluence)" in captured.out
+    assert "Run 1/1 failed: docs-home (confluence)" in captured.out
     assert (
         "knowledge-adapters run: error: Run 'docs-home' (confluence) failed while "
         "executing knowledge-adapters confluence --base-url https://example.com/wiki "
@@ -585,8 +588,9 @@ runs:
 
     assert exc_info.value.code == 2
     captured = capsys.readouterr()
-    assert "Run 1/2: docs-home (confluence)" in captured.out
-    assert "Run 2/2: team-notes (local_files)" not in captured.out
+    assert "Run 1/2 started: docs-home (confluence)" in captured.out
+    assert "Run 1/2 failed: docs-home (confluence)" in captured.out
+    assert "Run 2/2 started: team-notes (local_files)" not in captured.out
     assert "Aggregate summary:" not in captured.out
     assert "knowledge-adapters run: error: Run 'docs-home' (confluence) failed while " in (
         captured.err
@@ -627,8 +631,10 @@ runs:
 
     assert exit_code == 1
     captured = capsys.readouterr()
-    assert "Run 1/2: docs-home (confluence)" in captured.out
-    assert "Run 2/2: team-notes (local_files)" in captured.out
+    assert "Run 1/2 started: docs-home (confluence)" in captured.out
+    assert "Run 1/2 failed: docs-home (confluence)" in captured.out
+    assert "Run 2/2 started: team-notes (local_files)" in captured.out
+    assert "Run 2/2 completed: team-notes (local_files)" in captured.out
     assert "Aggregate summary:" in captured.out
     assert "runs_completed: 1" in captured.out
     assert "runs_failed: 1" in captured.out


### PR DESCRIPTION
Summary
- stream nested configured-run stdout so long-running config runs stay visibly active
- add concise Confluence tree traversal and incremental fetch progress lines
- cover the new output in smoke and run/traversal contract tests

Testing
- make check

Closes #144