### PR TITLE
feat: add llm bundle command

### DIFF
--- a/src/knowledge_adapters/bundle.py
+++ b/src/knowledge_adapters/bundle.py
@@ -1,0 +1,187 @@
+"""Bundle existing adapter artifacts into one prompt-ready markdown file."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from knowledge_adapters.confluence.manifest import manifest_path
+
+ORDERING_RULE = "lexical canonical_id order"
+
+
+@dataclass(frozen=True)
+class BundleArtifact:
+    """One manifest-backed artifact selected for bundle output."""
+
+    canonical_id: str
+    source_url: str
+    title: str | None
+    artifact_path: Path
+
+
+@dataclass(frozen=True)
+class BundlePlan:
+    """Resolved manifest inputs plus the unique artifacts chosen for output."""
+
+    manifests: tuple[Path, ...]
+    artifacts: tuple[BundleArtifact, ...]
+    duplicate_canonical_ids: tuple[str, ...]
+
+
+def load_bundle_plan(inputs: Sequence[str | Path]) -> BundlePlan:
+    """Load artifacts from output directories or manifest files."""
+    manifests: list[Path] = []
+    artifacts_by_id: dict[str, BundleArtifact] = {}
+    duplicate_canonical_ids: list[str] = []
+
+    for raw_input in inputs:
+        manifest = _resolve_manifest_input(raw_input)
+        manifests.append(manifest)
+        for artifact in _load_bundle_artifacts(manifest):
+            if artifact.canonical_id in artifacts_by_id:
+                duplicate_canonical_ids.append(artifact.canonical_id)
+                continue
+            artifacts_by_id[artifact.canonical_id] = artifact
+
+    return BundlePlan(
+        manifests=tuple(manifests),
+        artifacts=tuple(
+            sorted(artifacts_by_id.values(), key=lambda artifact: artifact.canonical_id)
+        ),
+        duplicate_canonical_ids=tuple(duplicate_canonical_ids),
+    )
+
+
+def render_bundle_markdown(artifacts: Sequence[BundleArtifact]) -> str:
+    """Render bundle output with stable separators and metadata lines."""
+    sections: list[str] = []
+    for artifact in artifacts:
+        title = artifact.title or artifact.canonical_id
+        content = _read_artifact_text(artifact)
+        sections.append(
+            "\n".join(
+                (
+                    f"## {title}",
+                    f"source_url: {artifact.source_url}",
+                    f"canonical_id: {artifact.canonical_id}",
+                    "",
+                    content.rstrip("\n"),
+                )
+            ).rstrip()
+        )
+
+    if not sections:
+        return ""
+
+    return "\n\n---\n\n".join(sections) + "\n"
+
+
+def write_bundle(output_path: str | Path, markdown: str) -> Path:
+    """Write bundle markdown, creating parent directories when needed."""
+    resolved_output_path = Path(output_path).expanduser().resolve()
+    resolved_output_path.parent.mkdir(parents=True, exist_ok=True)
+    resolved_output_path.write_text(markdown, encoding="utf-8")
+    return resolved_output_path
+
+
+def _resolve_manifest_input(raw_input: str | Path) -> Path:
+    path = Path(raw_input).expanduser()
+    resolved_path = path.resolve()
+    if not resolved_path.exists():
+        raise ValueError(
+            f"Bundle input not found: {resolved_path}. "
+            "Provide an existing output directory or manifest file."
+        )
+
+    if resolved_path.is_dir():
+        resolved_manifest_path = manifest_path(str(resolved_path)).resolve()
+        if not resolved_manifest_path.is_file():
+            raise ValueError(
+                f"Bundle input directory {resolved_path} does not contain manifest.json. "
+                "Provide an existing adapter output directory or manifest file."
+            )
+        return resolved_manifest_path
+
+    if not resolved_path.is_file():
+        raise ValueError(
+            f"Bundle input is not a file or directory: {resolved_path}. "
+            "Provide an existing output directory or manifest file."
+        )
+
+    return resolved_path
+
+
+def _load_bundle_artifacts(manifest: Path) -> tuple[BundleArtifact, ...]:
+    try:
+        payload = json.loads(manifest.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"Could not read bundle manifest {manifest}.") from exc
+
+    files = payload.get("files") if isinstance(payload, dict) else None
+    if not isinstance(files, list):
+        raise ValueError(
+            f"Bundle manifest {manifest} is invalid: expected a files list."
+        )
+
+    artifacts: list[BundleArtifact] = []
+    manifest_ids: set[str] = set()
+    manifest_output_paths: set[str] = set()
+    for entry in files:
+        if not isinstance(entry, dict):
+            raise ValueError(
+                f"Bundle manifest {manifest} is invalid: each files entry must be an object."
+            )
+
+        canonical_id = entry.get("canonical_id")
+        source_url = entry.get("source_url")
+        output_path = entry.get("output_path")
+        title = entry.get("title")
+        if not isinstance(canonical_id, str) or not isinstance(source_url, str):
+            raise ValueError(
+                f"Bundle manifest {manifest} is invalid: files entries must include "
+                "string canonical_id and source_url values."
+            )
+        if not isinstance(output_path, str):
+            raise ValueError(
+                f"Bundle manifest {manifest} is invalid: files entries must include "
+                "a string output_path value."
+            )
+        if title is not None and not isinstance(title, str):
+            raise ValueError(
+                f"Bundle manifest {manifest} is invalid: title values must be strings."
+            )
+        if canonical_id in manifest_ids:
+            raise ValueError(
+                f"Bundle manifest {manifest} is invalid: duplicate canonical_id "
+                f"{canonical_id!r}."
+            )
+        if output_path in manifest_output_paths:
+            raise ValueError(
+                f"Bundle manifest {manifest} is invalid: duplicate output_path {output_path!r}."
+            )
+
+        manifest_ids.add(canonical_id)
+        manifest_output_paths.add(output_path)
+        artifacts.append(
+            BundleArtifact(
+                canonical_id=canonical_id,
+                source_url=source_url,
+                title=title,
+                artifact_path=(manifest.parent / output_path).resolve(),
+            )
+        )
+
+    return tuple(artifacts)
+
+
+def _read_artifact_text(artifact: BundleArtifact) -> str:
+    try:
+        return artifact.artifact_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        raise ValueError(
+            f"Could not read artifact for canonical_id {artifact.canonical_id!r}: "
+            f"{artifact.artifact_path}."
+        ) from exc

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -20,6 +20,7 @@ TOP_LEVEL_HELP_EXAMPLES = """First steps:
   knowledge-adapters run runs.yaml
   knowledge-adapters local_files --help
   knowledge-adapters confluence --help
+  knowledge-adapters bundle ./artifacts --output ./bundle.md
 
 Typical flow:
   1. Start with local_files to try the artifact layout with a text file you
@@ -29,6 +30,8 @@ Typical flow:
   3. Re-run without --dry-run to write the same artifact layout under
      ./artifacts.
   4. Use knowledge-adapters run runs.yaml to refresh multiple sources in order.
+  5. Use knowledge-adapters bundle ./artifacts --output ./bundle.md to combine
+     generated artifacts into one prompt-ready markdown file.
 """
 
 CONFLUENCE_HELP_EXAMPLES = """Examples:
@@ -71,6 +74,12 @@ RUN_HELP_EXAMPLES = """Examples:
   knowledge-adapters run ./configs/runs.yaml
   knowledge-adapters run runs.yaml --only team-notes,docs-home
   knowledge-adapters run runs.yaml --continue-on-error
+"""
+
+BUNDLE_HELP_EXAMPLES = """Examples:
+  knowledge-adapters bundle ./artifacts/confluence --output ./bundle.md
+  knowledge-adapters bundle ./artifacts/a ./artifacts/b --output ./bundle.md
+  knowledge-adapters bundle ./artifacts/manifest.json --output ./bundle.md
 """
 
 _WRITE_SUMMARY_RE = re.compile(r"Summary: wrote (?P<wrote>\d+), skipped (?P<skipped>\d+)")
@@ -173,6 +182,43 @@ def exit_with_output_error(
             "Verify --output-dir and try again."
         ),
         command=command,
+    )
+
+
+def exit_with_bundle_output_error(output_path: str | Path, *, exc: OSError) -> None:
+    """Exit with a consistent filesystem error for bundle output writes."""
+    resolved_output_path = Path(output_path).expanduser()
+    if isinstance(exc, PermissionError):
+        exit_with_cli_error(
+            (
+                f"Bundle output is not writable: {resolved_output_path}. "
+                "Verify --output and check the path permissions."
+            ),
+            command="bundle",
+        )
+    if isinstance(exc, IsADirectoryError):
+        exit_with_cli_error(
+            (
+                f"Bundle output path is a directory: {resolved_output_path}. "
+                "Verify --output and use a file path."
+            ),
+            command="bundle",
+        )
+    if isinstance(exc, NotADirectoryError):
+        exit_with_cli_error(
+            (
+                f"Bundle output path is invalid: {resolved_output_path}. "
+                "Verify --output and use a file path."
+            ),
+            command="bundle",
+        )
+
+    exit_with_cli_error(
+        (
+            f"Could not write bundle output {resolved_output_path}. "
+            "Verify --output and try again."
+        ),
+        command="bundle",
     )
 
 
@@ -365,6 +411,32 @@ def build_parser() -> argparse.ArgumentParser:
             "Preview the resolved file path, artifact path, manifest path, and "
             "normalized markdown without writing files."
         ),
+    )
+
+    bundle_parser = subparsers.add_parser(
+        "bundle",
+        help="Combine existing artifacts into one prompt-ready markdown file.",
+        description=(
+            "Combine existing artifacts into one prompt-ready markdown file. Accept one "
+            "or more output directories or manifest files as input. Bundle output keeps "
+            "the original artifacts unchanged, removes duplicate canonical_id entries by "
+            "keeping the first artifact discovered from the provided inputs, and orders "
+            "the final sections using lexical canonical_id order."
+        ),
+        epilog=BUNDLE_HELP_EXAMPLES,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    bundle_parser.add_argument(
+        "inputs",
+        nargs="+",
+        metavar="INPUT",
+        help="One or more adapter output directories or manifest files to bundle.",
+    )
+    bundle_parser.add_argument(
+        "--output",
+        required=True,
+        metavar="FILE",
+        help="Markdown file to write with the bundled artifact content.",
     )
 
     run_parser = subparsers.add_parser(
@@ -1374,6 +1446,58 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         print(f"Manifest: {_display_output_path(manifest)}")
         print_write_complete(output_dir)
+        return 0
+
+    if args.command == "bundle":
+        from knowledge_adapters.bundle import (
+            ORDERING_RULE,
+            load_bundle_plan,
+            render_bundle_markdown,
+            write_bundle,
+        )
+
+        output_path_input = Path(args.output).expanduser()
+        output_path = output_path_input.resolve()
+        if output_path_input.exists() and output_path_input.is_dir():
+            exit_with_cli_error(
+                (
+                    f"Bundle output path is a directory: {output_path}. "
+                    "Verify --output and use a file path."
+                ),
+                command="bundle",
+            )
+
+        try:
+            bundle_plan = load_bundle_plan(args.inputs)
+            markdown = render_bundle_markdown(bundle_plan.artifacts)
+        except ValueError as exc:
+            exit_with_cli_error(str(exc), command="bundle")
+
+        print("Bundle command invoked")
+        print(f"  inputs: {len(args.inputs)}")
+        print(f"  output: {render_user_path(args.output)}")
+        print(f"  ordering: {ORDERING_RULE}")
+
+        print("\nPlan: Bundle run")
+        for manifest in bundle_plan.manifests:
+            print(f"  manifest: {render_user_path(manifest)}")
+        print(f"  artifacts_selected: {len(bundle_plan.artifacts)}")
+        print(f"  duplicates_skipped: {len(bundle_plan.duplicate_canonical_ids)}")
+        print("  action: write")
+
+        try:
+            written_bundle = write_bundle(args.output, markdown)
+        except OSError as exc:
+            exit_with_bundle_output_error(args.output, exc=exc)
+
+        print(f"\nWrote bundle: {render_user_path(written_bundle)}")
+        print(
+            "\nSummary: bundled "
+            f"{len(bundle_plan.artifacts)}, skipped "
+            f"{len(bundle_plan.duplicate_canonical_ids)} duplicates"
+        )
+        print(f"Output path: {render_user_path(written_bundle)}")
+        print(f"\nWrite complete. Bundle created at {render_user_path(written_bundle)}")
         return 0
 
     if args.command == "local_files":

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from knowledge_adapters.bundle import (
+    ORDERING_RULE,
+    load_bundle_plan,
+    render_bundle_markdown,
+    write_bundle,
+)
+
+
+def _write_output_dir(
+    output_dir: Path,
+    *,
+    files: list[dict[str, object]],
+    artifact_contents: dict[str, str],
+) -> Path:
+    (output_dir / "pages").mkdir(parents=True, exist_ok=True)
+    for relative_path, content in artifact_contents.items():
+        artifact_path = output_dir / relative_path
+        artifact_path.parent.mkdir(parents=True, exist_ok=True)
+        artifact_path.write_text(content, encoding="utf-8")
+
+    manifest = output_dir / "manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "generated_at": "2026-04-24T00:00:00Z",
+                "files": files,
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def test_load_bundle_plan_deduplicates_inputs_and_sorts_by_canonical_id(tmp_path: Path) -> None:
+    output_a = tmp_path / "artifacts" / "a"
+    output_b = tmp_path / "artifacts" / "b"
+    manifest_b = _write_output_dir(
+        output_b,
+        files=[
+            {
+                "canonical_id": "gamma",
+                "source_url": "https://example.com/gamma",
+                "output_path": "pages/gamma.md",
+                "title": "Gamma",
+            },
+            {
+                "canonical_id": "alpha",
+                "source_url": "https://example.com/alpha-b",
+                "output_path": "pages/alpha-b.md",
+                "title": "Alpha from B",
+            },
+        ],
+        artifact_contents={
+            "pages/gamma.md": "# Gamma\n\nGamma content.\n",
+            "pages/alpha-b.md": "# Alpha from B\n\nAlpha content from B.\n",
+        },
+    )
+    _write_output_dir(
+        output_a,
+        files=[
+            {
+                "canonical_id": "zeta",
+                "source_url": "https://example.com/zeta",
+                "output_path": "pages/zeta.md",
+                "title": "Zeta",
+            },
+            {
+                "canonical_id": "alpha",
+                "source_url": "https://example.com/alpha-a",
+                "output_path": "pages/alpha-a.md",
+                "title": "Alpha from A",
+            },
+        ],
+        artifact_contents={
+            "pages/zeta.md": "# Zeta\n\nZeta content.\n",
+            "pages/alpha-a.md": "# Alpha from A\n\nAlpha content from A.\n",
+        },
+    )
+
+    plan = load_bundle_plan((output_a, manifest_b))
+
+    assert plan.manifests == (output_a / "manifest.json", manifest_b)
+    assert [artifact.canonical_id for artifact in plan.artifacts] == ["alpha", "gamma", "zeta"]
+    assert [artifact.title for artifact in plan.artifacts] == ["Alpha from A", "Gamma", "Zeta"]
+    assert plan.duplicate_canonical_ids == ("alpha",)
+    assert ORDERING_RULE == "lexical canonical_id order"
+
+
+def test_render_bundle_markdown_reads_selected_artifacts_with_separators(tmp_path: Path) -> None:
+    output_dir = tmp_path / "artifacts"
+    _write_output_dir(
+        output_dir,
+        files=[
+            {
+                "canonical_id": "beta",
+                "source_url": "https://example.com/beta",
+                "output_path": "pages/beta.md",
+            },
+            {
+                "canonical_id": "alpha",
+                "source_url": "https://example.com/alpha",
+                "output_path": "pages/alpha.md",
+                "title": "Alpha",
+            },
+        ],
+        artifact_contents={
+            "pages/beta.md": "# Beta\n\nBeta content.\n",
+            "pages/alpha.md": "# Alpha\n\nAlpha content.\n",
+        },
+    )
+
+    plan = load_bundle_plan((output_dir,))
+
+    assert render_bundle_markdown(plan.artifacts) == (
+        """## Alpha
+source_url: https://example.com/alpha
+canonical_id: alpha
+
+# Alpha
+
+Alpha content.
+
+---
+
+## beta
+source_url: https://example.com/beta
+canonical_id: beta
+
+# Beta
+
+Beta content.
+"""
+    )
+
+
+def test_render_bundle_markdown_rejects_missing_artifact_file(tmp_path: Path) -> None:
+    output_dir = tmp_path / "artifacts"
+    _write_output_dir(
+        output_dir,
+        files=[
+            {
+                "canonical_id": "alpha",
+                "source_url": "https://example.com/alpha",
+                "output_path": "pages/alpha.md",
+            }
+        ],
+        artifact_contents={},
+    )
+
+    plan = load_bundle_plan((output_dir,))
+
+    with pytest.raises(ValueError, match="Could not read artifact for canonical_id 'alpha'"):
+        render_bundle_markdown(plan.artifacts)
+
+
+def test_write_bundle_creates_parent_directories(tmp_path: Path) -> None:
+    output_path = write_bundle(tmp_path / "bundles" / "llm.md", "bundle\n")
+
+    assert output_path == tmp_path / "bundles" / "llm.md"
+    assert output_path.read_text(encoding="utf-8") == "bundle\n"

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -44,12 +44,14 @@ def test_top_level_help_introduces_shared_cli_flow(tmp_path: Path) -> None:
     assert "Execute multiple configured adapter runs from one YAML file." in stdout
     assert "Normalize Confluence content into shared artifacts." in stdout
     assert "Normalize one local UTF-8 text file into shared artifacts." in stdout
+    assert "Combine existing artifacts into one prompt-ready markdown file." in stdout
     assert (
         "Start with --dry-run to preview the source, artifact path, manifest path,"
         in stdout
     )
     assert "Re-run without --dry-run to write the same artifact layout" in stdout
     assert "knowledge-adapters run runs.yaml" in stdout
+    assert "knowledge-adapters bundle ./artifacts --output ./bundle.md" in stdout
 
 
 def test_local_files_cli_smoke_uses_installed_entrypoint_with_readme_style_args(
@@ -140,6 +142,142 @@ def test_local_files_cli_help_includes_first_run_guidance(tmp_path: Path) -> Non
     assert "without writing files." in stdout
     assert "knowledge-adapters local_files" in stdout
     assert "--dry-run" in stdout
+
+
+def test_bundle_cli_help_includes_ordering_and_input_guidance(tmp_path: Path) -> None:
+    result = _run_cli(tmp_path, "bundle", "--help")
+    stdout = normalize_whitespace(result.stdout)
+
+    assert result.returncode == 0, result.stderr
+    assert "Combine existing artifacts into one prompt-ready markdown file." in stdout
+    assert "one or more output directories or manifest files" in stdout
+    assert "keeps the original artifacts unchanged" in stdout
+    assert "lexical canonical_id order" in stdout
+    assert "--output FILE" in stdout
+    assert "knowledge-adapters bundle ./artifacts/confluence --output ./bundle.md" in stdout
+
+
+def test_bundle_cli_smoke_combines_multiple_inputs_in_deterministic_order(
+    tmp_path: Path,
+) -> None:
+    output_a = tmp_path / "artifacts" / "a"
+    output_b = tmp_path / "artifacts" / "b"
+    (output_a / "pages").mkdir(parents=True)
+    (output_b / "pages").mkdir(parents=True)
+    (output_a / "pages" / "zeta.md").write_text(
+        "# Zeta artifact\n\nZeta content.\n",
+        encoding="utf-8",
+    )
+    (output_a / "pages" / "alpha.md").write_text(
+        "# Alpha artifact\n\nAlpha content.\n",
+        encoding="utf-8",
+    )
+    (output_b / "pages" / "alpha-copy.md").write_text(
+        "# Alpha duplicate\n\nDuplicate content.\n",
+        encoding="utf-8",
+    )
+    (output_b / "pages" / "beta.md").write_text(
+        "# Beta artifact\n\nBeta content.\n",
+        encoding="utf-8",
+    )
+    (output_a / "manifest.json").write_text(
+        json.dumps(
+            {
+                "generated_at": "2026-04-24T00:00:00Z",
+                "files": [
+                    {
+                        "canonical_id": "zeta",
+                        "source_url": "https://example.com/zeta",
+                        "output_path": "pages/zeta.md",
+                        "title": "Zeta",
+                    },
+                    {
+                        "canonical_id": "alpha",
+                        "source_url": "https://example.com/alpha",
+                        "output_path": "pages/alpha.md",
+                        "title": "Alpha",
+                    },
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (output_b / "manifest.json").write_text(
+        json.dumps(
+            {
+                "generated_at": "2026-04-24T00:00:00Z",
+                "files": [
+                    {
+                        "canonical_id": "alpha",
+                        "source_url": "https://example.com/alpha-duplicate",
+                        "output_path": "pages/alpha-copy.md",
+                        "title": "Alpha duplicate",
+                    },
+                    {
+                        "canonical_id": "beta",
+                        "source_url": "https://example.com/beta",
+                        "output_path": "pages/beta.md",
+                    },
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = _run_cli(
+        tmp_path,
+        "bundle",
+        "./artifacts/a",
+        "./artifacts/b/manifest.json",
+        "--output",
+        "./bundles/llm.md",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Bundle command invoked" in result.stdout
+    assert "ordering: lexical canonical_id order" in result.stdout
+    assert f"manifest: {output_a / 'manifest.json'}" in result.stdout
+    assert f"manifest: {output_b / 'manifest.json'}" in result.stdout
+    assert "artifacts_selected: 3" in result.stdout
+    assert "duplicates_skipped: 1" in result.stdout
+    assert f"Wrote bundle: {tmp_path / 'bundles' / 'llm.md'}" in result.stdout
+    assert "Summary: bundled 3, skipped 1 duplicates" in result.stdout
+    assert f"Write complete. Bundle created at {tmp_path / 'bundles' / 'llm.md'}" in result.stdout
+
+    assert (tmp_path / "bundles" / "llm.md").read_text(encoding="utf-8") == (
+        """## Alpha
+source_url: https://example.com/alpha
+canonical_id: alpha
+
+# Alpha artifact
+
+Alpha content.
+
+---
+
+## beta
+source_url: https://example.com/beta
+canonical_id: beta
+
+# Beta artifact
+
+Beta content.
+
+---
+
+## Zeta
+source_url: https://example.com/zeta
+canonical_id: zeta
+
+# Zeta artifact
+
+Zeta content.
+"""
+    )
 
 
 def test_run_cli_smoke_executes_multiple_sources_from_yaml(tmp_path: Path) -> None:


### PR DESCRIPTION
Summary
- add a bundle subcommand and module that combine manifest-backed artifacts into one markdown file
- resolve directories or manifest inputs, deduplicate by canonical_id, and order sections by lexical canonical_id
- add smoke and unit coverage for bundle help, mixed inputs, and output rendering

Testing
- make check

Closes #147