### PR TITLE
feat: add bundle ordering controls

### DIFF
--- a/src/knowledge_adapters/bundle.py
+++ b/src/knowledge_adapters/bundle.py
@@ -6,10 +6,20 @@ import json
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal
 
 from knowledge_adapters.confluence.manifest import manifest_path
 
-ORDERING_RULE = "lexical canonical_id order"
+BundleOrder = Literal["canonical_id", "manifest", "input"]
+
+DEFAULT_BUNDLE_ORDER: BundleOrder = "canonical_id"
+BUNDLE_ORDER_CHOICES: tuple[BundleOrder, ...] = ("canonical_id", "manifest", "input")
+BUNDLE_ORDER_LABELS: dict[BundleOrder, str] = {
+    "canonical_id": "lexical canonical_id order",
+    "manifest": "manifest entry order",
+    "input": "input order with manifest grouping",
+}
+ORDERING_RULE = BUNDLE_ORDER_LABELS[DEFAULT_BUNDLE_ORDER]
 
 
 @dataclass(frozen=True)
@@ -31,26 +41,55 @@ class BundlePlan:
     duplicate_canonical_ids: tuple[str, ...]
 
 
-def load_bundle_plan(inputs: Sequence[str | Path]) -> BundlePlan:
+@dataclass(frozen=True)
+class _BundleArtifactPosition:
+    """Stable discovery metadata used to order selected artifacts."""
+
+    input_index: int
+    manifest_index: int
+    manifest_entry_index: int
+
+
+def describe_bundle_order(order: BundleOrder) -> str:
+    """Return the human-readable description for one bundle ordering mode."""
+    return BUNDLE_ORDER_LABELS[order]
+
+
+def load_bundle_plan(
+    inputs: Sequence[str | Path],
+    *,
+    order: BundleOrder = DEFAULT_BUNDLE_ORDER,
+) -> BundlePlan:
     """Load artifacts from output directories or manifest files."""
+    if order not in BUNDLE_ORDER_CHOICES:
+        raise ValueError(
+            f"Unsupported bundle order {order!r}. "
+            f"Choose one of: {', '.join(BUNDLE_ORDER_CHOICES)}."
+        )
+
     manifests: list[Path] = []
     artifacts_by_id: dict[str, BundleArtifact] = {}
+    artifact_positions: dict[str, _BundleArtifactPosition] = {}
     duplicate_canonical_ids: list[str] = []
 
-    for raw_input in inputs:
+    for input_index, raw_input in enumerate(inputs):
         manifest = _resolve_manifest_input(raw_input)
         manifests.append(manifest)
-        for artifact in _load_bundle_artifacts(manifest):
+        manifest_index = len(manifests) - 1
+        for manifest_entry_index, artifact in enumerate(_load_bundle_artifacts(manifest)):
             if artifact.canonical_id in artifacts_by_id:
                 duplicate_canonical_ids.append(artifact.canonical_id)
                 continue
             artifacts_by_id[artifact.canonical_id] = artifact
+            artifact_positions[artifact.canonical_id] = _BundleArtifactPosition(
+                input_index=input_index,
+                manifest_index=manifest_index,
+                manifest_entry_index=manifest_entry_index,
+            )
 
     return BundlePlan(
         manifests=tuple(manifests),
-        artifacts=tuple(
-            sorted(artifacts_by_id.values(), key=lambda artifact: artifact.canonical_id)
-        ),
+        artifacts=tuple(_order_bundle_artifacts(artifacts_by_id, artifact_positions, order=order)),
         duplicate_canonical_ids=tuple(duplicate_canonical_ids),
     )
 
@@ -185,3 +224,40 @@ def _read_artifact_text(artifact: BundleArtifact) -> str:
             f"Could not read artifact for canonical_id {artifact.canonical_id!r}: "
             f"{artifact.artifact_path}."
         ) from exc
+
+
+def _order_bundle_artifacts(
+    artifacts_by_id: dict[str, BundleArtifact],
+    artifact_positions: dict[str, _BundleArtifactPosition],
+    *,
+    order: BundleOrder,
+) -> tuple[BundleArtifact, ...]:
+    artifacts = tuple(artifacts_by_id.values())
+    if order == "canonical_id":
+        return tuple(sorted(artifacts, key=lambda artifact: artifact.canonical_id))
+    if order == "manifest":
+        return tuple(
+            sorted(
+                artifacts,
+                key=lambda artifact: (
+                    artifact_positions[artifact.canonical_id].manifest_index,
+                    artifact_positions[artifact.canonical_id].manifest_entry_index,
+                    artifact.canonical_id,
+                ),
+            )
+        )
+    if order == "input":
+        return tuple(
+            sorted(
+                artifacts,
+                key=lambda artifact: (
+                    artifact_positions[artifact.canonical_id].input_index,
+                    artifact_positions[artifact.canonical_id].manifest_entry_index,
+                    artifact.canonical_id,
+                ),
+            )
+        )
+    raise ValueError(
+        f"Unsupported bundle order {order!r}. "
+        f"Choose one of: {', '.join(BUNDLE_ORDER_CHOICES)}."
+    )

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -13,6 +13,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TextIO
 
+from knowledge_adapters.bundle import (
+    BUNDLE_ORDER_CHOICES,
+    DEFAULT_BUNDLE_ORDER,
+    describe_bundle_order,
+)
 from knowledge_adapters.confluence.auth import SUPPORTED_AUTH_METHODS, resolve_tls_inputs
 
 TOP_LEVEL_HELP_EXAMPLES = """First steps:
@@ -421,7 +426,7 @@ def build_parser() -> argparse.ArgumentParser:
             "or more output directories or manifest files as input. Bundle output keeps "
             "the original artifacts unchanged, removes duplicate canonical_id entries by "
             "keeping the first artifact discovered from the provided inputs, and orders "
-            "the final sections using lexical canonical_id order."
+            "the final sections using the selected deterministic ordering mode."
         ),
         epilog=BUNDLE_HELP_EXAMPLES,
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -437,6 +442,16 @@ def build_parser() -> argparse.ArgumentParser:
         required=True,
         metavar="FILE",
         help="Markdown file to write with the bundled artifact content.",
+    )
+    bundle_parser.add_argument(
+        "--order",
+        choices=BUNDLE_ORDER_CHOICES,
+        default=DEFAULT_BUNDLE_ORDER,
+        help=(
+            "Deterministic output ordering: canonical_id sorts lexically by canonical_id "
+            "(default); manifest preserves manifest entry order; input preserves bundle "
+            "input order, then manifest order within each input."
+        ),
     )
 
     run_parser = subparsers.add_parser(
@@ -1450,7 +1465,6 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if args.command == "bundle":
         from knowledge_adapters.bundle import (
-            ORDERING_RULE,
             load_bundle_plan,
             render_bundle_markdown,
             write_bundle,
@@ -1468,7 +1482,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
 
         try:
-            bundle_plan = load_bundle_plan(args.inputs)
+            bundle_plan = load_bundle_plan(args.inputs, order=args.order)
             markdown = render_bundle_markdown(bundle_plan.artifacts)
         except ValueError as exc:
             exit_with_cli_error(str(exc), command="bundle")
@@ -1476,7 +1490,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         print("Bundle command invoked")
         print(f"  inputs: {len(args.inputs)}")
         print(f"  output: {render_user_path(args.output)}")
-        print(f"  ordering: {ORDERING_RULE}")
+        print(f"  ordering: {describe_bundle_order(args.order)}")
 
         print("\nPlan: Bundle run")
         for manifest in bundle_plan.manifests:

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -6,7 +6,9 @@ from pathlib import Path
 import pytest
 
 from knowledge_adapters.bundle import (
+    DEFAULT_BUNDLE_ORDER,
     ORDERING_RULE,
+    describe_bundle_order,
     load_bundle_plan,
     render_bundle_markdown,
     write_bundle,
@@ -93,6 +95,96 @@ def test_load_bundle_plan_deduplicates_inputs_and_sorts_by_canonical_id(tmp_path
     assert [artifact.title for artifact in plan.artifacts] == ["Alpha from A", "Gamma", "Zeta"]
     assert plan.duplicate_canonical_ids == ("alpha",)
     assert ORDERING_RULE == "lexical canonical_id order"
+    assert DEFAULT_BUNDLE_ORDER == "canonical_id"
+    assert describe_bundle_order(DEFAULT_BUNDLE_ORDER) == ORDERING_RULE
+
+
+def test_load_bundle_plan_preserves_manifest_entry_order_when_requested(tmp_path: Path) -> None:
+    output_dir = tmp_path / "artifacts"
+    _write_output_dir(
+        output_dir,
+        files=[
+            {
+                "canonical_id": "gamma",
+                "source_url": "https://example.com/gamma",
+                "output_path": "pages/gamma.md",
+            },
+            {
+                "canonical_id": "alpha",
+                "source_url": "https://example.com/alpha",
+                "output_path": "pages/alpha.md",
+            },
+            {
+                "canonical_id": "zeta",
+                "source_url": "https://example.com/zeta",
+                "output_path": "pages/zeta.md",
+            },
+        ],
+        artifact_contents={
+            "pages/gamma.md": "# Gamma\n",
+            "pages/alpha.md": "# Alpha\n",
+            "pages/zeta.md": "# Zeta\n",
+        },
+    )
+
+    plan = load_bundle_plan((output_dir,), order="manifest")
+
+    assert [artifact.canonical_id for artifact in plan.artifacts] == ["gamma", "alpha", "zeta"]
+
+
+def test_load_bundle_plan_preserves_input_grouping_and_first_wins_duplicates(
+    tmp_path: Path,
+) -> None:
+    output_a = tmp_path / "artifacts" / "a"
+    output_b = tmp_path / "artifacts" / "b"
+    _write_output_dir(
+        output_a,
+        files=[
+            {
+                "canonical_id": "zeta",
+                "source_url": "https://example.com/zeta",
+                "output_path": "pages/zeta.md",
+                "title": "Zeta",
+            },
+            {
+                "canonical_id": "alpha",
+                "source_url": "https://example.com/alpha-a",
+                "output_path": "pages/alpha.md",
+                "title": "Alpha from A",
+            },
+        ],
+        artifact_contents={
+            "pages/zeta.md": "# Zeta\n",
+            "pages/alpha.md": "# Alpha from A\n",
+        },
+    )
+    _write_output_dir(
+        output_b,
+        files=[
+            {
+                "canonical_id": "alpha",
+                "source_url": "https://example.com/alpha-b",
+                "output_path": "pages/alpha-duplicate.md",
+                "title": "Alpha from B",
+            },
+            {
+                "canonical_id": "beta",
+                "source_url": "https://example.com/beta",
+                "output_path": "pages/beta.md",
+                "title": "Beta",
+            },
+        ],
+        artifact_contents={
+            "pages/alpha-duplicate.md": "# Alpha from B\n",
+            "pages/beta.md": "# Beta\n",
+        },
+    )
+
+    plan = load_bundle_plan((output_a, output_b), order="input")
+
+    assert [artifact.canonical_id for artifact in plan.artifacts] == ["zeta", "alpha", "beta"]
+    assert [artifact.title for artifact in plan.artifacts] == ["Zeta", "Alpha from A", "Beta"]
+    assert plan.duplicate_canonical_ids == ("alpha",)
 
 
 def test_render_bundle_markdown_reads_selected_artifacts_with_separators(tmp_path: Path) -> None:

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -152,8 +152,12 @@ def test_bundle_cli_help_includes_ordering_and_input_guidance(tmp_path: Path) ->
     assert "Combine existing artifacts into one prompt-ready markdown file." in stdout
     assert "one or more output directories or manifest files" in stdout
     assert "keeps the original artifacts unchanged" in stdout
-    assert "lexical canonical_id order" in stdout
+    assert "selected deterministic ordering mode" in stdout
     assert "--output FILE" in stdout
+    assert "--order {canonical_id,manifest,input}" in stdout
+    assert "canonical_id sorts lexically by canonical_id (default)" in stdout
+    assert "manifest preserves manifest entry order" in stdout
+    assert "input preserves bundle input order" in stdout
     assert "knowledge-adapters bundle ./artifacts/confluence --output ./bundle.md" in stdout
 
 
@@ -276,6 +280,121 @@ canonical_id: zeta
 # Zeta artifact
 
 Zeta content.
+"""
+    )
+
+
+def test_bundle_cli_smoke_supports_input_ordering(tmp_path: Path) -> None:
+    output_a = tmp_path / "artifacts" / "a"
+    output_b = tmp_path / "artifacts" / "b"
+    (output_a / "pages").mkdir(parents=True)
+    (output_b / "pages").mkdir(parents=True)
+    (output_a / "pages" / "gamma.md").write_text(
+        "# Gamma artifact\n\nGamma content.\n",
+        encoding="utf-8",
+    )
+    (output_a / "pages" / "alpha.md").write_text(
+        "# Alpha artifact\n\nAlpha content from A.\n",
+        encoding="utf-8",
+    )
+    (output_b / "pages" / "alpha-copy.md").write_text(
+        "# Alpha duplicate\n\nAlpha content from B.\n",
+        encoding="utf-8",
+    )
+    (output_b / "pages" / "beta.md").write_text(
+        "# Beta artifact\n\nBeta content.\n",
+        encoding="utf-8",
+    )
+    (output_a / "manifest.json").write_text(
+        json.dumps(
+            {
+                "generated_at": "2026-04-24T00:00:00Z",
+                "files": [
+                    {
+                        "canonical_id": "gamma",
+                        "source_url": "https://example.com/gamma",
+                        "output_path": "pages/gamma.md",
+                        "title": "Gamma",
+                    },
+                    {
+                        "canonical_id": "alpha",
+                        "source_url": "https://example.com/alpha-a",
+                        "output_path": "pages/alpha.md",
+                        "title": "Alpha from A",
+                    },
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (output_b / "manifest.json").write_text(
+        json.dumps(
+            {
+                "generated_at": "2026-04-24T00:00:00Z",
+                "files": [
+                    {
+                        "canonical_id": "alpha",
+                        "source_url": "https://example.com/alpha-b",
+                        "output_path": "pages/alpha-copy.md",
+                        "title": "Alpha from B",
+                    },
+                    {
+                        "canonical_id": "beta",
+                        "source_url": "https://example.com/beta",
+                        "output_path": "pages/beta.md",
+                    },
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = _run_cli(
+        tmp_path,
+        "bundle",
+        "./artifacts/a",
+        "./artifacts/b",
+        "--order",
+        "input",
+        "--output",
+        "./bundles/input-order.md",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ordering: input order with manifest grouping" in result.stdout
+    assert "duplicates_skipped: 1" in result.stdout
+    assert (tmp_path / "bundles" / "input-order.md").read_text(encoding="utf-8") == (
+        """## Gamma
+source_url: https://example.com/gamma
+canonical_id: gamma
+
+# Gamma artifact
+
+Gamma content.
+
+---
+
+## Alpha from A
+source_url: https://example.com/alpha-a
+canonical_id: alpha
+
+# Alpha artifact
+
+Alpha content from A.
+
+---
+
+## beta
+source_url: https://example.com/beta
+canonical_id: beta
+
+# Beta artifact
+
+Beta content.
 """
     )
 


### PR DESCRIPTION
Summary
- add deterministic --order controls to knowledge-adapters bundle for canonical_id, manifest, and input ordering
- keep first-discovered duplicate handling while sorting selected artifacts according to the requested mode
- document the new ordering modes in bundle help text and cover them with bundle and CLI smoke tests

Testing
- make check

Closes #153