### PR TITLE
feat: add bundle include and exclude filters

### DIFF
--- a/src/knowledge_adapters/bundle.py
+++ b/src/knowledge_adapters/bundle.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import fnmatch
 import json
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -29,6 +30,7 @@ class BundleArtifact:
     canonical_id: str
     source_url: str
     title: str | None
+    output_path: str
     artifact_path: Path
 
 
@@ -39,6 +41,7 @@ class BundlePlan:
     manifests: tuple[Path, ...]
     artifacts: tuple[BundleArtifact, ...]
     duplicate_canonical_ids: tuple[str, ...]
+    filtered_out_count: int = 0
 
 
 @dataclass(frozen=True)
@@ -59,6 +62,8 @@ def load_bundle_plan(
     inputs: Sequence[str | Path],
     *,
     order: BundleOrder = DEFAULT_BUNDLE_ORDER,
+    include_patterns: Sequence[str] = (),
+    exclude_patterns: Sequence[str] = (),
 ) -> BundlePlan:
     """Load artifacts from output directories or manifest files."""
     if order not in BUNDLE_ORDER_CHOICES:
@@ -87,10 +92,22 @@ def load_bundle_plan(
                 manifest_entry_index=manifest_entry_index,
             )
 
+    ordered_artifacts = _order_bundle_artifacts(
+        artifacts_by_id,
+        artifact_positions,
+        order=order,
+    )
+    selected_artifacts, filtered_out_count = _filter_bundle_artifacts(
+        ordered_artifacts,
+        include_patterns=include_patterns,
+        exclude_patterns=exclude_patterns,
+    )
+
     return BundlePlan(
         manifests=tuple(manifests),
-        artifacts=tuple(_order_bundle_artifacts(artifacts_by_id, artifact_positions, order=order)),
+        artifacts=selected_artifacts,
         duplicate_canonical_ids=tuple(duplicate_canonical_ids),
+        filtered_out_count=filtered_out_count,
     )
 
 
@@ -209,6 +226,7 @@ def _load_bundle_artifacts(manifest: Path) -> tuple[BundleArtifact, ...]:
                 canonical_id=canonical_id,
                 source_url=source_url,
                 title=title,
+                output_path=output_path,
                 artifact_path=(manifest.parent / output_path).resolve(),
             )
         )
@@ -260,4 +278,41 @@ def _order_bundle_artifacts(
     raise ValueError(
         f"Unsupported bundle order {order!r}. "
         f"Choose one of: {', '.join(BUNDLE_ORDER_CHOICES)}."
+    )
+
+
+def _filter_bundle_artifacts(
+    artifacts: Sequence[BundleArtifact],
+    *,
+    include_patterns: Sequence[str],
+    exclude_patterns: Sequence[str],
+) -> tuple[tuple[BundleArtifact, ...], int]:
+    selected_artifacts: list[BundleArtifact] = []
+    filtered_out_count = 0
+    for artifact in artifacts:
+        if include_patterns and not _artifact_matches_patterns(artifact, include_patterns):
+            filtered_out_count += 1
+            continue
+        if exclude_patterns and _artifact_matches_patterns(artifact, exclude_patterns):
+            filtered_out_count += 1
+            continue
+        selected_artifacts.append(artifact)
+
+    return tuple(selected_artifacts), filtered_out_count
+
+
+def _artifact_matches_patterns(
+    artifact: BundleArtifact,
+    patterns: Sequence[str],
+) -> bool:
+    artifact_values = (
+        artifact.canonical_id,
+        artifact.title,
+        artifact.output_path,
+        artifact.source_url,
+    )
+    return any(
+        value is not None and fnmatch.fnmatchcase(value, pattern)
+        for pattern in patterns
+        for value in artifact_values
     )

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -85,6 +85,7 @@ BUNDLE_HELP_EXAMPLES = """Examples:
   knowledge-adapters bundle ./artifacts/confluence --output ./bundle.md
   knowledge-adapters bundle ./artifacts/a ./artifacts/b --output ./bundle.md
   knowledge-adapters bundle ./artifacts/manifest.json --output ./bundle.md
+  knowledge-adapters bundle ./artifacts --include "team-*" --exclude "*draft*" --output ./bundle.md
 """
 
 _WRITE_SUMMARY_RE = re.compile(r"Summary: wrote (?P<wrote>\d+), skipped (?P<skipped>\d+)")
@@ -426,7 +427,11 @@ def build_parser() -> argparse.ArgumentParser:
             "or more output directories or manifest files as input. Bundle output keeps "
             "the original artifacts unchanged, removes duplicate canonical_id entries by "
             "keeping the first artifact discovered from the provided inputs, and orders "
-            "the final sections using the selected deterministic ordering mode."
+            "the final sections using the selected deterministic ordering mode. Optional "
+            "glob-style include and exclude filters match canonical_id, title, "
+            "output_path, and source_url. If no --include filters are provided, all "
+            "artifacts start included. Exclude filters apply after include matching and "
+            "win on conflicts."
         ),
         epilog=BUNDLE_HELP_EXAMPLES,
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -451,6 +456,26 @@ def build_parser() -> argparse.ArgumentParser:
             "Deterministic output ordering: canonical_id sorts lexically by canonical_id "
             "(default); manifest preserves manifest entry order; input preserves bundle "
             "input order, then manifest order within each input."
+        ),
+    )
+    bundle_parser.add_argument(
+        "--include",
+        action="append",
+        default=[],
+        metavar="PATTERN",
+        help=(
+            "Repeatable glob-style filter. When provided, keep only artifacts matching "
+            "at least one pattern across canonical_id, title, output_path, or source_url."
+        ),
+    )
+    bundle_parser.add_argument(
+        "--exclude",
+        action="append",
+        default=[],
+        metavar="PATTERN",
+        help=(
+            "Repeatable glob-style filter applied after --include matching across "
+            "canonical_id, title, output_path, or source_url. Exclude wins on conflicts."
         ),
     )
 
@@ -1482,7 +1507,12 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
 
         try:
-            bundle_plan = load_bundle_plan(args.inputs, order=args.order)
+            bundle_plan = load_bundle_plan(
+                args.inputs,
+                order=args.order,
+                include_patterns=args.include,
+                exclude_patterns=args.exclude,
+            )
             markdown = render_bundle_markdown(bundle_plan.artifacts)
         except ValueError as exc:
             exit_with_cli_error(str(exc), command="bundle")
@@ -1491,12 +1521,24 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"  inputs: {len(args.inputs)}")
         print(f"  output: {render_user_path(args.output)}")
         print(f"  ordering: {describe_bundle_order(args.order)}")
+        if args.include:
+            print(f"  include_filters: {len(args.include)}")
+        if args.exclude:
+            print(f"  exclude_filters: {len(args.exclude)}")
 
         print("\nPlan: Bundle run")
         for manifest in bundle_plan.manifests:
             print(f"  manifest: {render_user_path(manifest)}")
         print(f"  artifacts_selected: {len(bundle_plan.artifacts)}")
         print(f"  duplicates_skipped: {len(bundle_plan.duplicate_canonical_ids)}")
+        if args.include:
+            for pattern in args.include:
+                print(f"  include: {pattern}")
+        if args.exclude:
+            for pattern in args.exclude:
+                print(f"  exclude: {pattern}")
+        if args.include or args.exclude:
+            print(f"  artifacts_filtered_out: {bundle_plan.filtered_out_count}")
         print("  action: write")
 
         try:
@@ -1505,11 +1547,19 @@ def main(argv: Sequence[str] | None = None) -> int:
             exit_with_bundle_output_error(args.output, exc=exc)
 
         print(f"\nWrote bundle: {render_user_path(written_bundle)}")
-        print(
-            "\nSummary: bundled "
-            f"{len(bundle_plan.artifacts)}, skipped "
-            f"{len(bundle_plan.duplicate_canonical_ids)} duplicates"
-        )
+        if args.include or args.exclude:
+            print(
+                "\nSummary: bundled "
+                f"{len(bundle_plan.artifacts)}, filtered out "
+                f"{bundle_plan.filtered_out_count}, skipped "
+                f"{len(bundle_plan.duplicate_canonical_ids)} duplicates"
+            )
+        else:
+            print(
+                "\nSummary: bundled "
+                f"{len(bundle_plan.artifacts)}, skipped "
+                f"{len(bundle_plan.duplicate_canonical_ids)} duplicates"
+            )
         print(f"Output path: {render_user_path(written_bundle)}")
         print(f"\nWrite complete. Bundle created at {render_user_path(written_bundle)}")
         return 0

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -187,6 +187,106 @@ def test_load_bundle_plan_preserves_input_grouping_and_first_wins_duplicates(
     assert plan.duplicate_canonical_ids == ("alpha",)
 
 
+def test_load_bundle_plan_supports_repeated_include_patterns_across_metadata_fields(
+    tmp_path: Path,
+) -> None:
+    output_dir = tmp_path / "artifacts"
+    _write_output_dir(
+        output_dir,
+        files=[
+            {
+                "canonical_id": "alpha",
+                "source_url": "https://example.com/alpha",
+                "output_path": "pages/alpha.md",
+                "title": "Alpha",
+            },
+            {
+                "canonical_id": "bravo",
+                "source_url": "https://example.com/bravo",
+                "output_path": "pages/bravo.md",
+                "title": "Release notes",
+            },
+            {
+                "canonical_id": "charlie",
+                "source_url": "https://example.com/charlie",
+                "output_path": "pages/docs/charlie.md",
+                "title": "Charlie",
+            },
+            {
+                "canonical_id": "delta",
+                "source_url": "https://example.com/special/delta",
+                "output_path": "pages/delta.md",
+                "title": "Delta",
+            },
+        ],
+        artifact_contents={
+            "pages/alpha.md": "# Alpha\n",
+            "pages/bravo.md": "# Bravo\n",
+            "pages/docs/charlie.md": "# Charlie\n",
+            "pages/delta.md": "# Delta\n",
+        },
+    )
+
+    plan = load_bundle_plan(
+        (output_dir,),
+        include_patterns=(
+            "alpha",
+            "Release*",
+            "pages/docs/*",
+            "https://example.com/special/*",
+        ),
+    )
+
+    assert [artifact.canonical_id for artifact in plan.artifacts] == [
+        "alpha",
+        "bravo",
+        "charlie",
+        "delta",
+    ]
+    assert plan.filtered_out_count == 0
+
+
+def test_load_bundle_plan_applies_repeated_excludes_after_include_matching(tmp_path: Path) -> None:
+    output_dir = tmp_path / "artifacts"
+    _write_output_dir(
+        output_dir,
+        files=[
+            {
+                "canonical_id": "alpha",
+                "source_url": "https://example.com/alpha",
+                "output_path": "pages/alpha.md",
+                "title": "Alpha",
+            },
+            {
+                "canonical_id": "bravo",
+                "source_url": "https://example.com/bravo",
+                "output_path": "pages/bravo.md",
+                "title": "Bravo",
+            },
+            {
+                "canonical_id": "charlie",
+                "source_url": "https://example.com/charlie",
+                "output_path": "pages/docs/charlie.md",
+                "title": "Charlie",
+            },
+        ],
+        artifact_contents={
+            "pages/alpha.md": "# Alpha\n",
+            "pages/bravo.md": "# Bravo\n",
+            "pages/docs/charlie.md": "# Charlie\n",
+        },
+    )
+
+    plan = load_bundle_plan(
+        (output_dir,),
+        include_patterns=("alpha", "bravo", "pages/docs/*"),
+        exclude_patterns=("bravo", "pages/docs/*"),
+    )
+
+    assert [artifact.canonical_id for artifact in plan.artifacts] == ["alpha"]
+    assert plan.filtered_out_count == 2
+
+
 def test_render_bundle_markdown_reads_selected_artifacts_with_separators(tmp_path: Path) -> None:
     output_dir = tmp_path / "artifacts"
     _write_output_dir(

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -155,10 +155,16 @@ def test_bundle_cli_help_includes_ordering_and_input_guidance(tmp_path: Path) ->
     assert "selected deterministic ordering mode" in stdout
     assert "--output FILE" in stdout
     assert "--order {canonical_id,manifest,input}" in stdout
+    assert "--include PATTERN" in stdout
+    assert "--exclude PATTERN" in stdout
     assert "canonical_id sorts lexically by canonical_id (default)" in stdout
     assert "manifest preserves manifest entry order" in stdout
     assert "input preserves bundle input order" in stdout
+    assert "glob-style include and exclude filters match canonical_id, title," in stdout
+    assert "output_path, and source_url" in stdout
+    assert "Exclude filters apply after include matching and win on conflicts." in stdout
     assert "knowledge-adapters bundle ./artifacts/confluence --output ./bundle.md" in stdout
+    assert '--include "team-*" --exclude "*draft*" --output ./bundle.md' in stdout
 
 
 def test_bundle_cli_smoke_combines_multiple_inputs_in_deterministic_order(
@@ -395,6 +401,110 @@ canonical_id: beta
 # Beta artifact
 
 Beta content.
+"""
+    )
+
+
+def test_bundle_cli_smoke_supports_include_and_exclude_filters(tmp_path: Path) -> None:
+    output_dir = tmp_path / "artifacts"
+    (output_dir / "pages" / "docs").mkdir(parents=True)
+    (output_dir / "pages" / "alpha.md").write_text(
+        "# Alpha artifact\n\nAlpha content.\n",
+        encoding="utf-8",
+    )
+    (output_dir / "pages" / "bravo.md").write_text(
+        "# Bravo artifact\n\nBravo content.\n",
+        encoding="utf-8",
+    )
+    (output_dir / "pages" / "docs" / "charlie.md").write_text(
+        "# Charlie artifact\n\nCharlie content.\n",
+        encoding="utf-8",
+    )
+    (output_dir / "pages" / "delta.md").write_text(
+        "# Delta artifact\n\nDelta content.\n",
+        encoding="utf-8",
+    )
+    (output_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "generated_at": "2026-04-24T00:00:00Z",
+                "files": [
+                    {
+                        "canonical_id": "alpha",
+                        "source_url": "https://example.com/alpha",
+                        "output_path": "pages/alpha.md",
+                        "title": "Alpha",
+                    },
+                    {
+                        "canonical_id": "bravo",
+                        "source_url": "https://example.com/bravo",
+                        "output_path": "pages/bravo.md",
+                        "title": "Release notes",
+                    },
+                    {
+                        "canonical_id": "charlie",
+                        "source_url": "https://example.com/charlie",
+                        "output_path": "pages/docs/charlie.md",
+                        "title": "Charlie",
+                    },
+                    {
+                        "canonical_id": "delta",
+                        "source_url": "https://example.com/special/delta",
+                        "output_path": "pages/delta.md",
+                        "title": "Delta",
+                    },
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = _run_cli(
+        tmp_path,
+        "bundle",
+        "./artifacts",
+        "--include",
+        "Release*",
+        "--include",
+        "pages/docs/*",
+        "--include",
+        "https://example.com/special/*",
+        "--exclude",
+        "pages/docs/*",
+        "--output",
+        "./bundles/filtered.md",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "include_filters: 3" in result.stdout
+    assert "exclude_filters: 1" in result.stdout
+    assert "include: Release*" in result.stdout
+    assert "include: pages/docs/*" in result.stdout
+    assert "include: https://example.com/special/*" in result.stdout
+    assert "exclude: pages/docs/*" in result.stdout
+    assert "artifacts_selected: 2" in result.stdout
+    assert "artifacts_filtered_out: 2" in result.stdout
+    assert "Summary: bundled 2, filtered out 2, skipped 0 duplicates" in result.stdout
+    assert (tmp_path / "bundles" / "filtered.md").read_text(encoding="utf-8") == (
+        """## Release notes
+source_url: https://example.com/bravo
+canonical_id: bravo
+
+# Bravo artifact
+
+Bravo content.
+
+---
+
+## Delta
+source_url: https://example.com/special/delta
+canonical_id: delta
+
+# Delta artifact
+
+Delta content.
 """
     )
 


### PR DESCRIPTION
Summary
- add repeatable --include and --exclude filters to knowledge-adapters bundle using simple glob-style matching
- match patterns against canonical_id, title, output_path, and source_url while keeping duplicate handling and ordering deterministic
- document the new filter behavior in bundle help text and extend bundle library and CLI smoke coverage

Testing
- make check

Closes #152