### PR TITLE
feat: add bundle header modes to bundle output

### DIFF
--- a/docs/project-map.md
+++ b/docs/project-map.md
@@ -15,17 +15,12 @@ grouping them into meaningful lanes.
 
 ## Active Arc
 
-### Bundle ergonomics
-
-- #152 Add basic include/exclude filters to the bundle command
-- #155 Add minimal and full header modes to the bundle command
-
-## Next Arcs
-
 ### Bundle advanced behavior
 
-- #157 Add changed-only bundle mode based on a prior manifest
 - #154 Add size-aware splitting to the bundle command
+- #157 Add changed-only bundle mode based on a prior manifest
+
+## Next Arcs
 
 ### Confluence expansion
 

--- a/src/knowledge_adapters/bundle.py
+++ b/src/knowledge_adapters/bundle.py
@@ -12,6 +12,7 @@ from typing import Literal
 from knowledge_adapters.confluence.manifest import manifest_path
 
 BundleOrder = Literal["canonical_id", "manifest", "input"]
+HeaderMode = Literal["minimal", "full"]
 
 DEFAULT_BUNDLE_ORDER: BundleOrder = "canonical_id"
 BUNDLE_ORDER_CHOICES: tuple[BundleOrder, ...] = ("canonical_id", "manifest", "input")
@@ -21,6 +22,12 @@ BUNDLE_ORDER_LABELS: dict[BundleOrder, str] = {
     "input": "input order with manifest grouping",
 }
 ORDERING_RULE = BUNDLE_ORDER_LABELS[DEFAULT_BUNDLE_ORDER]
+DEFAULT_HEADER_MODE: HeaderMode = "full"
+HEADER_MODE_CHOICES: tuple[HeaderMode, ...] = ("minimal", "full")
+HEADER_MODE_LABELS: dict[HeaderMode, str] = {
+    "minimal": "title plus source URL",
+    "full": "title, source URL, canonical_id, and optional manifest metadata",
+}
 
 
 @dataclass(frozen=True)
@@ -31,6 +38,9 @@ class BundleArtifact:
     source_url: str
     title: str | None
     output_path: str
+    fetched_at: str | None
+    path: str | None
+    ref: str | None
     artifact_path: Path
 
 
@@ -56,6 +66,11 @@ class _BundleArtifactPosition:
 def describe_bundle_order(order: BundleOrder) -> str:
     """Return the human-readable description for one bundle ordering mode."""
     return BUNDLE_ORDER_LABELS[order]
+
+
+def describe_header_mode(mode: HeaderMode) -> str:
+    """Return the human-readable description for one bundle header mode."""
+    return HEADER_MODE_LABELS[mode]
 
 
 def load_bundle_plan(
@@ -111,18 +126,25 @@ def load_bundle_plan(
     )
 
 
-def render_bundle_markdown(artifacts: Sequence[BundleArtifact]) -> str:
+def render_bundle_markdown(
+    artifacts: Sequence[BundleArtifact],
+    *,
+    header_mode: HeaderMode = DEFAULT_HEADER_MODE,
+) -> str:
     """Render bundle output with stable separators and metadata lines."""
+    if header_mode not in HEADER_MODE_CHOICES:
+        raise ValueError(
+            f"Unsupported bundle header mode {header_mode!r}. "
+            f"Choose one of: {', '.join(HEADER_MODE_CHOICES)}."
+        )
+
     sections: list[str] = []
     for artifact in artifacts:
-        title = artifact.title or artifact.canonical_id
         content = _read_artifact_text(artifact)
         sections.append(
             "\n".join(
                 (
-                    f"## {title}",
-                    f"source_url: {artifact.source_url}",
-                    f"canonical_id: {artifact.canonical_id}",
+                    *_render_bundle_header_lines(artifact, header_mode=header_mode),
                     "",
                     content.rstrip("\n"),
                 )
@@ -195,6 +217,9 @@ def _load_bundle_artifacts(manifest: Path) -> tuple[BundleArtifact, ...]:
         source_url = entry.get("source_url")
         output_path = entry.get("output_path")
         title = entry.get("title")
+        fetched_at = _optional_manifest_string(entry, "fetched_at", manifest=manifest)
+        path = _optional_manifest_string(entry, "path", manifest=manifest)
+        ref = _optional_manifest_string(entry, "ref", manifest=manifest)
         if not isinstance(canonical_id, str) or not isinstance(source_url, str):
             raise ValueError(
                 f"Bundle manifest {manifest} is invalid: files entries must include "
@@ -227,6 +252,9 @@ def _load_bundle_artifacts(manifest: Path) -> tuple[BundleArtifact, ...]:
                 source_url=source_url,
                 title=title,
                 output_path=output_path,
+                fetched_at=fetched_at,
+                path=path,
+                ref=ref,
                 artifact_path=(manifest.parent / output_path).resolve(),
             )
         )
@@ -242,6 +270,35 @@ def _read_artifact_text(artifact: BundleArtifact) -> str:
             f"Could not read artifact for canonical_id {artifact.canonical_id!r}: "
             f"{artifact.artifact_path}."
         ) from exc
+
+
+def _render_bundle_header_lines(
+    artifact: BundleArtifact,
+    *,
+    header_mode: HeaderMode,
+) -> tuple[str, ...]:
+    title = artifact.title or artifact.canonical_id
+    lines = [
+        f"## {title}",
+        f"source_url: {artifact.source_url}",
+    ]
+    if header_mode == "minimal":
+        return tuple(lines)
+    if header_mode == "full":
+        lines.append(f"canonical_id: {artifact.canonical_id}")
+        for label, value in (
+            ("fetched_at", artifact.fetched_at),
+            ("path", artifact.path),
+            ("ref", artifact.ref),
+        ):
+            if value:
+                lines.append(f"{label}: {value}")
+        return tuple(lines)
+
+    raise ValueError(
+        f"Unsupported bundle header mode {header_mode!r}. "
+        f"Choose one of: {', '.join(HEADER_MODE_CHOICES)}."
+    )
 
 
 def _order_bundle_artifacts(
@@ -316,3 +373,19 @@ def _artifact_matches_patterns(
         for pattern in patterns
         for value in artifact_values
     )
+
+
+def _optional_manifest_string(
+    entry: dict[str, object],
+    field_name: str,
+    *,
+    manifest: Path,
+) -> str | None:
+    value = entry.get(field_name)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError(
+            f"Bundle manifest {manifest} is invalid: {field_name} values must be strings."
+        )
+    return value or None

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -16,7 +16,10 @@ from typing import TextIO
 from knowledge_adapters.bundle import (
     BUNDLE_ORDER_CHOICES,
     DEFAULT_BUNDLE_ORDER,
+    DEFAULT_HEADER_MODE,
+    HEADER_MODE_CHOICES,
     describe_bundle_order,
+    describe_header_mode,
 )
 from knowledge_adapters.confluence.auth import SUPPORTED_AUTH_METHODS, resolve_tls_inputs
 
@@ -85,6 +88,7 @@ BUNDLE_HELP_EXAMPLES = """Examples:
   knowledge-adapters bundle ./artifacts/confluence --output ./bundle.md
   knowledge-adapters bundle ./artifacts/a ./artifacts/b --output ./bundle.md
   knowledge-adapters bundle ./artifacts/manifest.json --output ./bundle.md
+  knowledge-adapters bundle ./artifacts --header-mode minimal --output ./bundle.md
   knowledge-adapters bundle ./artifacts --include "team-*" --exclude "*draft*" --output ./bundle.md
 """
 
@@ -427,7 +431,8 @@ def build_parser() -> argparse.ArgumentParser:
             "or more output directories or manifest files as input. Bundle output keeps "
             "the original artifacts unchanged, removes duplicate canonical_id entries by "
             "keeping the first artifact discovered from the provided inputs, and orders "
-            "the final sections using the selected deterministic ordering mode. Optional "
+            "the final sections using the selected deterministic ordering mode. Header "
+            "modes control how much manifest metadata appears above each document. Optional "
             "glob-style include and exclude filters match canonical_id, title, "
             "output_path, and source_url. If no --include filters are provided, all "
             "artifacts start included. Exclude filters apply after include matching and "
@@ -456,6 +461,16 @@ def build_parser() -> argparse.ArgumentParser:
             "Deterministic output ordering: canonical_id sorts lexically by canonical_id "
             "(default); manifest preserves manifest entry order; input preserves bundle "
             "input order, then manifest order within each input."
+        ),
+    )
+    bundle_parser.add_argument(
+        "--header-mode",
+        choices=HEADER_MODE_CHOICES,
+        default=DEFAULT_HEADER_MODE,
+        help=(
+            "Per-document header detail: full includes source_url, canonical_id, and "
+            "optional fetched_at, path, and ref metadata when present (default); "
+            "minimal includes only the title and source_url."
         ),
     )
     bundle_parser.add_argument(
@@ -1513,7 +1528,10 @@ def main(argv: Sequence[str] | None = None) -> int:
                 include_patterns=args.include,
                 exclude_patterns=args.exclude,
             )
-            markdown = render_bundle_markdown(bundle_plan.artifacts)
+            markdown = render_bundle_markdown(
+                bundle_plan.artifacts,
+                header_mode=args.header_mode,
+            )
         except ValueError as exc:
             exit_with_cli_error(str(exc), command="bundle")
 
@@ -1521,6 +1539,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"  inputs: {len(args.inputs)}")
         print(f"  output: {render_user_path(args.output)}")
         print(f"  ordering: {describe_bundle_order(args.order)}")
+        print(f"  header_mode: {describe_header_mode(args.header_mode)}")
         if args.include:
             print(f"  include_filters: {len(args.include)}")
         if args.exclude:

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -7,6 +7,7 @@ import pytest
 
 from knowledge_adapters.bundle import (
     DEFAULT_BUNDLE_ORDER,
+    DEFAULT_HEADER_MODE,
     ORDERING_RULE,
     describe_bundle_order,
     load_bundle_plan,
@@ -312,6 +313,7 @@ def test_render_bundle_markdown_reads_selected_artifacts_with_separators(tmp_pat
 
     plan = load_bundle_plan((output_dir,))
 
+    assert DEFAULT_HEADER_MODE == "full"
     assert render_bundle_markdown(plan.artifacts) == (
         """## Alpha
 source_url: https://example.com/alpha
@@ -330,6 +332,93 @@ canonical_id: beta
 # Beta
 
 Beta content.
+"""
+    )
+
+
+def test_render_bundle_markdown_supports_minimal_headers(tmp_path: Path) -> None:
+    output_dir = tmp_path / "artifacts"
+    _write_output_dir(
+        output_dir,
+        files=[
+            {
+                "canonical_id": "beta",
+                "source_url": "https://example.com/beta",
+                "output_path": "pages/beta.md",
+            },
+            {
+                "canonical_id": "alpha",
+                "source_url": "https://example.com/alpha",
+                "output_path": "pages/alpha.md",
+                "title": "Alpha",
+                "fetched_at": "2026-04-24T12:00:00Z",
+                "path": "docs/alpha.md",
+                "ref": "refs/heads/main",
+            },
+        ],
+        artifact_contents={
+            "pages/beta.md": "# Beta\n\nBeta content.\n",
+            "pages/alpha.md": "# Alpha\n\nAlpha content.\n",
+        },
+    )
+
+    plan = load_bundle_plan((output_dir,))
+
+    assert render_bundle_markdown(plan.artifacts, header_mode="minimal") == (
+        """## Alpha
+source_url: https://example.com/alpha
+
+# Alpha
+
+Alpha content.
+
+---
+
+## beta
+source_url: https://example.com/beta
+
+# Beta
+
+Beta content.
+"""
+    )
+
+
+def test_render_bundle_markdown_includes_optional_full_header_metadata_when_present(
+    tmp_path: Path,
+) -> None:
+    output_dir = tmp_path / "artifacts"
+    _write_output_dir(
+        output_dir,
+        files=[
+            {
+                "canonical_id": "alpha",
+                "source_url": "https://example.com/alpha",
+                "output_path": "pages/alpha.md",
+                "title": "Alpha",
+                "fetched_at": "2026-04-24T12:00:00Z",
+                "path": "docs/alpha.md",
+                "ref": "refs/heads/main",
+            }
+        ],
+        artifact_contents={
+            "pages/alpha.md": "# Alpha\n\nAlpha content.\n",
+        },
+    )
+
+    plan = load_bundle_plan((output_dir,))
+
+    assert render_bundle_markdown(plan.artifacts) == (
+        """## Alpha
+source_url: https://example.com/alpha
+canonical_id: alpha
+fetched_at: 2026-04-24T12:00:00Z
+path: docs/alpha.md
+ref: refs/heads/main
+
+# Alpha
+
+Alpha content.
 """
     )
 

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -155,15 +155,23 @@ def test_bundle_cli_help_includes_ordering_and_input_guidance(tmp_path: Path) ->
     assert "selected deterministic ordering mode" in stdout
     assert "--output FILE" in stdout
     assert "--order {canonical_id,manifest,input}" in stdout
+    assert "--header-mode {minimal,full}" in stdout
     assert "--include PATTERN" in stdout
     assert "--exclude PATTERN" in stdout
     assert "canonical_id sorts lexically by canonical_id (default)" in stdout
     assert "manifest preserves manifest entry order" in stdout
     assert "input preserves bundle input order" in stdout
+    assert "full includes source_url, canonical_id, and optional fetched_at," in stdout
+    assert "path, and ref metadata when present (default)" in stdout
+    assert "minimal includes only the title and source_url." in stdout
     assert "glob-style include and exclude filters match canonical_id, title," in stdout
     assert "output_path, and source_url" in stdout
     assert "Exclude filters apply after include matching and win on conflicts." in stdout
     assert "knowledge-adapters bundle ./artifacts/confluence --output ./bundle.md" in stdout
+    assert (
+        "knowledge-adapters bundle ./artifacts --header-mode minimal --output ./bundle.md"
+        in stdout
+    )
     assert '--include "team-*" --exclude "*draft*" --output ./bundle.md' in stdout
 
 
@@ -250,6 +258,10 @@ def test_bundle_cli_smoke_combines_multiple_inputs_in_deterministic_order(
     assert result.returncode == 0, result.stderr
     assert "Bundle command invoked" in result.stdout
     assert "ordering: lexical canonical_id order" in result.stdout
+    assert (
+        "header_mode: title, source URL, canonical_id, and optional manifest metadata"
+        in result.stdout
+    )
     assert f"manifest: {output_a / 'manifest.json'}" in result.stdout
     assert f"manifest: {output_b / 'manifest.json'}" in result.stdout
     assert "artifacts_selected: 3" in result.stdout
@@ -286,6 +298,58 @@ canonical_id: zeta
 # Zeta artifact
 
 Zeta content.
+"""
+    )
+
+
+def test_bundle_cli_smoke_supports_minimal_headers(tmp_path: Path) -> None:
+    output_dir = tmp_path / "artifacts"
+    (output_dir / "pages").mkdir(parents=True)
+    (output_dir / "pages" / "alpha.md").write_text(
+        "# Alpha artifact\n\nAlpha content.\n",
+        encoding="utf-8",
+    )
+    (output_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "generated_at": "2026-04-24T00:00:00Z",
+                "files": [
+                    {
+                        "canonical_id": "alpha",
+                        "source_url": "https://example.com/alpha",
+                        "output_path": "pages/alpha.md",
+                        "title": "Alpha",
+                        "fetched_at": "2026-04-24T12:00:00Z",
+                        "path": "docs/alpha.md",
+                        "ref": "refs/heads/main",
+                    }
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = _run_cli(
+        tmp_path,
+        "bundle",
+        "./artifacts",
+        "--header-mode",
+        "minimal",
+        "--output",
+        "./bundles/minimal.md",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "header_mode: title plus source URL" in result.stdout
+    assert (tmp_path / "bundles" / "minimal.md").read_text(encoding="utf-8") == (
+        """## Alpha
+source_url: https://example.com/alpha
+
+# Alpha artifact
+
+Alpha content.
 """
     )
 


### PR DESCRIPTION
Summary
- add minimal and full header modes for bundle output while keeping existing full-header behavior as the default
- thread --header-mode through the bundle CLI and update help text/examples
- cover default, minimal, and optional metadata header rendering in tests
- refresh docs/project-map.md to remove completed bundle ergonomics arcs and promote the next bundle arc

Testing
- make check

Closes #155