### PR TITLE
feat: add changed-only bundle mode

### DIFF
--- a/docs/project-map.md
+++ b/docs/project-map.md
@@ -11,6 +11,7 @@ grouping them into meaningful lanes.
 - Bundle command:
   - v1 complete (#147)
   - ordering controls added (#153)
+  - changed-only bundle comparison in review (#157)
 - CLI, config-driven runs, and test coverage are stable
 
 ## Active Arc

--- a/src/knowledge_adapters/bundle.py
+++ b/src/knowledge_adapters/bundle.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import fnmatch
+import hashlib
 import json
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -41,6 +42,7 @@ class BundleArtifact:
     fetched_at: str | None
     path: str | None
     ref: str | None
+    content_hash: str | None
     artifact_path: Path
 
 
@@ -52,6 +54,8 @@ class BundlePlan:
     artifacts: tuple[BundleArtifact, ...]
     duplicate_canonical_ids: tuple[str, ...]
     filtered_out_count: int = 0
+    unchanged_count: int = 0
+    baseline_manifest: Path | None = None
 
 
 @dataclass(frozen=True)
@@ -61,6 +65,15 @@ class _BundleArtifactPosition:
     input_index: int
     manifest_index: int
     manifest_entry_index: int
+
+
+@dataclass(frozen=True)
+class _BaselineManifestEntry:
+    """Prior manifest entry used for changed-only bundle selection."""
+
+    canonical_id: str
+    content_hash: str | None
+    artifact_path: Path
 
 
 def describe_bundle_order(order: BundleOrder) -> str:
@@ -79,6 +92,8 @@ def load_bundle_plan(
     order: BundleOrder = DEFAULT_BUNDLE_ORDER,
     include_patterns: Sequence[str] = (),
     exclude_patterns: Sequence[str] = (),
+    changed_only: bool = False,
+    baseline_manifest: str | Path | None = None,
 ) -> BundlePlan:
     """Load artifacts from output directories or manifest files."""
     if order not in BUNDLE_ORDER_CHOICES:
@@ -86,6 +101,10 @@ def load_bundle_plan(
             f"Unsupported bundle order {order!r}. "
             f"Choose one of: {', '.join(BUNDLE_ORDER_CHOICES)}."
         )
+    if changed_only and baseline_manifest is None:
+        raise ValueError("Bundle --changed-only requires --baseline-manifest.")
+    if baseline_manifest is not None and not changed_only:
+        raise ValueError("Bundle --baseline-manifest requires --changed-only.")
 
     manifests: list[Path] = []
     artifacts_by_id: dict[str, BundleArtifact] = {}
@@ -107,6 +126,17 @@ def load_bundle_plan(
                 manifest_entry_index=manifest_entry_index,
             )
 
+    unchanged_count = 0
+    baseline_manifest_path = None
+    if changed_only:
+        assert baseline_manifest is not None
+        baseline_manifest_path = _resolve_manifest_input(baseline_manifest)
+        baseline_entries = _load_baseline_manifest_entries(baseline_manifest_path)
+        artifacts_by_id, unchanged_count = _select_changed_bundle_artifacts(
+            artifacts_by_id,
+            baseline_entries,
+        )
+
     ordered_artifacts = _order_bundle_artifacts(
         artifacts_by_id,
         artifact_positions,
@@ -123,6 +153,8 @@ def load_bundle_plan(
         artifacts=selected_artifacts,
         duplicate_canonical_ids=tuple(duplicate_canonical_ids),
         filtered_out_count=filtered_out_count,
+        unchanged_count=unchanged_count,
+        baseline_manifest=baseline_manifest_path,
     )
 
 
@@ -220,6 +252,7 @@ def _load_bundle_artifacts(manifest: Path) -> tuple[BundleArtifact, ...]:
         fetched_at = _optional_manifest_string(entry, "fetched_at", manifest=manifest)
         path = _optional_manifest_string(entry, "path", manifest=manifest)
         ref = _optional_manifest_string(entry, "ref", manifest=manifest)
+        content_hash = _optional_manifest_string(entry, "content_hash", manifest=manifest)
         if not isinstance(canonical_id, str) or not isinstance(source_url, str):
             raise ValueError(
                 f"Bundle manifest {manifest} is invalid: files entries must include "
@@ -255,11 +288,98 @@ def _load_bundle_artifacts(manifest: Path) -> tuple[BundleArtifact, ...]:
                 fetched_at=fetched_at,
                 path=path,
                 ref=ref,
+                content_hash=content_hash,
                 artifact_path=(manifest.parent / output_path).resolve(),
             )
         )
 
     return tuple(artifacts)
+
+
+def _load_baseline_manifest_entries(manifest: Path) -> dict[str, _BaselineManifestEntry]:
+    try:
+        payload = json.loads(manifest.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"Could not read baseline manifest {manifest}.") from exc
+
+    files = payload.get("files") if isinstance(payload, dict) else None
+    if not isinstance(files, list):
+        raise ValueError(
+            f"Baseline manifest {manifest} is invalid: expected a files list."
+        )
+
+    entries_by_id: dict[str, _BaselineManifestEntry] = {}
+    for entry in files:
+        if not isinstance(entry, dict):
+            raise ValueError(
+                f"Baseline manifest {manifest} is invalid: each files entry must be an object."
+            )
+
+        canonical_id = entry.get("canonical_id")
+        output_path = entry.get("output_path")
+        content_hash = _optional_manifest_string(entry, "content_hash", manifest=manifest)
+        if not isinstance(canonical_id, str) or not isinstance(output_path, str):
+            raise ValueError(
+                f"Baseline manifest {manifest} is invalid: files entries must include "
+                "string canonical_id and output_path values."
+            )
+        if canonical_id in entries_by_id:
+            raise ValueError(
+                f"Baseline manifest {manifest} is invalid: duplicate canonical_id "
+                f"{canonical_id!r}."
+            )
+
+        entries_by_id[canonical_id] = _BaselineManifestEntry(
+            canonical_id=canonical_id,
+            content_hash=content_hash,
+            artifact_path=(manifest.parent / output_path).resolve(),
+        )
+
+    return entries_by_id
+
+
+def _select_changed_bundle_artifacts(
+    artifacts_by_id: dict[str, BundleArtifact],
+    baseline_entries: dict[str, _BaselineManifestEntry],
+) -> tuple[dict[str, BundleArtifact], int]:
+    selected_artifacts: dict[str, BundleArtifact] = {}
+    unchanged_count = 0
+    for canonical_id, artifact in artifacts_by_id.items():
+        baseline_entry = baseline_entries.get(canonical_id)
+        if baseline_entry is None or _artifact_changed_since_baseline(
+            artifact,
+            baseline_entry,
+        ):
+            selected_artifacts[canonical_id] = artifact
+        else:
+            unchanged_count += 1
+
+    return selected_artifacts, unchanged_count
+
+
+def _artifact_changed_since_baseline(
+    artifact: BundleArtifact,
+    baseline_entry: _BaselineManifestEntry,
+) -> bool:
+    if not baseline_entry.artifact_path.is_file():
+        return True
+
+    current_hash = artifact.content_hash or _hash_file(artifact.artifact_path)
+    baseline_hash = baseline_entry.content_hash
+    if baseline_hash is None:
+        try:
+            baseline_hash = _hash_file(baseline_entry.artifact_path)
+        except ValueError:
+            return True
+
+    return current_hash != baseline_hash
+
+
+def _hash_file(path: Path) -> str:
+    try:
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError as exc:
+        raise ValueError(f"Could not read artifact while computing content hash: {path}.") from exc
 
 
 def _read_artifact_text(artifact: BundleArtifact) -> str:

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -90,6 +90,8 @@ BUNDLE_HELP_EXAMPLES = """Examples:
   knowledge-adapters bundle ./artifacts/manifest.json --output ./bundle.md
   knowledge-adapters bundle ./artifacts --header-mode minimal --output ./bundle.md
   knowledge-adapters bundle ./artifacts --include "team-*" --exclude "*draft*" --output ./bundle.md
+  knowledge-adapters bundle ./artifacts --changed-only \\
+    --baseline-manifest ./prior/manifest.json --output ./bundle.md
 """
 
 _WRITE_SUMMARY_RE = re.compile(r"Summary: wrote (?P<wrote>\d+), skipped (?P<skipped>\d+)")
@@ -436,7 +438,8 @@ def build_parser() -> argparse.ArgumentParser:
             "glob-style include and exclude filters match canonical_id, title, "
             "output_path, and source_url. If no --include filters are provided, all "
             "artifacts start included. Exclude filters apply after include matching and "
-            "win on conflicts."
+            "win on conflicts. With --changed-only, a baseline manifest is used to keep "
+            "only artifacts with new canonical_id values or changed content_hash values."
         ),
         epilog=BUNDLE_HELP_EXAMPLES,
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -491,6 +494,22 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "Repeatable glob-style filter applied after --include matching across "
             "canonical_id, title, output_path, or source_url. Exclude wins on conflicts."
+        ),
+    )
+    bundle_parser.add_argument(
+        "--changed-only",
+        action="store_true",
+        help=(
+            "Keep only artifacts that are new or changed compared with "
+            "--baseline-manifest. Requires --baseline-manifest."
+        ),
+    )
+    bundle_parser.add_argument(
+        "--baseline-manifest",
+        metavar="PATH",
+        help=(
+            "Prior manifest.json to compare by canonical_id and content_hash when "
+            "--changed-only is set."
         ),
     )
 
@@ -1527,6 +1546,8 @@ def main(argv: Sequence[str] | None = None) -> int:
                 order=args.order,
                 include_patterns=args.include,
                 exclude_patterns=args.exclude,
+                changed_only=args.changed_only,
+                baseline_manifest=args.baseline_manifest,
             )
             markdown = render_bundle_markdown(
                 bundle_plan.artifacts,
@@ -1544,12 +1565,21 @@ def main(argv: Sequence[str] | None = None) -> int:
             print(f"  include_filters: {len(args.include)}")
         if args.exclude:
             print(f"  exclude_filters: {len(args.exclude)}")
+        if args.changed_only:
+            print("  changed_only: true")
+            if bundle_plan.baseline_manifest is not None:
+                print(
+                    "  baseline_manifest: "
+                    f"{render_user_path(bundle_plan.baseline_manifest)}"
+                )
 
         print("\nPlan: Bundle run")
         for manifest in bundle_plan.manifests:
             print(f"  manifest: {render_user_path(manifest)}")
         print(f"  artifacts_selected: {len(bundle_plan.artifacts)}")
         print(f"  duplicates_skipped: {len(bundle_plan.duplicate_canonical_ids)}")
+        if args.changed_only:
+            print(f"  unchanged_skipped: {bundle_plan.unchanged_count}")
         if args.include:
             for pattern in args.include:
                 print(f"  include: {pattern}")
@@ -1566,7 +1596,14 @@ def main(argv: Sequence[str] | None = None) -> int:
             exit_with_bundle_output_error(args.output, exc=exc)
 
         print(f"\nWrote bundle: {render_user_path(written_bundle)}")
-        if args.include or args.exclude:
+        if args.changed_only:
+            print(
+                "\nSummary: bundled "
+                f"{len(bundle_plan.artifacts)}, skipped "
+                f"{bundle_plan.unchanged_count} unchanged, skipped "
+                f"{len(bundle_plan.duplicate_canonical_ids)} duplicates"
+            )
+        elif args.include or args.exclude:
             print(
                 "\nSummary: bundled "
                 f"{len(bundle_plan.artifacts)}, filtered out "

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -188,6 +188,188 @@ def test_load_bundle_plan_preserves_input_grouping_and_first_wins_duplicates(
     assert plan.duplicate_canonical_ids == ("alpha",)
 
 
+def test_load_bundle_plan_changed_only_selects_new_and_changed_artifacts(
+    tmp_path: Path,
+) -> None:
+    baseline_dir = tmp_path / "baseline"
+    baseline_manifest = _write_output_dir(
+        baseline_dir,
+        files=[
+            {
+                "canonical_id": "alpha",
+                "source_url": "https://example.com/alpha",
+                "output_path": "pages/alpha.md",
+                "content_hash": "same-alpha",
+            },
+            {
+                "canonical_id": "beta",
+                "source_url": "https://example.com/beta",
+                "output_path": "pages/beta.md",
+                "content_hash": "old-beta",
+            },
+        ],
+        artifact_contents={
+            "pages/alpha.md": "# Alpha\n",
+            "pages/beta.md": "# Beta old\n",
+        },
+    )
+    current_dir = tmp_path / "current"
+    _write_output_dir(
+        current_dir,
+        files=[
+            {
+                "canonical_id": "alpha",
+                "source_url": "https://example.com/alpha",
+                "output_path": "pages/alpha.md",
+                "content_hash": "same-alpha",
+            },
+            {
+                "canonical_id": "beta",
+                "source_url": "https://example.com/beta",
+                "output_path": "pages/beta.md",
+                "content_hash": "new-beta",
+            },
+            {
+                "canonical_id": "gamma",
+                "source_url": "https://example.com/gamma",
+                "output_path": "pages/gamma.md",
+                "content_hash": "new-gamma",
+            },
+        ],
+        artifact_contents={
+            "pages/alpha.md": "# Alpha\n",
+            "pages/beta.md": "# Beta new\n",
+            "pages/gamma.md": "# Gamma\n",
+        },
+    )
+
+    plan = load_bundle_plan(
+        (current_dir,),
+        changed_only=True,
+        baseline_manifest=baseline_manifest,
+    )
+
+    assert [artifact.canonical_id for artifact in plan.artifacts] == ["beta", "gamma"]
+    assert plan.unchanged_count == 1
+    assert plan.baseline_manifest == baseline_manifest
+
+
+def test_load_bundle_plan_changed_only_uses_file_hashes_when_manifest_hashes_are_absent(
+    tmp_path: Path,
+) -> None:
+    baseline_dir = tmp_path / "baseline"
+    baseline_manifest = _write_output_dir(
+        baseline_dir,
+        files=[
+            {
+                "canonical_id": "alpha",
+                "source_url": "https://example.com/alpha",
+                "output_path": "pages/alpha.md",
+            },
+            {
+                "canonical_id": "beta",
+                "source_url": "https://example.com/beta",
+                "output_path": "pages/beta.md",
+            },
+        ],
+        artifact_contents={
+            "pages/alpha.md": "# Alpha\n",
+            "pages/beta.md": "# Beta old\n",
+        },
+    )
+    current_dir = tmp_path / "current"
+    _write_output_dir(
+        current_dir,
+        files=[
+            {
+                "canonical_id": "alpha",
+                "source_url": "https://example.com/alpha",
+                "output_path": "pages/alpha.md",
+            },
+            {
+                "canonical_id": "beta",
+                "source_url": "https://example.com/beta",
+                "output_path": "pages/beta.md",
+            },
+        ],
+        artifact_contents={
+            "pages/alpha.md": "# Alpha\n",
+            "pages/beta.md": "# Beta new\n",
+        },
+    )
+
+    plan = load_bundle_plan(
+        (current_dir,),
+        changed_only=True,
+        baseline_manifest=baseline_manifest,
+    )
+
+    assert [artifact.canonical_id for artifact in plan.artifacts] == ["beta"]
+    assert plan.unchanged_count == 1
+
+
+def test_load_bundle_plan_changed_only_treats_missing_baseline_file_as_changed(
+    tmp_path: Path,
+) -> None:
+    baseline_dir = tmp_path / "baseline"
+    baseline_manifest = _write_output_dir(
+        baseline_dir,
+        files=[
+            {
+                "canonical_id": "alpha",
+                "source_url": "https://example.com/alpha",
+                "output_path": "pages/alpha.md",
+                "content_hash": "same-alpha",
+            }
+        ],
+        artifact_contents={},
+    )
+    current_dir = tmp_path / "current"
+    _write_output_dir(
+        current_dir,
+        files=[
+            {
+                "canonical_id": "alpha",
+                "source_url": "https://example.com/alpha",
+                "output_path": "pages/alpha.md",
+                "content_hash": "same-alpha",
+            }
+        ],
+        artifact_contents={
+            "pages/alpha.md": "# Alpha\n",
+        },
+    )
+
+    plan = load_bundle_plan(
+        (current_dir,),
+        changed_only=True,
+        baseline_manifest=baseline_manifest,
+    )
+
+    assert [artifact.canonical_id for artifact in plan.artifacts] == ["alpha"]
+    assert plan.unchanged_count == 0
+
+
+def test_load_bundle_plan_changed_only_requires_baseline_manifest(tmp_path: Path) -> None:
+    output_dir = tmp_path / "artifacts"
+    _write_output_dir(
+        output_dir,
+        files=[
+            {
+                "canonical_id": "alpha",
+                "source_url": "https://example.com/alpha",
+                "output_path": "pages/alpha.md",
+            }
+        ],
+        artifact_contents={
+            "pages/alpha.md": "# Alpha\n",
+        },
+    )
+
+    with pytest.raises(ValueError, match="requires --baseline-manifest"):
+        load_bundle_plan((output_dir,), changed_only=True)
+
+
 def test_load_bundle_plan_supports_repeated_include_patterns_across_metadata_fields(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -158,6 +158,8 @@ def test_bundle_cli_help_includes_ordering_and_input_guidance(tmp_path: Path) ->
     assert "--header-mode {minimal,full}" in stdout
     assert "--include PATTERN" in stdout
     assert "--exclude PATTERN" in stdout
+    assert "--changed-only" in stdout
+    assert "--baseline-manifest PATH" in stdout
     assert "canonical_id sorts lexically by canonical_id (default)" in stdout
     assert "manifest preserves manifest entry order" in stdout
     assert "input preserves bundle input order" in stdout
@@ -167,6 +169,8 @@ def test_bundle_cli_help_includes_ordering_and_input_guidance(tmp_path: Path) ->
     assert "glob-style include and exclude filters match canonical_id, title," in stdout
     assert "output_path, and source_url" in stdout
     assert "Exclude filters apply after include matching and win on conflicts." in stdout
+    assert "new or changed compared with --baseline-manifest" in stdout
+    assert "compare by canonical_id and content_hash" in stdout
     assert "knowledge-adapters bundle ./artifacts/confluence --output ./bundle.md" in stdout
     assert (
         "knowledge-adapters bundle ./artifacts --header-mode minimal --output ./bundle.md"
@@ -298,6 +302,108 @@ canonical_id: zeta
 # Zeta artifact
 
 Zeta content.
+"""
+    )
+
+
+def test_bundle_cli_smoke_supports_changed_only_against_baseline_manifest(
+    tmp_path: Path,
+) -> None:
+    baseline_dir = tmp_path / "baseline"
+    current_dir = tmp_path / "current"
+    (baseline_dir / "pages").mkdir(parents=True)
+    (current_dir / "pages").mkdir(parents=True)
+    (baseline_dir / "pages" / "alpha.md").write_text("# Alpha\n", encoding="utf-8")
+    (baseline_dir / "pages" / "beta.md").write_text("# Beta old\n", encoding="utf-8")
+    (current_dir / "pages" / "alpha.md").write_text("# Alpha\n", encoding="utf-8")
+    (current_dir / "pages" / "beta.md").write_text("# Beta new\n", encoding="utf-8")
+    (current_dir / "pages" / "gamma.md").write_text("# Gamma\n", encoding="utf-8")
+    (baseline_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "generated_at": "2026-04-24T00:00:00Z",
+                "files": [
+                    {
+                        "canonical_id": "alpha",
+                        "source_url": "https://example.com/alpha",
+                        "output_path": "pages/alpha.md",
+                        "content_hash": "same-alpha",
+                    },
+                    {
+                        "canonical_id": "beta",
+                        "source_url": "https://example.com/beta",
+                        "output_path": "pages/beta.md",
+                        "content_hash": "old-beta",
+                    },
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (current_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "generated_at": "2026-04-24T00:00:00Z",
+                "files": [
+                    {
+                        "canonical_id": "alpha",
+                        "source_url": "https://example.com/alpha",
+                        "output_path": "pages/alpha.md",
+                        "content_hash": "same-alpha",
+                    },
+                    {
+                        "canonical_id": "beta",
+                        "source_url": "https://example.com/beta",
+                        "output_path": "pages/beta.md",
+                        "content_hash": "new-beta",
+                    },
+                    {
+                        "canonical_id": "gamma",
+                        "source_url": "https://example.com/gamma",
+                        "output_path": "pages/gamma.md",
+                        "content_hash": "new-gamma",
+                    },
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = _run_cli(
+        tmp_path,
+        "bundle",
+        "./current",
+        "--changed-only",
+        "--baseline-manifest",
+        "./baseline/manifest.json",
+        "--output",
+        "./bundles/changed.md",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "changed_only: true" in result.stdout
+    assert f"baseline_manifest: {baseline_dir / 'manifest.json'}" in result.stdout
+    assert "artifacts_selected: 2" in result.stdout
+    assert "unchanged_skipped: 1" in result.stdout
+    assert "Summary: bundled 2, skipped 1 unchanged, skipped 0 duplicates" in result.stdout
+    assert (tmp_path / "bundles" / "changed.md").read_text(encoding="utf-8") == (
+        """## beta
+source_url: https://example.com/beta
+canonical_id: beta
+
+# Beta new
+
+---
+
+## gamma
+source_url: https://example.com/gamma
+canonical_id: gamma
+
+# Gamma
 """
     )
 


### PR DESCRIPTION
Summary
- add --changed-only bundle selection using a required --baseline-manifest comparison
- compare artifacts by canonical_id and content_hash, with file-hash fallback for older manifests and safe inclusion when baseline files are missing
- update bundle help, smoke coverage, focused bundle tests, and project map progress

Testing
- make check

Closes #157