### PR TITLE
feat: add bundle size splitting

### DIFF
--- a/docs/project-map.md
+++ b/docs/project-map.md
@@ -11,15 +11,13 @@ grouping them into meaningful lanes.
 - Bundle command:
   - v1 complete (#147)
   - ordering controls added (#153)
-  - changed-only bundle comparison in review (#157)
+  - changed-only bundle comparison complete (#157)
+  - size-aware bundle splitting complete (#154)
 - CLI, config-driven runs, and test coverage are stable
 
 ## Active Arc
 
-### Bundle advanced behavior
-
-- #154 Add size-aware splitting to the bundle command
-- #157 Add changed-only bundle mode based on a prior manifest
+Pending selection.
 
 ## Next Arcs
 

--- a/src/knowledge_adapters/bundle.py
+++ b/src/knowledge_adapters/bundle.py
@@ -29,6 +29,7 @@ HEADER_MODE_LABELS: dict[HeaderMode, str] = {
     "minimal": "title plus source URL",
     "full": "title, source URL, canonical_id, and optional manifest metadata",
 }
+BUNDLE_SECTION_SEPARATOR = "\n\n---\n\n"
 
 
 @dataclass(frozen=True)
@@ -56,6 +57,40 @@ class BundlePlan:
     filtered_out_count: int = 0
     unchanged_count: int = 0
     baseline_manifest: Path | None = None
+
+
+@dataclass(frozen=True)
+class BundleSection:
+    """One rendered artifact section ready for bundle output."""
+
+    canonical_id: str
+    markdown: str
+
+
+@dataclass(frozen=True)
+class OversizedBundleSection:
+    """A rendered section that exceeds the requested split size."""
+
+    canonical_id: str
+    byte_count: int
+
+
+@dataclass(frozen=True)
+class SplitBundleFile:
+    """One planned split bundle output file."""
+
+    path: Path
+    markdown: str
+    artifact_count: int
+    byte_count: int
+
+
+@dataclass(frozen=True)
+class SplitBundlePlan:
+    """A deterministic split bundle write plan."""
+
+    output_files: tuple[SplitBundleFile, ...]
+    oversized_sections: tuple[OversizedBundleSection, ...]
 
 
 @dataclass(frozen=True)
@@ -164,29 +199,38 @@ def render_bundle_markdown(
     header_mode: HeaderMode = DEFAULT_HEADER_MODE,
 ) -> str:
     """Render bundle output with stable separators and metadata lines."""
+    return _render_bundle_sections_markdown(
+        render_bundle_sections(artifacts, header_mode=header_mode)
+    )
+
+
+def render_bundle_sections(
+    artifacts: Sequence[BundleArtifact],
+    *,
+    header_mode: HeaderMode = DEFAULT_HEADER_MODE,
+) -> tuple[BundleSection, ...]:
+    """Render bundle output as stable artifact-level sections."""
     if header_mode not in HEADER_MODE_CHOICES:
         raise ValueError(
             f"Unsupported bundle header mode {header_mode!r}. "
             f"Choose one of: {', '.join(HEADER_MODE_CHOICES)}."
         )
 
-    sections: list[str] = []
+    sections: list[BundleSection] = []
     for artifact in artifacts:
         content = _read_artifact_text(artifact)
         sections.append(
-            "\n".join(
-                (
-                    *_render_bundle_header_lines(artifact, header_mode=header_mode),
-                    "",
-                    content.rstrip("\n"),
-                )
-            ).rstrip()
+            BundleSection(
+                canonical_id=artifact.canonical_id,
+                markdown=_render_bundle_section_markdown(
+                    artifact,
+                    content=content,
+                    header_mode=header_mode,
+                ),
+            )
         )
 
-    if not sections:
-        return ""
-
-    return "\n\n---\n\n".join(sections) + "\n"
+    return tuple(sections)
 
 
 def write_bundle(output_path: str | Path, markdown: str) -> Path:
@@ -195,6 +239,45 @@ def write_bundle(output_path: str | Path, markdown: str) -> Path:
     resolved_output_path.parent.mkdir(parents=True, exist_ok=True)
     resolved_output_path.write_text(markdown, encoding="utf-8")
     return resolved_output_path
+
+
+def plan_split_bundle(
+    output_path: str | Path,
+    sections: Sequence[BundleSection],
+    *,
+    max_bytes: int,
+) -> SplitBundlePlan:
+    """Plan deterministic numbered bundle files split between artifact sections."""
+    if max_bytes < 1:
+        raise ValueError("--max-bytes must be greater than 0.")
+
+    resolved_output_path = Path(output_path).expanduser().resolve()
+    chunks, oversized_sections = _split_bundle_sections(sections, max_bytes=max_bytes)
+    output_files: list[SplitBundleFile] = []
+    for index, chunk in enumerate(chunks, start=1):
+        markdown = _render_bundle_sections_markdown(chunk)
+        output_files.append(
+            SplitBundleFile(
+                path=_split_bundle_output_path(resolved_output_path, index),
+                markdown=markdown,
+                artifact_count=len(chunk),
+                byte_count=_bundle_byte_count(markdown),
+            )
+        )
+
+    return SplitBundlePlan(
+        output_files=tuple(output_files),
+        oversized_sections=oversized_sections,
+    )
+
+
+def write_split_bundle(plan: SplitBundlePlan) -> SplitBundlePlan:
+    """Write a split bundle plan, creating parent directories when needed."""
+    for output_file in plan.output_files:
+        output_file.path.parent.mkdir(parents=True, exist_ok=True)
+        output_file.path.write_text(output_file.markdown, encoding="utf-8")
+
+    return plan
 
 
 def _resolve_manifest_input(raw_input: str | Path) -> Path:
@@ -419,6 +502,77 @@ def _render_bundle_header_lines(
         f"Unsupported bundle header mode {header_mode!r}. "
         f"Choose one of: {', '.join(HEADER_MODE_CHOICES)}."
     )
+
+
+def _render_bundle_section_markdown(
+    artifact: BundleArtifact,
+    *,
+    content: str,
+    header_mode: HeaderMode,
+) -> str:
+    return "\n".join(
+        (
+            *_render_bundle_header_lines(artifact, header_mode=header_mode),
+            "",
+            content.rstrip("\n"),
+        )
+    ).rstrip()
+
+
+def _render_bundle_sections_markdown(sections: Sequence[BundleSection]) -> str:
+    if not sections:
+        return ""
+
+    return BUNDLE_SECTION_SEPARATOR.join(section.markdown for section in sections) + "\n"
+
+
+def _split_bundle_sections(
+    sections: Sequence[BundleSection],
+    *,
+    max_bytes: int,
+) -> tuple[tuple[tuple[BundleSection, ...], ...], tuple[OversizedBundleSection, ...]]:
+    chunks: list[tuple[BundleSection, ...]] = []
+    oversized_sections: list[OversizedBundleSection] = []
+    current_chunk: list[BundleSection] = []
+
+    for section in sections:
+        single_section_markdown = _render_bundle_sections_markdown((section,))
+        single_section_bytes = _bundle_byte_count(single_section_markdown)
+        if single_section_bytes > max_bytes:
+            oversized_sections.append(
+                OversizedBundleSection(
+                    canonical_id=section.canonical_id,
+                    byte_count=single_section_bytes,
+                )
+            )
+
+        if not current_chunk:
+            current_chunk.append(section)
+            continue
+
+        candidate_chunk = (*current_chunk, section)
+        candidate_markdown = _render_bundle_sections_markdown(candidate_chunk)
+        if _bundle_byte_count(candidate_markdown) <= max_bytes:
+            current_chunk.append(section)
+            continue
+
+        chunks.append(tuple(current_chunk))
+        current_chunk = [section]
+
+    if current_chunk:
+        chunks.append(tuple(current_chunk))
+    if not chunks:
+        chunks.append(())
+
+    return tuple(chunks), tuple(oversized_sections)
+
+
+def _split_bundle_output_path(output_path: Path, index: int) -> Path:
+    return output_path.with_name(f"{output_path.stem}-{index:03d}{output_path.suffix}")
+
+
+def _bundle_byte_count(markdown: str) -> int:
+    return len(markdown.encode("utf-8"))
 
 
 def _order_bundle_artifacts(

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -90,6 +90,7 @@ BUNDLE_HELP_EXAMPLES = """Examples:
   knowledge-adapters bundle ./artifacts/manifest.json --output ./bundle.md
   knowledge-adapters bundle ./artifacts --header-mode minimal --output ./bundle.md
   knowledge-adapters bundle ./artifacts --include "team-*" --exclude "*draft*" --output ./bundle.md
+  knowledge-adapters bundle ./artifacts --max-bytes 250000 --output ./bundle.md
   knowledge-adapters bundle ./artifacts --changed-only \\
     --baseline-manifest ./prior/manifest.json --output ./bundle.md
 """
@@ -161,6 +162,19 @@ def _parse_only_run_names(value: str) -> tuple[str, ...]:
         )
 
     return tuple(parsed_names)
+
+
+def _parse_positive_int(value: str) -> int:
+    """Parse a strictly positive integer CLI value."""
+    try:
+        parsed_value = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("expected a positive integer.") from exc
+
+    if parsed_value < 1:
+        raise argparse.ArgumentTypeError("expected a positive integer.")
+
+    return parsed_value
 
 
 def exit_with_output_error(
@@ -439,7 +453,9 @@ def build_parser() -> argparse.ArgumentParser:
             "output_path, and source_url. If no --include filters are provided, all "
             "artifacts start included. Exclude filters apply after include matching and "
             "win on conflicts. With --changed-only, a baseline manifest is used to keep "
-            "only artifacts with new canonical_id values or changed content_hash values."
+            "only artifacts with new canonical_id values or changed content_hash values. "
+            "With --max-bytes, bundle output is split into deterministic numbered "
+            "markdown files and sections are kept intact when possible."
         ),
         epilog=BUNDLE_HELP_EXAMPLES,
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -455,6 +471,16 @@ def build_parser() -> argparse.ArgumentParser:
         required=True,
         metavar="FILE",
         help="Markdown file to write with the bundled artifact content.",
+    )
+    bundle_parser.add_argument(
+        "--max-bytes",
+        type=_parse_positive_int,
+        metavar="N",
+        help=(
+            "Split bundle output into numbered markdown files when possible, each at "
+            "or below N UTF-8 bytes. Splits happen only between artifact sections; a "
+            "single oversized artifact is written to its own file and reported."
+        ),
     )
     bundle_parser.add_argument(
         "--order",
@@ -1524,9 +1550,13 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if args.command == "bundle":
         from knowledge_adapters.bundle import (
+            SplitBundlePlan,
             load_bundle_plan,
+            plan_split_bundle,
             render_bundle_markdown,
+            render_bundle_sections,
             write_bundle,
+            write_split_bundle,
         )
 
         output_path_input = Path(args.output).expanduser()
@@ -1549,16 +1579,31 @@ def main(argv: Sequence[str] | None = None) -> int:
                 changed_only=args.changed_only,
                 baseline_manifest=args.baseline_manifest,
             )
-            markdown = render_bundle_markdown(
-                bundle_plan.artifacts,
-                header_mode=args.header_mode,
-            )
+            split_bundle_plan: SplitBundlePlan | None = None
+            bundle_markdown: str | None = None
+            if args.max_bytes is None:
+                bundle_markdown = render_bundle_markdown(
+                    bundle_plan.artifacts,
+                    header_mode=args.header_mode,
+                )
+            else:
+                sections = render_bundle_sections(
+                    bundle_plan.artifacts,
+                    header_mode=args.header_mode,
+                )
+                split_bundle_plan = plan_split_bundle(
+                    args.output,
+                    sections,
+                    max_bytes=args.max_bytes,
+                )
         except ValueError as exc:
             exit_with_cli_error(str(exc), command="bundle")
 
         print("Bundle command invoked")
         print(f"  inputs: {len(args.inputs)}")
         print(f"  output: {render_user_path(args.output)}")
+        if args.max_bytes is not None:
+            print(f"  max_bytes: {args.max_bytes}")
         print(f"  ordering: {describe_bundle_order(args.order)}")
         print(f"  header_mode: {describe_header_mode(args.header_mode)}")
         if args.include:
@@ -1588,14 +1633,40 @@ def main(argv: Sequence[str] | None = None) -> int:
                 print(f"  exclude: {pattern}")
         if args.include or args.exclude:
             print(f"  artifacts_filtered_out: {bundle_plan.filtered_out_count}")
+        if split_bundle_plan is not None:
+            print(f"  output_files: {len(split_bundle_plan.output_files)}")
+            if split_bundle_plan.oversized_sections:
+                print(f"  oversized_sections: {len(split_bundle_plan.oversized_sections)}")
+                for oversized_section in split_bundle_plan.oversized_sections:
+                    print(
+                        "  oversized: "
+                        f"{oversized_section.canonical_id} "
+                        f"({oversized_section.byte_count} bytes > {args.max_bytes} max)"
+                    )
         print("  action: write")
 
         try:
-            written_bundle = write_bundle(args.output, markdown)
+            if split_bundle_plan is None:
+                assert bundle_markdown is not None
+                written_bundle = write_bundle(args.output, bundle_markdown)
+                written_split_bundle = None
+            else:
+                written_split_bundle = write_split_bundle(split_bundle_plan)
+                written_bundle = None
         except OSError as exc:
             exit_with_bundle_output_error(args.output, exc=exc)
 
-        print(f"\nWrote bundle: {render_user_path(written_bundle)}")
+        if written_split_bundle is None:
+            assert written_bundle is not None
+            print(f"\nWrote bundle: {render_user_path(written_bundle)}")
+        else:
+            print(f"\nWrote split bundle files: {len(written_split_bundle.output_files)}")
+            for output_file in written_split_bundle.output_files:
+                print(
+                    "  file: "
+                    f"{render_user_path(output_file.path)} "
+                    f"({output_file.artifact_count} artifacts, {output_file.byte_count} bytes)"
+                )
         if args.changed_only:
             print(
                 "\nSummary: bundled "
@@ -1616,8 +1687,25 @@ def main(argv: Sequence[str] | None = None) -> int:
                 f"{len(bundle_plan.artifacts)}, skipped "
                 f"{len(bundle_plan.duplicate_canonical_ids)} duplicates"
             )
-        print(f"Output path: {render_user_path(written_bundle)}")
-        print(f"\nWrite complete. Bundle created at {render_user_path(written_bundle)}")
+        if written_split_bundle is not None:
+            print(
+                "Summary: wrote "
+                f"{len(written_split_bundle.output_files)} files, "
+                f"{len(written_split_bundle.oversized_sections)} oversized sections"
+            )
+        if written_split_bundle is None:
+            assert written_bundle is not None
+            print(f"Output path: {render_user_path(written_bundle)}")
+            print(f"\nWrite complete. Bundle created at {render_user_path(written_bundle)}")
+        else:
+            first_output_file = written_split_bundle.output_files[0]
+            print(f"Output files: {len(written_split_bundle.output_files)}")
+            print(f"First output path: {render_user_path(first_output_file.path)}")
+            print(
+                "\nWrite complete. Bundle split into "
+                f"{len(written_split_bundle.output_files)} files under "
+                f"{render_user_path(first_output_file.path.parent)}"
+            )
         return 0
 
     if args.command == "local_files":

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -11,8 +11,11 @@ from knowledge_adapters.bundle import (
     ORDERING_RULE,
     describe_bundle_order,
     load_bundle_plan,
+    plan_split_bundle,
     render_bundle_markdown,
+    render_bundle_sections,
     write_bundle,
+    write_split_bundle,
 )
 
 
@@ -623,6 +626,129 @@ def test_render_bundle_markdown_rejects_missing_artifact_file(tmp_path: Path) ->
 
     with pytest.raises(ValueError, match="Could not read artifact for canonical_id 'alpha'"):
         render_bundle_markdown(plan.artifacts)
+
+
+def test_plan_split_bundle_writes_deterministic_numbered_files_between_sections(
+    tmp_path: Path,
+) -> None:
+    output_dir = tmp_path / "artifacts"
+    _write_output_dir(
+        output_dir,
+        files=[
+            {
+                "canonical_id": "draft",
+                "source_url": "https://example.com/draft",
+                "output_path": "pages/draft.md",
+                "title": "Draft",
+            },
+            {
+                "canonical_id": "gamma",
+                "source_url": "https://example.com/gamma",
+                "output_path": "pages/gamma.md",
+                "title": "Gamma",
+            },
+            {
+                "canonical_id": "alpha",
+                "source_url": "https://example.com/alpha",
+                "output_path": "pages/alpha.md",
+                "title": "Alpha",
+            },
+            {
+                "canonical_id": "beta",
+                "source_url": "https://example.com/beta",
+                "output_path": "pages/beta.md",
+                "title": "Beta",
+            },
+        ],
+        artifact_contents={
+            "pages/draft.md": "# Draft\n\nDraft content.\n",
+            "pages/gamma.md": "# Gamma\n\nGamma content.\n",
+            "pages/alpha.md": "# Alpha\n\nAlpha content.\n",
+            "pages/beta.md": "# Beta\n\nBeta content.\n",
+        },
+    )
+
+    bundle_plan = load_bundle_plan((output_dir,), order="input", exclude_patterns=("draft",))
+    split_plan = plan_split_bundle(
+        tmp_path / "bundles" / "llm.md",
+        render_bundle_sections(bundle_plan.artifacts, header_mode="minimal"),
+        max_bytes=95,
+    )
+
+    assert [output_file.path.name for output_file in split_plan.output_files] == [
+        "llm-001.md",
+        "llm-002.md",
+        "llm-003.md",
+    ]
+    assert [output_file.artifact_count for output_file in split_plan.output_files] == [1, 1, 1]
+    assert bundle_plan.filtered_out_count == 1
+    assert split_plan.oversized_sections == ()
+
+    write_split_bundle(split_plan)
+
+    assert (tmp_path / "bundles" / "llm.md").exists() is False
+    assert (tmp_path / "bundles" / "llm-001.md").read_text(encoding="utf-8") == (
+        """## Gamma
+source_url: https://example.com/gamma
+
+# Gamma
+
+Gamma content.
+"""
+    )
+    assert "canonical_id:" not in (tmp_path / "bundles" / "llm-001.md").read_text(encoding="utf-8")
+    assert (
+        (tmp_path / "bundles" / "llm-002.md").read_text(encoding="utf-8").startswith("## Alpha\n")
+    )
+    assert (tmp_path / "bundles" / "llm-003.md").read_text(encoding="utf-8").startswith("## Beta\n")
+
+
+def test_plan_split_bundle_writes_oversized_single_artifact_as_own_file(
+    tmp_path: Path,
+) -> None:
+    output_dir = tmp_path / "artifacts"
+    _write_output_dir(
+        output_dir,
+        files=[
+            {
+                "canonical_id": "alpha",
+                "source_url": "https://example.com/alpha",
+                "output_path": "pages/alpha.md",
+                "title": "Alpha",
+            },
+            {
+                "canonical_id": "beta",
+                "source_url": "https://example.com/beta",
+                "output_path": "pages/beta.md",
+                "title": "Beta",
+            },
+        ],
+        artifact_contents={
+            "pages/alpha.md": "# Alpha\n\n" + ("A" * 180) + "\n",
+            "pages/beta.md": "# Beta\n\nBeta content.\n",
+        },
+    )
+
+    bundle_plan = load_bundle_plan((output_dir,))
+    split_plan = plan_split_bundle(
+        tmp_path / "bundle.md",
+        render_bundle_sections(bundle_plan.artifacts),
+        max_bytes=120,
+    )
+
+    assert [output_file.path.name for output_file in split_plan.output_files] == [
+        "bundle-001.md",
+        "bundle-002.md",
+    ]
+    assert [output_file.artifact_count for output_file in split_plan.output_files] == [1, 1]
+    assert [section.canonical_id for section in split_plan.oversized_sections] == ["alpha"]
+    assert split_plan.oversized_sections[0].byte_count > 120
+
+    write_split_bundle(split_plan)
+
+    assert (tmp_path / "bundle-001.md").stat().st_size > 120
+    assert (tmp_path / "bundle-001.md").read_text(encoding="utf-8").startswith("## Alpha\n")
+    assert (tmp_path / "bundle-002.md").stat().st_size <= 120
 
 
 def test_write_bundle_creates_parent_directories(tmp_path: Path) -> None:

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -158,6 +158,7 @@ def test_bundle_cli_help_includes_ordering_and_input_guidance(tmp_path: Path) ->
     assert "--header-mode {minimal,full}" in stdout
     assert "--include PATTERN" in stdout
     assert "--exclude PATTERN" in stdout
+    assert "--max-bytes N" in stdout
     assert "--changed-only" in stdout
     assert "--baseline-manifest PATH" in stdout
     assert "canonical_id sorts lexically by canonical_id (default)" in stdout
@@ -171,12 +172,15 @@ def test_bundle_cli_help_includes_ordering_and_input_guidance(tmp_path: Path) ->
     assert "Exclude filters apply after include matching and win on conflicts." in stdout
     assert "new or changed compared with --baseline-manifest" in stdout
     assert "compare by canonical_id and content_hash" in stdout
+    assert "Split bundle output into numbered markdown files" in stdout
+    assert "single oversized artifact is written to its own file and reported" in stdout
     assert "knowledge-adapters bundle ./artifacts/confluence --output ./bundle.md" in stdout
     assert (
         "knowledge-adapters bundle ./artifacts --header-mode minimal --output ./bundle.md"
         in stdout
     )
     assert '--include "team-*" --exclude "*draft*" --output ./bundle.md' in stdout
+    assert "knowledge-adapters bundle ./artifacts --max-bytes 250000 --output ./bundle.md" in stdout
 
 
 def test_bundle_cli_smoke_combines_multiple_inputs_in_deterministic_order(
@@ -406,6 +410,158 @@ canonical_id: gamma
 # Gamma
 """
     )
+
+
+def test_bundle_cli_smoke_splits_changed_only_output_into_numbered_files(
+    tmp_path: Path,
+) -> None:
+    baseline_dir = tmp_path / "baseline"
+    current_dir = tmp_path / "current"
+    (baseline_dir / "pages").mkdir(parents=True)
+    (current_dir / "pages").mkdir(parents=True)
+    (baseline_dir / "pages" / "alpha.md").write_text("# Alpha\n", encoding="utf-8")
+    (baseline_dir / "pages" / "beta.md").write_text("# Beta old\n", encoding="utf-8")
+    (current_dir / "pages" / "alpha.md").write_text("# Alpha\n", encoding="utf-8")
+    (current_dir / "pages" / "beta.md").write_text("# Beta new\n", encoding="utf-8")
+    (current_dir / "pages" / "gamma.md").write_text("# Gamma\n", encoding="utf-8")
+    (baseline_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "generated_at": "2026-04-24T00:00:00Z",
+                "files": [
+                    {
+                        "canonical_id": "alpha",
+                        "source_url": "https://example.com/alpha",
+                        "output_path": "pages/alpha.md",
+                        "content_hash": "same-alpha",
+                    },
+                    {
+                        "canonical_id": "beta",
+                        "source_url": "https://example.com/beta",
+                        "output_path": "pages/beta.md",
+                        "content_hash": "old-beta",
+                    },
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (current_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "generated_at": "2026-04-24T00:00:00Z",
+                "files": [
+                    {
+                        "canonical_id": "alpha",
+                        "source_url": "https://example.com/alpha",
+                        "output_path": "pages/alpha.md",
+                        "content_hash": "same-alpha",
+                    },
+                    {
+                        "canonical_id": "beta",
+                        "source_url": "https://example.com/beta",
+                        "output_path": "pages/beta.md",
+                        "content_hash": "new-beta",
+                    },
+                    {
+                        "canonical_id": "gamma",
+                        "source_url": "https://example.com/gamma",
+                        "output_path": "pages/gamma.md",
+                        "content_hash": "new-gamma",
+                    },
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = _run_cli(
+        tmp_path,
+        "bundle",
+        "./current",
+        "--changed-only",
+        "--baseline-manifest",
+        "./baseline/manifest.json",
+        "--max-bytes",
+        "85",
+        "--output",
+        "./bundles/changed.md",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "changed_only: true" in result.stdout
+    assert "max_bytes: 85" in result.stdout
+    assert "output_files: 2" in result.stdout
+    assert "Wrote split bundle files: 2" in result.stdout
+    assert "Summary: bundled 2, skipped 1 unchanged, skipped 0 duplicates" in result.stdout
+    assert "Summary: wrote 2 files, 0 oversized sections" in result.stdout
+    assert f"First output path: {tmp_path / 'bundles' / 'changed-001.md'}" in result.stdout
+    assert (tmp_path / "bundles" / "changed.md").exists() is False
+    assert (tmp_path / "bundles" / "changed-001.md").read_text(encoding="utf-8") == (
+        """## beta
+source_url: https://example.com/beta
+canonical_id: beta
+
+# Beta new
+"""
+    )
+    assert (tmp_path / "bundles" / "changed-002.md").read_text(encoding="utf-8") == (
+        """## gamma
+source_url: https://example.com/gamma
+canonical_id: gamma
+
+# Gamma
+"""
+    )
+
+
+def test_bundle_cli_smoke_reports_oversized_split_section(tmp_path: Path) -> None:
+    output_dir = tmp_path / "artifacts"
+    (output_dir / "pages").mkdir(parents=True)
+    (output_dir / "pages" / "alpha.md").write_text(
+        "# Alpha\n\n" + ("A" * 160) + "\n",
+        encoding="utf-8",
+    )
+    (output_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "generated_at": "2026-04-24T00:00:00Z",
+                "files": [
+                    {
+                        "canonical_id": "alpha",
+                        "source_url": "https://example.com/alpha",
+                        "output_path": "pages/alpha.md",
+                        "title": "Alpha",
+                    }
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = _run_cli(
+        tmp_path,
+        "bundle",
+        "./artifacts",
+        "--max-bytes",
+        "100",
+        "--output",
+        "./bundles/oversized.md",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "output_files: 1" in result.stdout
+    assert "oversized_sections: 1" in result.stdout
+    assert "oversized: alpha (" in result.stdout
+    assert "bytes > 100 max)" in result.stdout
+    assert "Summary: wrote 1 files, 1 oversized sections" in result.stdout
+    assert (tmp_path / "bundles" / "oversized-001.md").stat().st_size > 100
 
 
 def test_bundle_cli_smoke_supports_minimal_headers(tmp_path: Path) -> None:


### PR DESCRIPTION
Summary
- add --max-bytes to split bundle output into deterministic numbered markdown files
- keep artifact sections intact, with oversized single sections written safely and reported
- cover split behavior with ordering, filtering, header mode, changed-only, help, and oversized reporting tests
- update docs/project-map.md to mark #154 and #157 complete and clear the active arc

Testing
- make check

Closes #154