### PR TITLE
feat: add Confluence space discovery

### DIFF
--- a/docs/project-map.md
+++ b/docs/project-map.md
@@ -7,7 +7,7 @@ grouping them into meaningful lanes.
 ## Current State
 
 - Confluence adapter: mature (single-page, tree traversal, incremental sync,
-  TLS/auth, progress output)
+  space discovery, TLS/auth, progress output)
 - Bundle command:
   - v1 complete (#147)
   - ordering controls added (#153)
@@ -17,19 +17,11 @@ grouping them into meaningful lanes.
 
 ## Active Arc
 
-Pending selection.
+- #159 Add `git_repo` adapter for ingesting repository contents
 
 ## Next Arcs
 
-### Confluence expansion
-
-- #148 Add Confluence space-wide page discovery via space URL or space key
-
 ### New adapters
-
-#### Git source ingestion
-
-- #159 Add `git_repo` adapter for ingesting repository contents
 
 #### GitHub metadata ingestion
 

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -315,11 +315,24 @@ def build_parser() -> argparse.ArgumentParser:
     )
     confluence_parser.add_argument(
         "--target",
-        required=True,
         help=(
             "Confluence page ID or full page URL under --base-url. The CLI resolves "
             "either input into one canonical page ID and source URL for artifact "
             "and manifest reporting."
+        ),
+    )
+    confluence_parser.add_argument(
+        "--space-key",
+        help=(
+            "Confluence space key for bounded real-mode discovery of all pages "
+            "in one space."
+        ),
+    )
+    confluence_parser.add_argument(
+        "--space-url",
+        help=(
+            "Full Confluence space overview URL matching /spaces/{SPACE}/overview "
+            "for bounded real-mode discovery of all pages in one space."
         ),
     )
     confluence_parser.add_argument(
@@ -871,6 +884,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             fetch_real_page,
             fetch_real_page_summary,
             list_real_child_page_ids,
+            list_real_space_page_ids,
         )
         from knowledge_adapters.confluence.config import (
             ConfluenceConfig,
@@ -891,7 +905,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         from knowledge_adapters.confluence.models import ResolvedTarget
         from knowledge_adapters.confluence.normalize import normalize_to_markdown
-        from knowledge_adapters.confluence.resolve import resolve_target_for_base_url
+        from knowledge_adapters.confluence.resolve import (
+            resolve_target_for_base_url,
+            space_key_from_url_for_base_url,
+            validate_space_key,
+        )
         from knowledge_adapters.confluence.traversal import TreeWalkProgress, walk_pages
         from knowledge_adapters.confluence.writer import markdown_path, write_markdown
 
@@ -899,6 +917,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             base_url=args.base_url,
             target=args.target,
             output_dir=args.output_dir,
+            space_key=args.space_key,
+            space_url=args.space_url,
             ca_bundle=args.ca_bundle,
             client_cert_file=args.client_cert_file,
             client_key_file=args.client_key_file,
@@ -924,6 +944,54 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "--max-depth must be greater than or equal to 0.",
                 command="confluence",
             )
+        space_mode = (
+            confluence_config.space_key is not None
+            or confluence_config.space_url is not None
+        )
+        explicit_max_depth = "--max-depth" in raw_argv
+        resolved_space_key: str | None = None
+        if confluence_config.space_key is not None and confluence_config.space_url is not None:
+            exit_with_cli_error(
+                "--space-key and --space-url are mutually exclusive.",
+                command="confluence",
+            )
+        if space_mode:
+            if confluence_config.client_mode != "real":
+                exit_with_cli_error(
+                    "space mode requires --client-mode real",
+                    command="confluence",
+                )
+            if confluence_config.target is not None:
+                exit_with_cli_error(
+                    "space mode cannot be combined with --target.",
+                    command="confluence",
+                )
+            if confluence_config.tree:
+                exit_with_cli_error(
+                    "space mode cannot be combined with --tree.",
+                    command="confluence",
+                )
+            if explicit_max_depth:
+                exit_with_cli_error(
+                    "space mode cannot be combined with --max-depth.",
+                    command="confluence",
+                )
+            try:
+                resolved_space_key = (
+                    validate_space_key(confluence_config.space_key)
+                    if confluence_config.space_key is not None
+                    else space_key_from_url_for_base_url(
+                        confluence_config.space_url or "",
+                        base_url=confluence_config.base_url,
+                    )
+                )
+            except ValueError as exc:
+                exit_with_cli_error(str(exc), command="confluence")
+        elif confluence_config.target is None:
+            exit_with_cli_error(
+                "--target, --space-key, or --space-url is required.",
+                command="confluence",
+            )
         try:
             validate_explicit_tls_paths(
                 ca_bundle=confluence_config.ca_bundle,
@@ -935,20 +1003,23 @@ def main(argv: Sequence[str] | None = None) -> int:
         except ValueError as exc:
             exit_with_cli_error(str(exc), command="confluence")
 
-        try:
-            target = resolve_target_for_base_url(
-                confluence_config.target,
-                base_url=confluence_config.base_url,
-            )
-        except ValueError as exc:
-            exit_with_cli_error(
-                str(exc),
-                command="confluence",
-            )
+        target: ResolvedTarget | None = None
+        if not space_mode:
+            try:
+                target = resolve_target_for_base_url(
+                    confluence_config.target or "",
+                    base_url=confluence_config.base_url,
+                )
+            except ValueError as exc:
+                exit_with_cli_error(
+                    str(exc),
+                    command="confluence",
+                )
 
         selected_fetch_page: Callable[[ResolvedTarget], dict[str, object]]
         selected_fetch_page_summary: Callable[[ResolvedTarget], dict[str, object]]
         selected_list_child_page_ids: Callable[[ResolvedTarget], list[str]] | None = None
+        selected_list_space_page_ids: Callable[[str], list[str]] | None = None
         if confluence_config.client_mode == "real":
 
             def selected_fetch_page(resolved_target: ResolvedTarget) -> dict[str, object]:
@@ -984,6 +1055,16 @@ def main(argv: Sequence[str] | None = None) -> int:
                     client_cert_file=confluence_config.client_cert_file,
                     client_key_file=confluence_config.client_key_file,
                 )
+
+            def selected_list_space_page_ids(space_key: str) -> list[str]:
+                return list_real_space_page_ids(
+                    space_key,
+                    base_url=confluence_config.base_url,
+                    auth_method=confluence_config.auth_method,
+                    ca_bundle=confluence_config.ca_bundle,
+                    client_cert_file=confluence_config.client_cert_file,
+                    client_key_file=confluence_config.client_key_file,
+                )
         else:
             selected_fetch_page = fetch_page
             selected_fetch_page_summary = fetch_page
@@ -1009,15 +1090,22 @@ def main(argv: Sequence[str] | None = None) -> int:
             run_mode = "dry-run" if confluence_config.dry_run else "write"
             print("Confluence adapter invoked")
             print(f"  base_url: {confluence_config.base_url}")
-            print(f"  target: {target.raw_value}")
+            if space_mode:
+                print(f"  space_key: {resolved_space_key}")
+                if confluence_config.space_url is not None:
+                    print(f"  space_url: {confluence_config.space_url}")
+            elif target is not None:
+                print(f"  target: {target.raw_value}")
             print(f"  output_dir: {render_user_path(confluence_config.output_dir)}")
             print(f"  client_mode: {confluence_config.client_mode}")
             print(f"  content_source: {content_source}")
             if confluence_config.dry_run:
-                mode = "tree" if confluence_config.tree else "single"
+                mode = "space" if space_mode else "tree" if confluence_config.tree else "single"
                 print(f"  mode: {mode}")
             else:
-                fetch_scope = "tree" if confluence_config.tree else "page"
+                fetch_scope = (
+                    "space" if space_mode else "tree" if confluence_config.tree else "page"
+                )
                 print(f"  fetch_scope: {fetch_scope}")
             print(f"  run_mode: {run_mode}")
             if confluence_config.tree:
@@ -1146,18 +1234,31 @@ def main(argv: Sequence[str] | None = None) -> int:
             write_count: int,
             skip_count: int,
             stale_count: int | None = None,
+            space_key: str | None = None,
+            discovered_count: int | None = None,
         ) -> None:
             descendant_count = max(total_pages - 1, 0)
-            summary_lines = [
-                f"    mode: {mode}",
-                "    pages_in_plan: "
-                f"{total_pages} (root 1, descendants {descendant_count})",
-                f"    new_pages: {new_count}",
-                f"    changed_pages: {changed_count}",
-                f"    unchanged_pages: {unchanged_count}",
-                f"    would_write: {write_count}",
-                f"    would_skip: {skip_count}",
-            ]
+            summary_lines = [f"    mode: {mode}"]
+            if mode == "space":
+                if space_key is not None:
+                    summary_lines.append(f"    space_key: {space_key}")
+                if discovered_count is not None:
+                    summary_lines.append(f"    pages_discovered: {discovered_count}")
+                summary_lines.append(f"    pages_in_plan: {total_pages}")
+            else:
+                summary_lines.append(
+                    "    pages_in_plan: "
+                    f"{total_pages} (root 1, descendants {descendant_count})"
+                )
+            summary_lines.extend(
+                [
+                    f"    new_pages: {new_count}",
+                    f"    changed_pages: {changed_count}",
+                    f"    unchanged_pages: {unchanged_count}",
+                    f"    would_write: {write_count}",
+                    f"    would_skip: {skip_count}",
+                ]
+            )
             if stale_count is not None:
                 summary_lines.append(f"    stale_artifacts: {stale_count}")
             print("  Summary:")
@@ -1221,7 +1322,241 @@ def main(argv: Sequence[str] | None = None) -> int:
         def _should_report_fetch_progress(*, fetched_count: int, total_count: int) -> bool:
             return total_count <= 5 or fetched_count == total_count or fetched_count % 10 == 0
 
+        if space_mode:
+            previous_manifest_index = load_previous_manifest_index(confluence_config.output_dir)
+            space_fetch_page = (
+                selected_fetch_page
+                if previous_manifest_index is None
+                else selected_fetch_page_summary
+            )
+            if selected_list_space_page_ids is None or resolved_space_key is None:
+                exit_with_cli_error(
+                    "space mode requires --client-mode real",
+                    command="confluence",
+                )
+            assert selected_list_space_page_ids is not None
+            assert resolved_space_key is not None
+
+            print(f"Space progress: discovery started, space_key {resolved_space_key}")
+            try:
+                discovered_page_ids = sorted(set(selected_list_space_page_ids(resolved_space_key)))
+                print(
+                    "Space progress: "
+                    f"discovered {len(discovered_page_ids)} pages, "
+                    f"planned {len(discovered_page_ids)}"
+                )
+                pages: list[dict[str, object]] = []
+                for index, page_id in enumerate(discovered_page_ids, start=1):
+                    pages.append(
+                        space_fetch_page(
+                            ResolvedTarget(
+                                raw_value=page_id,
+                                page_id=page_id,
+                                page_url=None,
+                            )
+                        )
+                    )
+                    if _should_report_fetch_progress(
+                        fetched_count=index,
+                        total_count=len(discovered_page_ids),
+                    ):
+                        print(
+                            "Space fetch progress: "
+                            f"fetched {index}/{len(discovered_page_ids)}, "
+                            f"planned {len(discovered_page_ids)}"
+                        )
+            except (RuntimeError, ValueError) as exc:
+                exit_with_cli_error(
+                    str(exc),
+                    command="confluence",
+                    debug_lines=_confluence_debug_lines(exc),
+                )
+
+            _print_confluence_invocation()
+            space_page_records: list[
+                tuple[dict[str, object], Path, PageSyncDecision, str]
+            ] = []
+            for page in pages:
+                canonical_id = str(page.get("canonical_id") or "")
+                output_path = markdown_path(confluence_config.output_dir, canonical_id)
+                page_decision = classify_page_sync(
+                    confluence_config.output_dir,
+                    previous_manifest_index,
+                    page=page,
+                    output_path=output_path,
+                )
+                action = "skip" if page_decision.status == "unchanged" else "write"
+                space_page_records.append((page, output_path, page_decision, action))
+            stale_artifacts = [
+                (artifact.canonical_id, artifact.output_path)
+                for artifact in find_stale_artifacts(
+                    confluence_config.output_dir,
+                    previous_manifest_index,
+                    current_page_ids=[
+                        str(page.get("canonical_id") or "")
+                        for page, _output_path, _page_decision, _action in space_page_records
+                    ],
+                    current_output_paths=[
+                        output_path.relative_to(Path(confluence_config.output_dir)).as_posix()
+                        for _page, output_path, _page_decision, _action in space_page_records
+                    ],
+                )
+            ]
+
+            write_count = sum(
+                1
+                for _page, _output_path, _page_decision, action in space_page_records
+                if action == "write"
+            )
+            skip_count = len(space_page_records) - write_count
+            new_count = sum(
+                1
+                for _page, _output_path, page_decision, _action in space_page_records
+                if page_decision.status == "new"
+            )
+            changed_count = sum(
+                1
+                for _page, _output_path, page_decision, _action in space_page_records
+                if page_decision.status == "changed"
+            )
+            unchanged_count = len(space_page_records) - new_count - changed_count
+            manifest_output_path = manifest_path(confluence_config.output_dir)
+
+            print("\nPlan: Confluence run")
+            print(f"  space_key: {resolved_space_key}")
+            print(f"  Manifest: {_display_output_path(manifest_output_path)}")
+            print(f"  pages_discovered: {len(discovered_page_ids)}")
+            print(f"  pages_planned: {len(space_page_records)}")
+
+            if confluence_config.dry_run:
+                _print_confluence_dry_run_summary(
+                    mode="space",
+                    total_pages=len(space_page_records),
+                    new_count=new_count,
+                    changed_count=changed_count,
+                    unchanged_count=unchanged_count,
+                    write_count=write_count,
+                    skip_count=skip_count,
+                    stale_count=len(stale_artifacts),
+                    space_key=resolved_space_key,
+                    discovered_count=len(discovered_page_ids),
+                )
+                _print_stale_artifacts(stale_artifacts)
+                for _page, output_path, page_decision, action in space_page_records:
+                    print(
+                        "  would "
+                        f"{action} {_display_output_path(output_path)} "
+                        f"({_format_page_sync_decision(page_decision)})"
+                    )
+                print_dry_run_complete()
+                return 0
+
+            files = [
+                _build_manifest_entry_for_page(page, output_path)
+                for page, output_path, _page_decision, _action in space_page_records
+            ]
+
+            space_pages_to_write: dict[str, dict[str, object]] = {}
+            pages_needing_fetch = sum(
+                1
+                for page, _output_path, _page_decision, action in space_page_records
+                if action == "write" and page.get("content") is None
+            )
+            fetched_write_pages = 0
+            if pages_needing_fetch > 0:
+                print(
+                    "Space write fetch progress: "
+                    f"fetched 0/{pages_needing_fetch}, "
+                    f"skipped {skip_count}, "
+                    f"planned {len(space_page_records)}"
+                )
+            try:
+                for page, _output_path, _page_decision, action in space_page_records:
+                    if action == "skip":
+                        continue
+
+                    if page.get("content") is not None:
+                        space_pages_to_write[str(page.get("canonical_id") or "")] = page
+                        continue
+
+                    page_id = str(page.get("canonical_id") or "")
+                    space_pages_to_write[page_id] = selected_fetch_page(
+                        ResolvedTarget(
+                            raw_value=page_id,
+                            page_id=page_id,
+                            page_url=None,
+                        )
+                    )
+                    fetched_write_pages += 1
+                    if _should_report_fetch_progress(
+                        fetched_count=fetched_write_pages,
+                        total_count=pages_needing_fetch,
+                    ):
+                        print(
+                            "Space write fetch progress: "
+                            f"fetched {fetched_write_pages}/{pages_needing_fetch}, "
+                            f"skipped {skip_count}, "
+                            f"planned {len(space_page_records)}"
+                        )
+            except (RuntimeError, ValueError) as exc:
+                exit_with_cli_error(
+                    str(exc),
+                    command="confluence",
+                    debug_lines=_confluence_debug_lines(exc),
+                )
+
+            try:
+                for page, output_path, page_decision, action in space_page_records:
+                    if action == "skip":
+                        print(
+                            "\nSkipped: "
+                            f"{_display_output_path(output_path)} "
+                            f"({_format_page_sync_decision(page_decision)})"
+                        )
+                        continue
+
+                    page_to_write = space_pages_to_write[
+                        str(page.get("canonical_id") or "")
+                    ]
+                    markdown = normalize_to_markdown(page_to_write)
+                    write_markdown(
+                        confluence_config.output_dir,
+                        str(page_to_write.get("canonical_id") or ""),
+                        markdown,
+                    )
+                    print(
+                        "\nWrote: "
+                        f"{_display_output_path(output_path)} "
+                        f"({_format_page_sync_decision(page_decision)})"
+                    )
+
+                manifest = write_manifest(confluence_config.output_dir, files)
+            except OSError as exc:
+                exit_with_output_error(
+                    confluence_config.output_dir,
+                    command="confluence",
+                    exc=exc,
+                )
+            _print_confluence_write_summary(
+                new_count=new_count,
+                changed_count=changed_count,
+                unchanged_count=unchanged_count,
+                write_count=write_count,
+                skip_count=skip_count,
+                stale_count=len(stale_artifacts),
+            )
+            _print_stale_artifacts(stale_artifacts)
+            print(f"Manifest: {_display_output_path(manifest)}")
+            print_write_complete(output_dir)
+            return 0
+
         if confluence_config.tree:
+            if target is None:
+                exit_with_cli_error(
+                    "--target is required for tree mode.",
+                    command="confluence",
+                )
+            assert target is not None
             previous_manifest_index = load_previous_manifest_index(confluence_config.output_dir)
             tree_fetch_page = (
                 selected_fetch_page
@@ -1432,6 +1767,13 @@ def main(argv: Sequence[str] | None = None) -> int:
             print(f"Manifest: {_display_output_path(manifest)}")
             print_write_complete(output_dir)
             return 0
+
+        if target is None:
+            exit_with_cli_error(
+                "--target is required for single-page mode.",
+                command="confluence",
+            )
+        assert target is not None
 
         previous_manifest_index = load_previous_manifest_index(confluence_config.output_dir)
         try:

--- a/src/knowledge_adapters/confluence/client.py
+++ b/src/knowledge_adapters/confluence/client.py
@@ -59,6 +59,42 @@ def _child_page_api_url(base_url: str, page_id: str) -> str:
     return f"{normalized_base}/rest/api/content/{encoded_page_id}/child/page"
 
 
+def _space_page_api_url(
+    base_url: str,
+    space_key: str,
+    *,
+    start: int,
+    limit: int,
+) -> str:
+    normalized_base = base_url.rstrip("/")
+    query = parse.urlencode(
+        {
+            "spaceKey": space_key,
+            "type": "page",
+            "start": start,
+            "limit": limit,
+        }
+    )
+    return f"{normalized_base}/rest/api/content?{query}"
+
+
+def _absolute_api_url(base_url: str, url: str) -> str:
+    parsed_url = parse.urlparse(url)
+    if parsed_url.scheme and parsed_url.netloc:
+        return url
+
+    normalized_base = base_url.rstrip("/")
+    if url.startswith("/"):
+        parsed_base = parse.urlparse(normalized_base)
+        normalized_base_path = parsed_base.path.rstrip("/")
+        if normalized_base_path and (
+            url == normalized_base_path or url.startswith(f"{normalized_base_path}/")
+        ):
+            return f"{parsed_base.scheme}://{parsed_base.netloc}{url}"
+        return f"{normalized_base}{url}"
+    return f"{normalized_base}/{url.lstrip('/')}"
+
+
 def _require_string(payload: dict[str, object], key: str) -> str:
     value = payload.get(key)
     if not isinstance(value, str) or not value:
@@ -176,6 +212,39 @@ def _map_child_page_ids(payload: dict[str, object]) -> list[str]:
         child_page_ids.append(child_page_id)
 
     return child_page_ids
+
+
+def _map_content_page_ids(payload: dict[str, object]) -> list[str]:
+    results = payload.get("results")
+    if not isinstance(results, list):
+        raise ValueError("Response error: invalid space page-list payload.")
+
+    page_ids: list[str] = []
+    for result in results:
+        if not isinstance(result, dict):
+            raise ValueError("Response error: invalid space page-list payload.")
+
+        content_type = result.get("type")
+        if content_type != "page":
+            raise ValueError("Response error: invalid non-page content in space page-list.")
+
+        page_id = result.get("id")
+        if not isinstance(page_id, str) or not page_id:
+            raise ValueError("Response error: invalid space page ID.")
+        page_ids.append(page_id)
+
+    return page_ids
+
+
+def _next_page_url(payload: dict[str, object], *, base_url: str) -> str | None:
+    links = payload.get("_links")
+    if not isinstance(links, dict):
+        return None
+
+    next_url = links.get("next")
+    if not isinstance(next_url, str) or not next_url:
+        return None
+    return _absolute_api_url(base_url, next_url)
 
 
 def _sanitize_debug_value(value: str) -> str:
@@ -375,3 +444,43 @@ def list_real_child_page_ids(
         client_key_file=client_key_file,
     )
     return _map_child_page_ids(raw_payload)
+
+
+def list_real_space_page_ids(
+    space_key: str,
+    *,
+    base_url: str,
+    auth_method: str,
+    ca_bundle: str | None = None,
+    client_cert_file: str | None = None,
+    client_key_file: str | None = None,
+    page_limit: int = 100,
+) -> list[str]:
+    """List all page IDs in one Confluence space in deterministic order."""
+    if not space_key:
+        raise ValueError("Response error: invalid space key.")
+
+    next_url: str | None = _space_page_api_url(
+        base_url,
+        space_key,
+        start=0,
+        limit=page_limit,
+    )
+    page_ids: set[str] = set()
+    seen_page_urls: set[str] = set()
+    while next_url is not None:
+        if next_url in seen_page_urls:
+            raise ValueError("Response error: repeated space page-list pagination URL.")
+        seen_page_urls.add(next_url)
+
+        raw_payload = _request_json(
+            next_url,
+            auth_method=auth_method,
+            ca_bundle=ca_bundle,
+            client_cert_file=client_cert_file,
+            client_key_file=client_key_file,
+        )
+        page_ids.update(_map_content_page_ids(raw_payload))
+        next_url = _next_page_url(raw_payload, base_url=base_url)
+
+    return sorted(page_ids)

--- a/src/knowledge_adapters/confluence/config.py
+++ b/src/knowledge_adapters/confluence/config.py
@@ -13,8 +13,10 @@ class ConfluenceConfig:
     """Runtime configuration for the Confluence adapter."""
 
     base_url: str
-    target: str
+    target: str | None
     output_dir: str
+    space_key: str | None = None
+    space_url: str | None = None
     ca_bundle: str | None = None
     client_cert_file: str | None = None
     client_key_file: str | None = None

--- a/src/knowledge_adapters/confluence/resolve.py
+++ b/src/knowledge_adapters/confluence/resolve.py
@@ -9,6 +9,7 @@ from knowledge_adapters.confluence.models import ResolvedTarget
 
 _PAGE_ID_RE = re.compile(r"^\d+$")
 _PAGE_ID_IN_PATH_RE = re.compile(r"/pages/(\d+)(?:/|$)")
+_SPACE_KEY_RE = re.compile(r"^[^\s/]+$")
 
 
 def _parse_absolute_http_url(value: str) -> parse.ParseResult | None:
@@ -28,6 +29,49 @@ def validate_base_url(base_url: str) -> str:
             "for example 'https://example.com/wiki'."
         )
     return normalized_base_url
+
+
+def validate_space_key(space_key: str) -> str:
+    """Validate and normalize a CLI-facing Confluence space key."""
+    normalized_space_key = space_key.strip()
+    if not normalized_space_key:
+        raise ValueError("--space-key cannot be empty.")
+    if _SPACE_KEY_RE.fullmatch(normalized_space_key) is None:
+        raise ValueError("--space-key must not contain whitespace or '/'.")
+    return normalized_space_key
+
+
+def space_key_from_url_for_base_url(space_url: str, *, base_url: str) -> str:
+    """Extract and validate a Confluence space key from a space overview URL."""
+    validated_base_url = validate_base_url(base_url)
+    cleaned = space_url.strip()
+    parsed_url = _parse_absolute_http_url(cleaned)
+    if parsed_url is None:
+        raise ValueError(
+            f"--space-url {space_url!r} is malformed. "
+            "Provide a full Confluence space overview URL."
+        )
+
+    if not _url_matches_base_url(page_url=cleaned, base_url=validated_base_url):
+        raise ValueError(
+            f"--space-url {space_url!r} does not match --base-url {validated_base_url!r}. "
+            "Use a URL under that base URL."
+        )
+
+    path_parts = [parse.unquote(part) for part in parsed_url.path.strip("/").split("/")]
+    for index, part in enumerate(path_parts):
+        if part != "spaces":
+            continue
+        if index + 2 >= len(path_parts):
+            break
+        space_key = path_parts[index + 1]
+        overview = path_parts[index + 2]
+        if overview == "overview" and index + 3 == len(path_parts):
+            return validate_space_key(space_key)
+
+    raise ValueError(
+        f"--space-url {space_url!r} must match /spaces/{{SPACE}}/overview."
+    )
 
 
 def _page_id_from_url(parsed_url: parse.ParseResult) -> str | None:

--- a/src/knowledge_adapters/run_config.py
+++ b/src/knowledge_adapters/run_config.py
@@ -9,7 +9,12 @@ import yaml  # type: ignore[import-untyped]
 
 from knowledge_adapters.confluence.auth import SUPPORTED_AUTH_METHODS
 from knowledge_adapters.confluence.config import validate_explicit_tls_paths
-from knowledge_adapters.confluence.resolve import resolve_target_for_base_url, validate_base_url
+from knowledge_adapters.confluence.resolve import (
+    resolve_target_for_base_url,
+    space_key_from_url_for_base_url,
+    validate_base_url,
+    validate_space_key,
+)
 
 SUPPORTED_RUN_TYPES = frozenset({"confluence", "local_files"})
 _SUPPORTED_CONFLUENCE_CLIENT_MODES = frozenset({"real", "stub"})
@@ -27,6 +32,8 @@ _CONFLUENCE_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
         "dry_run",
         "enabled",
         "max_depth",
+        "space_key",
+        "space_url",
         "target",
         "tree",
     }
@@ -207,38 +214,93 @@ def _build_confluence_argv(
             f"Run {name!r} in {config_path} has invalid 'base_url': {exc}"
         ) from exc
 
-    target = _require_string(run_config, "target", index=index, config_path=config_path)
-    try:
-        resolve_target_for_base_url(target, base_url=base_url)
-    except ValueError as exc:
-        raise ValueError(
-            f"Run {name!r} in {config_path} has invalid 'target': {exc}"
-        ) from exc
-
     output_dir = _resolve_path_string(
         _require_string(run_config, "output_dir", index=index, config_path=config_path),
         config_path=config_path,
     )
+    client_mode = _optional_string(run_config, "client_mode", index=index, config_path=config_path)
+    if client_mode is not None and client_mode not in _SUPPORTED_CONFLUENCE_CLIENT_MODES:
+        supported_values = " or ".join(
+            repr(mode) for mode in sorted(_SUPPORTED_CONFLUENCE_CLIENT_MODES)
+        )
+        raise ValueError(
+            f"Run {name!r} in {config_path} has unsupported 'client_mode' value "
+            f"{client_mode!r}. Use {supported_values}."
+        )
+
+    target = _optional_string(run_config, "target", index=index, config_path=config_path)
+    space_key = _optional_string(run_config, "space_key", index=index, config_path=config_path)
+    space_url = _optional_string(run_config, "space_url", index=index, config_path=config_path)
+    space_mode = space_key is not None or space_url is not None
+    tree = _optional_bool(run_config, "tree", index=index, config_path=config_path, default=False)
+    max_depth = run_config.get("max_depth")
+
+    if space_key is not None and space_url is not None:
+        raise ValueError(
+            f"Run {name!r} in {config_path} must set only one of 'space_key' or 'space_url'."
+        )
+    if space_mode:
+        if client_mode != "real":
+            raise ValueError(
+                f"Run {name!r} in {config_path}: space mode requires --client-mode real."
+            )
+        if target is not None:
+            raise ValueError(
+                f"Run {name!r} in {config_path} cannot combine space mode with 'target'."
+            )
+        if tree:
+            raise ValueError(
+                f"Run {name!r} in {config_path} cannot combine space mode with 'tree'."
+            )
+        if max_depth is not None:
+            raise ValueError(
+                f"Run {name!r} in {config_path} cannot combine space mode with 'max_depth'."
+            )
+        if space_key is not None:
+            try:
+                validate_space_key(space_key)
+            except ValueError as exc:
+                raise ValueError(
+                    f"Run {name!r} in {config_path} has invalid 'space_key': {exc}"
+                ) from exc
+        if space_url is not None:
+            try:
+                space_key_from_url_for_base_url(space_url, base_url=base_url)
+            except ValueError as exc:
+                raise ValueError(
+                    f"Run {name!r} in {config_path} has invalid 'space_url': {exc}"
+                ) from exc
+    else:
+        if target is None:
+            raise ValueError(
+                f"Run {name!r} in {config_path} must set 'target', 'space_key', or "
+                "'space_url'."
+            )
+        try:
+            resolve_target_for_base_url(target, base_url=base_url)
+        except ValueError as exc:
+            raise ValueError(
+                f"Run {name!r} in {config_path} has invalid 'target': {exc}"
+            ) from exc
+
     argv: list[str] = [
         "confluence",
         "--base-url",
         base_url,
-        "--target",
-        target,
-        "--output-dir",
-        output_dir,
     ]
-
-    client_mode = _optional_string(run_config, "client_mode", index=index, config_path=config_path)
+    if target is not None:
+        argv.extend(["--target", target])
+    if space_key is not None:
+        argv.extend(["--space-key", space_key])
+    if space_url is not None:
+        argv.extend(["--space-url", space_url])
+    argv.extend(
+        [
+            "--output-dir",
+            output_dir,
+        ]
+    )
     if client_mode is not None:
-        if client_mode not in _SUPPORTED_CONFLUENCE_CLIENT_MODES:
-            supported_values = " or ".join(
-                repr(mode) for mode in sorted(_SUPPORTED_CONFLUENCE_CLIENT_MODES)
-            )
-            raise ValueError(
-                f"Run {name!r} in {config_path} has unsupported 'client_mode' value "
-                f"{client_mode!r}. Use {supported_values}."
-            )
         argv.extend(["--client-mode", client_mode])
 
     auth_method = _optional_string(run_config, "auth_method", index=index, config_path=config_path)
@@ -317,10 +379,9 @@ def _build_confluence_argv(
         argv.append("--debug")
     if _optional_bool(run_config, "dry_run", index=index, config_path=config_path, default=False):
         argv.append("--dry-run")
-    if _optional_bool(run_config, "tree", index=index, config_path=config_path, default=False):
+    if tree:
         argv.append("--tree")
 
-    max_depth = run_config.get("max_depth")
     if max_depth is not None:
         if isinstance(max_depth, bool) or not isinstance(max_depth, int):
             raise ValueError(

--- a/tests/test_confluence_real_client_contract.py
+++ b/tests/test_confluence_real_client_contract.py
@@ -112,6 +112,31 @@ def _list_real_child_page_ids(
     return cast(list[str], child_page_ids)
 
 
+def _list_real_space_page_ids(
+    space_key: str,
+    *,
+    base_url: str = "https://example.com/wiki",
+    auth_method: str = "bearer-env",
+    ca_bundle: str | None = None,
+    client_cert_file: str | None = None,
+    client_key_file: str | None = None,
+    page_limit: int = 100,
+) -> list[str]:
+    from knowledge_adapters.confluence import client as client_module
+
+    client_module_any = cast(Any, client_module)
+    page_ids = client_module_any.list_real_space_page_ids(
+        space_key,
+        base_url=base_url,
+        auth_method=auth_method,
+        ca_bundle=ca_bundle,
+        client_cert_file=client_cert_file,
+        client_key_file=client_key_file,
+        page_limit=page_limit,
+    )
+    return cast(list[str], page_ids)
+
+
 class _FakeHTTPResponse:
     def __init__(self, payload: dict[str, object], *, status: int = 200) -> None:
         self.status = status
@@ -170,6 +195,19 @@ def _valid_child_list_payload(*, child_page_ids: list[str]) -> dict[str, object]
             for child_page_id in child_page_ids
         ]
     }
+
+
+def _valid_space_page_list_payload(
+    *,
+    page_ids: list[str],
+    next_url: str | None = None,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "results": [{"id": page_id, "type": "page"} for page_id in page_ids]
+    }
+    if next_url is not None:
+        payload["_links"] = {"next": next_url}
+    return payload
 
 
 def _http_error(status_code: int) -> HTTPError:
@@ -977,6 +1015,58 @@ def test_real_child_list_ignores_extra_irrelevant_fields_in_valid_response(
     child_page_ids = _list_real_child_page_ids(_real_target())
 
     assert child_page_ids == ["200", "300"]
+
+
+def test_real_space_page_list_paginates_and_returns_lexical_page_ids(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    payloads = [
+        _valid_space_page_list_payload(
+            page_ids=["300", "100"],
+            next_url="/wiki/rest/api/content?spaceKey=ENG&type=page&start=2&limit=2",
+        ),
+        _valid_space_page_list_payload(page_ids=["200", "100"]),
+    ]
+    requested_urls: list[str] = []
+
+    def fake_urlopen(*args: object, **kwargs: object) -> _FakeHTTPResponse:
+        del kwargs
+        request = cast(Any, args[0])
+        requested_urls.append(str(request.full_url))
+        return _FakeHTTPResponse(payloads.pop(0))
+
+    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    page_ids = _list_real_space_page_ids("ENG", page_limit=2)
+
+    assert page_ids == ["100", "200", "300"]
+    assert requested_urls == [
+        "https://example.com/wiki/rest/api/content?spaceKey=ENG&type=page&start=0&limit=2",
+        "https://example.com/wiki/rest/api/content?spaceKey=ENG&type=page&start=2&limit=2",
+    ]
+
+
+def test_real_space_page_list_rejects_non_page_content(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    payload: dict[str, object] = {
+        "results": [
+            {
+                "id": "blog-1",
+                "type": "blogpost",
+            }
+        ]
+    }
+
+    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *args, **kwargs: _FakeHTTPResponse(payload),
+    )
+
+    with pytest.raises(ValueError, match="invalid non-page content"):
+        _list_real_space_page_ids("ENG")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_confluence_real_traversal_contract.py
+++ b/tests/test_confluence_real_traversal_contract.py
@@ -35,6 +35,25 @@ def _real_tree_argv(
     ]
 
 
+def _real_space_argv(
+    output_dir: Path,
+    *,
+    space_flag: str = "--space-key",
+    space_value: str = "ENG",
+) -> list[str]:
+    return [
+        "confluence",
+        "--base-url",
+        "https://example.com/wiki",
+        space_flag,
+        space_value,
+        "--output-dir",
+        str(output_dir),
+        "--client-mode",
+        "real",
+    ]
+
+
 def _load_manifest(output_dir: Path) -> dict[str, object]:
     payload = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
     return cast(dict[str, object], payload)
@@ -241,6 +260,247 @@ def _run_real_recursive_cli(
     output_dir = tmp_path / "out"
     exit_code = main(_real_tree_argv(output_dir, target=target, max_depth=max_depth))
     return exit_code, output_dir, page_fetch_counts, child_list_calls
+
+
+def _run_real_space_cli(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    *,
+    pages: dict[str, dict[str, object]] | None = None,
+    discovered_page_ids: list[str] | None = None,
+    space_flag: str = "--space-key",
+    space_value: str = "ENG",
+) -> tuple[int, Path, dict[str, int], list[str]]:
+    from knowledge_adapters.confluence import client as client_module
+
+    if pages is None:
+        pages = _real_pages()
+    if discovered_page_ids is None:
+        discovered_page_ids = ["300", "100", "200"]
+
+    page_fetch_counts: dict[str, int] = {}
+    space_list_calls: list[str] = []
+
+    def stub_real_fetch(
+        target: ResolvedTarget,
+        *,
+        base_url: str = "https://example.com/wiki",
+        auth_method: str = "bearer-env",
+        ca_bundle: str | None = None,
+        client_cert_file: str | None = None,
+        client_key_file: str | None = None,
+    ) -> dict[str, object]:
+        del base_url, auth_method, ca_bundle, client_cert_file, client_key_file
+
+        page_id = str(target.page_id)
+        page_fetch_counts[page_id] = page_fetch_counts.get(page_id, 0) + 1
+        return dict(pages[page_id])
+
+    def stub_space_discovery(
+        space_key: str,
+        *,
+        base_url: str = "https://example.com/wiki",
+        auth_method: str = "bearer-env",
+        ca_bundle: str | None = None,
+        client_cert_file: str | None = None,
+        client_key_file: str | None = None,
+    ) -> list[str]:
+        del base_url, auth_method, ca_bundle, client_cert_file, client_key_file
+        space_list_calls.append(space_key)
+        return list(discovered_page_ids or [])
+
+    def fail_if_child_discovery_used(*args: object, **kwargs: object) -> list[str]:
+        del args, kwargs
+        raise AssertionError("child discovery should not be used in space mode")
+
+    monkeypatch.setattr(client_module, "fetch_real_page", stub_real_fetch, raising=False)
+    monkeypatch.setattr(
+        client_module,
+        "list_real_space_page_ids",
+        stub_space_discovery,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        client_module,
+        "list_real_child_page_ids",
+        fail_if_child_discovery_used,
+        raising=False,
+    )
+
+    output_dir = tmp_path / "out"
+    exit_code = main(
+        _real_space_argv(
+            output_dir,
+            space_flag=space_flag,
+            space_value=space_value,
+        )
+    )
+    return exit_code, output_dir, page_fetch_counts, space_list_calls
+
+
+@pytest.mark.parametrize(
+    ("space_flag", "space_value"),
+    [
+        ("--space-key", "ENG"),
+        ("--space-url", "https://example.com/wiki/spaces/ENG/overview"),
+    ],
+)
+def test_real_space_mode_discovers_pages_and_writes_in_lexical_order(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+    space_flag: str,
+    space_value: str,
+) -> None:
+    exit_code, output_dir, page_fetch_counts, space_list_calls = _run_real_space_cli(
+        tmp_path,
+        monkeypatch,
+        discovered_page_ids=["300", "100", "200", "100"],
+        space_flag=space_flag,
+        space_value=space_value,
+    )
+
+    assert exit_code == 0
+
+    payload = _load_manifest(output_dir)
+    assert "root_page_id" not in payload
+    assert "max_depth" not in payload
+    assert [entry["canonical_id"] for entry in _manifest_files(payload)] == [
+        "100",
+        "200",
+        "300",
+    ]
+    assert page_fetch_counts == {"100": 1, "200": 1, "300": 1}
+    assert space_list_calls == ["ENG"]
+
+    output = capsys.readouterr().out
+    assert "mode: space" not in output
+    assert "fetch_scope: space" in output
+    assert "space_key: ENG" in output
+    assert "pages_discovered: 3" in output
+    assert "pages_planned: 3" in output
+    assert "Summary: wrote 3, skipped 0" in output
+
+
+def test_real_space_dry_run_reports_space_summary_and_planned_actions(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    from knowledge_adapters.confluence import client as client_module
+
+    pages = _real_pages()
+
+    def stub_real_fetch(
+        target: ResolvedTarget,
+        *,
+        base_url: str = "https://example.com/wiki",
+        auth_method: str = "bearer-env",
+        ca_bundle: str | None = None,
+        client_cert_file: str | None = None,
+        client_key_file: str | None = None,
+    ) -> dict[str, object]:
+        del base_url, auth_method, ca_bundle, client_cert_file, client_key_file
+        return dict(pages[str(target.page_id)])
+
+    monkeypatch.setattr(client_module, "fetch_real_page", stub_real_fetch, raising=False)
+    monkeypatch.setattr(
+        client_module,
+        "list_real_space_page_ids",
+        lambda space_key, **kwargs: ["200", "100"] if space_key == "ENG" else [],
+        raising=False,
+    )
+
+    output_dir = tmp_path / "out"
+    exit_code = main([*_real_space_argv(output_dir), "--dry-run"])
+
+    assert exit_code == 0
+    assert not (output_dir / "manifest.json").exists()
+
+    output = capsys.readouterr().out
+    assert "mode: space" in output
+    assert "space_key: ENG" in output
+    assert "pages_discovered: 2" in output
+    assert "pages_in_plan: 2" in output
+    assert "would_write: 2" in output
+    assert "would write " in output
+    assert "pages/100.md" in output
+    assert "pages/200.md" in output
+
+
+@pytest.mark.parametrize(
+    ("extra_args", "expected_message"),
+    [
+        ([], "space mode requires --client-mode real"),
+        (
+            ["--client-mode", "real", "--target", "100"],
+            "space mode cannot be combined with --target.",
+        ),
+        (
+            ["--client-mode", "real", "--tree"],
+            "space mode cannot be combined with --tree.",
+        ),
+        (
+            ["--client-mode", "real", "--max-depth", "1"],
+            "space mode cannot be combined with --max-depth.",
+        ),
+        (
+            ["--client-mode", "real", "--space-url", "https://example.com/wiki/spaces/ENG/overview"],
+            "--space-key and --space-url are mutually exclusive.",
+        ),
+    ],
+)
+def test_space_mode_rejects_invalid_cli_combinations(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+    extra_args: list[str],
+    expected_message: str,
+) -> None:
+    output_dir = tmp_path / "out"
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(
+            [
+                "confluence",
+                "--base-url",
+                "https://example.com/wiki",
+                "--space-key",
+                "ENG",
+                "--output-dir",
+                str(output_dir),
+                *extra_args,
+            ]
+        )
+
+    assert exc_info.value.code == 2
+    _assert_concise_cli_error(capsys, expected_message=expected_message)
+    _assert_no_artifacts_written(output_dir)
+
+
+def test_space_mode_rejects_invalid_space_url_shape(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    output_dir = tmp_path / "out"
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(
+            _real_space_argv(
+                output_dir,
+                space_flag="--space-url",
+                space_value="https://example.com/wiki/spaces/ENG/pages",
+            )
+        )
+
+    assert exc_info.value.code == 2
+    _assert_concise_cli_error(
+        capsys,
+        expected_message=(
+            "--space-url 'https://example.com/wiki/spaces/ENG/pages' must match "
+            "/spaces/{SPACE}/overview."
+        ),
+    )
+    _assert_no_artifacts_written(output_dir)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -3,7 +3,9 @@ import pytest
 from knowledge_adapters.confluence.resolve import (
     resolve_target,
     resolve_target_for_base_url,
+    space_key_from_url_for_base_url,
     validate_base_url,
+    validate_space_key,
 )
 
 
@@ -157,5 +159,27 @@ def test_resolve_target_for_base_url_rejects_base_url_mismatch() -> None:
     ):
         resolve_target_for_base_url(
             "https://other.example.com/wiki/spaces/ENG/pages/7890/Team+Runbook",
+            base_url="https://example.com/wiki",
+        )
+
+
+def test_validate_space_key_trims_valid_key() -> None:
+    assert validate_space_key(" ENG ") == "ENG"
+
+
+def test_space_key_from_url_for_base_url_extracts_overview_space_key() -> None:
+    assert (
+        space_key_from_url_for_base_url(
+            "https://example.com/wiki/spaces/ENG/overview",
+            base_url="https://example.com/wiki",
+        )
+        == "ENG"
+    )
+
+
+def test_space_key_from_url_for_base_url_rejects_invalid_shape() -> None:
+    with pytest.raises(ValueError, match="/spaces/\\{SPACE\\}/overview"):
+        space_key_from_url_for_base_url(
+            "https://example.com/wiki/spaces/ENG/pages",
             base_url="https://example.com/wiki",
         )

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -79,6 +79,92 @@ runs:
     )
 
 
+@pytest.mark.parametrize(
+    ("space_block", "expected_arg"),
+    [
+        ("space_key: ENG", ("--space-key", "ENG")),
+        (
+            "space_url: https://example.com/wiki/spaces/ENG/overview",
+            ("--space-url", "https://example.com/wiki/spaces/ENG/overview"),
+        ),
+    ],
+)
+def test_load_run_config_supports_confluence_space_mode(
+    tmp_path: Path,
+    space_block: str,
+    expected_arg: tuple[str, str],
+) -> None:
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        f"""
+runs:
+  - name: docs-space
+    type: confluence
+    base_url: https://example.com/wiki
+    {space_block}
+    output_dir: ./artifacts/confluence/docs-space
+    client_mode: real
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    run_config = load_run_config(config_path)
+
+    assert run_config.runs == (
+        ConfiguredRun(
+            name="docs-space",
+            run_type="confluence",
+            argv=(
+                "confluence",
+                "--base-url",
+                "https://example.com/wiki",
+                *expected_arg,
+                "--output-dir",
+                str((tmp_path / "artifacts" / "confluence" / "docs-space").resolve()),
+                "--client-mode",
+                "real",
+            ),
+            dry_run=False,
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    ("extra_block", "expected_fragment"),
+    [
+        ("target: '12345'", "cannot combine space mode with 'target'"),
+        ("tree: true", "cannot combine space mode with 'tree'"),
+        ("max_depth: 1", "cannot combine space mode with 'max_depth'"),
+        ("client_mode: stub", "space mode requires --client-mode real"),
+        ("space_url: https://example.com/wiki/spaces/ENG/overview", "only one"),
+    ],
+)
+def test_load_run_config_rejects_invalid_confluence_space_mode_combinations(
+    tmp_path: Path,
+    extra_block: str,
+    expected_fragment: str,
+) -> None:
+    config_path = tmp_path / "runs.yaml"
+    client_mode_block = "" if "client_mode" in extra_block else "    client_mode: real\n"
+    config_path.write_text(
+        f"""
+runs:
+  - name: docs-space
+    type: confluence
+    base_url: https://example.com/wiki
+    space_key: ENG
+    output_dir: ./artifacts/confluence/docs-space
+{client_mode_block}    {extra_block}
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match=expected_fragment):
+        load_run_config(config_path)
+
+
 def test_load_run_config_rejects_unsupported_keys(tmp_path: Path) -> None:
     config_path = tmp_path / "runs.yaml"
     config_path.write_text(


### PR DESCRIPTION
Summary
- add real-mode Confluence space discovery via --space-key or --space-url with early mutual-exclusion validation
- list space pages through paginated type=page API results and plan/write them in lexical canonical ID order
- wire runs.yaml support and preserve existing incremental, stale detection, manifest, and writer behavior
- update project map to mark #159 as the active arc after #148

Testing
- make check

Closes #148