### PR TITLE
feat: add Confluence CA bundle overrides

### DIFF
--- a/docs/project-map.md
+++ b/docs/project-map.md
@@ -7,7 +7,8 @@ grouping them into meaningful lanes.
 ## Current State
 
 - Confluence adapter: mature (single-page, tree traversal, incremental sync,
-  space discovery, TLS/auth, progress output)
+  space discovery, TLS/auth, environment-specific config overrides, progress
+  output)
 - Bundle command:
   - v1 complete (#147)
   - ordering controls added (#153)

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -11,7 +11,7 @@ from collections.abc import Callable, Sequence
 from contextlib import redirect_stderr, redirect_stdout
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TextIO
+from typing import TextIO, TypedDict
 
 from knowledge_adapters.bundle import (
     BUNDLE_ORDER_CHOICES,
@@ -105,6 +105,7 @@ _CLI_ERROR_RE = re.compile(r"^knowledge-adapters (?P<command>\S+): error: (?P<me
 _CONFLUENCE_REAL_ONLY_INPUT_FLAGS = (
     "--auth-method",
     "--ca-bundle",
+    "--no-ca-bundle",
     "--client-cert-file",
     "--client-key-file",
 )
@@ -117,6 +118,15 @@ class MultiRunSummary:
     dry_run: bool
     wrote: int
     skipped: int
+
+
+class RealClientTLSKwargs(TypedDict, total=False):
+    """Keyword arguments shared by Confluence real-client calls."""
+
+    ca_bundle: str | None
+    no_ca_bundle: bool
+    client_cert_file: str | None
+    client_key_file: str | None
 
 
 class _TeeStream:
@@ -347,6 +357,14 @@ def build_parser() -> argparse.ArgumentParser:
             "PEM bundle to trust for TLS verification in --client-mode real. "
             "When set, this overrides default certificate discovery for "
             "Confluence HTTPS requests."
+        ),
+    )
+    confluence_parser.add_argument(
+        "--no-ca-bundle",
+        action="store_true",
+        help=(
+            "Disable Confluence CA bundle usage for this run, overriding "
+            "--ca-bundle and KNOWLEDGE_ADAPTERS_CONFLUENCE_CA_BUNDLE."
         ),
     )
     confluence_parser.add_argument(
@@ -595,6 +613,14 @@ def build_parser() -> argparse.ArgumentParser:
             "details and effective TLS inputs are surfaced without editing runs.yaml."
         ),
     )
+    run_parser.add_argument(
+        "--no-ca-bundle",
+        action="store_true",
+        help=(
+            "Append --no-ca-bundle to configured Confluence runs so CA bundle "
+            "usage can be disabled without editing runs.yaml."
+        ),
+    )
 
     return parser
 
@@ -728,7 +754,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         from knowledge_adapters.run_config import load_run_config, select_runs
 
         try:
-            run_config = load_run_config(args.config_path)
+            run_config = load_run_config(
+                args.config_path,
+                no_confluence_ca_bundle=args.no_ca_bundle,
+            )
             selected_runs = select_runs(run_config, only_names=args.only)
         except ValueError as exc:
             exit_with_cli_error(str(exc), command="run")
@@ -920,6 +949,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             space_key=args.space_key,
             space_url=args.space_url,
             ca_bundle=args.ca_bundle,
+            no_ca_bundle=args.no_ca_bundle,
             client_cert_file=args.client_cert_file,
             client_key_file=args.client_key_file,
             client_mode=args.client_mode,
@@ -994,7 +1024,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
         try:
             validate_explicit_tls_paths(
-                ca_bundle=confluence_config.ca_bundle,
+                ca_bundle=None if confluence_config.no_ca_bundle else confluence_config.ca_bundle,
                 client_cert_file=confluence_config.client_cert_file,
                 client_key_file=confluence_config.client_key_file,
             )
@@ -1022,14 +1052,22 @@ def main(argv: Sequence[str] | None = None) -> int:
         selected_list_space_page_ids: Callable[[str], list[str]] | None = None
         if confluence_config.client_mode == "real":
 
+            def real_client_tls_kwargs() -> RealClientTLSKwargs:
+                kwargs = RealClientTLSKwargs(
+                    ca_bundle=confluence_config.ca_bundle,
+                    client_cert_file=confluence_config.client_cert_file,
+                    client_key_file=confluence_config.client_key_file,
+                )
+                if confluence_config.no_ca_bundle:
+                    kwargs["no_ca_bundle"] = True
+                return kwargs
+
             def selected_fetch_page(resolved_target: ResolvedTarget) -> dict[str, object]:
                 return fetch_real_page(
                     resolved_target,
                     base_url=confluence_config.base_url,
                     auth_method=confluence_config.auth_method,
-                    ca_bundle=confluence_config.ca_bundle,
-                    client_cert_file=confluence_config.client_cert_file,
-                    client_key_file=confluence_config.client_key_file,
+                    **real_client_tls_kwargs(),
                 )
 
             def selected_fetch_page_summary(
@@ -1039,9 +1077,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     resolved_target,
                     base_url=confluence_config.base_url,
                     auth_method=confluence_config.auth_method,
-                    ca_bundle=confluence_config.ca_bundle,
-                    client_cert_file=confluence_config.client_cert_file,
-                    client_key_file=confluence_config.client_key_file,
+                    **real_client_tls_kwargs(),
                 )
 
             def selected_list_child_page_ids(
@@ -1051,9 +1087,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     resolved_target,
                     base_url=confluence_config.base_url,
                     auth_method=confluence_config.auth_method,
-                    ca_bundle=confluence_config.ca_bundle,
-                    client_cert_file=confluence_config.client_cert_file,
-                    client_key_file=confluence_config.client_key_file,
+                    **real_client_tls_kwargs(),
                 )
 
             def selected_list_space_page_ids(space_key: str) -> list[str]:
@@ -1061,9 +1095,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     space_key,
                     base_url=confluence_config.base_url,
                     auth_method=confluence_config.auth_method,
-                    ca_bundle=confluence_config.ca_bundle,
-                    client_cert_file=confluence_config.client_cert_file,
-                    client_key_file=confluence_config.client_key_file,
+                    **real_client_tls_kwargs(),
                 )
         else:
             selected_fetch_page = fetch_page
@@ -1121,10 +1153,13 @@ def main(argv: Sequence[str] | None = None) -> int:
             if confluence_config.client_mode == "real":
                 resolved_tls_inputs = resolve_tls_inputs(
                     ca_bundle=confluence_config.ca_bundle,
+                    no_ca_bundle=confluence_config.no_ca_bundle,
                     client_cert_file=confluence_config.client_cert_file,
                     client_key_file=confluence_config.client_key_file,
                 )
                 tls_inputs: list[str] = []
+                if confluence_config.no_ca_bundle:
+                    tls_inputs.append("ca_bundle=disabled")
                 if resolved_tls_inputs.ca_bundle:
                     tls_inputs.append(
                         f"ca_bundle={render_user_path(resolved_tls_inputs.ca_bundle)}"

--- a/src/knowledge_adapters/confluence/auth.py
+++ b/src/knowledge_adapters/confluence/auth.py
@@ -7,6 +7,7 @@ import ssl
 from dataclasses import dataclass
 
 SUPPORTED_AUTH_METHODS = ("bearer-env", "client-cert-env")
+CONFLUENCE_CA_BUNDLE_ENV = "KNOWLEDGE_ADAPTERS_CONFLUENCE_CA_BUNDLE"
 
 
 @dataclass(frozen=True)
@@ -30,6 +31,7 @@ def build_request_auth(
     auth_method: str,
     *,
     ca_bundle: str | None = None,
+    no_ca_bundle: bool = False,
     client_cert_file: str | None = None,
     client_key_file: str | None = None,
 ) -> RequestAuth:
@@ -49,6 +51,7 @@ def build_request_auth(
         ssl_context=_client_cert_ssl_context(
             auth_method,
             ca_bundle=ca_bundle,
+            no_ca_bundle=no_ca_bundle,
             client_cert_file=client_cert_file,
             client_key_file=client_key_file,
         ),
@@ -58,16 +61,13 @@ def build_request_auth(
 def resolve_tls_inputs(
     *,
     ca_bundle: str | None = None,
+    no_ca_bundle: bool = False,
     client_cert_file: str | None = None,
     client_key_file: str | None = None,
 ) -> ResolvedTLSInputs:
     """Resolve the effective TLS/client-certificate file inputs."""
     return ResolvedTLSInputs(
-        ca_bundle=_first_non_empty(
-            ca_bundle,
-            os.getenv("REQUESTS_CA_BUNDLE"),
-            os.getenv("SSL_CERT_FILE"),
-        ),
+        ca_bundle=_resolve_ca_bundle(ca_bundle=ca_bundle, no_ca_bundle=no_ca_bundle),
         client_cert_file=_first_non_empty(
             client_cert_file,
             os.getenv("CONFLUENCE_CLIENT_CERT_FILE"),
@@ -94,11 +94,13 @@ def _client_cert_ssl_context(
     auth_method: str,
     *,
     ca_bundle: str | None = None,
+    no_ca_bundle: bool = False,
     client_cert_file: str | None = None,
     client_key_file: str | None = None,
 ) -> ssl.SSLContext | None:
     resolved_tls_inputs = resolve_tls_inputs(
         ca_bundle=ca_bundle,
+        no_ca_bundle=no_ca_bundle,
         client_cert_file=client_cert_file,
         client_key_file=client_key_file,
     )
@@ -142,6 +144,21 @@ def _client_cert_ssl_context(
         ) from exc
 
     return ssl_context
+
+
+def _resolve_ca_bundle(*, ca_bundle: str | None, no_ca_bundle: bool) -> str | None:
+    if no_ca_bundle:
+        return None
+
+    confluence_ca_bundle = os.getenv(CONFLUENCE_CA_BUNDLE_ENV)
+    if confluence_ca_bundle is not None:
+        return _first_non_empty(confluence_ca_bundle)
+
+    return _first_non_empty(
+        ca_bundle,
+        os.getenv("REQUESTS_CA_BUNDLE"),
+        os.getenv("SSL_CERT_FILE"),
+    )
 
 
 def _first_non_empty(*values: str | None) -> str | None:

--- a/src/knowledge_adapters/confluence/client.py
+++ b/src/knowledge_adapters/confluence/client.py
@@ -341,12 +341,14 @@ def _request_json(
     *,
     auth_method: str,
     ca_bundle: str | None = None,
+    no_ca_bundle: bool = False,
     client_cert_file: str | None = None,
     client_key_file: str | None = None,
 ) -> dict[str, object]:
     request_auth = build_request_auth(
         auth_method,
         ca_bundle=ca_bundle,
+        no_ca_bundle=no_ca_bundle,
         client_cert_file=client_cert_file,
         client_key_file=client_key_file,
     )
@@ -380,6 +382,7 @@ def fetch_real_page(
     base_url: str,
     auth_method: str,
     ca_bundle: str | None = None,
+    no_ca_bundle: bool = False,
     client_cert_file: str | None = None,
     client_key_file: str | None = None,
 ) -> dict[str, object]:
@@ -392,6 +395,7 @@ def fetch_real_page(
         _content_api_url(base_url, page_id, expand="body.storage,_links,version"),
         auth_method=auth_method,
         ca_bundle=ca_bundle,
+        no_ca_bundle=no_ca_bundle,
         client_cert_file=client_cert_file,
         client_key_file=client_key_file,
     )
@@ -404,6 +408,7 @@ def fetch_real_page_summary(
     base_url: str,
     auth_method: str,
     ca_bundle: str | None = None,
+    no_ca_bundle: bool = False,
     client_cert_file: str | None = None,
     client_key_file: str | None = None,
 ) -> dict[str, object]:
@@ -416,6 +421,7 @@ def fetch_real_page_summary(
         _content_api_url(base_url, page_id, expand="version,_links"),
         auth_method=auth_method,
         ca_bundle=ca_bundle,
+        no_ca_bundle=no_ca_bundle,
         client_cert_file=client_cert_file,
         client_key_file=client_key_file,
     )
@@ -428,6 +434,7 @@ def list_real_child_page_ids(
     base_url: str,
     auth_method: str,
     ca_bundle: str | None = None,
+    no_ca_bundle: bool = False,
     client_cert_file: str | None = None,
     client_key_file: str | None = None,
 ) -> list[str]:
@@ -440,6 +447,7 @@ def list_real_child_page_ids(
         _child_page_api_url(base_url, page_id),
         auth_method=auth_method,
         ca_bundle=ca_bundle,
+        no_ca_bundle=no_ca_bundle,
         client_cert_file=client_cert_file,
         client_key_file=client_key_file,
     )
@@ -452,6 +460,7 @@ def list_real_space_page_ids(
     base_url: str,
     auth_method: str,
     ca_bundle: str | None = None,
+    no_ca_bundle: bool = False,
     client_cert_file: str | None = None,
     client_key_file: str | None = None,
     page_limit: int = 100,
@@ -477,6 +486,7 @@ def list_real_space_page_ids(
             next_url,
             auth_method=auth_method,
             ca_bundle=ca_bundle,
+            no_ca_bundle=no_ca_bundle,
             client_cert_file=client_cert_file,
             client_key_file=client_key_file,
         )

--- a/src/knowledge_adapters/confluence/config.py
+++ b/src/knowledge_adapters/confluence/config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
-from knowledge_adapters.confluence.auth import resolve_tls_inputs
+from knowledge_adapters.confluence.auth import CONFLUENCE_CA_BUNDLE_ENV, resolve_tls_inputs
 
 
 @dataclass(frozen=True)
@@ -18,6 +18,7 @@ class ConfluenceConfig:
     space_key: str | None = None
     space_url: str | None = None
     ca_bundle: str | None = None
+    no_ca_bundle: bool = False
     client_cert_file: str | None = None
     client_key_file: str | None = None
     client_mode: str = "stub"
@@ -35,7 +36,7 @@ _TLS_INPUT_OPTION_NAMES = {
 }
 
 _TLS_INPUT_ENV_NAMES = {
-    "ca_bundle": ("REQUESTS_CA_BUNDLE", "SSL_CERT_FILE"),
+    "ca_bundle": (CONFLUENCE_CA_BUNDLE_ENV, "REQUESTS_CA_BUNDLE", "SSL_CERT_FILE"),
     "client_cert_file": ("CONFLUENCE_CLIENT_CERT_FILE",),
     "client_key_file": ("CONFLUENCE_CLIENT_KEY_FILE",),
 }
@@ -66,6 +67,7 @@ def validate_selected_real_tls_paths(config: ConfluenceConfig) -> None:
     """Fail fast when real-mode TLS/client-certificate file paths do not exist."""
     resolved_tls_inputs = resolve_tls_inputs(
         ca_bundle=config.ca_bundle,
+        no_ca_bundle=config.no_ca_bundle,
         client_cert_file=config.client_cert_file,
         client_key_file=config.client_key_file,
     )

--- a/src/knowledge_adapters/run_config.py
+++ b/src/knowledge_adapters/run_config.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from pathlib import Path
 
 import yaml  # type: ignore[import-untyped]
 
-from knowledge_adapters.confluence.auth import SUPPORTED_AUTH_METHODS
+from knowledge_adapters.confluence.auth import CONFLUENCE_CA_BUNDLE_ENV, SUPPORTED_AUTH_METHODS
 from knowledge_adapters.confluence.config import validate_explicit_tls_paths
 from knowledge_adapters.confluence.resolve import (
     resolve_target_for_base_url,
@@ -62,7 +63,11 @@ class RunConfig:
     runs: tuple[ConfiguredRun, ...]
 
 
-def load_run_config(config_path: str | Path) -> RunConfig:
+def load_run_config(
+    config_path: str | Path,
+    *,
+    no_confluence_ca_bundle: bool = False,
+) -> RunConfig:
     """Load and validate a config-driven run file."""
     resolved_config_path = Path(config_path).expanduser().resolve()
     try:
@@ -92,7 +97,12 @@ def load_run_config(config_path: str | Path) -> RunConfig:
     return RunConfig(
         config_path=resolved_config_path,
         runs=tuple(
-            _parse_run(run_config, index=index, config_path=resolved_config_path)
+            _parse_run(
+                run_config,
+                index=index,
+                config_path=resolved_config_path,
+                no_confluence_ca_bundle=no_confluence_ca_bundle,
+            )
             for index, run_config in enumerate(runs, start=1)
         ),
     )
@@ -130,6 +140,7 @@ def _parse_run(
     *,
     index: int,
     config_path: Path,
+    no_confluence_ca_bundle: bool,
 ) -> ConfiguredRun:
     if not isinstance(run_config, dict):
         raise ValueError(
@@ -146,7 +157,12 @@ def _parse_run(
         )
 
     if run_type == "confluence":
-        argv = _build_confluence_argv(run_config, name=name, config_path=config_path)
+        argv = _build_confluence_argv(
+            run_config,
+            name=name,
+            config_path=config_path,
+            no_ca_bundle=no_confluence_ca_bundle,
+        )
         dry_run = _optional_bool(
             run_config,
             "dry_run",
@@ -198,6 +214,7 @@ def _build_confluence_argv(
     *,
     name: str,
     config_path: Path,
+    no_ca_bundle: bool,
 ) -> tuple[str, ...]:
     _reject_unknown_keys(
         run_config,
@@ -314,8 +331,10 @@ def _build_confluence_argv(
         argv.extend(["--auth-method", auth_method])
 
     ca_bundle = _optional_string(run_config, "ca_bundle", index=index, config_path=config_path)
-    resolved_ca_bundle = (
-        _resolve_path_string(ca_bundle, config_path=config_path) if ca_bundle is not None else None
+    resolved_ca_bundle = _resolve_configured_ca_bundle(
+        ca_bundle,
+        config_path=config_path,
+        no_ca_bundle=no_ca_bundle,
     )
     client_cert_file = _optional_string(
         run_config,
@@ -360,6 +379,8 @@ def _build_confluence_argv(
                 resolved_ca_bundle,
             ]
         )
+    if no_ca_bundle:
+        argv.append("--no-ca-bundle")
     if resolved_client_cert_file is not None:
         argv.extend(
             [
@@ -395,6 +416,26 @@ def _build_confluence_argv(
         argv.extend(["--max-depth", str(max_depth)])
 
     return tuple(argv)
+
+
+def _resolve_configured_ca_bundle(
+    ca_bundle: str | None,
+    *,
+    config_path: Path,
+    no_ca_bundle: bool,
+) -> str | None:
+    if no_ca_bundle:
+        return None
+
+    env_ca_bundle = os.getenv(CONFLUENCE_CA_BUNDLE_ENV)
+    if env_ca_bundle is not None:
+        normalized_env_ca_bundle = env_ca_bundle.strip()
+        return normalized_env_ca_bundle or None
+
+    if ca_bundle is None:
+        return None
+
+    return _resolve_path_string(ca_bundle, config_path=config_path)
 
 
 def _build_local_files_argv(

--- a/tests/test_confluence_real_client_contract.py
+++ b/tests/test_confluence_real_client_contract.py
@@ -49,6 +49,7 @@ def _fetch_real_page(
     base_url: str = "https://example.com/wiki",
     auth_method: str = "bearer-env",
     ca_bundle: str | None = None,
+    no_ca_bundle: bool = False,
     client_cert_file: str | None = None,
     client_key_file: str | None = None,
 ) -> dict[str, object]:
@@ -60,6 +61,7 @@ def _fetch_real_page(
         base_url=base_url,
         auth_method=auth_method,
         ca_bundle=ca_bundle,
+        no_ca_bundle=no_ca_bundle,
         client_cert_file=client_cert_file,
         client_key_file=client_key_file,
     )
@@ -519,6 +521,48 @@ def test_real_single_page_dry_run_surfaces_env_tls_input_paths(
     ) in output
 
 
+def test_real_single_page_dry_run_surfaces_disabled_ca_bundle(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    from knowledge_adapters.confluence import client as client_module
+
+    observed_no_ca_bundle: list[bool] = []
+
+    def stub_real_fetch(*args: object, **kwargs: object) -> dict[str, object]:
+        del args
+        observed_no_ca_bundle.append(cast(bool, kwargs.get("no_ca_bundle")))
+        return {
+            "canonical_id": "12345",
+            "title": "Real Page",
+            "content": "<p>Hello from Confluence.</p>",
+            "source_url": "https://example.com/wiki/spaces/ENG/pages/12345",
+            "page_version": 7,
+            "last_modified": "2026-04-20T12:34:56Z",
+        }
+
+    monkeypatch.setattr(client_module, "fetch_real_page", stub_real_fetch, raising=False)
+    monkeypatch.setenv("KNOWLEDGE_ADAPTERS_CONFLUENCE_CA_BUNDLE", "/tmp/env-ca.pem")
+
+    exit_code = main(
+        _confluence_argv(
+            tmp_path / "out",
+            "--client-mode",
+            "real",
+            "--dry-run",
+            "--ca-bundle",
+            "/tmp/config-ca.pem",
+            "--no-ca-bundle",
+        )
+    )
+
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert "tls_inputs: ca_bundle=disabled" in output
+    assert observed_no_ca_bundle == [True]
+
+
 def test_real_client_cli_rejects_missing_env_selected_ca_bundle_before_request(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -676,6 +720,68 @@ def test_real_fetch_prefers_explicit_ca_bundle_over_env_fallback(
 
     assert page["canonical_id"] == "12345"
     assert observed_cafiles == ["/tmp/config-ca.pem"]
+
+
+def test_real_fetch_uses_confluence_ca_bundle_env_over_explicit_ca_bundle(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    ssl_context = _FakeSSLContext()
+    observed_cafiles: list[str | None] = []
+
+    def fake_create_default_context(*, cafile: str | None = None) -> _FakeSSLContext:
+        observed_cafiles.append(cafile)
+        return ssl_context
+
+    monkeypatch.setattr(
+        "knowledge_adapters.confluence.auth.ssl.create_default_context",
+        fake_create_default_context,
+    )
+    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
+    monkeypatch.setenv("KNOWLEDGE_ADAPTERS_CONFLUENCE_CA_BUNDLE", "/tmp/env-ca.pem")
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *args, **kwargs: _FakeHTTPResponse(_valid_confluence_payload()),
+    )
+
+    page = _fetch_real_page(_real_target(), ca_bundle="/tmp/config-ca.pem")
+
+    assert page["canonical_id"] == "12345"
+    assert observed_cafiles == ["/tmp/env-ca.pem"]
+
+
+def test_real_fetch_no_ca_bundle_disables_confluence_ca_bundle_inputs(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    observed_contexts: list[object | None] = []
+    observed_cafiles: list[str | None] = []
+
+    def fake_create_default_context(*, cafile: str | None = None) -> _FakeSSLContext:
+        observed_cafiles.append(cafile)
+        return _FakeSSLContext()
+
+    def fake_urlopen(*args: object, **kwargs: object) -> _FakeHTTPResponse:
+        del args
+        observed_contexts.append(kwargs.get("context"))
+        return _FakeHTTPResponse(_valid_confluence_payload())
+
+    monkeypatch.setattr(
+        "knowledge_adapters.confluence.auth.ssl.create_default_context",
+        fake_create_default_context,
+    )
+    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
+    monkeypatch.setenv("KNOWLEDGE_ADAPTERS_CONFLUENCE_CA_BUNDLE", "/tmp/env-ca.pem")
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", "/tmp/requests-ca.pem")
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    page = _fetch_real_page(
+        _real_target(),
+        ca_bundle="/tmp/config-ca.pem",
+        no_ca_bundle=True,
+    )
+
+    assert page["canonical_id"] == "12345"
+    assert observed_cafiles == []
+    assert observed_contexts == [None]
 
 
 def test_real_fetch_uses_requests_ca_bundle_env_when_explicit_ca_bundle_omitted(

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -788,6 +788,146 @@ runs:
     )
 
 
+def test_load_run_config_env_ca_bundle_overrides_confluence_config_path(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    certs_dir = tmp_path / "certs"
+    certs_dir.mkdir()
+    (certs_dir / "config-ca.pem").write_text("config ca\n", encoding="utf-8")
+    env_ca_bundle = tmp_path / "env-ca.pem"
+    env_ca_bundle.write_text("env ca\n", encoding="utf-8")
+    monkeypatch.setenv("KNOWLEDGE_ADAPTERS_CONFLUENCE_CA_BUNDLE", str(env_ca_bundle))
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: docs-home
+    type: confluence
+    base_url: https://example.com/wiki
+    target: "12345"
+    output_dir: ./artifacts/confluence/docs-home
+    ca_bundle: ./certs/config-ca.pem
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    run_config = load_run_config(config_path)
+
+    assert "--ca-bundle" in run_config.runs[0].argv
+    assert str(env_ca_bundle) in run_config.runs[0].argv
+    assert str((certs_dir / "config-ca.pem").resolve()) not in run_config.runs[0].argv
+
+
+def test_load_run_config_empty_env_ca_bundle_disables_confluence_config_path(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("KNOWLEDGE_ADAPTERS_CONFLUENCE_CA_BUNDLE", "")
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: docs-home
+    type: confluence
+    base_url: https://example.com/wiki
+    target: "12345"
+    output_dir: ./artifacts/confluence/docs-home
+    ca_bundle: ./certs/missing-ca.pem
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    run_config = load_run_config(config_path)
+
+    assert "--ca-bundle" not in run_config.runs[0].argv
+
+
+def test_load_run_config_no_ca_bundle_flag_disables_env_and_config_ca_bundle(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    env_ca_bundle = tmp_path / "env-ca.pem"
+    env_ca_bundle.write_text("env ca\n", encoding="utf-8")
+    monkeypatch.setenv("KNOWLEDGE_ADAPTERS_CONFLUENCE_CA_BUNDLE", str(env_ca_bundle))
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: docs-home
+    type: confluence
+    base_url: https://example.com/wiki
+    target: "12345"
+    output_dir: ./artifacts/confluence/docs-home
+    ca_bundle: ./certs/missing-ca.pem
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    run_config = load_run_config(config_path, no_confluence_ca_bundle=True)
+
+    assert "--ca-bundle" not in run_config.runs[0].argv
+    assert "--no-ca-bundle" in run_config.runs[0].argv
+
+
+def test_run_command_no_ca_bundle_flag_disables_env_and_config_ca_bundle(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    from knowledge_adapters.confluence import client as client_module
+
+    observed_kwargs: list[dict[str, object]] = []
+
+    def stub_real_fetch(*args: object, **kwargs: object) -> dict[str, object]:
+        del args
+        observed_kwargs.append(dict(kwargs))
+        return {
+            "canonical_id": "12345",
+            "title": "Real Page",
+            "content": "<p>Hello from Confluence.</p>",
+            "source_url": "https://example.com/wiki/spaces/ENG/pages/12345",
+            "page_version": 7,
+            "last_modified": "2026-04-20T12:34:56Z",
+        }
+
+    env_ca_bundle = tmp_path / "env-ca.pem"
+    env_ca_bundle.write_text("env ca\n", encoding="utf-8")
+    monkeypatch.setattr(client_module, "fetch_real_page", stub_real_fetch, raising=False)
+    monkeypatch.setenv("KNOWLEDGE_ADAPTERS_CONFLUENCE_CA_BUNDLE", str(env_ca_bundle))
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: docs-home
+    type: confluence
+    client_mode: real
+    base_url: https://example.com/wiki
+    target: "12345"
+    output_dir: ./artifacts/confluence/docs-home
+    ca_bundle: ./certs/missing-ca.pem
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    exit_code = main(["run", "--no-ca-bundle", str(config_path)])
+
+    assert exit_code == 0
+    assert observed_kwargs == [
+        {
+            "base_url": "https://example.com/wiki",
+            "auth_method": "bearer-env",
+            "ca_bundle": None,
+            "client_cert_file": None,
+            "client_key_file": None,
+            "no_ca_bundle": True,
+        }
+    ]
+
+
 def test_load_run_config_rejects_confluence_client_key_without_client_cert(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
Summary
- add KNOWLEDGE_ADAPTERS_CONFLUENCE_CA_BUNDLE override for configured Confluence CA bundle paths, with an empty value disabling CA bundle use
- add --no-ca-bundle for direct Confluence and config-driven runs, with precedence over env and runs.yaml
- thread the no-CA option through real-client TLS setup and surface disabled CA state in run output
- update project map current-state note for environment-specific config overrides

Testing
- make check

Closes #167