### PR TITLE
chore: prepare v0.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ Formal changelog coverage begins at `0.2.0`, when this repository started using
 `CHANGELOG.md` as part of the release flow. Earlier tagged releases `v0.1.0` and
 `v0.1.1` predate that practice and are not backfilled here.
 
+## 0.7.0
+
+This minor release expands Confluence ingestion, rounds out the first bundle
+packaging flow, and makes config-driven runs easier to carry across
+environments.
+
+### Confluence ingestion
+
+- Added space-wide Confluence discovery through either a space key or a space
+  URL, making broader ingestion runs easier to start from operator-facing
+  inputs.
+
+### Bundle / LLM packaging
+
+- Shipped the bundle command as a first-class packaging flow for turning
+  adapter output into LLM-friendly bundles.
+- Added ordering controls, include/exclude filters, and header modes so bundle
+  output is easier to shape for different downstream consumers.
+- Added changed-only comparison and size-aware splitting so repeat bundle runs
+  can stay smaller, more targeted, and easier to transport.
+
+### Configuration / portability
+
+- Added Confluence CA bundle environment and CLI overrides for portable
+  `runs.yaml` workflows, improving TLS portability across environments without
+  rewriting shared config.
+
 ## 0.6.0
 
 This minor release expands config-driven automation and makes live Confluence

--- a/docs/project-map.md
+++ b/docs/project-map.md
@@ -7,11 +7,13 @@ grouping them into meaningful lanes.
 ## Current State
 
 - Confluence adapter: mature (single-page, tree traversal, incremental sync,
-  space discovery, TLS/auth, environment-specific config overrides, progress
-  output)
+  space discovery by key/URL, TLS/auth, portable CA bundle overrides,
+  environment-specific config overrides, progress output)
 - Bundle command:
   - v1 complete (#147)
   - ordering controls added (#153)
+  - include/exclude filters added (#152)
+  - header modes added (#155)
   - changed-only bundle comparison complete (#157)
   - size-aware bundle splitting complete (#154)
 - CLI, config-driven runs, and test coverage are stable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "knowledge-adapters"
-version = "0.6.0"
+version = "0.7.0"
 description = "Generic adapters for acquiring and normalizing knowledge sources into local LLM-ready artifacts."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/knowledge_adapters/__init__.py
+++ b/src/knowledge_adapters/__init__.py
@@ -1,3 +1,3 @@
 """knowledge_adapters package."""
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"


### PR DESCRIPTION
Summary
- prepare the v0.7.0 release checkpoint across version metadata, changelog, and project map
- capture the completed Confluence space discovery, bundle packaging improvements, and portable CA bundle override work since v0.6.0
- point the active project arc at #159 for git_repo ingestion

Testing
- make check
