### PR TITLE
feat: add git_repo adapter

### DIFF
--- a/docs/project-map.md
+++ b/docs/project-map.md
@@ -21,6 +21,7 @@ grouping them into meaningful lanes.
 ## Active Arc
 
 - #159 Add `git_repo` adapter for ingesting repository contents
+- Status: implement clone/fetch + checkout ingestion, deterministic file filtering, and manifest metadata without broadening adapter scope
 
 ## Next Arcs
 

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -27,6 +27,7 @@ TOP_LEVEL_HELP_EXAMPLES = """First steps:
   knowledge-adapters --help
   knowledge-adapters run runs.yaml
   knowledge-adapters local_files --help
+  knowledge-adapters git_repo --help
   knowledge-adapters confluence --help
   knowledge-adapters bundle ./artifacts --output ./bundle.md
 
@@ -74,6 +75,23 @@ LOCAL_FILES_HELP_EXAMPLES = """Examples:
     --dry-run
   knowledge-adapters local_files \\
     --file-path ./notes/today.txt \\
+    --output-dir ./artifacts
+"""
+
+GIT_REPO_HELP_EXAMPLES = """Examples:
+  knowledge-adapters git_repo \\
+    --repo-url https://github.com/example/project.git \\
+    --output-dir ./artifacts \\
+    --dry-run
+  knowledge-adapters git_repo \\
+    --repo-url https://github.com/example/project.git \\
+    --ref v1.2.3 \\
+    --include \"docs/**/*.md\" \\
+    --exclude \"docs/archive/*\" \\
+    --output-dir ./artifacts
+  knowledge-adapters git_repo \\
+    --repo-url https://github.com/example/project.git \\
+    --subdir docs \\
     --output-dir ./artifacts
 """
 
@@ -467,6 +485,72 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "Preview the resolved file path, artifact path, manifest path, and "
             "normalized markdown without writing files."
+        ),
+    )
+
+    git_repo_parser = subparsers.add_parser(
+        "git_repo",
+        help="Normalize selected UTF-8 text files from a Git repository into shared artifacts.",
+        description=(
+            "Clone or refresh a Git repository with system git, check out the selected "
+            "ref or the repository default branch, enumerate tracked files, apply optional "
+            "include/exclude glob filters, and normalize one artifact per UTF-8 text file "
+            "into the shared artifact layout. An optional --subdir limits enumeration to "
+            "one repository-relative directory. Binary and non-UTF-8 files are skipped "
+            "with explicit reporting. File ordering is deterministic and lexical by "
+            "repository path."
+        ),
+        epilog=GIT_REPO_HELP_EXAMPLES,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    git_repo_parser.add_argument(
+        "--repo-url",
+        required=True,
+        help=(
+            "Git repository URL or other git clone locator. Relative local paths resolve "
+            "from the cwd."
+        ),
+    )
+    git_repo_parser.add_argument(
+        "--output-dir",
+        required=True,
+        metavar="DIR",
+        help="Directory where pages/ and manifest.json are written.",
+    )
+    git_repo_parser.add_argument(
+        "--ref",
+        help="Branch, tag, or commit to check out. Defaults to the repository default branch.",
+    )
+    git_repo_parser.add_argument(
+        "--include",
+        action="append",
+        default=[],
+        metavar="PATTERN",
+        help=(
+            "Glob pattern matched against repository-relative file paths. Repeat to include "
+            "multiple patterns. If omitted, all tracked files start included."
+        ),
+    )
+    git_repo_parser.add_argument(
+        "--exclude",
+        action="append",
+        default=[],
+        metavar="PATTERN",
+        help=(
+            "Glob pattern matched against repository-relative file paths after include "
+            "filtering. Repeat to exclude multiple patterns."
+        ),
+    )
+    git_repo_parser.add_argument(
+        "--subdir",
+        help="Optional repository-relative directory to enumerate instead of the whole checkout.",
+    )
+    git_repo_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Preview the resolved ref, commit SHA, selected files, artifact paths, and "
+            "skip reasons without writing files."
         ),
     )
 
@@ -2201,6 +2285,183 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"\nWrote: {render_user_path(output_path)}")
         print("\nSummary: wrote 1, skipped 0")
         print(f"Artifact path: {render_user_path(output_path)}")
+        print(f"Manifest path: {render_user_path(manifest)}")
+        print_write_complete(output_dir)
+        return 0
+
+    if args.command == "git_repo":
+        import hashlib
+
+        from knowledge_adapters.confluence.manifest import (
+            build_manifest_entry,
+            write_manifest,
+        )
+        from knowledge_adapters.git_repo.client import fetch_repo_snapshot
+        from knowledge_adapters.git_repo.config import GitRepoConfig
+        from knowledge_adapters.git_repo.normalize import normalize_to_markdown
+        from knowledge_adapters.git_repo.writer import (
+            markdown_path as git_repo_markdown_path,
+        )
+        from knowledge_adapters.git_repo.writer import (
+            write_markdown as write_git_repo_markdown,
+        )
+
+        git_repo_config = GitRepoConfig(
+            repo_url=args.repo_url,
+            output_dir=args.output_dir,
+            ref=args.ref,
+            include=tuple(args.include),
+            exclude=tuple(args.exclude),
+            subdir=args.subdir,
+            dry_run=args.dry_run,
+        )
+
+        output_dir_input = Path(git_repo_config.output_dir).expanduser()
+        output_dir = output_dir_input.resolve()
+        if output_dir_input.exists() and not output_dir_input.is_dir():
+            exit_with_cli_error(
+                (
+                    f"Output path is not a directory: {output_dir}. "
+                    "Verify --output-dir and use a directory path."
+                ),
+                command="git_repo",
+            )
+
+        try:
+            snapshot = fetch_repo_snapshot(
+                git_repo_config.repo_url,
+                ref=git_repo_config.ref,
+                include=git_repo_config.include,
+                exclude=git_repo_config.exclude,
+                subdir=git_repo_config.subdir,
+            )
+        except ValueError as exc:
+            exit_with_cli_error(str(exc), command="git_repo")
+
+        print("Git repo adapter invoked")
+        print(f"  repo_url: {git_repo_config.repo_url}")
+        print(f"  output_dir: {render_user_path(git_repo_config.output_dir)}")
+        requested_ref_label = (
+            git_repo_config.ref if git_repo_config.ref is not None else "(default branch)"
+        )
+        print(
+            f"  requested_ref: {requested_ref_label}"
+        )
+        if git_repo_config.subdir is not None:
+            print(f"  subdir: {git_repo_config.subdir}")
+        if git_repo_config.include:
+            print(f"  include: {', '.join(git_repo_config.include)}")
+        if git_repo_config.exclude:
+            print(f"  exclude: {', '.join(git_repo_config.exclude)}")
+        print(f"  run_mode: {'dry-run' if git_repo_config.dry_run else 'write'}")
+
+        print("\nPlan: Git repo run")
+        print(f"  working_dir: {render_user_path(snapshot.repo_dir)}")
+        print(f"  resolved_ref: {snapshot.ref}")
+        print(f"  commit_sha: {snapshot.commit_sha}")
+        print(f"  tracked_files: {len(snapshot.discovered_paths)}")
+        filtered_out_count = len(snapshot.discovered_paths) - len(snapshot.selected_paths)
+        print(f"  selected_files: {len(snapshot.selected_paths)}")
+        print(f"  filtered_out: {filtered_out_count}")
+
+        manifest_entries: list[dict[str, object]] = []
+        written_output_paths: list[Path] = []
+        for repo_file in snapshot.files:
+            markdown = normalize_to_markdown(
+                {
+                    "title": repo_file.title,
+                    "canonical_id": repo_file.canonical_id,
+                    "source_url": repo_file.source_url,
+                    "content": repo_file.content,
+                    "source": repo_file.source,
+                    "adapter": repo_file.adapter,
+                }
+            )
+            output_path = git_repo_markdown_path(git_repo_config.output_dir, repo_file.repo_path)
+            manifest_entries.append(
+                build_manifest_entry(
+                    canonical_id=repo_file.canonical_id,
+                    source_url=repo_file.source_url,
+                    output_path=output_path,
+                    output_dir=git_repo_config.output_dir,
+                    title=repo_file.title,
+                    content_hash=hashlib.sha256(markdown.encode("utf-8")).hexdigest(),
+                    path=repo_file.repo_path,
+                    ref=snapshot.ref,
+                    commit_sha=snapshot.commit_sha,
+                )
+            )
+            written_output_paths.append(output_path)
+
+        for repo_file, output_path in zip(snapshot.files, written_output_paths, strict=True):
+            print(f"\n  path: {repo_file.repo_path}")
+            print(f"  Artifact path: {render_user_path(output_path)}")
+            content = repo_file.content
+            if content:
+                print("  content_status: UTF-8 text with content")
+            else:
+                print(
+                    "  content_status: empty UTF-8 file; output will contain metadata "
+                    "and an empty content section"
+                )
+            print(f"  action: {'would write' if git_repo_config.dry_run else 'write'}")
+
+        for skipped_file in snapshot.skipped_files:
+            output_path = git_repo_markdown_path(
+                git_repo_config.output_dir,
+                skipped_file.repo_path,
+            )
+            print(f"\n  path: {skipped_file.repo_path}")
+            print(f"  Artifact path: {render_user_path(output_path)}")
+            print(f"  content_status: skipped ({skipped_file.reason})")
+            print(f"  action: {'would skip' if git_repo_config.dry_run else 'skip'}")
+
+        manifest_output_path = output_dir / "manifest.json"
+        if git_repo_config.dry_run:
+            print(
+                "\nSummary: would write "
+                f"{len(snapshot.files)}, would skip {len(snapshot.skipped_files)}"
+            )
+            print(f"Manifest path: {render_user_path(manifest_output_path)}")
+            print_dry_run_complete()
+            return 0
+
+        try:
+            for repo_file in snapshot.files:
+                markdown = normalize_to_markdown(
+                    {
+                        "title": repo_file.title,
+                        "canonical_id": repo_file.canonical_id,
+                        "source_url": repo_file.source_url,
+                        "content": repo_file.content,
+                        "source": repo_file.source,
+                        "adapter": repo_file.adapter,
+                    }
+                )
+                write_git_repo_markdown(
+                    git_repo_config.output_dir,
+                    repo_file.repo_path,
+                    markdown,
+                )
+            manifest = write_manifest(
+                git_repo_config.output_dir,
+                manifest_entries,
+            )
+        except OSError as exc:
+            exit_with_output_error(
+                git_repo_config.output_dir,
+                command="git_repo",
+                exc=exc,
+            )
+
+        for output_path in written_output_paths:
+            print(f"\nWrote: {render_user_path(output_path)}")
+        for skipped_file in snapshot.skipped_files:
+            print(f"\nSkipped: {skipped_file.repo_path} ({skipped_file.reason})")
+        print(
+            "\nSummary: wrote "
+            f"{len(snapshot.files)}, skipped {len(snapshot.skipped_files)}"
+        )
         print(f"Manifest path: {render_user_path(manifest)}")
         print_write_complete(output_dir)
         return 0

--- a/src/knowledge_adapters/confluence/manifest.py
+++ b/src/knowledge_adapters/confluence/manifest.py
@@ -21,6 +21,10 @@ def build_manifest_entry(
     title: str | None = None,
     page_version: int | str | None = None,
     last_modified: str | None = None,
+    content_hash: str | None = None,
+    path: str | None = None,
+    ref: str | None = None,
+    commit_sha: str | None = None,
 ) -> dict[str, object]:
     """Build a minimal manifest entry for a generated file."""
     entry: dict[str, object] = {
@@ -35,6 +39,14 @@ def build_manifest_entry(
         entry["page_version"] = page_version
     if last_modified:
         entry["last_modified"] = last_modified
+    if content_hash:
+        entry["content_hash"] = content_hash
+    if path:
+        entry["path"] = path
+    if ref:
+        entry["ref"] = ref
+    if commit_sha:
+        entry["commit_sha"] = commit_sha
 
     return entry
 

--- a/src/knowledge_adapters/git_repo/__init__.py
+++ b/src/knowledge_adapters/git_repo/__init__.py
@@ -1,0 +1,1 @@
+"""Git repository adapter package."""

--- a/src/knowledge_adapters/git_repo/client.py
+++ b/src/knowledge_adapters/git_repo/client.py
@@ -1,0 +1,355 @@
+"""Git-backed file ingestion for the git_repo adapter."""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+
+
+@dataclass(frozen=True)
+class GitRepoFile:
+    """One normalized source file loaded from a repository checkout."""
+
+    repo_path: str
+    title: str
+    canonical_id: str
+    source_url: str
+    content: str
+    source: str = "git_repo"
+    adapter: str = "git_repo"
+
+
+@dataclass(frozen=True)
+class SkippedGitRepoFile:
+    """One repository file skipped during ingestion."""
+
+    repo_path: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class GitRepoSnapshot:
+    """Resolved repository checkout plus selected files."""
+
+    repo_dir: Path
+    ref: str
+    commit_sha: str
+    discovered_paths: tuple[str, ...]
+    selected_paths: tuple[str, ...]
+    files: tuple[GitRepoFile, ...]
+    skipped_files: tuple[SkippedGitRepoFile, ...]
+
+
+def cache_dir_for_repo(repo_url: str) -> Path:
+    """Return the deterministic local checkout cache path for one repo URL."""
+    repo_hash = hashlib.sha256(repo_url.encode("utf-8")).hexdigest()[:16]
+    return Path(tempfile.gettempdir()) / "knowledge-adapters" / "git_repo" / repo_hash
+
+
+def fetch_repo_snapshot(
+    repo_url: str,
+    *,
+    ref: str | None = None,
+    include: tuple[str, ...] = (),
+    exclude: tuple[str, ...] = (),
+    subdir: str | None = None,
+) -> GitRepoSnapshot:
+    """Clone or refresh a repository checkout and read selected UTF-8 files."""
+    repo_dir = cache_dir_for_repo(repo_url)
+    _ensure_repo_checkout(repo_url, repo_dir)
+    resolved_ref = _checkout_ref(repo_dir, ref)
+    commit_sha = _run_git(
+        "rev-parse",
+        "HEAD",
+        cwd=repo_dir,
+        operation="resolve checked out commit",
+    )
+
+    normalized_subdir = normalize_subdir(subdir)
+    if normalized_subdir is not None:
+        subdir_path = repo_dir / Path(*PurePosixPath(normalized_subdir).parts)
+        if not subdir_path.exists():
+            raise ValueError(
+                f"Subdirectory does not exist at ref {resolved_ref!r}: {normalized_subdir}."
+            )
+        if not subdir_path.is_dir():
+            raise ValueError(
+                "Subdirectory path is not a directory at ref "
+                f"{resolved_ref!r}: {normalized_subdir}."
+            )
+
+    discovered_paths = _list_repo_files(repo_dir, subdir=normalized_subdir)
+    selected_paths = tuple(
+        repo_path
+        for repo_path in discovered_paths
+        if _path_is_selected(
+            repo_path,
+            include_patterns=include,
+            exclude_patterns=exclude,
+        )
+    )
+
+    files: list[GitRepoFile] = []
+    skipped_files: list[SkippedGitRepoFile] = []
+    for repo_path in selected_paths:
+        source_path = repo_dir / Path(*PurePosixPath(repo_path).parts)
+        if not source_path.exists():
+            skipped_files.append(
+                SkippedGitRepoFile(
+                    repo_path=repo_path,
+                    reason="missing after checkout",
+                )
+            )
+            continue
+        if not source_path.is_file():
+            skipped_files.append(
+                SkippedGitRepoFile(
+                    repo_path=repo_path,
+                    reason="not a regular file; submodules are not supported",
+                )
+            )
+            continue
+
+        try:
+            raw_content = source_path.read_bytes()
+        except OSError as exc:
+            raise ValueError(f"Could not read repository file: {repo_path}.") from exc
+
+        if b"\x00" in raw_content:
+            skipped_files.append(
+                SkippedGitRepoFile(
+                    repo_path=repo_path,
+                    reason="binary file",
+                )
+            )
+            continue
+
+        try:
+            content = raw_content.decode("utf-8")
+        except UnicodeDecodeError:
+            skipped_files.append(
+                SkippedGitRepoFile(
+                    repo_path=repo_path,
+                    reason="binary or non-UTF-8 file",
+                )
+            )
+            continue
+
+        files.append(
+            GitRepoFile(
+                repo_path=repo_path,
+                title=repo_path,
+                canonical_id=f"{repo_url}@{commit_sha}:{repo_path}",
+                source_url=repo_url,
+                content=content,
+            )
+        )
+
+    return GitRepoSnapshot(
+        repo_dir=repo_dir,
+        ref=resolved_ref,
+        commit_sha=commit_sha,
+        discovered_paths=discovered_paths,
+        selected_paths=selected_paths,
+        files=tuple(files),
+        skipped_files=tuple(skipped_files),
+    )
+
+
+def normalize_subdir(subdir: str | None) -> str | None:
+    """Normalize and validate an optional repository-relative subdirectory."""
+    if subdir is None:
+        return None
+
+    normalized_value = subdir.strip().replace("\\", "/")
+    if not normalized_value or normalized_value == ".":
+        return None
+
+    normalized_path = PurePosixPath(normalized_value)
+    if normalized_path.is_absolute() or ".." in normalized_path.parts:
+        raise ValueError(
+            "Subdirectory must stay within the repository checkout. "
+            "Use a relative path without '..'."
+        )
+
+    return normalized_path.as_posix()
+
+
+def _ensure_repo_checkout(repo_url: str, repo_dir: Path) -> None:
+    if not repo_dir.exists():
+        repo_dir.parent.mkdir(parents=True, exist_ok=True)
+        _run_git(
+            "clone",
+            "--quiet",
+            repo_url,
+            str(repo_dir),
+            operation=f"clone {repo_url!r}",
+        )
+        return
+
+    if not (repo_dir / ".git").is_dir():
+        raise ValueError(
+            f"Cached git_repo checkout is not a git repository: {repo_dir}. "
+            "Remove the cache directory and try again."
+        )
+
+    origin_url = _run_git(
+        "remote",
+        "get-url",
+        "origin",
+        cwd=repo_dir,
+        operation="inspect cached origin URL",
+    )
+    if origin_url != repo_url:
+        raise ValueError(
+            f"Cached git_repo checkout at {repo_dir} points to {origin_url!r}, "
+            f"not {repo_url!r}. Remove the cache directory and try again."
+        )
+
+    _run_git(
+        "fetch",
+        "--quiet",
+        "--tags",
+        "origin",
+        cwd=repo_dir,
+        operation=f"fetch {repo_url!r}",
+    )
+
+
+def _checkout_ref(repo_dir: Path, requested_ref: str | None) -> str:
+    if requested_ref is None:
+        default_branch = _default_branch(repo_dir)
+        _run_git(
+            "checkout",
+            "--quiet",
+            "--force",
+            "--detach",
+            f"origin/{default_branch}",
+            cwd=repo_dir,
+            operation=f"checkout default branch {default_branch!r}",
+        )
+        return default_branch
+
+    for candidate in (requested_ref, f"origin/{requested_ref}"):
+        if _git_ref_exists(repo_dir, candidate):
+            _run_git(
+                "checkout",
+                "--quiet",
+                "--force",
+                "--detach",
+                candidate,
+                cwd=repo_dir,
+                operation=f"checkout ref {requested_ref!r}",
+            )
+            return requested_ref
+
+    _run_git(
+        "fetch",
+        "--quiet",
+        "--tags",
+        "origin",
+        requested_ref,
+        cwd=repo_dir,
+        operation=f"fetch ref {requested_ref!r}",
+    )
+    for candidate in ("FETCH_HEAD", requested_ref, f"origin/{requested_ref}"):
+        if _git_ref_exists(repo_dir, candidate):
+            _run_git(
+                "checkout",
+                "--quiet",
+                "--force",
+                "--detach",
+                candidate,
+                cwd=repo_dir,
+                operation=f"checkout ref {requested_ref!r}",
+            )
+            return requested_ref
+
+    raise ValueError(f"Could not resolve git ref {requested_ref!r}.")
+
+
+def _default_branch(repo_dir: Path) -> str:
+    remote_head = _run_git(
+        "symbolic-ref",
+        "--quiet",
+        "--short",
+        "refs/remotes/origin/HEAD",
+        cwd=repo_dir,
+        operation="resolve default branch",
+    )
+    if not remote_head.startswith("origin/"):
+        raise ValueError(f"Could not resolve default branch from {remote_head!r}.")
+    return remote_head.removeprefix("origin/")
+
+
+def _git_ref_exists(repo_dir: Path, candidate: str) -> bool:
+    try:
+        _run_git(
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            f"{candidate}^{{commit}}",
+            cwd=repo_dir,
+            operation=f"resolve ref {candidate!r}",
+        )
+    except ValueError:
+        return False
+    return True
+
+
+def _list_repo_files(repo_dir: Path, *, subdir: str | None) -> tuple[str, ...]:
+    args = ["ls-files", "-z", "--cached", "--full-name"]
+    if subdir is not None:
+        args.extend(["--", subdir])
+
+    output = _run_git(
+        *args,
+        cwd=repo_dir,
+        operation="list tracked files",
+    )
+    if not output:
+        return ()
+
+    repo_paths = sorted(path for path in output.split("\x00") if path)
+    return tuple(repo_paths)
+
+
+def _path_is_selected(
+    repo_path: str,
+    *,
+    include_patterns: tuple[str, ...],
+    exclude_patterns: tuple[str, ...],
+) -> bool:
+    repo_pure_path = PurePosixPath(repo_path)
+    if include_patterns and not any(repo_pure_path.match(pattern) for pattern in include_patterns):
+        return False
+    if exclude_patterns and any(repo_pure_path.match(pattern) for pattern in exclude_patterns):
+        return False
+    return True
+
+
+def _run_git(
+    *args: str,
+    cwd: Path | None = None,
+    operation: str,
+) -> str:
+    try:
+        completed = subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        raise ValueError(
+            "System git is not available. Install git and try again."
+        ) from exc
+
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout).strip() or "git command failed."
+        raise ValueError(f"Could not {operation}: {detail}")
+    return completed.stdout.strip()

--- a/src/knowledge_adapters/git_repo/config.py
+++ b/src/knowledge_adapters/git_repo/config.py
@@ -1,0 +1,18 @@
+"""Configuration models for the git_repo adapter."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class GitRepoConfig:
+    """Runtime configuration for the git_repo adapter."""
+
+    repo_url: str
+    output_dir: str
+    ref: str | None = None
+    include: tuple[str, ...] = ()
+    exclude: tuple[str, ...] = ()
+    subdir: str | None = None
+    dry_run: bool = False

--- a/src/knowledge_adapters/git_repo/normalize.py
+++ b/src/knowledge_adapters/git_repo/normalize.py
@@ -1,0 +1,5 @@
+"""Normalization logic for the git_repo adapter."""
+
+from knowledge_adapters.confluence.normalize import normalize_to_markdown
+
+__all__ = ["normalize_to_markdown"]

--- a/src/knowledge_adapters/git_repo/writer.py
+++ b/src/knowledge_adapters/git_repo/writer.py
@@ -1,0 +1,31 @@
+"""File writing utilities for the git_repo adapter."""
+
+from __future__ import annotations
+
+from pathlib import Path, PurePosixPath
+
+
+def markdown_path(output_dir: str, repo_path: str) -> Path:
+    """Return the deterministic markdown path for one repository file."""
+    repo_relative_path = PurePosixPath(repo_path)
+    output_relative_path = repo_relative_path.with_name(f"{repo_relative_path.name}.md")
+    return Path(output_dir) / "pages" / Path(*output_relative_path.parts)
+
+
+def write_markdown(
+    output_dir: str,
+    repo_path: str,
+    markdown: str,
+    *,
+    dry_run: bool = False,
+) -> Path:
+    """Write normalized markdown to a deterministic local path."""
+    output_path = markdown_path(output_dir, repo_path)
+    pages_dir = output_path.parent
+
+    if dry_run:
+        return output_path
+
+    pages_dir.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(markdown, encoding="utf-8")
+    return output_path

--- a/src/knowledge_adapters/run_config.py
+++ b/src/knowledge_adapters/run_config.py
@@ -17,7 +17,7 @@ from knowledge_adapters.confluence.resolve import (
     validate_space_key,
 )
 
-SUPPORTED_RUN_TYPES = frozenset({"confluence", "local_files"})
+SUPPORTED_RUN_TYPES = frozenset({"confluence", "git_repo", "local_files"})
 _SUPPORTED_CONFLUENCE_CLIENT_MODES = frozenset({"real", "stub"})
 
 _COMMON_REQUIRED_KEYS = frozenset({"name", "type", "output_dir"})
@@ -41,6 +41,9 @@ _CONFLUENCE_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
 )
 _LOCAL_FILES_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
     {"dry_run", "enabled", "file_path"}
+)
+_GIT_REPO_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
+    {"dry_run", "enabled", "exclude", "include", "ref", "repo_url", "subdir"}
 )
 
 
@@ -185,7 +188,10 @@ def _parse_run(
             enabled=enabled,
         )
 
-    argv = _build_local_files_argv(run_config, name=name, config_path=config_path)
+    if run_type == "git_repo":
+        argv = _build_git_repo_argv(run_config, name=name, config_path=config_path)
+    else:
+        argv = _build_local_files_argv(run_config, name=name, config_path=config_path)
     dry_run = _optional_bool(
         run_config,
         "dry_run",
@@ -471,6 +477,60 @@ def _build_local_files_argv(
     return tuple(argv)
 
 
+def _build_git_repo_argv(
+    run_config: dict[str, object],
+    *,
+    name: str,
+    config_path: Path,
+) -> tuple[str, ...]:
+    _reject_unknown_keys(
+        run_config,
+        allowed_keys=_GIT_REPO_ALLOWED_KEYS,
+        name=name,
+        config_path=config_path,
+    )
+    index = _run_index(name=name, config_path=config_path)
+    repo_url = _require_string(run_config, "repo_url", index=index, config_path=config_path)
+    output_dir = _resolve_path_string(
+        _require_string(run_config, "output_dir", index=index, config_path=config_path),
+        config_path=config_path,
+    )
+    argv: list[str] = [
+        "git_repo",
+        "--repo-url",
+        repo_url,
+        "--output-dir",
+        output_dir,
+    ]
+
+    ref = _optional_string(run_config, "ref", index=index, config_path=config_path)
+    if ref is not None:
+        argv.extend(["--ref", ref])
+
+    subdir = _optional_string(run_config, "subdir", index=index, config_path=config_path)
+    if subdir is not None:
+        argv.extend(["--subdir", subdir])
+
+    for include_pattern in _optional_string_sequence(
+        run_config,
+        "include",
+        index=index,
+        config_path=config_path,
+    ):
+        argv.extend(["--include", include_pattern])
+    for exclude_pattern in _optional_string_sequence(
+        run_config,
+        "exclude",
+        index=index,
+        config_path=config_path,
+    ):
+        argv.extend(["--exclude", exclude_pattern])
+
+    if _optional_bool(run_config, "dry_run", index=index, config_path=config_path, default=False):
+        argv.append("--dry-run")
+    return tuple(argv)
+
+
 def _reject_unknown_keys(
     run_config: dict[str, object],
     *,
@@ -516,6 +576,42 @@ def _optional_string(
             f"Run {index!r} in {config_path} must define a non-empty string for {key!r}."
         )
     return value.strip()
+
+
+def _optional_string_sequence(
+    run_config: dict[str, object],
+    key: str,
+    *,
+    index: int | str,
+    config_path: Path,
+) -> tuple[str, ...]:
+    if key not in run_config:
+        return ()
+
+    raw_value = run_config.get(key)
+    if isinstance(raw_value, str):
+        normalized_value = raw_value.strip()
+        if not normalized_value:
+            raise ValueError(
+                f"Run {index!r} in {config_path} must define a non-empty string for {key!r}."
+            )
+        return (normalized_value,)
+
+    if not isinstance(raw_value, list) or not raw_value:
+        raise ValueError(
+            f"Run {index!r} in {config_path} must define {key!r} as a non-empty string "
+            "or list of non-empty strings."
+        )
+
+    normalized_values: list[str] = []
+    for item in raw_value:
+        if not isinstance(item, str) or not item.strip():
+            raise ValueError(
+                f"Run {index!r} in {config_path} must define {key!r} as a non-empty "
+                "string or list of non-empty strings."
+            )
+        normalized_values.append(item.strip())
+    return tuple(normalized_values)
 
 
 def _optional_bool(

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -43,6 +43,10 @@ def test_top_level_help_introduces_shared_cli_flow(tmp_path: Path) -> None:
     assert "plans a markdown artifact under pages/ plus manifest.json" in stdout
     assert "Execute multiple configured adapter runs from one YAML file." in stdout
     assert "Normalize Confluence content into shared artifacts." in stdout
+    assert (
+        "Normalize selected UTF-8 text files from a Git repository into shared artifacts."
+        in stdout
+    )
     assert "Normalize one local UTF-8 text file into shared artifacts." in stdout
     assert "Combine existing artifacts into one prompt-ready markdown file." in stdout
     assert (
@@ -51,6 +55,7 @@ def test_top_level_help_introduces_shared_cli_flow(tmp_path: Path) -> None:
     )
     assert "Re-run without --dry-run to write the same artifact layout" in stdout
     assert "knowledge-adapters run runs.yaml" in stdout
+    assert "knowledge-adapters git_repo --help" in stdout
     assert "knowledge-adapters bundle ./artifacts --output ./bundle.md" in stdout
 
 
@@ -142,6 +147,25 @@ def test_local_files_cli_help_includes_first_run_guidance(tmp_path: Path) -> Non
     assert "without writing files." in stdout
     assert "knowledge-adapters local_files" in stdout
     assert "--dry-run" in stdout
+
+
+def test_git_repo_cli_help_includes_filter_and_binary_guidance(tmp_path: Path) -> None:
+    result = _run_cli(tmp_path, "git_repo", "--help")
+    stdout = normalize_whitespace(result.stdout)
+
+    assert result.returncode == 0, result.stderr
+    assert "Clone or refresh a Git repository with system git" in stdout
+    assert "Binary and non-UTF-8 files are skipped with explicit reporting." in stdout
+    assert "File ordering is deterministic and lexical by repository path." in stdout
+    assert "--repo-url REPO_URL" in stdout
+    assert "--ref REF" in stdout
+    assert "--include PATTERN" in stdout
+    assert "--exclude PATTERN" in stdout
+    assert "--subdir SUBDIR" in stdout
+    assert "--dry-run" in stdout
+    assert "knowledge-adapters git_repo" in stdout
+    assert "--include \"docs/**/*.md\"" in stdout
+    assert "--subdir docs" in stdout
 
 
 def test_bundle_cli_help_includes_ordering_and_input_guidance(tmp_path: Path) -> None:

--- a/tests/test_git_repo.py
+++ b/tests/test_git_repo.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+
+from pytest import CaptureFixture
+
+from knowledge_adapters.cli import main
+from tests.artifact_assertions import assert_markdown_document
+from tests.cli_output_assertions import assert_dry_run_summary, assert_write_summary
+
+
+def _git(cwd: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
+def _write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _write_bytes(path: Path, content: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+
+
+def _commit_all(repo_dir: Path, message: str) -> str:
+    _git(repo_dir, "add", "-A")
+    _git(repo_dir, "commit", "--quiet", "-m", message)
+    return _git(repo_dir, "rev-parse", "HEAD")
+
+
+def _init_repo(repo_dir: Path) -> None:
+    repo_dir.mkdir()
+    _git(repo_dir, "init", "--quiet", "--initial-branch=main")
+    _git(repo_dir, "config", "user.name", "Test User")
+    _git(repo_dir, "config", "user.email", "test@example.com")
+
+
+def _sha256_text(path: Path) -> str:
+    return hashlib.sha256(path.read_text(encoding="utf-8").encode("utf-8")).hexdigest()
+
+
+def test_git_repo_cli_writes_repo_files_with_manifest_metadata(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    repo_dir = tmp_path / "repo"
+    _init_repo(repo_dir)
+    _write_text(repo_dir / "README.md", "# Repo\n")
+    _write_text(repo_dir / "docs" / "guide.txt", "Guide text.\n")
+    _write_text(repo_dir / "src" / "module.py", "print('hello')\n")
+    _write_bytes(repo_dir / "assets" / "logo.bin", b"\x00binary")
+    commit_sha = _commit_all(repo_dir, "initial import")
+    output_dir = tmp_path / "out"
+
+    exit_code = main(
+        [
+            "git_repo",
+            "--repo-url",
+            str(repo_dir),
+            "--output-dir",
+            str(output_dir),
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "Git repo adapter invoked" in captured.out
+    assert f"repo_url: {repo_dir}" in captured.out
+    assert f"output_dir: {output_dir.resolve()}" in captured.out
+    assert "resolved_ref: main" in captured.out
+    assert f"commit_sha: {commit_sha}" in captured.out
+    assert "tracked_files: 4" in captured.out
+    assert "selected_files: 4" in captured.out
+    assert "filtered_out: 0" in captured.out
+    assert "Skipped: assets/logo.bin (binary file)" in captured.out
+    assert_write_summary(captured.out, wrote=3, skipped=1)
+    assert f"Manifest path: {output_dir / 'manifest.json'}" in captured.out
+
+    readme_output = output_dir / "pages" / "README.md.md"
+    guide_output = output_dir / "pages" / "docs" / "guide.txt.md"
+    module_output = output_dir / "pages" / "src" / "module.py.md"
+    assert readme_output.exists()
+    assert guide_output.exists()
+    assert module_output.exists()
+
+    assert_markdown_document(
+        readme_output.read_text(encoding="utf-8"),
+        title="README.md",
+        metadata={
+            "source": "git_repo",
+            "canonical_id": f"{repo_dir}@{commit_sha}:README.md",
+            "parent_id": "",
+            "source_url": str(repo_dir),
+            "fetched_at": "",
+            "updated_at": "",
+            "adapter": "git_repo",
+        },
+        content="# Repo",
+    )
+
+    manifest_payload = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
+    readme_hash = _sha256_text(readme_output)
+    guide_hash = _sha256_text(guide_output)
+    module_hash = _sha256_text(module_output)
+    assert [entry["path"] for entry in manifest_payload["files"]] == [
+        "README.md",
+        "docs/guide.txt",
+        "src/module.py",
+    ]
+    assert manifest_payload["files"] == [
+        {
+            "canonical_id": f"{repo_dir}@{commit_sha}:README.md",
+            "source_url": str(repo_dir),
+            "output_path": "pages/README.md.md",
+            "title": "README.md",
+            "content_hash": readme_hash,
+            "path": "README.md",
+            "ref": "main",
+            "commit_sha": commit_sha,
+        },
+        {
+            "canonical_id": f"{repo_dir}@{commit_sha}:docs/guide.txt",
+            "source_url": str(repo_dir),
+            "output_path": "pages/docs/guide.txt.md",
+            "title": "docs/guide.txt",
+            "content_hash": guide_hash,
+            "path": "docs/guide.txt",
+            "ref": "main",
+            "commit_sha": commit_sha,
+        },
+        {
+            "canonical_id": f"{repo_dir}@{commit_sha}:src/module.py",
+            "source_url": str(repo_dir),
+            "output_path": "pages/src/module.py.md",
+            "title": "src/module.py",
+            "content_hash": module_hash,
+            "path": "src/module.py",
+            "ref": "main",
+            "commit_sha": commit_sha,
+        },
+    ]
+
+
+def test_git_repo_cli_dry_run_respects_subdir_and_include_filters(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    repo_dir = tmp_path / "repo"
+    _init_repo(repo_dir)
+    _write_text(repo_dir / "docs" / "guide.md", "# Guide\n")
+    _write_text(repo_dir / "docs" / "notes.txt", "Notes.\n")
+    _write_text(repo_dir / "README.md", "# Root\n")
+    _commit_all(repo_dir, "docs import")
+    output_dir = tmp_path / "out"
+
+    exit_code = main(
+        [
+            "git_repo",
+            "--repo-url",
+            str(repo_dir),
+            "--output-dir",
+            str(output_dir),
+            "--subdir",
+            "docs",
+            "--include",
+            "*.md",
+            "--dry-run",
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "subdir: docs" in captured.out
+    assert "include: *.md" in captured.out
+    assert "tracked_files: 2" in captured.out
+    assert "selected_files: 1" in captured.out
+    assert "filtered_out: 1" in captured.out
+    assert "path: docs/guide.md" in captured.out
+    assert "Artifact path: " in captured.out
+    assert "pages/docs/guide.md.md" in captured.out
+    assert_dry_run_summary(captured.out, would_write=1, would_skip=0)
+    assert not output_dir.exists()
+
+
+def test_git_repo_cli_uses_requested_ref_for_artifact_content_and_manifest(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    repo_dir = tmp_path / "repo"
+    _init_repo(repo_dir)
+    readme_path = repo_dir / "README.md"
+    _write_text(readme_path, "# First version\n")
+    first_commit = _commit_all(repo_dir, "first version")
+    _git(repo_dir, "tag", "v1.0.0")
+    _write_text(readme_path, "# Second version\n")
+    _commit_all(repo_dir, "second version")
+    output_dir = tmp_path / "out"
+
+    exit_code = main(
+        [
+            "git_repo",
+            "--repo-url",
+            str(repo_dir),
+            "--ref",
+            "v1.0.0",
+            "--output-dir",
+            str(output_dir),
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "requested_ref: v1.0.0" in captured.out
+    assert "resolved_ref: v1.0.0" in captured.out
+    assert f"commit_sha: {first_commit}" in captured.out
+
+    readme_output = output_dir / "pages" / "README.md.md"
+    assert "# First version" in readme_output.read_text(encoding="utf-8")
+    manifest_payload = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest_payload["files"][0]["ref"] == "v1.0.0"
+    assert manifest_payload["files"][0]["commit_sha"] == first_commit

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -79,6 +79,80 @@ runs:
     )
 
 
+def test_load_run_config_supports_git_repo_filters_and_ref(tmp_path: Path) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        f"""
+runs:
+  - name: repo-docs
+    type: git_repo
+    repo_url: {repo_dir}
+    ref: v1.2.3
+    include:
+      - docs/**/*.md
+      - README.md
+    exclude:
+      - docs/archive/*
+    subdir: docs
+    output_dir: ./artifacts/git/repo-docs
+    dry_run: true
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    run_config = load_run_config(config_path)
+
+    assert run_config.runs == (
+        ConfiguredRun(
+            name="repo-docs",
+            run_type="git_repo",
+            argv=(
+                "git_repo",
+                "--repo-url",
+                str(repo_dir),
+                "--output-dir",
+                str((tmp_path / "artifacts" / "git" / "repo-docs").resolve()),
+                "--ref",
+                "v1.2.3",
+                "--subdir",
+                "docs",
+                "--include",
+                "docs/**/*.md",
+                "--include",
+                "README.md",
+                "--exclude",
+                "docs/archive/*",
+                "--dry-run",
+            ),
+            dry_run=True,
+        ),
+    )
+
+
+def test_load_run_config_rejects_invalid_git_repo_pattern_values(tmp_path: Path) -> None:
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: repo-docs
+    type: git_repo
+    repo_url: https://github.com/example/project.git
+    include:
+      - docs/**/*.md
+      - ""
+    output_dir: ./artifacts/git/repo-docs
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="must define 'include' as a non-empty string or list"):
+        load_run_config(config_path)
+
+
 @pytest.mark.parametrize(
     ("space_block", "expected_arg"),
     [


### PR DESCRIPTION
Summary
- add a bounded `git_repo` adapter that clones or fetches a repository with system git, checks out a requested ref or the default branch, and ingests tracked UTF-8 text files into shared artifacts
- support deterministic lexical ordering, include/exclude glob filtering, optional `subdir` scoping, manifest metadata for `path`, `ref`, `commit_sha`, and `content_hash`, and explicit skipping for binary or non-UTF-8 files
- wire `git_repo` into the CLI help, `runs.yaml` config loading, focused adapter tests, smoke/help coverage, and the project map status for issue #159

Testing
- make check

Closes #159