### PR TITLE
docs: add git_repo run example

### DIFF
--- a/docs/project-map.md
+++ b/docs/project-map.md
@@ -9,6 +9,7 @@ grouping them into meaningful lanes.
 - Confluence adapter: mature (single-page, tree traversal, incremental sync,
   space discovery by key/URL, TLS/auth, portable CA bundle overrides,
   environment-specific config overrides, progress output)
+- Git repo ingestion: complete (`git_repo` adapter, polish, and example config)
 - Bundle command:
   - v1 complete (#147)
   - ordering controls added (#153)

--- a/runs.example.yaml
+++ b/runs.example.yaml
@@ -8,6 +8,16 @@ runs:
     file_path: ./example-inputs/team-notes.txt
     output_dir: ./artifacts/local/team-notes
 
+  # Minimal git_repo example. Use include filters by default; ingesting an
+  # entire repository is usually not the safest starting point.
+  - name: example-repo
+    type: git_repo
+    repo_url: https://github.com/ctrl-alt-keith/ai-workflow-playbook.git
+    output_dir: ./artifacts/git/example-repo
+    include:
+      - "docs/**/*.md"
+      - "README.md"
+
   # Minimal Confluence example using the default stub client.
   - name: docs-home
     type: confluence


### PR DESCRIPTION
Summary
- add a minimal git_repo example to runs.example.yaml
- keep the example safe by scoping ingestion with include filters and a brief cautionary comment
- update the project map to note that git_repo ingestion is complete

Testing
- make check

Closes #173