### PR TITLE
fix: allow Ctrl-C to skip the current config run

### DIFF
--- a/docs/project-map.md
+++ b/docs/project-map.md
@@ -17,12 +17,11 @@ grouping them into meaningful lanes.
   - header modes added (#155)
   - changed-only bundle comparison complete (#157)
   - size-aware bundle splitting complete (#154)
-- CLI, config-driven runs, and test coverage are stable
+- CLI, config-driven runs, interrupt handling, and test coverage are stable
 
 ## Active Arc
 
-- #169 Allow Ctrl-C to skip current run and continue in config-driven execution
-- Status: keep config-driven runs moving by treating one interrupt as a per-run skip and a second interrupt as process exit
+- No active arc at the moment
 
 ## Next Arcs
 

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -828,6 +828,19 @@ def _effective_configured_run_argv(
     return (*effective_argv, "--debug")
 
 
+def _execute_configured_run(
+    argv: Sequence[str],
+    *,
+    captured_stdout: TextIO,
+    captured_stderr: TextIO,
+) -> int:
+    """Execute one configured run while teeing nested stdout into the parent CLI."""
+    with redirect_stdout(_TeeStream(sys.stdout, captured_stdout)), redirect_stderr(
+        captured_stderr
+    ):
+        return main(argv)
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     """Run the CLI."""
     raw_argv = tuple(sys.argv[1:] if argv is None else argv)
@@ -869,12 +882,14 @@ def main(argv: Sequence[str] | None = None) -> int:
 
         completed_runs = 0
         failed_runs = 0
+        interrupted_runs = 0
         write_runs = 0
         dry_run_runs = 0
         total_wrote = 0
         total_skipped = 0
         total_would_write = 0
         total_would_skip = 0
+        interrupt_requested = False
 
         for index, configured_run in enumerate(selected_runs, start=1):
             effective_argv = _effective_configured_run_argv(
@@ -892,10 +907,24 @@ def main(argv: Sequence[str] | None = None) -> int:
             captured_stdout = io.StringIO()
             captured_stderr = io.StringIO()
             try:
-                with redirect_stdout(_TeeStream(sys.stdout, captured_stdout)), redirect_stderr(
-                    captured_stderr
-                ):
-                    exit_code = main(effective_argv)
+                exit_code = _execute_configured_run(
+                    effective_argv,
+                    captured_stdout=captured_stdout,
+                    captured_stderr=captured_stderr,
+                )
+            except KeyboardInterrupt:
+                if interrupt_requested:
+                    raise
+
+                interrupt_requested = True
+                interrupted_runs += 1
+                print(
+                    f"Run {index}/{len(selected_runs)} interrupted: "
+                    f"{configured_run.name} ({configured_run.run_type})"
+                )
+                print("Run interrupted: skipping remaining work for this run")
+                print("Run summary: interrupted, skipped remaining work for this run")
+                continue
             except SystemExit:
                 print(
                     f"Run {index}/{len(selected_runs)} failed: "
@@ -968,6 +997,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         print("\nAggregate summary:")
         print(f"  runs_completed: {completed_runs}")
         print(f"  runs_failed: {failed_runs}")
+        print(f"  runs_interrupted: {interrupted_runs}")
         print(f"  runs_skipped_disabled: {len(skipped_disabled_runs)}")
         print(f"  write_runs: {write_runs}")
         print(f"  dry_run_runs: {dry_run_runs}")
@@ -977,17 +1007,32 @@ def main(argv: Sequence[str] | None = None) -> int:
             print(f"  would_write: {total_would_write}")
             print(f"  would_skip: {total_would_skip}")
         if failed_runs > 0:
-            print(
-                "Config run completed with failures. "
-                f"Processed {completed_runs} successful run(s) and {failed_runs} failed "
-                f"run(s) from {render_user_path(run_config.config_path)}"
-            )
+            if interrupted_runs > 0:
+                print(
+                    "Config run completed with failures. "
+                    f"Processed {completed_runs} successful run(s), {failed_runs} failed "
+                    f"run(s), and {interrupted_runs} interrupted run(s) from "
+                    f"{render_user_path(run_config.config_path)}"
+                )
+            else:
+                print(
+                    "Config run completed with failures. "
+                    f"Processed {completed_runs} successful run(s) and {failed_runs} failed "
+                    f"run(s) from {render_user_path(run_config.config_path)}"
+                )
             return 1
 
-        print(
-            "Config run complete. "
-            f"Processed {completed_runs} run(s) from {render_user_path(run_config.config_path)}"
-        )
+        if interrupted_runs > 0:
+            print(
+                "Config run complete. "
+                f"Processed {completed_runs} completed run(s) and {interrupted_runs} "
+                f"interrupted run(s) from {render_user_path(run_config.config_path)}"
+            )
+        else:
+            print(
+                "Config run complete. "
+                f"Processed {completed_runs} run(s) from {render_user_path(run_config.config_path)}"
+            )
         return 0
 
     if args.command == "confluence":

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -7,6 +7,7 @@ from typing import Any, Literal, cast
 import pytest
 from pytest import CaptureFixture, MonkeyPatch
 
+import knowledge_adapters.cli as cli
 from knowledge_adapters.cli import main
 from knowledge_adapters.run_config import ConfiguredRun, load_run_config, select_runs
 
@@ -811,6 +812,138 @@ runs:
     local_output_path = tmp_path / "artifacts" / "local" / "team-notes" / "pages" / "team-notes.md"
     assert local_output_path.exists()
     assert "Ship it." in local_output_path.read_text(encoding="utf-8")
+
+
+def test_run_command_keyboard_interrupt_skips_current_run_and_continues(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    first_source = tmp_path / "inputs" / "first.txt"
+    second_source = tmp_path / "inputs" / "second.txt"
+    first_source.parent.mkdir(parents=True)
+    first_source.write_text("First file.\n", encoding="utf-8")
+    second_source.write_text("Second file.\n", encoding="utf-8")
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: first-run
+    type: local_files
+    file_path: ./inputs/first.txt
+    output_dir: ./artifacts/local/first-run
+  - name: second-run
+    type: local_files
+    file_path: ./inputs/second.txt
+    output_dir: ./artifacts/local/second-run
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    real_execute_configured_run = cli._execute_configured_run
+    attempt_count = 0
+
+    def interrupt_once(
+        argv: tuple[str, ...],
+        *,
+        captured_stdout: Any,
+        captured_stderr: Any,
+    ) -> int:
+        nonlocal attempt_count
+        attempt_count += 1
+        if attempt_count == 1:
+            raise KeyboardInterrupt
+        return real_execute_configured_run(
+            argv,
+            captured_stdout=captured_stdout,
+            captured_stderr=captured_stderr,
+        )
+
+    monkeypatch.setattr(cli, "_execute_configured_run", interrupt_once)
+
+    exit_code = main(["run", str(config_path)])
+
+    assert exit_code == 0
+    assert attempt_count == 2
+    captured = capsys.readouterr()
+    assert "Run 1/2 started: first-run (local_files)" in captured.out
+    assert "Run 1/2 interrupted: first-run (local_files)" in captured.out
+    assert "Run interrupted: skipping remaining work for this run" in captured.out
+    assert "Run summary: interrupted, skipped remaining work for this run" in captured.out
+    assert "Run 2/2 started: second-run (local_files)" in captured.out
+    assert "Run 2/2 completed: second-run (local_files)" in captured.out
+    assert "Aggregate summary:" in captured.out
+    assert "runs_completed: 1" in captured.out
+    assert "runs_failed: 0" in captured.out
+    assert "runs_interrupted: 1" in captured.out
+    assert "write_runs: 1" in captured.out
+    assert "dry_run_runs: 0" in captured.out
+    assert "wrote: 1" in captured.out
+    assert "skipped: 0" in captured.out
+    assert "Config run complete. Processed 1 completed run(s) and 1 interrupted run(s)" in (
+        captured.out
+    )
+
+    assert not (tmp_path / "artifacts" / "local" / "first-run").exists()
+    second_output_path = (
+        tmp_path / "artifacts" / "local" / "second-run" / "pages" / "second.md"
+    )
+    assert second_output_path.exists()
+    assert "Second file." in second_output_path.read_text(encoding="utf-8")
+
+
+def test_run_command_second_keyboard_interrupt_propagates_immediately(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    source_file = tmp_path / "inputs" / "team-notes.txt"
+    source_file.parent.mkdir(parents=True)
+    source_file.write_text("Ship it.\n", encoding="utf-8")
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: first-run
+    type: local_files
+    file_path: ./inputs/team-notes.txt
+    output_dir: ./artifacts/local/first-run
+  - name: second-run
+    type: local_files
+    file_path: ./inputs/team-notes.txt
+    output_dir: ./artifacts/local/second-run
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    attempt_count = 0
+
+    def always_interrupt(
+        argv: tuple[str, ...],
+        *,
+        captured_stdout: Any,
+        captured_stderr: Any,
+    ) -> int:
+        del argv, captured_stdout, captured_stderr
+        nonlocal attempt_count
+        attempt_count += 1
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(cli, "_execute_configured_run", always_interrupt)
+
+    with pytest.raises(KeyboardInterrupt):
+        main(["run", str(config_path)])
+
+    assert attempt_count == 2
+    captured = capsys.readouterr()
+    assert "Run 1/2 started: first-run (local_files)" in captured.out
+    assert "Run 1/2 interrupted: first-run (local_files)" in captured.out
+    assert "Run interrupted: skipping remaining work for this run" in captured.out
+    assert "Run 2/2 started: second-run (local_files)" in captured.out
+    assert "Run 2/2 interrupted: second-run (local_files)" not in captured.out
+    assert "Aggregate summary:" not in captured.out
 
 
 def test_load_run_config_includes_confluence_tls_and_client_cert_paths(tmp_path: Path) -> None:


### PR DESCRIPTION
Summary
- allow the config-driven run loop to treat the first Ctrl-C as a per-run skip
- propagate the second Ctrl-C immediately and report interrupted runs in the summary
- add interrupt coverage for config runs and advance the project map

Testing
- make check

Closes #169