### PR TITLE
feat: add github metadata issues adapter

### DIFF
--- a/docs/project-map.md
+++ b/docs/project-map.md
@@ -10,6 +10,8 @@ grouping them into meaningful lanes.
   space discovery by key/URL, TLS/auth, portable CA bundle overrides,
   environment-specific config overrides, progress output)
 - Git repo ingestion: complete (`git_repo` adapter, polish, and example config)
+- GitHub metadata ingestion: issues-only v1 complete (`github_metadata` adapter
+  for GitHub/GHE repository issues)
 - Bundle command:
   - v1 complete (#147)
   - ordering controls added (#153)
@@ -19,20 +21,14 @@ grouping them into meaningful lanes.
   - size-aware bundle splitting complete (#154)
 - CLI, config-driven runs, interrupt handling, and test coverage are stable
 
-## Active Arc
-
-- #160 Add `github_metadata` adapter for issues, PRs, and releases
-  - current design narrows v1 to issues-only metadata ingestion
-  - see [GitHub Metadata v1 Contract](./github-metadata-v1.md)
-
 ## Next Arcs
 
 ### New adapters
 
 #### GitHub metadata ingestion
 
-- #160 implementation should start with the issues-only v1 contract, then split
-  PRs, releases, and comments into follow-up issues
+- Split PRs, releases, and comments into follow-up issues after the issues-only
+  v1 adapter proves out
 
 ## Deferred / Usage-driven
 

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -28,6 +28,7 @@ TOP_LEVEL_HELP_EXAMPLES = """First steps:
   knowledge-adapters run runs.yaml
   knowledge-adapters local_files --help
   knowledge-adapters git_repo --help
+  knowledge-adapters github_metadata --help
   knowledge-adapters confluence --help
   knowledge-adapters bundle ./artifacts --output ./bundle.md
 
@@ -92,6 +93,26 @@ GIT_REPO_HELP_EXAMPLES = """Examples:
   knowledge-adapters git_repo \\
     --repo-url https://github.com/example/project.git \\
     --subdir docs \\
+    --output-dir ./artifacts
+"""
+
+GITHUB_METADATA_HELP_EXAMPLES = """Examples:
+  GITHUB_TOKEN=... knowledge-adapters github_metadata \\
+    --repo example/project \\
+    --token-env GITHUB_TOKEN \\
+    --output-dir ./artifacts \\
+    --dry-run
+  GITHUB_TOKEN=... knowledge-adapters github_metadata \\
+    --repo example/project \\
+    --token-env GITHUB_TOKEN \\
+    --state all \\
+    --since 2026-01-01T00:00:00Z \\
+    --max-items 25 \\
+    --output-dir ./artifacts
+  GHE_TOKEN=... knowledge-adapters github_metadata \\
+    --repo example/project \\
+    --base-url https://github.example.com \\
+    --token-env GHE_TOKEN \\
     --output-dir ./artifacts
 """
 
@@ -551,6 +572,75 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "Preview the resolved ref, commit SHA, selected files, artifact paths, and "
             "skip reasons without writing files."
+        ),
+    )
+
+    github_metadata_parser = subparsers.add_parser(
+        "github_metadata",
+        help="Normalize GitHub issue metadata from one repository into shared artifacts.",
+        description=(
+            "Fetch issues from one GitHub or GitHub Enterprise repository through the "
+            "REST issues API, filter out pull requests returned by that endpoint, and "
+            "normalize one markdown artifact per issue under issues/. v1 is intentionally "
+            "bounded to issues only: comments, pull requests, releases, timelines, "
+            "reactions, reviews, checks, GraphQL, attachments, and live sync are not "
+            "included. The token is read only from --token-env, and token values are "
+            "never printed."
+        ),
+        epilog=GITHUB_METADATA_HELP_EXAMPLES,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    github_metadata_parser.add_argument(
+        "--repo",
+        required=True,
+        metavar="OWNER/NAME",
+        help="Repository to read, in owner/name form.",
+    )
+    github_metadata_parser.add_argument(
+        "--base-url",
+        help=(
+            "GitHub Enterprise web root or API root ending in /api/v3. Defaults to "
+            "GitHub.com, using https://github.com for source URLs and "
+            "https://api.github.com for REST API requests."
+        ),
+    )
+    github_metadata_parser.add_argument(
+        "--token-env",
+        required=True,
+        metavar="ENV_VAR",
+        help=(
+            "Name of the environment variable containing the GitHub token. The token "
+            "value is read from the environment only and is never printed."
+        ),
+    )
+    github_metadata_parser.add_argument(
+        "--output-dir",
+        required=True,
+        metavar="DIR",
+        help="Directory where issues/ and manifest.json are written.",
+    )
+    github_metadata_parser.add_argument(
+        "--state",
+        choices=("open", "closed", "all"),
+        default="open",
+        help="Issue state filter for the REST API. Defaults to open.",
+    )
+    github_metadata_parser.add_argument(
+        "--since",
+        help="ISO 8601 timestamp for issues updated at or after that time.",
+    )
+    github_metadata_parser.add_argument(
+        "--max-items",
+        type=_parse_positive_int,
+        metavar="N",
+        help="Positive issue limit applied after filtering out pull requests.",
+    )
+    github_metadata_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Fetch and plan matching issues without creating directories, writing "
+            "issue artifacts, or writing manifest.json."
         ),
     )
 
@@ -2330,6 +2420,163 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"\nWrote: {render_user_path(output_path)}")
         print("\nSummary: wrote 1, skipped 0")
         print(f"Artifact path: {render_user_path(output_path)}")
+        print(f"Manifest path: {render_user_path(manifest)}")
+        print_write_complete(output_dir)
+        return 0
+
+    if args.command == "github_metadata":
+        import hashlib
+
+        from knowledge_adapters.confluence.manifest import write_manifest
+        from knowledge_adapters.github_metadata.client import (
+            GitHubMetadataRequestError,
+            list_repository_issues,
+            resolve_base_urls,
+        )
+        from knowledge_adapters.github_metadata.config import GitHubMetadataConfig
+        from knowledge_adapters.github_metadata.normalize import normalize_issue_to_markdown
+        from knowledge_adapters.github_metadata.writer import (
+            markdown_path as github_issue_markdown_path,
+        )
+        from knowledge_adapters.github_metadata.writer import (
+            write_markdown as write_github_issue_markdown,
+        )
+
+        github_metadata_config = GitHubMetadataConfig(
+            repo=args.repo,
+            base_url=args.base_url,
+            token_env=args.token_env,
+            output_dir=args.output_dir,
+            state=args.state,
+            since=args.since,
+            max_items=args.max_items,
+            dry_run=args.dry_run,
+        )
+
+        output_dir_input = Path(github_metadata_config.output_dir).expanduser()
+        output_dir = output_dir_input.resolve()
+        if output_dir_input.exists() and not output_dir_input.is_dir():
+            exit_with_cli_error(
+                (
+                    f"Output path is not a directory: {output_dir}. "
+                    "Verify --output-dir and use a directory path."
+                ),
+                command="github_metadata",
+            )
+
+        try:
+            base_urls = resolve_base_urls(github_metadata_config.base_url)
+            issues = list_repository_issues(
+                repo=github_metadata_config.repo,
+                base_url=github_metadata_config.base_url,
+                token_env=github_metadata_config.token_env,
+                state=github_metadata_config.state,
+                since=github_metadata_config.since,
+                max_items=github_metadata_config.max_items,
+            )
+        except (GitHubMetadataRequestError, ValueError) as exc:
+            exit_with_cli_error(str(exc), command="github_metadata")
+
+        print("GitHub metadata adapter invoked")
+        print(f"  repo: {github_metadata_config.repo}")
+        print(f"  web_root: {base_urls.web_root}")
+        print(f"  api_root: {base_urls.api_root}")
+        print(f"  token_env: {github_metadata_config.token_env}")
+        print(f"  output_dir: {render_user_path(github_metadata_config.output_dir)}")
+        print(f"  state: {github_metadata_config.state}")
+        if github_metadata_config.since is not None:
+            print(f"  since: {github_metadata_config.since}")
+        if github_metadata_config.max_items is not None:
+            print(f"  max_items: {github_metadata_config.max_items}")
+        print(f"  run_mode: {'dry-run' if github_metadata_config.dry_run else 'write'}")
+
+        print("\nPlan: GitHub metadata run")
+        print("  resource_type: issue")
+        print(f"  issues_planned: {len(issues)}")
+
+        issue_markdowns: dict[int, str] = {}
+        github_manifest_entries: list[dict[str, object]] = []
+        github_written_output_paths: list[Path] = []
+        for issue in issues:
+            markdown = normalize_issue_to_markdown(
+                {
+                    "repo": issue.repo,
+                    "number": issue.number,
+                    "title": issue.title,
+                    "state": issue.state,
+                    "author": issue.author,
+                    "created_at": issue.created_at,
+                    "updated_at": issue.updated_at,
+                    "source_url": issue.source_url,
+                    "body": issue.body,
+                }
+            )
+            output_path = github_issue_markdown_path(
+                github_metadata_config.output_dir,
+                issue.number,
+            )
+            issue_markdowns[issue.number] = markdown
+            github_written_output_paths.append(output_path)
+            github_manifest_entries.append(
+                {
+                    "canonical_id": issue.canonical_id,
+                    "source_url": issue.source_url,
+                    "title": issue.title,
+                    "repo": issue.repo,
+                    "resource_type": "issue",
+                    "number": issue.number,
+                    "state": issue.state,
+                    "created_at": issue.created_at,
+                    "updated_at": issue.updated_at,
+                    "author": issue.author,
+                    "content_hash": hashlib.sha256(markdown.encode("utf-8")).hexdigest(),
+                    "output_path": output_path.relative_to(
+                        Path(github_metadata_config.output_dir)
+                    ).as_posix(),
+                }
+            )
+
+        for issue, output_path in zip(issues, github_written_output_paths, strict=True):
+            print(f"\n  issue: #{issue.number}")
+            print(f"  title: {issue.title}")
+            print(f"  source_url: {issue.source_url}")
+            print(f"  Artifact path: {render_user_path(output_path)}")
+            if issue.body:
+                print("  body_status: markdown/text with content")
+            else:
+                print("  body_status: empty issue body; output will include an empty-body marker")
+            print(
+                f"  action: {'would write' if github_metadata_config.dry_run else 'write'}"
+            )
+
+        manifest_output_path = output_dir / "manifest.json"
+        if github_metadata_config.dry_run:
+            print(f"\nSummary: would write {len(issues)}, would skip 0")
+            print(f"Manifest path: {render_user_path(manifest_output_path)}")
+            print_dry_run_complete()
+            return 0
+
+        try:
+            for issue in issues:
+                write_github_issue_markdown(
+                    github_metadata_config.output_dir,
+                    issue.number,
+                    issue_markdowns[issue.number],
+                )
+            manifest = write_manifest(
+                github_metadata_config.output_dir,
+                github_manifest_entries,
+            )
+        except OSError as exc:
+            exit_with_output_error(
+                github_metadata_config.output_dir,
+                command="github_metadata",
+                exc=exc,
+            )
+
+        for output_path in github_written_output_paths:
+            print(f"\nWrote: {render_user_path(output_path)}")
+        print(f"\nSummary: wrote {len(issues)}, skipped 0")
         print(f"Manifest path: {render_user_path(manifest)}")
         print_write_complete(output_dir)
         return 0

--- a/src/knowledge_adapters/github_metadata/__init__.py
+++ b/src/knowledge_adapters/github_metadata/__init__.py
@@ -1,0 +1,2 @@
+"""GitHub metadata adapter."""
+

--- a/src/knowledge_adapters/github_metadata/client.py
+++ b/src/knowledge_adapters/github_metadata/client.py
@@ -1,0 +1,383 @@
+"""REST client and payload mapping for the github_metadata adapter."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from datetime import datetime
+from urllib import parse, request
+from urllib.error import HTTPError, URLError
+
+SUPPORTED_ISSUE_STATES = frozenset({"open", "closed", "all"})
+DEFAULT_GITHUB_WEB_ROOT = "https://github.com"
+DEFAULT_GITHUB_API_ROOT = "https://api.github.com"
+GITHUB_API_VERSION = "2022-11-28"
+_PAGE_SIZE = 100
+
+
+@dataclass(frozen=True)
+class GitHubMetadataBaseUrls:
+    """Resolved GitHub web/API roots for one run."""
+
+    web_root: str
+    api_root: str
+    host: str
+
+
+@dataclass(frozen=True)
+class GitHubIssue:
+    """One normalized GitHub issue record."""
+
+    repo: str
+    host: str
+    number: int
+    title: str
+    state: str
+    author: str | None
+    created_at: str
+    updated_at: str
+    source_url: str
+    body: str
+
+    @property
+    def canonical_id(self) -> str:
+        """Return the issue canonical ID."""
+        return f"github_metadata:{self.host}:{self.repo}:issue:{self.number}"
+
+
+class GitHubMetadataRequestError(RuntimeError):
+    """Stable request failure for github_metadata API reads."""
+
+
+def resolve_base_urls(base_url: str | None = None) -> GitHubMetadataBaseUrls:
+    """Resolve GitHub.com or GHE web/API roots from a configured base URL."""
+    raw_base_url = (base_url or DEFAULT_GITHUB_WEB_ROOT).strip().rstrip("/")
+    if not raw_base_url:
+        raise ValueError("base_url must be a non-empty URL when provided.")
+
+    parsed = parse.urlparse(raw_base_url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError("base_url must be an absolute http(s) URL.")
+    if parsed.query or parsed.fragment:
+        raise ValueError("base_url must not include query strings or fragments.")
+
+    normalized = parse.urlunparse(
+        (parsed.scheme, parsed.netloc, parsed.path.rstrip("/"), "", "", "")
+    )
+    path = parsed.path.rstrip("/")
+
+    if parsed.netloc == "github.com" and path in {"", "/"}:
+        web_root = DEFAULT_GITHUB_WEB_ROOT
+        api_root = DEFAULT_GITHUB_API_ROOT
+    elif parsed.netloc == "api.github.com" and path in {"", "/"}:
+        web_root = DEFAULT_GITHUB_WEB_ROOT
+        api_root = DEFAULT_GITHUB_API_ROOT
+    elif path.endswith("/api/v3"):
+        api_root = normalized
+        web_path = path.removesuffix("/api/v3").rstrip("/")
+        web_root = parse.urlunparse((parsed.scheme, parsed.netloc, web_path, "", "", ""))
+    else:
+        web_root = normalized
+        api_root = f"{normalized}/api/v3"
+
+    host = parse.urlparse(web_root).netloc
+    if not host:
+        raise ValueError("base_url must resolve to a web host.")
+
+    return GitHubMetadataBaseUrls(web_root=web_root, api_root=api_root, host=host)
+
+
+def validate_repo(repo: str) -> tuple[str, str, str]:
+    """Validate and split an owner/name repository input."""
+    normalized_repo = repo.strip()
+    parts = normalized_repo.split("/")
+    if (
+        len(parts) != 2
+        or not parts[0]
+        or not parts[1]
+        or any(part.strip() != part for part in parts)
+    ):
+        raise ValueError("repo must use owner/name form.")
+    return parts[0], parts[1], normalized_repo
+
+
+def validate_state(state: str) -> str:
+    """Validate the configured issue state filter."""
+    normalized_state = state.strip()
+    if normalized_state not in SUPPORTED_ISSUE_STATES:
+        supported = ", ".join(sorted(SUPPORTED_ISSUE_STATES))
+        raise ValueError(f"state must be one of: {supported}.")
+    return normalized_state
+
+
+def validate_since(since: str | None) -> str | None:
+    """Validate an optional ISO 8601 timestamp without reformatting it."""
+    if since is None:
+        return None
+    normalized_since = since.strip()
+    if not normalized_since:
+        raise ValueError("since must be a non-empty ISO 8601 timestamp when provided.")
+    try:
+        datetime.fromisoformat(normalized_since.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError("since must be an ISO 8601 timestamp.") from exc
+    return normalized_since
+
+
+def validate_max_items(max_items: int | None) -> int | None:
+    """Validate an optional positive max_items limit."""
+    if max_items is None:
+        return None
+    if isinstance(max_items, bool) or max_items < 1:
+        raise ValueError("max_items must be a positive integer.")
+    return max_items
+
+
+def resolve_token(token_env: str) -> tuple[str, str]:
+    """Resolve the GitHub token from an environment variable name."""
+    normalized_token_env = token_env.strip()
+    if not normalized_token_env:
+        raise ValueError("token_env must name a non-empty environment variable.")
+
+    token = os.getenv(normalized_token_env)
+    if token is None or not token.strip():
+        raise ValueError(
+            f"token_env {normalized_token_env!r} is not set or contains an empty value."
+        )
+    return normalized_token_env, token.strip()
+
+
+def issue_list_api_url(
+    *,
+    api_root: str,
+    owner: str,
+    repo_name: str,
+    state: str,
+    since: str | None,
+) -> str:
+    """Build the first repository issues API URL."""
+    encoded_owner = parse.quote(owner, safe="")
+    encoded_repo = parse.quote(repo_name, safe="")
+    query: dict[str, str | int] = {
+        "state": state,
+        "per_page": _PAGE_SIZE,
+    }
+    if since is not None:
+        query["since"] = since
+    return (
+        f"{api_root.rstrip('/')}/repos/{encoded_owner}/{encoded_repo}/issues?"
+        f"{parse.urlencode(query)}"
+    )
+
+
+def list_repository_issues(
+    *,
+    repo: str,
+    token_env: str,
+    base_url: str | None = None,
+    state: str = "open",
+    since: str | None = None,
+    max_items: int | None = None,
+) -> tuple[GitHubIssue, ...]:
+    """List normalized issues for one repository through the REST API."""
+    owner, repo_name, normalized_repo = validate_repo(repo)
+    normalized_state = validate_state(state)
+    normalized_since = validate_since(since)
+    normalized_max_items = validate_max_items(max_items)
+    base_urls = resolve_base_urls(base_url)
+    token_env_name, token = resolve_token(token_env)
+
+    next_url: str | None = issue_list_api_url(
+        api_root=base_urls.api_root,
+        owner=owner,
+        repo_name=repo_name,
+        state=normalized_state,
+        since=normalized_since,
+    )
+    seen_urls: set[str] = set()
+    issues: list[GitHubIssue] = []
+    while next_url is not None:
+        if next_url in seen_urls:
+            raise ValueError("Response error: repeated GitHub issues pagination URL.")
+        seen_urls.add(next_url)
+
+        payload, link_header = _request_json_list(
+            next_url,
+            token=token,
+            token_env=token_env_name,
+            repo=normalized_repo,
+            api_root=base_urls.api_root,
+        )
+        for item in payload:
+            if "pull_request" in item:
+                continue
+            issues.append(
+                _map_issue(
+                    item,
+                    repo=normalized_repo,
+                    owner=owner,
+                    repo_name=repo_name,
+                    base_urls=base_urls,
+                )
+            )
+        next_url = _next_link_url(link_header)
+
+    ordered_issues = tuple(sorted(issues, key=lambda issue: issue.number))
+    if normalized_max_items is None:
+        return ordered_issues
+    return ordered_issues[:normalized_max_items]
+
+
+def _map_issue(
+    payload: dict[str, object],
+    *,
+    repo: str,
+    owner: str,
+    repo_name: str,
+    base_urls: GitHubMetadataBaseUrls,
+) -> GitHubIssue:
+    number = payload.get("number")
+    if not isinstance(number, int) or isinstance(number, bool):
+        raise ValueError("Response error: invalid issue number.")
+
+    title = _require_string(payload, "title")
+    state = _require_string(payload, "state")
+    created_at = _require_string(payload, "created_at")
+    updated_at = _require_string(payload, "updated_at")
+    body_value = payload.get("body")
+    if body_value is None:
+        body = ""
+    elif isinstance(body_value, str):
+        body = body_value
+    else:
+        raise ValueError("Response error: invalid issue body.")
+
+    user = payload.get("user")
+    author: str | None = None
+    if isinstance(user, dict):
+        login = user.get("login")
+        if isinstance(login, str) and login:
+            author = login
+
+    encoded_owner = parse.quote(owner, safe="")
+    encoded_repo = parse.quote(repo_name, safe="")
+    source_url = f"{base_urls.web_root}/{encoded_owner}/{encoded_repo}/issues/{number}"
+    return GitHubIssue(
+        repo=repo,
+        host=base_urls.host,
+        number=number,
+        title=title,
+        state=state,
+        author=author,
+        created_at=created_at,
+        updated_at=updated_at,
+        source_url=source_url,
+        body=body,
+    )
+
+
+def _require_string(payload: dict[str, object], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str):
+        raise ValueError(f"Response error: missing or invalid {key}.")
+    return value
+
+
+def _request_json_list(
+    api_url: str,
+    *,
+    token: str,
+    token_env: str,
+    repo: str,
+    api_root: str,
+) -> tuple[list[dict[str, object]], str | None]:
+    api_request = request.Request(
+        api_url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "User-Agent": "knowledge-adapters-github-metadata",
+            "X-GitHub-Api-Version": GITHUB_API_VERSION,
+        },
+    )
+    try:
+        with request.urlopen(api_request, timeout=30) as response:
+            raw_payload = json.loads(response.read().decode("utf-8"))
+            link_header = response.headers.get("Link")
+    except HTTPError as exc:
+        raise GitHubMetadataRequestError(
+            _request_failure_message(exc, repo=repo, api_root=api_root, token_env=token_env)
+        ) from exc
+    except URLError as exc:
+        raise GitHubMetadataRequestError(
+            f"GitHub request failed while reading {repo} from {api_root}: {exc.reason}."
+        ) from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError("Response error: invalid JSON payload.") from exc
+
+    if not isinstance(raw_payload, list):
+        raise ValueError("Response error: expected a list of GitHub issues.")
+
+    payload: list[dict[str, object]] = []
+    for item in raw_payload:
+        if not isinstance(item, dict):
+            raise ValueError("Response error: invalid issue payload.")
+        payload.append(item)
+    return payload, link_header
+
+
+def _request_failure_message(
+    exc: HTTPError,
+    *,
+    repo: str,
+    api_root: str,
+    token_env: str,
+) -> str:
+    rate_limit_hint = _rate_limit_hint(exc)
+    if rate_limit_hint is not None:
+        return f"GitHub API rate limit exceeded while reading {repo}: {rate_limit_hint}."
+    if exc.code == 401:
+        return f"GitHub auth failed while reading {repo} using token_env {token_env!r}."
+    if exc.code == 403:
+        return f"GitHub authorization failed while reading {repo} using token_env {token_env!r}."
+    if exc.code == 404:
+        return f"GitHub repository not found or inaccessible: {repo} at {api_root}."
+    if 500 <= exc.code <= 599:
+        return f"GitHub request failed (status {exc.code}) while reading {repo} from {api_root}."
+    return f"GitHub request failed (status {exc.code}) while reading {repo} from {api_root}."
+
+
+def _rate_limit_hint(exc: HTTPError) -> str | None:
+    retry_after = exc.headers.get("Retry-After") if exc.headers is not None else None
+    if retry_after:
+        return f"retry after {retry_after} second(s)"
+
+    remaining = (
+        exc.headers.get("X-RateLimit-Remaining") if exc.headers is not None else None
+    )
+    if remaining != "0" and exc.code != 429:
+        return None
+
+    reset = exc.headers.get("X-RateLimit-Reset") if exc.headers is not None else None
+    if reset:
+        try:
+            reset_time = datetime.fromtimestamp(int(reset)).isoformat()
+        except ValueError:
+            reset_time = reset
+        return f"reset at {reset_time}"
+    return "no retry time provided"
+
+
+def _next_link_url(link_header: str | None) -> str | None:
+    if not link_header:
+        return None
+    for raw_link in link_header.split(","):
+        link_url, separator, link_params = raw_link.strip().partition(";")
+        if not separator:
+            continue
+        if 'rel="next"' not in link_params:
+            continue
+        if link_url.startswith("<") and link_url.endswith(">"):
+            return link_url[1:-1]
+    return None

--- a/src/knowledge_adapters/github_metadata/config.py
+++ b/src/knowledge_adapters/github_metadata/config.py
@@ -1,0 +1,20 @@
+"""Configuration models for the github_metadata adapter."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class GitHubMetadataConfig:
+    """Runtime configuration for the github_metadata adapter."""
+
+    repo: str
+    token_env: str
+    output_dir: str
+    base_url: str | None = None
+    state: str = "open"
+    since: str | None = None
+    max_items: int | None = None
+    dry_run: bool = False
+

--- a/src/knowledge_adapters/github_metadata/normalize.py
+++ b/src/knowledge_adapters/github_metadata/normalize.py
@@ -1,0 +1,42 @@
+"""Normalization logic for the github_metadata adapter."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+EMPTY_BODY_MARKER = "(empty issue body)"
+
+
+def normalize_issue_to_markdown(issue: Mapping[str, object]) -> str:
+    """Normalize one issue payload into deterministic markdown."""
+    number_value = issue.get("number")
+    if not isinstance(number_value, int) or isinstance(number_value, bool):
+        raise ValueError("issue number must be an integer.")
+    number = number_value
+    title = str(issue.get("title", ""))
+    state = str(issue.get("state", ""))
+    author = issue.get("author")
+    author_text = "" if author is None else str(author)
+    created_at = str(issue.get("created_at", ""))
+    updated_at = str(issue.get("updated_at", ""))
+    source_url = str(issue.get("source_url", ""))
+    repo = str(issue.get("repo", ""))
+    body = str(issue.get("body") or "").rstrip("\n")
+    body_text = body if body else EMPTY_BODY_MARKER
+
+    return f"""# Issue #{number}: {title}
+
+## Metadata
+- repo: {repo}
+- resource_type: issue
+- number: {number}
+- state: {state}
+- author: {author_text}
+- created_at: {created_at}
+- updated_at: {updated_at}
+- source_url: {source_url}
+
+## Body
+
+{body_text}
+"""

--- a/src/knowledge_adapters/github_metadata/writer.py
+++ b/src/knowledge_adapters/github_metadata/writer.py
@@ -1,0 +1,29 @@
+"""File writing utilities for the github_metadata adapter."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def markdown_path(output_dir: str, number: int) -> Path:
+    """Return the deterministic markdown path for one issue."""
+    return Path(output_dir) / "issues" / f"{number}.md"
+
+
+def write_markdown(
+    output_dir: str,
+    number: int,
+    markdown: str,
+    *,
+    dry_run: bool = False,
+) -> Path:
+    """Write normalized issue markdown to a deterministic local path."""
+    output_path = markdown_path(output_dir, number)
+
+    if dry_run:
+        return output_path
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(markdown, encoding="utf-8")
+    return output_path
+

--- a/src/knowledge_adapters/run_config.py
+++ b/src/knowledge_adapters/run_config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
 
 import yaml  # type: ignore[import-untyped]
@@ -17,8 +18,9 @@ from knowledge_adapters.confluence.resolve import (
     validate_space_key,
 )
 
-SUPPORTED_RUN_TYPES = frozenset({"confluence", "git_repo", "local_files"})
+SUPPORTED_RUN_TYPES = frozenset({"confluence", "git_repo", "github_metadata", "local_files"})
 _SUPPORTED_CONFLUENCE_CLIENT_MODES = frozenset({"real", "stub"})
+_SUPPORTED_GITHUB_METADATA_STATES = frozenset({"open", "closed", "all"})
 
 _COMMON_REQUIRED_KEYS = frozenset({"name", "type", "output_dir"})
 _CONFLUENCE_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
@@ -44,6 +46,9 @@ _LOCAL_FILES_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
 )
 _GIT_REPO_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
     {"dry_run", "enabled", "exclude", "include", "ref", "repo_url", "subdir"}
+)
+_GITHUB_METADATA_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
+    {"base_url", "dry_run", "enabled", "max_items", "repo", "since", "state", "token_env"}
 )
 
 
@@ -190,6 +195,8 @@ def _parse_run(
 
     if run_type == "git_repo":
         argv = _build_git_repo_argv(run_config, name=name, config_path=config_path)
+    elif run_type == "github_metadata":
+        argv = _build_github_metadata_argv(run_config, name=name, config_path=config_path)
     else:
         argv = _build_local_files_argv(run_config, name=name, config_path=config_path)
     dry_run = _optional_bool(
@@ -531,6 +538,68 @@ def _build_git_repo_argv(
     return tuple(argv)
 
 
+def _build_github_metadata_argv(
+    run_config: dict[str, object],
+    *,
+    name: str,
+    config_path: Path,
+) -> tuple[str, ...]:
+    _reject_unknown_keys(
+        run_config,
+        allowed_keys=_GITHUB_METADATA_ALLOWED_KEYS,
+        name=name,
+        config_path=config_path,
+    )
+    index = _run_index(name=name, config_path=config_path)
+    repo = _require_string(run_config, "repo", index=index, config_path=config_path)
+    token_env = _require_string(run_config, "token_env", index=index, config_path=config_path)
+    output_dir = _resolve_path_string(
+        _require_string(run_config, "output_dir", index=index, config_path=config_path),
+        config_path=config_path,
+    )
+    argv: list[str] = [
+        "github_metadata",
+        "--repo",
+        repo,
+        "--token-env",
+        token_env,
+        "--output-dir",
+        output_dir,
+    ]
+
+    base_url = _optional_string(run_config, "base_url", index=index, config_path=config_path)
+    if base_url is not None:
+        argv.extend(["--base-url", base_url])
+
+    state = _optional_string(run_config, "state", index=index, config_path=config_path)
+    if state is not None:
+        if state not in _SUPPORTED_GITHUB_METADATA_STATES:
+            supported_values = " or ".join(
+                repr(value) for value in sorted(_SUPPORTED_GITHUB_METADATA_STATES)
+            )
+            raise ValueError(
+                f"Run {name!r} in {config_path} has unsupported 'state' value "
+                f"{state!r}. Use {supported_values}."
+            )
+        argv.extend(["--state", state])
+
+    since = _optional_string_or_datetime(run_config, "since", index=index, config_path=config_path)
+    if since is not None:
+        argv.extend(["--since", since])
+
+    max_items = run_config.get("max_items")
+    if max_items is not None:
+        if isinstance(max_items, bool) or not isinstance(max_items, int) or max_items < 1:
+            raise ValueError(
+                f"Run {name!r} in {config_path} must set 'max_items' to a positive integer."
+            )
+        argv.extend(["--max-items", str(max_items)])
+
+    if _optional_bool(run_config, "dry_run", index=index, config_path=config_path, default=False):
+        argv.append("--dry-run")
+    return tuple(argv)
+
+
 def _reject_unknown_keys(
     run_config: dict[str, object],
     *,
@@ -576,6 +645,28 @@ def _optional_string(
             f"Run {index!r} in {config_path} must define a non-empty string for {key!r}."
         )
     return value.strip()
+
+
+def _optional_string_or_datetime(
+    run_config: dict[str, object],
+    key: str,
+    *,
+    index: int | str,
+    config_path: Path,
+) -> str | None:
+    if key not in run_config:
+        return None
+    value = run_config.get(key)
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    if isinstance(value, datetime):
+        normalized_datetime = value
+        if normalized_datetime.tzinfo is UTC:
+            return normalized_datetime.isoformat().replace("+00:00", "Z")
+        return normalized_datetime.isoformat()
+    raise ValueError(
+        f"Run {index!r} in {config_path} must define a non-empty string for {key!r}."
+    )
 
 
 def _optional_string_sequence(

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -47,6 +47,7 @@ def test_top_level_help_introduces_shared_cli_flow(tmp_path: Path) -> None:
         "Normalize selected UTF-8 text files from a Git repository into shared artifacts."
         in stdout
     )
+    assert "Normalize GitHub issue metadata from one repository into shared artifacts." in stdout
     assert "Normalize one local UTF-8 text file into shared artifacts." in stdout
     assert "Combine existing artifacts into one prompt-ready markdown file." in stdout
     assert (
@@ -56,6 +57,7 @@ def test_top_level_help_introduces_shared_cli_flow(tmp_path: Path) -> None:
     assert "Re-run without --dry-run to write the same artifact layout" in stdout
     assert "knowledge-adapters run runs.yaml" in stdout
     assert "knowledge-adapters git_repo --help" in stdout
+    assert "knowledge-adapters github_metadata --help" in stdout
     assert "knowledge-adapters bundle ./artifacts --output ./bundle.md" in stdout
 
 
@@ -166,6 +168,27 @@ def test_git_repo_cli_help_includes_filter_and_binary_guidance(tmp_path: Path) -
     assert "knowledge-adapters git_repo" in stdout
     assert "--include \"docs/**/*.md\"" in stdout
     assert "--subdir docs" in stdout
+
+
+def test_github_metadata_cli_help_includes_issues_only_guidance(tmp_path: Path) -> None:
+    result = _run_cli(tmp_path, "github_metadata", "--help")
+    stdout = normalize_whitespace(result.stdout)
+
+    assert result.returncode == 0, result.stderr
+    assert "Fetch issues from one GitHub or GitHub Enterprise repository" in stdout
+    assert "filter out pull requests returned by that endpoint" in stdout
+    assert "bounded to issues only" in stdout
+    assert "comments, pull requests, releases, timelines" in stdout
+    assert "--repo OWNER/NAME" in stdout
+    assert "--base-url BASE_URL" in stdout
+    assert "--token-env ENV_VAR" in stdout
+    assert "--output-dir DIR" in stdout
+    assert "--state {open,closed,all}" in stdout
+    assert "--since SINCE" in stdout
+    assert "--max-items N" in stdout
+    assert "--dry-run" in stdout
+    assert "token value is read from the environment only and is never printed" in stdout
+    assert "knowledge-adapters github_metadata" in stdout
 
 
 def test_bundle_cli_help_includes_ordering_and_input_guidance(tmp_path: Path) -> None:

--- a/tests/test_github_metadata.py
+++ b/tests/test_github_metadata.py
@@ -1,0 +1,314 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, Literal
+from urllib import request
+
+import pytest
+from pytest import CaptureFixture, MonkeyPatch
+
+from knowledge_adapters.cli import main
+from knowledge_adapters.github_metadata.client import (
+    issue_list_api_url,
+    list_repository_issues,
+    resolve_base_urls,
+)
+from knowledge_adapters.github_metadata.normalize import EMPTY_BODY_MARKER
+from tests.cli_output_assertions import assert_dry_run_summary, assert_write_summary
+
+
+class _FakeGitHubResponse:
+    def __init__(
+        self,
+        payload: list[dict[str, object]],
+        *,
+        headers: Mapping[str, str] | None = None,
+    ) -> None:
+        self._payload = payload
+        self.headers = dict(headers or {})
+
+    def __enter__(self) -> _FakeGitHubResponse:
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> Literal[False]:
+        return False
+
+    def read(self) -> bytes:
+        return json.dumps(self._payload).encode("utf-8")
+
+
+class _FakeUrlopen:
+    def __init__(self, responses: Mapping[str, _FakeGitHubResponse]) -> None:
+        self._responses = dict(responses)
+        self.calls: list[str] = []
+
+    def __call__(self, api_request: request.Request, timeout: int) -> _FakeGitHubResponse:
+        del timeout
+        url = api_request.full_url
+        self.calls.append(url)
+        return self._responses[url]
+
+
+def _issue(
+    number: int,
+    *,
+    title: str | None = None,
+    body: str | None = "Body",
+    state: str = "open",
+    author: str | None = "alice",
+    extra: Mapping[str, Any] | None = None,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "number": number,
+        "title": title or f"Issue {number}",
+        "state": state,
+        "created_at": f"2026-04-{number:02d}T00:00:00Z",
+        "updated_at": f"2026-04-{number:02d}T01:00:00Z",
+        "body": body,
+    }
+    if author is not None:
+        payload["user"] = {"login": author}
+    if extra is not None:
+        payload.update(extra)
+    return payload
+
+
+def _install_fake_urlopen(
+    monkeypatch: MonkeyPatch,
+    responses: Mapping[str, _FakeGitHubResponse],
+) -> _FakeUrlopen:
+    fake_urlopen = _FakeUrlopen(responses)
+    monkeypatch.setattr("knowledge_adapters.github_metadata.client.request.urlopen", fake_urlopen)
+    return fake_urlopen
+
+
+def test_github_metadata_resolves_github_and_ghe_base_urls() -> None:
+    github_urls = resolve_base_urls(None)
+    assert github_urls.web_root == "https://github.com"
+    assert github_urls.api_root == "https://api.github.com"
+    assert github_urls.host == "github.com"
+    assert (
+        issue_list_api_url(
+            api_root=github_urls.api_root,
+            owner="octo",
+            repo_name="project",
+            state="open",
+            since=None,
+        )
+        == "https://api.github.com/repos/octo/project/issues?state=open&per_page=100"
+    )
+
+    ghe_web_urls = resolve_base_urls("https://github.example.com")
+    assert ghe_web_urls.web_root == "https://github.example.com"
+    assert ghe_web_urls.api_root == "https://github.example.com/api/v3"
+    assert ghe_web_urls.host == "github.example.com"
+
+    ghe_api_urls = resolve_base_urls("https://github.example.com/api/v3")
+    assert ghe_api_urls.web_root == "https://github.example.com"
+    assert ghe_api_urls.api_root == "https://github.example.com/api/v3"
+    assert ghe_api_urls.host == "github.example.com"
+
+
+def test_github_metadata_missing_token_env_fails_before_request(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+
+    def fail_urlopen(api_request: request.Request, timeout: int) -> None:
+        del api_request, timeout
+        raise AssertionError("urlopen should not be called")
+
+    monkeypatch.setattr(
+        "knowledge_adapters.github_metadata.client.request.urlopen",
+        fail_urlopen,
+    )
+
+    with pytest.raises(ValueError, match="token_env 'GH_TOKEN' is not set"):
+        list_repository_issues(
+            repo="octo/project",
+            token_env="GH_TOKEN",
+        )
+
+
+def test_github_metadata_paginates_filters_prs_orders_and_limits_after_filtering(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GH_TOKEN", "secret-token")
+    first_url = issue_list_api_url(
+        api_root="https://api.github.com",
+        owner="octo",
+        repo_name="project",
+        state="all",
+        since=None,
+    )
+    second_url = "https://api.github.com/repos/octo/project/issues?state=all&per_page=100&page=2"
+    fake_urlopen = _install_fake_urlopen(
+        monkeypatch,
+        {
+            first_url: _FakeGitHubResponse(
+                [
+                    _issue(3),
+                    _issue(2, extra={"pull_request": {"url": "https://api.github.com/pr/2"}}),
+                ],
+                headers={"Link": f'<{second_url}>; rel="next"'},
+            ),
+            second_url: _FakeGitHubResponse([_issue(4), _issue(1)]),
+        },
+    )
+
+    issues = list_repository_issues(
+        repo="octo/project",
+        token_env="GH_TOKEN",
+        state="all",
+        max_items=3,
+    )
+
+    assert fake_urlopen.calls == [first_url, second_url]
+    assert [issue.number for issue in issues] == [1, 3, 4]
+    assert [issue.canonical_id for issue in issues] == [
+        "github_metadata:github.com:octo/project:issue:1",
+        "github_metadata:github.com:octo/project:issue:3",
+        "github_metadata:github.com:octo/project:issue:4",
+    ]
+
+
+def test_github_metadata_cli_writes_issue_artifacts_and_manifest(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("GH_TOKEN", "secret-token")
+    first_url = issue_list_api_url(
+        api_root="https://api.github.com",
+        owner="octo",
+        repo_name="project",
+        state="open",
+        since=None,
+    )
+    _install_fake_urlopen(
+        monkeypatch,
+        {
+            first_url: _FakeGitHubResponse(
+                [
+                    _issue(7, title="Empty body", body=None, author=None),
+                    _issue(2, title="Useful bug", body="Bug details.\n"),
+                    _issue(3, extra={"pull_request": {"url": "https://api.github.com/pr/3"}}),
+                ],
+            )
+        },
+    )
+    output_dir = tmp_path / "out"
+
+    exit_code = main(
+        [
+            "github_metadata",
+            "--repo",
+            "octo/project",
+            "--token-env",
+            "GH_TOKEN",
+            "--output-dir",
+            str(output_dir),
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "GitHub metadata adapter invoked" in captured.out
+    assert "repo: octo/project" in captured.out
+    assert "api_root: https://api.github.com" in captured.out
+    assert "token_env: GH_TOKEN" in captured.out
+    assert "secret-token" not in captured.out
+    assert_write_summary(captured.out, wrote=2, skipped=0)
+
+    issue_2_path = output_dir / "issues" / "2.md"
+    issue_7_path = output_dir / "issues" / "7.md"
+    assert issue_2_path.exists()
+    assert issue_7_path.exists()
+    issue_2_markdown = issue_2_path.read_text(encoding="utf-8")
+    issue_7_markdown = issue_7_path.read_text(encoding="utf-8")
+    assert "# Issue #2: Useful bug" in issue_2_markdown
+    assert "Bug details." in issue_2_markdown
+    assert EMPTY_BODY_MARKER in issue_7_markdown
+
+    manifest_payload = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
+    assert isinstance(manifest_payload["generated_at"], str)
+    assert manifest_payload["files"] == [
+        {
+            "canonical_id": "github_metadata:github.com:octo/project:issue:2",
+            "source_url": "https://github.com/octo/project/issues/2",
+            "title": "Useful bug",
+            "repo": "octo/project",
+            "resource_type": "issue",
+            "number": 2,
+            "state": "open",
+            "created_at": "2026-04-02T00:00:00Z",
+            "updated_at": "2026-04-02T01:00:00Z",
+            "author": "alice",
+            "content_hash": hashlib.sha256(issue_2_markdown.encode("utf-8")).hexdigest(),
+            "output_path": "issues/2.md",
+        },
+        {
+            "canonical_id": "github_metadata:github.com:octo/project:issue:7",
+            "source_url": "https://github.com/octo/project/issues/7",
+            "title": "Empty body",
+            "repo": "octo/project",
+            "resource_type": "issue",
+            "number": 7,
+            "state": "open",
+            "created_at": "2026-04-07T00:00:00Z",
+            "updated_at": "2026-04-07T01:00:00Z",
+            "author": None,
+            "content_hash": hashlib.sha256(issue_7_markdown.encode("utf-8")).hexdigest(),
+            "output_path": "issues/7.md",
+        },
+    ]
+
+
+def test_github_metadata_cli_dry_run_does_not_write_files(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("GH_TOKEN", "secret-token")
+    first_url = issue_list_api_url(
+        api_root="https://github.example.com/api/v3",
+        owner="octo",
+        repo_name="project",
+        state="closed",
+        since="2026-01-01T00:00:00Z",
+    )
+    _install_fake_urlopen(
+        monkeypatch,
+        {first_url: _FakeGitHubResponse([_issue(5, state="closed")])},
+    )
+    output_dir = tmp_path / "out"
+
+    exit_code = main(
+        [
+            "github_metadata",
+            "--repo",
+            "octo/project",
+            "--base-url",
+            "https://github.example.com/api/v3",
+            "--token-env",
+            "GH_TOKEN",
+            "--output-dir",
+            str(output_dir),
+            "--state",
+            "closed",
+            "--since",
+            "2026-01-01T00:00:00Z",
+            "--dry-run",
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "web_root: https://github.example.com" in captured.out
+    assert "api_root: https://github.example.com/api/v3" in captured.out
+    assert "source_url: https://github.example.com/octo/project/issues/5" in captured.out
+    assert_dry_run_summary(captured.out, would_write=1, would_skip=0)
+    assert not output_dir.exists()

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -133,6 +133,86 @@ runs:
     )
 
 
+def test_load_run_config_supports_github_metadata_inputs(tmp_path: Path) -> None:
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: repo-issues
+    type: github_metadata
+    repo: octo/project
+    base_url: https://github.example.com/api/v3
+    token_env: GH_TOKEN
+    state: all
+    since: 2026-01-01T00:00:00Z
+    max_items: 25
+    output_dir: ./artifacts/github/repo-issues
+    dry_run: true
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    run_config = load_run_config(config_path)
+
+    assert run_config.runs == (
+        ConfiguredRun(
+            name="repo-issues",
+            run_type="github_metadata",
+            argv=(
+                "github_metadata",
+                "--repo",
+                "octo/project",
+                "--token-env",
+                "GH_TOKEN",
+                "--output-dir",
+                str((tmp_path / "artifacts" / "github" / "repo-issues").resolve()),
+                "--base-url",
+                "https://github.example.com/api/v3",
+                "--state",
+                "all",
+                "--since",
+                "2026-01-01T00:00:00Z",
+                "--max-items",
+                "25",
+                "--dry-run",
+            ),
+            dry_run=True,
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    ("field_block", "expected_fragment"),
+    [
+        ("state: merged", "unsupported 'state' value"),
+        ("max_items: 0", "'max_items' to a positive integer"),
+    ],
+)
+def test_load_run_config_rejects_invalid_github_metadata_values(
+    tmp_path: Path,
+    field_block: str,
+    expected_fragment: str,
+) -> None:
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        f"""
+runs:
+  - name: repo-issues
+    type: github_metadata
+    repo: octo/project
+    token_env: GH_TOKEN
+    output_dir: ./artifacts/github/repo-issues
+    {field_block}
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match=expected_fragment):
+        load_run_config(config_path)
+
+
 def test_load_run_config_rejects_invalid_git_repo_pattern_values(tmp_path: Path) -> None:
     config_path = tmp_path / "runs.yaml"
     config_path.write_text(


### PR DESCRIPTION
Summary
- add a bounded `github_metadata` adapter for GitHub/GHE repository issues only
- support REST issue pagination, token-env auth preflight, GitHub.com and GHE base URL mapping, PR filtering, ascending issue ordering, `max_items`, dry-run planning, markdown artifacts, and required manifest metadata
- wire the adapter into the CLI and `runs.yaml` config flow, with focused smoke/config/client tests
- update the project map to move issues-only GitHub metadata ingestion into Current State and keep deferred GitHub metadata work as follow-up scope

Testing
- `make check`

Closes #160