### PR TITLE
feat: add github metadata pull request ingestion

### DIFF
--- a/src/knowledge_adapters/bundle.py
+++ b/src/knowledge_adapters/bundle.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
-from knowledge_adapters.confluence.manifest import manifest_path
+from knowledge_adapters.manifest import manifest_path
 
 BundleOrder = Literal["canonical_id", "manifest", "input"]
 HeaderMode = Literal["minimal", "full"]
@@ -133,8 +133,7 @@ def load_bundle_plan(
     """Load artifacts from output directories or manifest files."""
     if order not in BUNDLE_ORDER_CHOICES:
         raise ValueError(
-            f"Unsupported bundle order {order!r}. "
-            f"Choose one of: {', '.join(BUNDLE_ORDER_CHOICES)}."
+            f"Unsupported bundle order {order!r}. Choose one of: {', '.join(BUNDLE_ORDER_CHOICES)}."
         )
     if changed_only and baseline_manifest is None:
         raise ValueError("Bundle --changed-only requires --baseline-manifest.")
@@ -315,9 +314,7 @@ def _load_bundle_artifacts(manifest: Path) -> tuple[BundleArtifact, ...]:
 
     files = payload.get("files") if isinstance(payload, dict) else None
     if not isinstance(files, list):
-        raise ValueError(
-            f"Bundle manifest {manifest} is invalid: expected a files list."
-        )
+        raise ValueError(f"Bundle manifest {manifest} is invalid: expected a files list.")
 
     artifacts: list[BundleArtifact] = []
     manifest_ids: set[str] = set()
@@ -352,8 +349,7 @@ def _load_bundle_artifacts(manifest: Path) -> tuple[BundleArtifact, ...]:
             )
         if canonical_id in manifest_ids:
             raise ValueError(
-                f"Bundle manifest {manifest} is invalid: duplicate canonical_id "
-                f"{canonical_id!r}."
+                f"Bundle manifest {manifest} is invalid: duplicate canonical_id {canonical_id!r}."
             )
         if output_path in manifest_output_paths:
             raise ValueError(
@@ -387,9 +383,7 @@ def _load_baseline_manifest_entries(manifest: Path) -> dict[str, _BaselineManife
 
     files = payload.get("files") if isinstance(payload, dict) else None
     if not isinstance(files, list):
-        raise ValueError(
-            f"Baseline manifest {manifest} is invalid: expected a files list."
-        )
+        raise ValueError(f"Baseline manifest {manifest} is invalid: expected a files list.")
 
     entries_by_id: dict[str, _BaselineManifestEntry] = {}
     for entry in files:
@@ -408,8 +402,7 @@ def _load_baseline_manifest_entries(manifest: Path) -> dict[str, _BaselineManife
             )
         if canonical_id in entries_by_id:
             raise ValueError(
-                f"Baseline manifest {manifest} is invalid: duplicate canonical_id "
-                f"{canonical_id!r}."
+                f"Baseline manifest {manifest} is invalid: duplicate canonical_id {canonical_id!r}."
             )
 
         entries_by_id[canonical_id] = _BaselineManifestEntry(
@@ -607,8 +600,7 @@ def _order_bundle_artifacts(
             )
         )
     raise ValueError(
-        f"Unsupported bundle order {order!r}. "
-        f"Choose one of: {', '.join(BUNDLE_ORDER_CHOICES)}."
+        f"Unsupported bundle order {order!r}. Choose one of: {', '.join(BUNDLE_ORDER_CHOICES)}."
     )
 
 

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -105,6 +105,12 @@ GITHUB_METADATA_HELP_EXAMPLES = """Examples:
   GITHUB_TOKEN=... knowledge-adapters github_metadata \\
     --repo example/project \\
     --token-env GITHUB_TOKEN \\
+    --resource-type pull_request \\
+    --output-dir ./artifacts \\
+    --dry-run
+  GITHUB_TOKEN=... knowledge-adapters github_metadata \\
+    --repo example/project \\
+    --token-env GITHUB_TOKEN \\
     --state all \\
     --since 2026-01-01T00:00:00Z \\
     --max-items 25 \\
@@ -565,12 +571,15 @@ def build_parser() -> argparse.ArgumentParser:
 
     github_metadata_parser = subparsers.add_parser(
         "github_metadata",
-        help="Normalize GitHub issue metadata from one repository into shared artifacts.",
+        help=(
+            "Normalize GitHub issue or pull request metadata from one repository into "
+            "shared artifacts."
+        ),
         description=(
-            "Fetch issues from one GitHub or GitHub Enterprise repository through the "
-            "REST issues API, filter out pull requests returned by that endpoint, and "
-            "normalize one markdown artifact per issue under issues/. v1 is intentionally "
-            "bounded to issues only: comments, pull requests, releases, timelines, "
+            "Fetch issues or pull requests from one GitHub or GitHub Enterprise "
+            "repository through the REST API and normalize one markdown artifact per "
+            "record under issues/ or pull_requests/. Issue mode filters out pull "
+            "requests returned by the issues endpoint. Comments, releases, timelines, "
             "reactions, reviews, checks, GraphQL, attachments, and live sync are not "
             "included. The token is read only from --token-env, and token values are "
             "never printed."
@@ -605,7 +614,13 @@ def build_parser() -> argparse.ArgumentParser:
         "--output-dir",
         required=True,
         metavar="DIR",
-        help="Directory where issues/ and manifest.json are written.",
+        help="Directory where issues/ or pull_requests/ plus manifest.json are written.",
+    )
+    github_metadata_parser.add_argument(
+        "--resource-type",
+        choices=("issue", "pull_request"),
+        default="issue",
+        help="GitHub metadata resource type to ingest. Defaults to issue.",
     )
     github_metadata_parser.add_argument(
         "--state",
@@ -1146,12 +1161,6 @@ def main(argv: Sequence[str] | None = None) -> int:
             PageSyncDecision,
             classify_page_sync,
         )
-        from knowledge_adapters.confluence.manifest import (
-            build_manifest_entry,
-            manifest_path,
-            write_manifest,
-            write_manifest_with_context,
-        )
         from knowledge_adapters.confluence.models import ResolvedTarget
         from knowledge_adapters.confluence.normalize import normalize_to_markdown
         from knowledge_adapters.confluence.resolve import (
@@ -1161,6 +1170,12 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         from knowledge_adapters.confluence.traversal import TreeWalkProgress, walk_pages
         from knowledge_adapters.confluence.writer import markdown_path, write_markdown
+        from knowledge_adapters.manifest import (
+            build_manifest_entry,
+            manifest_path,
+            write_manifest,
+            write_manifest_with_context,
+        )
         from knowledge_adapters.manifest_stale import (
             find_stale_artifacts,
             load_previous_manifest_index,
@@ -2285,14 +2300,14 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 0
 
     if args.command == "local_files":
-        from knowledge_adapters.confluence.manifest import (
-            build_manifest_entry,
-            write_manifest,
-        )
         from knowledge_adapters.local_files.client import fetch_file
         from knowledge_adapters.local_files.config import LocalFilesConfig
         from knowledge_adapters.local_files.normalize import normalize_to_markdown
         from knowledge_adapters.local_files.writer import write_markdown
+        from knowledge_adapters.manifest import (
+            build_manifest_entry,
+            write_manifest,
+        )
         from knowledge_adapters.manifest_stale import (
             find_stale_artifacts,
             load_previous_manifest_index,
@@ -2422,20 +2437,26 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.command == "github_metadata":
         import hashlib
 
-        from knowledge_adapters.confluence.manifest import write_manifest
         from knowledge_adapters.github_metadata.client import (
+            GitHubIssue,
             GitHubMetadataRequestError,
+            GitHubPullRequest,
             list_repository_issues,
+            list_repository_pull_requests,
             resolve_base_urls,
         )
         from knowledge_adapters.github_metadata.config import GitHubMetadataConfig
-        from knowledge_adapters.github_metadata.normalize import normalize_issue_to_markdown
-        from knowledge_adapters.github_metadata.writer import (
-            markdown_path as github_issue_markdown_path,
+        from knowledge_adapters.github_metadata.normalize import (
+            normalize_issue_to_markdown,
+            normalize_pull_request_to_markdown,
         )
         from knowledge_adapters.github_metadata.writer import (
-            write_markdown as write_github_issue_markdown,
+            markdown_path as github_metadata_markdown_path,
         )
+        from knowledge_adapters.github_metadata.writer import (
+            write_markdown as write_github_metadata_markdown,
+        )
+        from knowledge_adapters.manifest import write_manifest
         from knowledge_adapters.manifest_stale import (
             find_stale_artifacts,
             load_previous_manifest_index,
@@ -2443,6 +2464,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 
         github_metadata_config = GitHubMetadataConfig(
             repo=args.repo,
+            resource_type=args.resource_type,
             base_url=args.base_url,
             token_env=args.token_env,
             output_dir=args.output_dir,
@@ -2465,14 +2487,25 @@ def main(argv: Sequence[str] | None = None) -> int:
 
         try:
             base_urls = resolve_base_urls(github_metadata_config.base_url)
-            issues = list_repository_issues(
-                repo=github_metadata_config.repo,
-                base_url=github_metadata_config.base_url,
-                token_env=github_metadata_config.token_env,
-                state=github_metadata_config.state,
-                since=github_metadata_config.since,
-                max_items=github_metadata_config.max_items,
-            )
+            records: tuple[GitHubIssue | GitHubPullRequest, ...]
+            if github_metadata_config.resource_type == "issue":
+                records = list_repository_issues(
+                    repo=github_metadata_config.repo,
+                    base_url=github_metadata_config.base_url,
+                    token_env=github_metadata_config.token_env,
+                    state=github_metadata_config.state,
+                    since=github_metadata_config.since,
+                    max_items=github_metadata_config.max_items,
+                )
+            else:
+                records = list_repository_pull_requests(
+                    repo=github_metadata_config.repo,
+                    base_url=github_metadata_config.base_url,
+                    token_env=github_metadata_config.token_env,
+                    state=github_metadata_config.state,
+                    since=github_metadata_config.since,
+                    max_items=github_metadata_config.max_items,
+                )
         except (GitHubMetadataRequestError, ValueError) as exc:
             exit_with_cli_error(str(exc), command="github_metadata")
 
@@ -2482,6 +2515,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"  api_root: {base_urls.api_root}")
         print(f"  token_env: {github_metadata_config.token_env}")
         print(f"  output_dir: {render_user_path(github_metadata_config.output_dir)}")
+        print(f"  resource_type: {github_metadata_config.resource_type}")
         print(f"  state: {github_metadata_config.state}")
         if github_metadata_config.since is not None:
             print(f"  since: {github_metadata_config.since}")
@@ -2497,44 +2531,55 @@ def main(argv: Sequence[str] | None = None) -> int:
             exit_with_cli_error(str(exc), command="github_metadata")
 
         print("\nPlan: GitHub metadata run")
-        print("  resource_type: issue")
-        print(f"  issues_planned: {len(issues)}")
+        resource_label = (
+            "issue" if github_metadata_config.resource_type == "issue" else "pull_request"
+        )
+        resource_count_label = (
+            "issues_planned"
+            if github_metadata_config.resource_type == "issue"
+            else "pull_requests_planned"
+        )
+        print(f"  resource_type: {github_metadata_config.resource_type}")
+        print(f"  {resource_count_label}: {len(records)}")
 
-        issue_markdowns: dict[int, str] = {}
+        record_markdowns: dict[int, str] = {}
         github_manifest_entries: list[dict[str, object]] = []
         github_written_output_paths: list[Path] = []
-        for issue in issues:
-            markdown = normalize_issue_to_markdown(
-                {
-                    "repo": issue.repo,
-                    "number": issue.number,
-                    "title": issue.title,
-                    "state": issue.state,
-                    "author": issue.author,
-                    "created_at": issue.created_at,
-                    "updated_at": issue.updated_at,
-                    "source_url": issue.source_url,
-                    "body": issue.body,
-                }
-            )
-            output_path = github_issue_markdown_path(
+        for record in records:
+            normalized_record = {
+                "repo": record.repo,
+                "number": record.number,
+                "title": record.title,
+                "state": record.state,
+                "author": record.author,
+                "created_at": record.created_at,
+                "updated_at": record.updated_at,
+                "source_url": record.source_url,
+                "body": record.body,
+            }
+            if github_metadata_config.resource_type == "issue":
+                markdown = normalize_issue_to_markdown(normalized_record)
+            else:
+                markdown = normalize_pull_request_to_markdown(normalized_record)
+            output_path = github_metadata_markdown_path(
                 github_metadata_config.output_dir,
-                issue.number,
+                github_metadata_config.resource_type,
+                record.number,
             )
-            issue_markdowns[issue.number] = markdown
+            record_markdowns[record.number] = markdown
             github_written_output_paths.append(output_path)
             github_manifest_entries.append(
                 {
-                    "canonical_id": issue.canonical_id,
-                    "source_url": issue.source_url,
-                    "title": issue.title,
-                    "repo": issue.repo,
-                    "resource_type": "issue",
-                    "number": issue.number,
-                    "state": issue.state,
-                    "created_at": issue.created_at,
-                    "updated_at": issue.updated_at,
-                    "author": issue.author,
+                    "canonical_id": record.canonical_id,
+                    "source_url": record.source_url,
+                    "title": record.title,
+                    "repo": record.repo,
+                    "resource_type": github_metadata_config.resource_type,
+                    "number": record.number,
+                    "state": record.state,
+                    "created_at": record.created_at,
+                    "updated_at": record.updated_at,
+                    "author": record.author,
                     "content_hash": hashlib.sha256(markdown.encode("utf-8")).hexdigest(),
                     "output_path": output_path.relative_to(
                         Path(github_metadata_config.output_dir)
@@ -2552,20 +2597,24 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
         ]
 
-        for issue, output_path in zip(issues, github_written_output_paths, strict=True):
-            print(f"\n  issue: #{issue.number}")
-            print(f"  title: {issue.title}")
-            print(f"  source_url: {issue.source_url}")
+        for record, output_path in zip(records, github_written_output_paths, strict=True):
+            print(f"\n  {resource_label}: #{record.number}")
+            print(f"  title: {record.title}")
+            print(f"  source_url: {record.source_url}")
             print(f"  Artifact path: {render_user_path(output_path)}")
-            if issue.body:
+            if record.body:
                 print("  body_status: markdown/text with content")
             else:
-                print("  body_status: empty issue body; output will include an empty-body marker")
+                print(
+                    "  body_status: empty "
+                    f"{resource_label.replace('_', ' ')} body; output will include an "
+                    "empty-body marker"
+                )
             print(f"  action: {'would write' if github_metadata_config.dry_run else 'write'}")
 
         manifest_output_path = output_dir / "manifest.json"
         if github_metadata_config.dry_run:
-            print(f"\nSummary: would write {len(issues)}, would skip 0")
+            print(f"\nSummary: would write {len(records)}, would skip 0")
             print(f"  stale_artifacts: {len(stale_artifacts)}")
             print_stale_artifacts(github_metadata_config.output_dir, stale_artifacts)
             print(f"Manifest path: {render_user_path(manifest_output_path)}")
@@ -2573,11 +2622,12 @@ def main(argv: Sequence[str] | None = None) -> int:
             return 0
 
         try:
-            for issue in issues:
-                write_github_issue_markdown(
+            for record in records:
+                write_github_metadata_markdown(
                     github_metadata_config.output_dir,
-                    issue.number,
-                    issue_markdowns[issue.number],
+                    github_metadata_config.resource_type,
+                    record.number,
+                    record_markdowns[record.number],
                 )
             manifest = write_manifest(
                 github_metadata_config.output_dir,
@@ -2592,7 +2642,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 
         for output_path in github_written_output_paths:
             print(f"\nWrote: {render_user_path(output_path)}")
-        print(f"\nSummary: wrote {len(issues)}, skipped 0")
+        print(f"\nSummary: wrote {len(records)}, skipped 0")
         print(f"  stale_artifacts: {len(stale_artifacts)}")
         print_stale_artifacts(github_metadata_config.output_dir, stale_artifacts)
         print(f"Manifest path: {render_user_path(manifest)}")
@@ -2602,10 +2652,6 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.command == "git_repo":
         import hashlib
 
-        from knowledge_adapters.confluence.manifest import (
-            build_manifest_entry,
-            write_manifest,
-        )
         from knowledge_adapters.git_repo.client import fetch_repo_snapshot
         from knowledge_adapters.git_repo.config import GitRepoConfig
         from knowledge_adapters.git_repo.normalize import normalize_to_markdown
@@ -2614,6 +2660,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         from knowledge_adapters.git_repo.writer import (
             write_markdown as write_git_repo_markdown,
+        )
+        from knowledge_adapters.manifest import (
+            build_manifest_entry,
+            write_manifest,
         )
         from knowledge_adapters.manifest_stale import (
             find_stale_artifacts,

--- a/src/knowledge_adapters/confluence/manifest.py
+++ b/src/knowledge_adapters/confluence/manifest.py
@@ -1,79 +1,15 @@
-"""Manifest handling for the Confluence adapter."""
+"""Backward-compatible imports for Confluence manifest helpers."""
 
-from __future__ import annotations
+from knowledge_adapters.manifest import (
+    build_manifest_entry,
+    manifest_path,
+    write_manifest,
+    write_manifest_with_context,
+)
 
-import json
-from datetime import UTC, datetime
-from pathlib import Path
-
-
-def manifest_path(output_dir: str) -> Path:
-    """Return the manifest path for an output directory."""
-    return Path(output_dir) / "manifest.json"
-
-
-def build_manifest_entry(
-    *,
-    canonical_id: str,
-    source_url: str,
-    output_path: Path,
-    output_dir: str,
-    title: str | None = None,
-    page_version: int | str | None = None,
-    last_modified: str | None = None,
-    content_hash: str | None = None,
-    path: str | None = None,
-    ref: str | None = None,
-    commit_sha: str | None = None,
-) -> dict[str, object]:
-    """Build a minimal manifest entry for a generated file."""
-    entry: dict[str, object] = {
-        "canonical_id": canonical_id,
-        "source_url": source_url,
-        "output_path": output_path.relative_to(Path(output_dir)).as_posix(),
-    }
-
-    if title:
-        entry["title"] = title
-    if page_version is not None:
-        entry["page_version"] = page_version
-    if last_modified:
-        entry["last_modified"] = last_modified
-    if content_hash:
-        entry["content_hash"] = content_hash
-    if path:
-        entry["path"] = path
-    if ref:
-        entry["ref"] = ref
-    if commit_sha:
-        entry["commit_sha"] = commit_sha
-
-    return entry
-
-
-def write_manifest(output_dir: str, files: list[dict[str, object]]) -> Path:
-    """Write a per-run manifest describing generated files."""
-    return write_manifest_with_context(output_dir, files)
-
-
-def write_manifest_with_context(
-    output_dir: str,
-    files: list[dict[str, object]],
-    *,
-    root_page_id: str | None = None,
-    max_depth: int | None = None,
-) -> Path:
-    """Write a per-run manifest describing generated files."""
-    path = manifest_path(output_dir)
-    payload: dict[str, object] = {
-        "generated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
-    }
-    if root_page_id is not None:
-        payload["root_page_id"] = root_page_id
-    if max_depth is not None:
-        payload["max_depth"] = max_depth
-    payload["files"] = files
-
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(f"{json.dumps(payload, indent=2)}\n", encoding="utf-8")
-    return path
+__all__ = [
+    "build_manifest_entry",
+    "manifest_path",
+    "write_manifest",
+    "write_manifest_with_context",
+]

--- a/src/knowledge_adapters/github_metadata/client.py
+++ b/src/knowledge_adapters/github_metadata/client.py
@@ -46,6 +46,27 @@ class GitHubIssue:
         return f"github_metadata:{self.host}:{self.repo}:issue:{self.number}"
 
 
+@dataclass(frozen=True)
+class GitHubPullRequest:
+    """One normalized GitHub pull request record."""
+
+    repo: str
+    host: str
+    number: int
+    title: str
+    state: str
+    author: str | None
+    created_at: str
+    updated_at: str
+    source_url: str
+    body: str
+
+    @property
+    def canonical_id(self) -> str:
+        """Return the pull request canonical ID."""
+        return f"github_metadata:{self.host}:{self.repo}:pull_request:{self.number}"
+
+
 class GitHubMetadataRequestError(RuntimeError):
     """Stable request failure for github_metadata API reads."""
 
@@ -171,6 +192,26 @@ def issue_list_api_url(
     )
 
 
+def pull_request_list_api_url(
+    *,
+    api_root: str,
+    owner: str,
+    repo_name: str,
+    state: str,
+) -> str:
+    """Build the first repository pull requests API URL."""
+    encoded_owner = parse.quote(owner, safe="")
+    encoded_repo = parse.quote(repo_name, safe="")
+    query: dict[str, str | int] = {
+        "state": state,
+        "per_page": _PAGE_SIZE,
+    }
+    return (
+        f"{api_root.rstrip('/')}/repos/{encoded_owner}/{encoded_repo}/pulls?"
+        f"{parse.urlencode(query)}"
+    )
+
+
 def list_repository_issues(
     *,
     repo: str,
@@ -229,6 +270,70 @@ def list_repository_issues(
     return ordered_issues[:normalized_max_items]
 
 
+def list_repository_pull_requests(
+    *,
+    repo: str,
+    token_env: str,
+    base_url: str | None = None,
+    state: str = "open",
+    since: str | None = None,
+    max_items: int | None = None,
+) -> tuple[GitHubPullRequest, ...]:
+    """List normalized pull requests for one repository through the REST API."""
+    owner, repo_name, normalized_repo = validate_repo(repo)
+    normalized_state = validate_state(state)
+    normalized_since = validate_since(since)
+    normalized_max_items = validate_max_items(max_items)
+    base_urls = resolve_base_urls(base_url)
+    token_env_name, token = resolve_token(token_env)
+
+    next_url: str | None = pull_request_list_api_url(
+        api_root=base_urls.api_root,
+        owner=owner,
+        repo_name=repo_name,
+        state=normalized_state,
+    )
+    seen_urls: set[str] = set()
+    pull_requests: list[GitHubPullRequest] = []
+    while next_url is not None:
+        if next_url in seen_urls:
+            raise ValueError("Response error: repeated GitHub pull requests pagination URL.")
+        seen_urls.add(next_url)
+
+        payload, link_header = _request_json_list(
+            next_url,
+            token=token,
+            token_env=token_env_name,
+            repo=normalized_repo,
+            api_root=base_urls.api_root,
+        )
+        for item in payload:
+            pull_requests.append(
+                _map_pull_request(
+                    item,
+                    repo=normalized_repo,
+                    owner=owner,
+                    repo_name=repo_name,
+                    base_urls=base_urls,
+                )
+            )
+        next_url = _next_link_url(link_header)
+
+    ordered_pull_requests = tuple(
+        sorted(pull_requests, key=lambda pull_request: pull_request.number)
+    )
+    if normalized_since is not None:
+        since_cutoff = _parse_timestamp(normalized_since)
+        ordered_pull_requests = tuple(
+            pull_request
+            for pull_request in ordered_pull_requests
+            if _parse_timestamp(pull_request.updated_at) >= since_cutoff
+        )
+    if normalized_max_items is None:
+        return ordered_pull_requests
+    return ordered_pull_requests[:normalized_max_items]
+
+
 def _map_issue(
     payload: dict[str, object],
     *,
@@ -264,6 +369,54 @@ def _map_issue(
     encoded_repo = parse.quote(repo_name, safe="")
     source_url = f"{base_urls.web_root}/{encoded_owner}/{encoded_repo}/issues/{number}"
     return GitHubIssue(
+        repo=repo,
+        host=base_urls.host,
+        number=number,
+        title=title,
+        state=state,
+        author=author,
+        created_at=created_at,
+        updated_at=updated_at,
+        source_url=source_url,
+        body=body,
+    )
+
+
+def _map_pull_request(
+    payload: dict[str, object],
+    *,
+    repo: str,
+    owner: str,
+    repo_name: str,
+    base_urls: GitHubMetadataBaseUrls,
+) -> GitHubPullRequest:
+    number = payload.get("number")
+    if not isinstance(number, int) or isinstance(number, bool):
+        raise ValueError("Response error: invalid pull request number.")
+
+    title = _require_string(payload, "title")
+    state = _require_string(payload, "state")
+    created_at = _require_string(payload, "created_at")
+    updated_at = _require_string(payload, "updated_at")
+    body_value = payload.get("body")
+    if body_value is None:
+        body = ""
+    elif isinstance(body_value, str):
+        body = body_value
+    else:
+        raise ValueError("Response error: invalid pull request body.")
+
+    user = payload.get("user")
+    author: str | None = None
+    if isinstance(user, dict):
+        login = user.get("login")
+        if isinstance(login, str) and login:
+            author = login
+
+    encoded_owner = parse.quote(owner, safe="")
+    encoded_repo = parse.quote(repo_name, safe="")
+    source_url = f"{base_urls.web_root}/{encoded_owner}/{encoded_repo}/pull/{number}"
+    return GitHubPullRequest(
         repo=repo,
         host=base_urls.host,
         number=number,
@@ -317,12 +470,12 @@ def _request_json_list(
         raise ValueError("Response error: invalid JSON payload.") from exc
 
     if not isinstance(raw_payload, list):
-        raise ValueError("Response error: expected a list of GitHub issues.")
+        raise ValueError("Response error: expected a list of GitHub resources.")
 
     payload: list[dict[str, object]] = []
     for item in raw_payload:
         if not isinstance(item, dict):
-            raise ValueError("Response error: invalid issue payload.")
+            raise ValueError("Response error: invalid GitHub resource payload.")
         payload.append(item)
     return payload, link_header
 
@@ -353,9 +506,7 @@ def _rate_limit_hint(exc: HTTPError) -> str | None:
     if retry_after:
         return f"retry after {retry_after} second(s)"
 
-    remaining = (
-        exc.headers.get("X-RateLimit-Remaining") if exc.headers is not None else None
-    )
+    remaining = exc.headers.get("X-RateLimit-Remaining") if exc.headers is not None else None
     if remaining != "0" and exc.code != 429:
         return None
 
@@ -381,3 +532,7 @@ def _next_link_url(link_header: str | None) -> str | None:
         if link_url.startswith("<") and link_url.endswith(">"):
             return link_url[1:-1]
     return None
+
+
+def _parse_timestamp(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))

--- a/src/knowledge_adapters/github_metadata/config.py
+++ b/src/knowledge_adapters/github_metadata/config.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+SUPPORTED_RESOURCE_TYPES = frozenset({"issue", "pull_request"})
+
 
 @dataclass(frozen=True)
 class GitHubMetadataConfig:
@@ -12,9 +14,9 @@ class GitHubMetadataConfig:
     repo: str
     token_env: str
     output_dir: str
+    resource_type: str = "issue"
     base_url: str | None = None
     state: str = "open"
     since: str | None = None
     max_items: int | None = None
     dry_run: bool = False
-

--- a/src/knowledge_adapters/github_metadata/normalize.py
+++ b/src/knowledge_adapters/github_metadata/normalize.py
@@ -5,30 +5,56 @@ from __future__ import annotations
 from collections.abc import Mapping
 
 EMPTY_BODY_MARKER = "(empty issue body)"
+EMPTY_PULL_REQUEST_BODY_MARKER = "(empty pull request body)"
 
 
 def normalize_issue_to_markdown(issue: Mapping[str, object]) -> str:
     """Normalize one issue payload into deterministic markdown."""
-    number_value = issue.get("number")
-    if not isinstance(number_value, int) or isinstance(number_value, bool):
-        raise ValueError("issue number must be an integer.")
-    number = number_value
-    title = str(issue.get("title", ""))
-    state = str(issue.get("state", ""))
-    author = issue.get("author")
-    author_text = "" if author is None else str(author)
-    created_at = str(issue.get("created_at", ""))
-    updated_at = str(issue.get("updated_at", ""))
-    source_url = str(issue.get("source_url", ""))
-    repo = str(issue.get("repo", ""))
-    body = str(issue.get("body") or "").rstrip("\n")
-    body_text = body if body else EMPTY_BODY_MARKER
+    return _normalize_record_to_markdown(
+        issue,
+        heading_prefix="Issue",
+        resource_type="issue",
+        empty_body_marker=EMPTY_BODY_MARKER,
+    )
 
-    return f"""# Issue #{number}: {title}
+
+def normalize_pull_request_to_markdown(pull_request: Mapping[str, object]) -> str:
+    """Normalize one pull request payload into deterministic markdown."""
+    return _normalize_record_to_markdown(
+        pull_request,
+        heading_prefix="Pull Request",
+        resource_type="pull_request",
+        empty_body_marker=EMPTY_PULL_REQUEST_BODY_MARKER,
+    )
+
+
+def _normalize_record_to_markdown(
+    record: Mapping[str, object],
+    *,
+    heading_prefix: str,
+    resource_type: str,
+    empty_body_marker: str,
+) -> str:
+    number_value = record.get("number")
+    if not isinstance(number_value, int) or isinstance(number_value, bool):
+        raise ValueError(f"{resource_type} number must be an integer.")
+    number = number_value
+    title = str(record.get("title", ""))
+    state = str(record.get("state", ""))
+    author = record.get("author")
+    author_text = "" if author is None else str(author)
+    created_at = str(record.get("created_at", ""))
+    updated_at = str(record.get("updated_at", ""))
+    source_url = str(record.get("source_url", ""))
+    repo = str(record.get("repo", ""))
+    body = str(record.get("body") or "").rstrip("\n")
+    body_text = body if body else empty_body_marker
+
+    return f"""# {heading_prefix} #{number}: {title}
 
 ## Metadata
 - repo: {repo}
-- resource_type: issue
+- resource_type: {resource_type}
 - number: {number}
 - state: {state}
 - author: {author_text}

--- a/src/knowledge_adapters/github_metadata/writer.py
+++ b/src/knowledge_adapters/github_metadata/writer.py
@@ -4,21 +4,31 @@ from __future__ import annotations
 
 from pathlib import Path
 
+_RESOURCE_DIRECTORIES = {
+    "issue": "issues",
+    "pull_request": "pull_requests",
+}
 
-def markdown_path(output_dir: str, number: int) -> Path:
-    """Return the deterministic markdown path for one issue."""
-    return Path(output_dir) / "issues" / f"{number}.md"
+
+def markdown_path(output_dir: str, resource_type: str, number: int) -> Path:
+    """Return the deterministic markdown path for one GitHub metadata record."""
+    try:
+        directory = _RESOURCE_DIRECTORIES[resource_type]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported github_metadata resource_type: {resource_type!r}.") from exc
+    return Path(output_dir) / directory / f"{number}.md"
 
 
 def write_markdown(
     output_dir: str,
+    resource_type: str,
     number: int,
     markdown: str,
     *,
     dry_run: bool = False,
 ) -> Path:
-    """Write normalized issue markdown to a deterministic local path."""
-    output_path = markdown_path(output_dir, number)
+    """Write normalized GitHub metadata markdown to a deterministic local path."""
+    output_path = markdown_path(output_dir, resource_type, number)
 
     if dry_run:
         return output_path
@@ -26,4 +36,3 @@ def write_markdown(
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(markdown, encoding="utf-8")
     return output_path
-

--- a/src/knowledge_adapters/manifest.py
+++ b/src/knowledge_adapters/manifest.py
@@ -1,0 +1,79 @@
+"""Shared manifest helpers for manifest-backed adapters."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+def manifest_path(output_dir: str) -> Path:
+    """Return the manifest path for an output directory."""
+    return Path(output_dir) / "manifest.json"
+
+
+def build_manifest_entry(
+    *,
+    canonical_id: str,
+    source_url: str,
+    output_path: Path,
+    output_dir: str,
+    title: str | None = None,
+    page_version: int | str | None = None,
+    last_modified: str | None = None,
+    content_hash: str | None = None,
+    path: str | None = None,
+    ref: str | None = None,
+    commit_sha: str | None = None,
+) -> dict[str, object]:
+    """Build a minimal manifest entry for a generated file."""
+    entry: dict[str, object] = {
+        "canonical_id": canonical_id,
+        "source_url": source_url,
+        "output_path": output_path.relative_to(Path(output_dir)).as_posix(),
+    }
+
+    if title:
+        entry["title"] = title
+    if page_version is not None:
+        entry["page_version"] = page_version
+    if last_modified:
+        entry["last_modified"] = last_modified
+    if content_hash:
+        entry["content_hash"] = content_hash
+    if path:
+        entry["path"] = path
+    if ref:
+        entry["ref"] = ref
+    if commit_sha:
+        entry["commit_sha"] = commit_sha
+
+    return entry
+
+
+def write_manifest(output_dir: str, files: list[dict[str, object]]) -> Path:
+    """Write a per-run manifest describing generated files."""
+    return write_manifest_with_context(output_dir, files)
+
+
+def write_manifest_with_context(
+    output_dir: str,
+    files: list[dict[str, object]],
+    *,
+    root_page_id: str | None = None,
+    max_depth: int | None = None,
+) -> Path:
+    """Write a per-run manifest describing generated files."""
+    path = manifest_path(output_dir)
+    payload: dict[str, object] = {
+        "generated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+    }
+    if root_page_id is not None:
+        payload["root_page_id"] = root_page_id
+    if max_depth is not None:
+        payload["max_depth"] = max_depth
+    payload["files"] = files
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"{json.dumps(payload, indent=2)}\n", encoding="utf-8")
+    return path

--- a/src/knowledge_adapters/run_config.py
+++ b/src/knowledge_adapters/run_config.py
@@ -17,10 +17,12 @@ from knowledge_adapters.confluence.resolve import (
     validate_base_url,
     validate_space_key,
 )
+from knowledge_adapters.github_metadata.config import SUPPORTED_RESOURCE_TYPES
 
 SUPPORTED_RUN_TYPES = frozenset({"confluence", "git_repo", "github_metadata", "local_files"})
 _SUPPORTED_CONFLUENCE_CLIENT_MODES = frozenset({"real", "stub"})
 _SUPPORTED_GITHUB_METADATA_STATES = frozenset({"open", "closed", "all"})
+_SUPPORTED_GITHUB_METADATA_RESOURCE_TYPES = SUPPORTED_RESOURCE_TYPES
 
 _COMMON_REQUIRED_KEYS = frozenset({"name", "type", "output_dir"})
 _CONFLUENCE_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
@@ -41,14 +43,22 @@ _CONFLUENCE_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
         "tree",
     }
 )
-_LOCAL_FILES_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
-    {"dry_run", "enabled", "file_path"}
-)
+_LOCAL_FILES_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset({"dry_run", "enabled", "file_path"})
 _GIT_REPO_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
     {"dry_run", "enabled", "exclude", "include", "ref", "repo_url", "subdir"}
 )
 _GITHUB_METADATA_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
-    {"base_url", "dry_run", "enabled", "max_items", "repo", "since", "state", "token_env"}
+    {
+        "base_url",
+        "dry_run",
+        "enabled",
+        "max_items",
+        "repo",
+        "resource_type",
+        "since",
+        "state",
+        "token_env",
+    }
 )
 
 
@@ -240,9 +250,7 @@ def _build_confluence_argv(
     try:
         validate_base_url(base_url)
     except ValueError as exc:
-        raise ValueError(
-            f"Run {name!r} in {config_path} has invalid 'base_url': {exc}"
-        ) from exc
+        raise ValueError(f"Run {name!r} in {config_path} has invalid 'base_url': {exc}") from exc
 
     output_dir = _resolve_path_string(
         _require_string(run_config, "output_dir", index=index, config_path=config_path),
@@ -303,15 +311,12 @@ def _build_confluence_argv(
     else:
         if target is None:
             raise ValueError(
-                f"Run {name!r} in {config_path} must set 'target', 'space_key', or "
-                "'space_url'."
+                f"Run {name!r} in {config_path} must set 'target', 'space_key', or 'space_url'."
             )
         try:
             resolve_target_for_base_url(target, base_url=base_url)
         except ValueError as exc:
-            raise ValueError(
-                f"Run {name!r} in {config_path} has invalid 'target': {exc}"
-            ) from exc
+            raise ValueError(f"Run {name!r} in {config_path} has invalid 'target': {exc}") from exc
 
     argv: list[str] = [
         "confluence",
@@ -418,9 +423,7 @@ def _build_confluence_argv(
 
     if max_depth is not None:
         if isinstance(max_depth, bool) or not isinstance(max_depth, int):
-            raise ValueError(
-                f"Run {name!r} in {config_path} must set 'max_depth' to an integer."
-            )
+            raise ValueError(f"Run {name!r} in {config_path} must set 'max_depth' to an integer.")
         if max_depth < 0:
             raise ValueError(
                 f"Run {name!r} in {config_path} must set 'max_depth' to an integer "
@@ -567,6 +570,23 @@ def _build_github_metadata_argv(
         output_dir,
     ]
 
+    resource_type = _optional_string(
+        run_config,
+        "resource_type",
+        index=index,
+        config_path=config_path,
+    )
+    if resource_type is not None:
+        if resource_type not in _SUPPORTED_GITHUB_METADATA_RESOURCE_TYPES:
+            supported_values = " or ".join(
+                repr(value) for value in sorted(_SUPPORTED_GITHUB_METADATA_RESOURCE_TYPES)
+            )
+            raise ValueError(
+                f"Run {name!r} in {config_path} has unsupported 'resource_type' value "
+                f"{resource_type!r}. Use {supported_values}."
+            )
+        argv.extend(["--resource-type", resource_type])
+
     base_url = _optional_string(run_config, "base_url", index=index, config_path=config_path)
     if base_url is not None:
         argv.extend(["--base-url", base_url])
@@ -664,9 +684,7 @@ def _optional_string_or_datetime(
         if normalized_datetime.tzinfo is UTC:
             return normalized_datetime.isoformat().replace("+00:00", "Z")
         return normalized_datetime.isoformat()
-    raise ValueError(
-        f"Run {index!r} in {config_path} must define a non-empty string for {key!r}."
-    )
+    raise ValueError(f"Run {index!r} in {config_path} must define a non-empty string for {key!r}.")
 
 
 def _optional_string_sequence(

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -44,16 +44,15 @@ def test_top_level_help_introduces_shared_cli_flow(tmp_path: Path) -> None:
     assert "Execute multiple configured adapter runs from one YAML file." in stdout
     assert "Normalize Confluence content into shared artifacts." in stdout
     assert (
-        "Normalize selected UTF-8 text files from a Git repository into shared artifacts."
+        "Normalize selected UTF-8 text files from a Git repository into shared artifacts." in stdout
+    )
+    assert (
+        "Normalize GitHub issue or pull request metadata from one repository into shared artifacts."
         in stdout
     )
-    assert "Normalize GitHub issue metadata from one repository into shared artifacts." in stdout
     assert "Normalize one local UTF-8 text file into shared artifacts." in stdout
     assert "Combine existing artifacts into one prompt-ready markdown file." in stdout
-    assert (
-        "Start with --dry-run to preview the source, artifact path, manifest path,"
-        in stdout
-    )
+    assert "Start with --dry-run to preview the source, artifact path, manifest path," in stdout
     assert "Re-run without --dry-run to write the same artifact layout" in stdout
     assert "knowledge-adapters run runs.yaml" in stdout
     assert "knowledge-adapters git_repo --help" in stdout
@@ -128,10 +127,7 @@ def test_local_files_cli_help_includes_first_run_guidance(tmp_path: Path) -> Non
     stdout = normalize_whitespace(result.stdout)
 
     assert result.returncode == 0, result.stderr
-    assert (
-        "Normalize one existing UTF-8 text file into the shared artifact layout."
-        in stdout
-    )
+    assert "Normalize one existing UTF-8 text file into the shared artifact layout." in stdout
     assert "Empty UTF-8 files are allowed" in stdout
     assert "produce an empty content section." in stdout
     assert "Files that are not valid UTF-8 text are rejected" in stdout
@@ -166,23 +162,24 @@ def test_git_repo_cli_help_includes_filter_and_binary_guidance(tmp_path: Path) -
     assert "--subdir SUBDIR" in stdout
     assert "--dry-run" in stdout
     assert "knowledge-adapters git_repo" in stdout
-    assert "--include \"docs/**/*.md\"" in stdout
+    assert '--include "docs/**/*.md"' in stdout
     assert "--subdir docs" in stdout
 
 
-def test_github_metadata_cli_help_includes_issues_only_guidance(tmp_path: Path) -> None:
+def test_github_metadata_cli_help_includes_resource_type_guidance(tmp_path: Path) -> None:
     result = _run_cli(tmp_path, "github_metadata", "--help")
     stdout = normalize_whitespace(result.stdout)
 
     assert result.returncode == 0, result.stderr
-    assert "Fetch issues from one GitHub or GitHub Enterprise repository" in stdout
-    assert "filter out pull requests returned by that endpoint" in stdout
-    assert "bounded to issues only" in stdout
-    assert "comments, pull requests, releases, timelines" in stdout
+    assert "Fetch issues or pull requests from one GitHub or GitHub Enterprise repository" in stdout
+    assert "Issue mode filters out pull requests returned by the issues endpoint." in stdout
+    assert "under issues/ or pull_requests/." in stdout
+    assert "Comments, releases, timelines, reactions, reviews, checks" in stdout
     assert "--repo OWNER/NAME" in stdout
     assert "--base-url BASE_URL" in stdout
     assert "--token-env ENV_VAR" in stdout
     assert "--output-dir DIR" in stdout
+    assert "--resource-type {issue,pull_request}" in stdout
     assert "--state {open,closed,all}" in stdout
     assert "--since SINCE" in stdout
     assert "--max-items N" in stdout
@@ -223,8 +220,7 @@ def test_bundle_cli_help_includes_ordering_and_input_guidance(tmp_path: Path) ->
     assert "single oversized artifact is written to its own file and reported" in stdout
     assert "knowledge-adapters bundle ./artifacts/confluence --output ./bundle.md" in stdout
     assert (
-        "knowledge-adapters bundle ./artifacts --header-mode minimal --output ./bundle.md"
-        in stdout
+        "knowledge-adapters bundle ./artifacts --header-mode minimal --output ./bundle.md" in stdout
     )
     assert '--include "team-*" --exclude "*draft*" --output ./bundle.md' in stdout
     assert "knowledge-adapters bundle ./artifacts --max-bytes 250000 --output ./bundle.md" in stdout

--- a/tests/test_git_repo.py
+++ b/tests/test_git_repo.py
@@ -48,6 +48,7 @@ def _commit_all(repo_dir: Path, message: str) -> str:
 def _init_repo(repo_dir: Path) -> None:
     repo_dir.mkdir()
     _git(repo_dir, "init", "--quiet", "--initial-branch=main")
+    _git(repo_dir, "config", "commit.gpgsign", "false")
     _git(repo_dir, "config", "user.name", "Test User")
     _git(repo_dir, "config", "user.email", "test@example.com")
 

--- a/tests/test_github_metadata.py
+++ b/tests/test_github_metadata.py
@@ -14,10 +14,19 @@ from knowledge_adapters.cli import main
 from knowledge_adapters.github_metadata.client import (
     issue_list_api_url,
     list_repository_issues,
+    list_repository_pull_requests,
+    pull_request_list_api_url,
     resolve_base_urls,
 )
-from knowledge_adapters.github_metadata.normalize import EMPTY_BODY_MARKER
-from tests.cli_output_assertions import assert_dry_run_summary, assert_write_summary
+from knowledge_adapters.github_metadata.normalize import (
+    EMPTY_BODY_MARKER,
+    EMPTY_PULL_REQUEST_BODY_MARKER,
+)
+from tests.cli_output_assertions import (
+    assert_dry_run_summary,
+    assert_stale_artifacts,
+    assert_write_summary,
+)
 
 
 class _FakeGitHubResponse:
@@ -76,6 +85,28 @@ def _issue(
     return payload
 
 
+def _pull_request(
+    number: int,
+    *,
+    title: str | None = None,
+    body: str | None = "Body",
+    state: str = "open",
+    author: str | None = "alice",
+    updated_at: str | None = None,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "number": number,
+        "title": title or f"Pull Request {number}",
+        "state": state,
+        "created_at": f"2026-04-{number:02d}T00:00:00Z",
+        "updated_at": updated_at or f"2026-04-{number:02d}T01:00:00Z",
+        "body": body,
+    }
+    if author is not None:
+        payload["user"] = {"login": author}
+    return payload
+
+
 def _install_fake_urlopen(
     monkeypatch: MonkeyPatch,
     responses: Mapping[str, _FakeGitHubResponse],
@@ -99,6 +130,15 @@ def test_github_metadata_resolves_github_and_ghe_base_urls() -> None:
             since=None,
         )
         == "https://api.github.com/repos/octo/project/issues?state=open&per_page=100"
+    )
+    assert (
+        pull_request_list_api_url(
+            api_root=github_urls.api_root,
+            owner="octo",
+            repo_name="project",
+            state="open",
+        )
+        == "https://api.github.com/repos/octo/project/pulls?state=open&per_page=100"
     )
 
     ghe_web_urls = resolve_base_urls("https://github.example.com")
@@ -172,6 +212,47 @@ def test_github_metadata_paginates_filters_prs_orders_and_limits_after_filtering
         "github_metadata:github.com:octo/project:issue:1",
         "github_metadata:github.com:octo/project:issue:3",
         "github_metadata:github.com:octo/project:issue:4",
+    ]
+
+
+def test_github_metadata_pull_requests_paginate_filter_since_and_limit(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GH_TOKEN", "secret-token")
+    first_url = pull_request_list_api_url(
+        api_root="https://api.github.com",
+        owner="octo",
+        repo_name="project",
+        state="all",
+    )
+    second_url = "https://api.github.com/repos/octo/project/pulls?state=all&per_page=100&page=2"
+    fake_urlopen = _install_fake_urlopen(
+        monkeypatch,
+        {
+            first_url: _FakeGitHubResponse(
+                [
+                    _pull_request(9, updated_at="2025-12-31T23:59:59Z"),
+                    _pull_request(4),
+                ],
+                headers={"Link": f'<{second_url}>; rel="next"'},
+            ),
+            second_url: _FakeGitHubResponse([_pull_request(7), _pull_request(2)]),
+        },
+    )
+
+    pull_requests = list_repository_pull_requests(
+        repo="octo/project",
+        token_env="GH_TOKEN",
+        state="all",
+        since="2026-01-01T00:00:00Z",
+        max_items=2,
+    )
+
+    assert fake_urlopen.calls == [first_url, second_url]
+    assert [pull_request.number for pull_request in pull_requests] == [2, 4]
+    assert [pull_request.canonical_id for pull_request in pull_requests] == [
+        "github_metadata:github.com:octo/project:pull_request:2",
+        "github_metadata:github.com:octo/project:pull_request:4",
     ]
 
 
@@ -312,3 +393,162 @@ def test_github_metadata_cli_dry_run_does_not_write_files(
     assert "source_url: https://github.example.com/octo/project/issues/5" in captured.out
     assert_dry_run_summary(captured.out, would_write=1, would_skip=0)
     assert not output_dir.exists()
+
+
+def test_github_metadata_cli_writes_pull_request_artifacts_and_manifest(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("GH_TOKEN", "secret-token")
+    first_url = pull_request_list_api_url(
+        api_root="https://api.github.com",
+        owner="octo",
+        repo_name="project",
+        state="open",
+    )
+    _install_fake_urlopen(
+        monkeypatch,
+        {
+            first_url: _FakeGitHubResponse(
+                [
+                    _pull_request(8, title="Empty PR body", body=None, author=None),
+                    _pull_request(4, title="Add API docs", body="Implements docs.\n"),
+                ]
+            )
+        },
+    )
+    output_dir = tmp_path / "out"
+
+    exit_code = main(
+        [
+            "github_metadata",
+            "--repo",
+            "octo/project",
+            "--token-env",
+            "GH_TOKEN",
+            "--resource-type",
+            "pull_request",
+            "--output-dir",
+            str(output_dir),
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "resource_type: pull_request" in captured.out
+    assert "pull_requests_planned: 2" in captured.out
+    assert_write_summary(captured.out, wrote=2, skipped=0)
+
+    pr_4_path = output_dir / "pull_requests" / "4.md"
+    pr_8_path = output_dir / "pull_requests" / "8.md"
+    assert pr_4_path.exists()
+    assert pr_8_path.exists()
+    pr_4_markdown = pr_4_path.read_text(encoding="utf-8")
+    pr_8_markdown = pr_8_path.read_text(encoding="utf-8")
+    assert "# Pull Request #4: Add API docs" in pr_4_markdown
+    assert "Implements docs." in pr_4_markdown
+    assert EMPTY_PULL_REQUEST_BODY_MARKER in pr_8_markdown
+
+    manifest_payload = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
+    assert isinstance(manifest_payload["generated_at"], str)
+    assert manifest_payload["files"] == [
+        {
+            "canonical_id": "github_metadata:github.com:octo/project:pull_request:4",
+            "source_url": "https://github.com/octo/project/pull/4",
+            "title": "Add API docs",
+            "repo": "octo/project",
+            "resource_type": "pull_request",
+            "number": 4,
+            "state": "open",
+            "created_at": "2026-04-04T00:00:00Z",
+            "updated_at": "2026-04-04T01:00:00Z",
+            "author": "alice",
+            "content_hash": hashlib.sha256(pr_4_markdown.encode("utf-8")).hexdigest(),
+            "output_path": "pull_requests/4.md",
+        },
+        {
+            "canonical_id": "github_metadata:github.com:octo/project:pull_request:8",
+            "source_url": "https://github.com/octo/project/pull/8",
+            "title": "Empty PR body",
+            "repo": "octo/project",
+            "resource_type": "pull_request",
+            "number": 8,
+            "state": "open",
+            "created_at": "2026-04-08T00:00:00Z",
+            "updated_at": "2026-04-08T01:00:00Z",
+            "author": None,
+            "content_hash": hashlib.sha256(pr_8_markdown.encode("utf-8")).hexdigest(),
+            "output_path": "pull_requests/8.md",
+        },
+    ]
+
+
+def test_github_metadata_pull_request_dry_run_reports_stale_artifacts(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("GH_TOKEN", "secret-token")
+    first_url = pull_request_list_api_url(
+        api_root="https://api.github.com",
+        owner="octo",
+        repo_name="project",
+        state="open",
+    )
+    _install_fake_urlopen(
+        monkeypatch,
+        {first_url: _FakeGitHubResponse([_pull_request(7, title="Current PR")])},
+    )
+    output_dir = tmp_path / "out"
+    stale_pull_request = output_dir / "pull_requests" / "5.md"
+    stale_pull_request.parent.mkdir(parents=True, exist_ok=True)
+    stale_pull_request.write_text("legacy artifact\n", encoding="utf-8")
+    (output_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "generated_at": "2026-04-01T00:00:00Z",
+                "files": [
+                    {
+                        "canonical_id": "github_metadata:github.com:octo/project:pull_request:5",
+                        "source_url": "https://github.com/octo/project/pull/5",
+                        "title": "Legacy PR",
+                        "repo": "octo/project",
+                        "resource_type": "pull_request",
+                        "number": 5,
+                        "state": "open",
+                        "created_at": "2026-04-05T00:00:00Z",
+                        "updated_at": "2026-04-05T01:00:00Z",
+                        "author": "alice",
+                        "content_hash": "legacy",
+                        "output_path": "pull_requests/5.md",
+                    }
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    exit_code = main(
+        [
+            "github_metadata",
+            "--repo",
+            "octo/project",
+            "--token-env",
+            "GH_TOKEN",
+            "--resource-type",
+            "pull_request",
+            "--output-dir",
+            str(output_dir),
+            "--dry-run",
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert_dry_run_summary(captured.out, would_write=1, would_skip=0)
+    assert_stale_artifacts(captured.out, count=1, artifact_paths=[stale_pull_request])
+    assert stale_pull_request.read_text(encoding="utf-8") == "legacy artifact\n"
+    assert not (output_dir / "pull_requests" / "7.md").exists()

--- a/tests/test_normalize_writer.py
+++ b/tests/test_normalize_writer.py
@@ -4,9 +4,9 @@ import pytest
 from pytest import CaptureFixture
 
 from knowledge_adapters.cli import main
-from knowledge_adapters.confluence.manifest import build_manifest_entry, write_manifest
 from knowledge_adapters.confluence.normalize import normalize_to_markdown
 from knowledge_adapters.confluence.writer import write_markdown
+from knowledge_adapters.manifest import build_manifest_entry, write_manifest
 from tests.artifact_assertions import (
     assert_manifest_entries,
     assert_manifest_entry,
@@ -198,8 +198,7 @@ def test_confluence_cli_dry_run_reports_same_resolved_target_details_for_full_ur
     assert "source_url: https://example.com/wiki/pages/viewpage.action?pageId=12345" in captured.out
     assert f"Artifact: {output_dir / 'pages' / '12345.md'}" in captured.out
     assert (
-        "- source_url: https://example.com/wiki/pages/viewpage.action?pageId=12345"
-        in captured.out
+        "- source_url: https://example.com/wiki/pages/viewpage.action?pageId=12345" in captured.out
     )
 
 

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -141,6 +141,7 @@ runs:
   - name: repo-issues
     type: github_metadata
     repo: octo/project
+    resource_type: pull_request
     base_url: https://github.example.com/api/v3
     token_env: GH_TOKEN
     state: all
@@ -167,6 +168,8 @@ runs:
                 "GH_TOKEN",
                 "--output-dir",
                 str((tmp_path / "artifacts" / "github" / "repo-issues").resolve()),
+                "--resource-type",
+                "pull_request",
                 "--base-url",
                 "https://github.example.com/api/v3",
                 "--state",
@@ -186,6 +189,7 @@ runs:
     ("field_block", "expected_fragment"),
     [
         ("state: merged", "unsupported 'state' value"),
+        ("resource_type: release", "unsupported 'resource_type' value"),
         ("max_items: 0", "'max_items' to a positive integer"),
     ],
 )
@@ -433,8 +437,7 @@ runs:
     run_config = load_run_config(config_path)
 
     assert tuple(
-        run.name
-        for run in select_runs(run_config, only_names=("docs-tree", "docs-home"))
+        run.name for run in select_runs(run_config, only_names=("docs-tree", "docs-home"))
     ) == (
         "docs-home",
         "docs-tree",
@@ -658,9 +661,7 @@ runs:
     assert "Run 1/1 started: docs-home (confluence)" not in captured.out
     assert "runs_completed: 1" in captured.out
 
-    local_output_path = (
-        tmp_path / "artifacts" / "local" / "team-notes" / "pages" / "team-notes.md"
-    )
+    local_output_path = tmp_path / "artifacts" / "local" / "team-notes" / "pages" / "team-notes.md"
     assert local_output_path.exists()
     disabled_output_path = (
         tmp_path / "artifacts" / "confluence" / "docs-home" / "pages" / "12345.md"
@@ -966,9 +967,7 @@ runs:
     )
 
     assert not (tmp_path / "artifacts" / "local" / "first-run").exists()
-    second_output_path = (
-        tmp_path / "artifacts" / "local" / "second-run" / "pages" / "second.md"
-    )
+    second_output_path = tmp_path / "artifacts" / "local" / "second-run" / "pages" / "second.md"
     assert second_output_path.exists()
     assert "Second file." in second_output_path.read_text(encoding="utf-8")
 


### PR DESCRIPTION
Summary
- add pull_request resource selection, REST pagination, and deterministic artifact/manifest output for github_metadata
- move shared manifest helpers into knowledge_adapters.manifest so the new path does not extend Confluence-specific coupling
- cover PR stale-artifact reporting, run config wiring, and deterministic git_repo test commits

Validation
- make check

Closes #181
Refs #172