### PR TITLE
feat: add optional github issue comments

### DIFF
--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -579,7 +579,8 @@ def build_parser() -> argparse.ArgumentParser:
             "Fetch issues or pull requests from one GitHub or GitHub Enterprise "
             "repository through the REST API and normalize one markdown artifact per "
             "record under issues/ or pull_requests/. Issue mode filters out pull "
-            "requests returned by the issues endpoint. Comments, releases, timelines, "
+            "requests returned by the issues endpoint. Issue comments can be included "
+            "optionally in issue mode. Pull request comments, releases, timelines, "
             "reactions, reviews, checks, GraphQL, attachments, and live sync are not "
             "included. The token is read only from --token-env, and token values are "
             "never printed."
@@ -637,6 +638,14 @@ def build_parser() -> argparse.ArgumentParser:
         type=_parse_positive_int,
         metavar="N",
         help="Positive issue limit applied after filtering out pull requests.",
+    )
+    github_metadata_parser.add_argument(
+        "--include-issue-comments",
+        action="store_true",
+        help=(
+            "Fetch issue comments and append them to issue artifacts. Ignored for "
+            "pull_request resource type."
+        ),
     )
     github_metadata_parser.add_argument(
         "--dry-run",
@@ -2471,6 +2480,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             state=args.state,
             since=args.since,
             max_items=args.max_items,
+            include_issue_comments=args.include_issue_comments,
             dry_run=args.dry_run,
         )
 
@@ -2496,6 +2506,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     state=github_metadata_config.state,
                     since=github_metadata_config.since,
                     max_items=github_metadata_config.max_items,
+                    include_issue_comments=github_metadata_config.include_issue_comments,
                 )
             else:
                 records = list_repository_pull_requests(
@@ -2521,6 +2532,11 @@ def main(argv: Sequence[str] | None = None) -> int:
             print(f"  since: {github_metadata_config.since}")
         if github_metadata_config.max_items is not None:
             print(f"  max_items: {github_metadata_config.max_items}")
+        if (
+            github_metadata_config.resource_type == "issue"
+            and github_metadata_config.include_issue_comments
+        ):
+            print("  include_issue_comments: true")
         print(f"  run_mode: {'dry-run' if github_metadata_config.dry_run else 'write'}")
 
         try:
@@ -2558,6 +2574,17 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "body": record.body,
             }
             if github_metadata_config.resource_type == "issue":
+                assert isinstance(record, GitHubIssue)
+                if record.comments:
+                    normalized_record["comments"] = [
+                        {
+                            "author": comment.author,
+                            "created_at": comment.created_at,
+                            "updated_at": comment.updated_at,
+                            "body": comment.body,
+                        }
+                        for comment in record.comments
+                    ]
                 markdown = normalize_issue_to_markdown(normalized_record)
             else:
                 markdown = normalize_pull_request_to_markdown(normalized_record)

--- a/src/knowledge_adapters/github_metadata/client.py
+++ b/src/knowledge_adapters/github_metadata/client.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime
 from urllib import parse, request
 from urllib.error import HTTPError, URLError
@@ -39,11 +39,22 @@ class GitHubIssue:
     updated_at: str
     source_url: str
     body: str
+    comments: tuple[GitHubIssueComment, ...] = ()
 
     @property
     def canonical_id(self) -> str:
         """Return the issue canonical ID."""
         return f"github_metadata:{self.host}:{self.repo}:issue:{self.number}"
+
+
+@dataclass(frozen=True)
+class GitHubIssueComment:
+    """One normalized GitHub issue comment record."""
+
+    author: str | None
+    created_at: str
+    updated_at: str
+    body: str
 
 
 @dataclass(frozen=True)
@@ -220,6 +231,7 @@ def list_repository_issues(
     state: str = "open",
     since: str | None = None,
     max_items: int | None = None,
+    include_issue_comments: bool = False,
 ) -> tuple[GitHubIssue, ...]:
     """List normalized issues for one repository through the REST API."""
     owner, repo_name, normalized_repo = validate_repo(repo)
@@ -265,9 +277,27 @@ def list_repository_issues(
         next_url = _next_link_url(link_header)
 
     ordered_issues = tuple(sorted(issues, key=lambda issue: issue.number))
-    if normalized_max_items is None:
-        return ordered_issues
-    return ordered_issues[:normalized_max_items]
+    selected_issues = (
+        ordered_issues if normalized_max_items is None else ordered_issues[:normalized_max_items]
+    )
+    if not include_issue_comments:
+        return selected_issues
+
+    return tuple(
+        replace(
+            issue,
+            comments=_list_issue_comments(
+                issue_number=issue.number,
+                owner=owner,
+                repo_name=repo_name,
+                repo=normalized_repo,
+                api_root=base_urls.api_root,
+                token=token,
+                token_env=token_env_name,
+            ),
+        )
+        for issue in selected_issues
+    )
 
 
 def list_repository_pull_requests(
@@ -426,6 +456,96 @@ def _map_pull_request(
         created_at=created_at,
         updated_at=updated_at,
         source_url=source_url,
+        body=body,
+    )
+
+
+def issue_comments_api_url(
+    *,
+    api_root: str,
+    owner: str,
+    repo_name: str,
+    issue_number: int,
+) -> str:
+    """Build the first issue comments API URL."""
+    encoded_owner = parse.quote(owner, safe="")
+    encoded_repo = parse.quote(repo_name, safe="")
+    query = parse.urlencode({"per_page": _PAGE_SIZE})
+    return (
+        f"{api_root.rstrip('/')}/repos/{encoded_owner}/{encoded_repo}/issues/"
+        f"{issue_number}/comments?{query}"
+    )
+
+
+def _list_issue_comments(
+    *,
+    issue_number: int,
+    owner: str,
+    repo_name: str,
+    repo: str,
+    api_root: str,
+    token: str,
+    token_env: str,
+) -> tuple[GitHubIssueComment, ...]:
+    next_url: str | None = issue_comments_api_url(
+        api_root=api_root,
+        owner=owner,
+        repo_name=repo_name,
+        issue_number=issue_number,
+    )
+    seen_urls: set[str] = set()
+    comments: list[GitHubIssueComment] = []
+    while next_url is not None:
+        if next_url in seen_urls:
+            raise ValueError("Response error: repeated GitHub issue comments pagination URL.")
+        seen_urls.add(next_url)
+
+        payload, link_header = _request_json_list(
+            next_url,
+            token=token,
+            token_env=token_env,
+            repo=repo,
+            api_root=api_root,
+        )
+        for item in payload:
+            comments.append(_map_issue_comment(item))
+        next_url = _next_link_url(link_header)
+
+    return tuple(
+        sorted(
+            comments,
+            key=lambda comment: (
+                comment.created_at,
+                comment.updated_at,
+                "" if comment.author is None else comment.author,
+                comment.body,
+            ),
+        )
+    )
+
+
+def _map_issue_comment(payload: dict[str, object]) -> GitHubIssueComment:
+    created_at = _require_string(payload, "created_at")
+    updated_at = _require_string(payload, "updated_at")
+    body_value = payload.get("body")
+    if body_value is None:
+        body = ""
+    elif isinstance(body_value, str):
+        body = body_value
+    else:
+        raise ValueError("Response error: invalid issue comment body.")
+
+    user = payload.get("user")
+    author: str | None = None
+    if isinstance(user, dict):
+        login = user.get("login")
+        if isinstance(login, str) and login:
+            author = login
+
+    return GitHubIssueComment(
+        author=author,
+        created_at=created_at,
+        updated_at=updated_at,
         body=body,
     )
 

--- a/src/knowledge_adapters/github_metadata/config.py
+++ b/src/knowledge_adapters/github_metadata/config.py
@@ -19,4 +19,5 @@ class GitHubMetadataConfig:
     state: str = "open"
     since: str | None = None
     max_items: int | None = None
+    include_issue_comments: bool = False
     dry_run: bool = False

--- a/src/knowledge_adapters/github_metadata/normalize.py
+++ b/src/knowledge_adapters/github_metadata/normalize.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping
 
 EMPTY_BODY_MARKER = "(empty issue body)"
 EMPTY_PULL_REQUEST_BODY_MARKER = "(empty pull request body)"
+EMPTY_COMMENT_BODY_MARKER = "(empty issue comment body)"
 
 
 def normalize_issue_to_markdown(issue: Mapping[str, object]) -> str:
@@ -15,6 +16,7 @@ def normalize_issue_to_markdown(issue: Mapping[str, object]) -> str:
         heading_prefix="Issue",
         resource_type="issue",
         empty_body_marker=EMPTY_BODY_MARKER,
+        include_comments=True,
     )
 
 
@@ -25,6 +27,7 @@ def normalize_pull_request_to_markdown(pull_request: Mapping[str, object]) -> st
         heading_prefix="Pull Request",
         resource_type="pull_request",
         empty_body_marker=EMPTY_PULL_REQUEST_BODY_MARKER,
+        include_comments=False,
     )
 
 
@@ -34,6 +37,7 @@ def _normalize_record_to_markdown(
     heading_prefix: str,
     resource_type: str,
     empty_body_marker: str,
+    include_comments: bool,
 ) -> str:
     number_value = record.get("number")
     if not isinstance(number_value, int) or isinstance(number_value, bool):
@@ -49,6 +53,9 @@ def _normalize_record_to_markdown(
     repo = str(record.get("repo", ""))
     body = str(record.get("body") or "").rstrip("\n")
     body_text = body if body else empty_body_marker
+    comments_section = (
+        _normalize_comments_section(record.get("comments")) if include_comments else ""
+    )
 
     return f"""# {heading_prefix} #{number}: {title}
 
@@ -64,5 +71,36 @@ def _normalize_record_to_markdown(
 
 ## Body
 
+{body_text}{comments_section}
+"""
+
+
+def _normalize_comments_section(comments_value: object) -> str:
+    if comments_value is None:
+        return ""
+    if not isinstance(comments_value, (list, tuple)):
+        raise ValueError("issue comments must be a list or tuple when provided.")
+    if not comments_value:
+        return ""
+
+    rendered_comments: list[str] = []
+    for index, comment_value in enumerate(comments_value, start=1):
+        if not isinstance(comment_value, Mapping):
+            raise ValueError("issue comments must contain mapping entries.")
+        author = comment_value.get("author")
+        author_text = "" if author is None else str(author)
+        created_at = str(comment_value.get("created_at", ""))
+        updated_at = str(comment_value.get("updated_at", ""))
+        body = str(comment_value.get("body") or "").rstrip("\n")
+        body_text = body if body else EMPTY_COMMENT_BODY_MARKER
+        rendered_comments.append(
+            f"""### Comment {index}
+
+- author: {author_text}
+- created_at: {created_at}
+- updated_at: {updated_at}
+
 {body_text}
 """
+        )
+    return "\n\n## Comments\n\n" + "\n".join(rendered_comments).rstrip("\n")

--- a/src/knowledge_adapters/run_config.py
+++ b/src/knowledge_adapters/run_config.py
@@ -52,6 +52,7 @@ _GITHUB_METADATA_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
         "base_url",
         "dry_run",
         "enabled",
+        "include_issue_comments",
         "max_items",
         "repo",
         "resource_type",
@@ -614,6 +615,15 @@ def _build_github_metadata_argv(
                 f"Run {name!r} in {config_path} must set 'max_items' to a positive integer."
             )
         argv.extend(["--max-items", str(max_items)])
+
+    if _optional_bool(
+        run_config,
+        "include_issue_comments",
+        index=index,
+        config_path=config_path,
+        default=False,
+    ):
+        argv.append("--include-issue-comments")
 
     if _optional_bool(run_config, "dry_run", index=index, config_path=config_path, default=False):
         argv.append("--dry-run")

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -174,7 +174,8 @@ def test_github_metadata_cli_help_includes_resource_type_guidance(tmp_path: Path
     assert "Fetch issues or pull requests from one GitHub or GitHub Enterprise repository" in stdout
     assert "Issue mode filters out pull requests returned by the issues endpoint." in stdout
     assert "under issues/ or pull_requests/." in stdout
-    assert "Comments, releases, timelines, reactions, reviews, checks" in stdout
+    assert "Issue comments can be included optionally in issue mode." in stdout
+    assert "Pull request comments, releases, timelines, reactions, reviews, checks" in stdout
     assert "--repo OWNER/NAME" in stdout
     assert "--base-url BASE_URL" in stdout
     assert "--token-env ENV_VAR" in stdout
@@ -183,6 +184,7 @@ def test_github_metadata_cli_help_includes_resource_type_guidance(tmp_path: Path
     assert "--state {open,closed,all}" in stdout
     assert "--since SINCE" in stdout
     assert "--max-items N" in stdout
+    assert "--include-issue-comments" in stdout
     assert "--dry-run" in stdout
     assert "token value is read from the environment only and is never printed" in stdout
     assert "knowledge-adapters github_metadata" in stdout

--- a/tests/test_github_metadata.py
+++ b/tests/test_github_metadata.py
@@ -12,6 +12,7 @@ from pytest import CaptureFixture, MonkeyPatch
 
 from knowledge_adapters.cli import main
 from knowledge_adapters.github_metadata.client import (
+    issue_comments_api_url,
     issue_list_api_url,
     list_repository_issues,
     list_repository_pull_requests,
@@ -100,6 +101,24 @@ def _pull_request(
         "state": state,
         "created_at": f"2026-04-{number:02d}T00:00:00Z",
         "updated_at": updated_at or f"2026-04-{number:02d}T01:00:00Z",
+        "body": body,
+    }
+    if author is not None:
+        payload["user"] = {"login": author}
+    return payload
+
+
+def _issue_comment(
+    number: int,
+    *,
+    body: str | None = "Comment",
+    author: str | None = "alice",
+    created_at: str | None = None,
+    updated_at: str | None = None,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "created_at": created_at or f"2026-04-{number:02d}T02:00:00Z",
+        "updated_at": updated_at or f"2026-04-{number:02d}T03:00:00Z",
         "body": body,
     }
     if author is not None:
@@ -256,6 +275,84 @@ def test_github_metadata_pull_requests_paginate_filter_since_and_limit(
     ]
 
 
+def test_github_metadata_issue_comments_paginate_and_sort_deterministically(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GH_TOKEN", "secret-token")
+    issues_url = issue_list_api_url(
+        api_root="https://api.github.com",
+        owner="octo",
+        repo_name="project",
+        state="open",
+        since=None,
+    )
+    issue_1_comments_url = issue_comments_api_url(
+        api_root="https://api.github.com",
+        owner="octo",
+        repo_name="project",
+        issue_number=1,
+    )
+    issue_1_comments_page_2_url = (
+        "https://api.github.com/repos/octo/project/issues/1/comments?per_page=100&page=2"
+    )
+    issue_2_comments_url = issue_comments_api_url(
+        api_root="https://api.github.com",
+        owner="octo",
+        repo_name="project",
+        issue_number=2,
+    )
+    fake_urlopen = _install_fake_urlopen(
+        monkeypatch,
+        {
+            issues_url: _FakeGitHubResponse([_issue(2), _issue(1)]),
+            issue_1_comments_url: _FakeGitHubResponse(
+                [
+                    _issue_comment(
+                        1,
+                        body="Second chronologically",
+                        created_at="2026-04-01T05:00:00Z",
+                        updated_at="2026-04-01T05:30:00Z",
+                    )
+                ],
+                headers={"Link": f'<{issue_1_comments_page_2_url}>; rel="next"'},
+            ),
+            issue_1_comments_page_2_url: _FakeGitHubResponse(
+                [
+                    _issue_comment(
+                        1,
+                        body="First chronologically",
+                        author="bob",
+                        created_at="2026-04-01T04:00:00Z",
+                        updated_at="2026-04-01T04:30:00Z",
+                    )
+                ]
+            ),
+            issue_2_comments_url: _FakeGitHubResponse([_issue_comment(2, body=None, author=None)]),
+        },
+    )
+
+    issues = list_repository_issues(
+        repo="octo/project",
+        token_env="GH_TOKEN",
+        include_issue_comments=True,
+    )
+
+    assert fake_urlopen.calls == [
+        issues_url,
+        issue_1_comments_url,
+        issue_1_comments_page_2_url,
+        issue_2_comments_url,
+    ]
+    assert [issue.number for issue in issues] == [1, 2]
+    assert [comment.body for comment in issues[0].comments] == [
+        "First chronologically",
+        "Second chronologically",
+    ]
+    assert issues[0].comments[0].author == "bob"
+    assert issues[1].comments[0].body == ""
+    assert issues[1].comments[0].author is None
+
+
 def test_github_metadata_cli_writes_issue_artifacts_and_manifest(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -312,6 +409,7 @@ def test_github_metadata_cli_writes_issue_artifacts_and_manifest(
     issue_7_markdown = issue_7_path.read_text(encoding="utf-8")
     assert "# Issue #2: Useful bug" in issue_2_markdown
     assert "Bug details." in issue_2_markdown
+    assert "## Comments" not in issue_2_markdown
     assert EMPTY_BODY_MARKER in issue_7_markdown
 
     manifest_payload = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
@@ -346,6 +444,91 @@ def test_github_metadata_cli_writes_issue_artifacts_and_manifest(
             "output_path": "issues/7.md",
         },
     ]
+
+
+def test_github_metadata_cli_writes_issue_comments_when_enabled(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("GH_TOKEN", "secret-token")
+    issues_url = issue_list_api_url(
+        api_root="https://api.github.com",
+        owner="octo",
+        repo_name="project",
+        state="open",
+        since=None,
+    )
+    issue_2_comments_url = issue_comments_api_url(
+        api_root="https://api.github.com",
+        owner="octo",
+        repo_name="project",
+        issue_number=2,
+    )
+    issue_7_comments_url = issue_comments_api_url(
+        api_root="https://api.github.com",
+        owner="octo",
+        repo_name="project",
+        issue_number=7,
+    )
+    fake_urlopen = _install_fake_urlopen(
+        monkeypatch,
+        {
+            issues_url: _FakeGitHubResponse(
+                [
+                    _issue(7, title="Follow-up", body="Body for issue 7.\n"),
+                    _issue(2, title="Useful bug", body="Bug details.\n"),
+                ]
+            ),
+            issue_2_comments_url: _FakeGitHubResponse(
+                [
+                    _issue_comment(
+                        2,
+                        body="Later comment",
+                        created_at="2026-04-02T04:00:00Z",
+                        updated_at="2026-04-02T05:00:00Z",
+                    ),
+                    _issue_comment(
+                        2,
+                        body="Earlier comment",
+                        author="bob",
+                        created_at="2026-04-02T03:00:00Z",
+                        updated_at="2026-04-02T03:30:00Z",
+                    ),
+                ]
+            ),
+            issue_7_comments_url: _FakeGitHubResponse([]),
+        },
+    )
+    output_dir = tmp_path / "out"
+
+    exit_code = main(
+        [
+            "github_metadata",
+            "--repo",
+            "octo/project",
+            "--token-env",
+            "GH_TOKEN",
+            "--output-dir",
+            str(output_dir),
+            "--include-issue-comments",
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "include_issue_comments: true" in captured.out
+    assert_write_summary(captured.out, wrote=2, skipped=0)
+    assert fake_urlopen.calls == [issues_url, issue_2_comments_url, issue_7_comments_url]
+
+    issue_2_markdown = (output_dir / "issues" / "2.md").read_text(encoding="utf-8")
+    issue_7_markdown = (output_dir / "issues" / "7.md").read_text(encoding="utf-8")
+    assert "## Comments" in issue_2_markdown
+    assert "### Comment 1" in issue_2_markdown
+    assert "- author: bob" in issue_2_markdown
+    assert "Earlier comment" in issue_2_markdown
+    assert issue_2_markdown.index("Earlier comment") < issue_2_markdown.index("Later comment")
+    assert "## Comments" not in issue_7_markdown
 
 
 def test_github_metadata_cli_dry_run_does_not_write_files(

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -147,6 +147,7 @@ runs:
     state: all
     since: 2026-01-01T00:00:00Z
     max_items: 25
+    include_issue_comments: true
     output_dir: ./artifacts/github/repo-issues
     dry_run: true
 """.strip()
@@ -178,6 +179,7 @@ runs:
                 "2026-01-01T00:00:00Z",
                 "--max-items",
                 "25",
+                "--include-issue-comments",
                 "--dry-run",
             ),
             dry_run=True,


### PR DESCRIPTION
Summary
- add opt-in issue comment ingestion for `github_metadata` issue runs through CLI and run config
- fetch and normalize issue comments deterministically after issue selection so default issue and pull request behavior stays unchanged
- add focused coverage for help text, run-config wiring, comment pagination, and enabled/disabled output behavior

Testing
- `make check`

Closes #180