### PR TITLE
feat: add github_metadata release ingestion

### DIFF
--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -111,6 +111,12 @@ GITHUB_METADATA_HELP_EXAMPLES = """Examples:
   GITHUB_TOKEN=... knowledge-adapters github_metadata \\
     --repo example/project \\
     --token-env GITHUB_TOKEN \\
+    --resource-type release \\
+    --output-dir ./artifacts \\
+    --dry-run
+  GITHUB_TOKEN=... knowledge-adapters github_metadata \\
+    --repo example/project \\
+    --token-env GITHUB_TOKEN \\
     --state all \\
     --since 2026-01-01T00:00:00Z \\
     --max-items 25 \\
@@ -572,18 +578,19 @@ def build_parser() -> argparse.ArgumentParser:
     github_metadata_parser = subparsers.add_parser(
         "github_metadata",
         help=(
-            "Normalize GitHub issue or pull request metadata from one repository into "
-            "shared artifacts."
+            "Normalize GitHub issue, pull request, or release metadata from one "
+            "repository into shared artifacts."
         ),
         description=(
-            "Fetch issues or pull requests from one GitHub or GitHub Enterprise "
-            "repository through the REST API and normalize one markdown artifact per "
-            "record under issues/ or pull_requests/. Issue mode filters out pull "
-            "requests returned by the issues endpoint. Issue comments can be included "
-            "optionally in issue mode. Pull request comments, releases, timelines, "
-            "reactions, reviews, checks, GraphQL, attachments, and live sync are not "
-            "included. The token is read only from --token-env, and token values are "
-            "never printed."
+            "Fetch issues, pull requests, or releases from one GitHub or GitHub "
+            "Enterprise repository through the REST API and normalize one markdown "
+            "artifact per record under issues/, pull_requests/, or releases/. Issue "
+            "mode filters out pull requests returned by the issues endpoint. Issue "
+            "comments can be included optionally in issue mode. Pull request "
+            "comments, release assets, changelog generation, timelines, reactions, "
+            "reviews, checks, GraphQL, attachments, and live sync are not included. "
+            "The token is read only from --token-env, and token values are never "
+            "printed."
         ),
         epilog=GITHUB_METADATA_HELP_EXAMPLES,
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -615,11 +622,14 @@ def build_parser() -> argparse.ArgumentParser:
         "--output-dir",
         required=True,
         metavar="DIR",
-        help="Directory where issues/ or pull_requests/ plus manifest.json are written.",
+        help=(
+            "Directory where issues/, pull_requests/, or releases/ plus "
+            "manifest.json are written."
+        ),
     )
     github_metadata_parser.add_argument(
         "--resource-type",
-        choices=("issue", "pull_request"),
+        choices=("issue", "pull_request", "release"),
         default="issue",
         help="GitHub metadata resource type to ingest. Defaults to issue.",
     )
@@ -627,24 +637,27 @@ def build_parser() -> argparse.ArgumentParser:
         "--state",
         choices=("open", "closed", "all"),
         default="open",
-        help="Issue state filter for the REST API. Defaults to open.",
+        help="Issue or pull request state filter for the REST API. Ignored for release.",
     )
     github_metadata_parser.add_argument(
         "--since",
-        help="ISO 8601 timestamp for issues updated at or after that time.",
+        help=(
+            "ISO 8601 timestamp for issues or pull requests updated, or releases "
+            "published, at or after that time."
+        ),
     )
     github_metadata_parser.add_argument(
         "--max-items",
         type=_parse_positive_int,
         metavar="N",
-        help="Positive issue limit applied after filtering out pull requests.",
+        help="Positive record limit applied after filtering.",
     )
     github_metadata_parser.add_argument(
         "--include-issue-comments",
         action="store_true",
         help=(
             "Fetch issue comments and append them to issue artifacts. Ignored for "
-            "pull_request resource type."
+            "pull_request and release resource types."
         ),
     )
     github_metadata_parser.add_argument(
@@ -2450,14 +2463,17 @@ def main(argv: Sequence[str] | None = None) -> int:
             GitHubIssue,
             GitHubMetadataRequestError,
             GitHubPullRequest,
+            GitHubRelease,
             list_repository_issues,
             list_repository_pull_requests,
+            list_repository_releases,
             resolve_base_urls,
         )
         from knowledge_adapters.github_metadata.config import GitHubMetadataConfig
         from knowledge_adapters.github_metadata.normalize import (
             normalize_issue_to_markdown,
             normalize_pull_request_to_markdown,
+            normalize_release_to_markdown,
         )
         from knowledge_adapters.github_metadata.writer import (
             markdown_path as github_metadata_markdown_path,
@@ -2497,7 +2513,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 
         try:
             base_urls = resolve_base_urls(github_metadata_config.base_url)
-            records: tuple[GitHubIssue | GitHubPullRequest, ...]
+            records: tuple[GitHubIssue | GitHubPullRequest | GitHubRelease, ...]
             if github_metadata_config.resource_type == "issue":
                 records = list_repository_issues(
                     repo=github_metadata_config.repo,
@@ -2508,12 +2524,20 @@ def main(argv: Sequence[str] | None = None) -> int:
                     max_items=github_metadata_config.max_items,
                     include_issue_comments=github_metadata_config.include_issue_comments,
                 )
-            else:
+            elif github_metadata_config.resource_type == "pull_request":
                 records = list_repository_pull_requests(
                     repo=github_metadata_config.repo,
                     base_url=github_metadata_config.base_url,
                     token_env=github_metadata_config.token_env,
                     state=github_metadata_config.state,
+                    since=github_metadata_config.since,
+                    max_items=github_metadata_config.max_items,
+                )
+            else:
+                records = list_repository_releases(
+                    repo=github_metadata_config.repo,
+                    base_url=github_metadata_config.base_url,
+                    token_env=github_metadata_config.token_env,
                     since=github_metadata_config.since,
                     max_items=github_metadata_config.max_items,
                 )
@@ -2527,7 +2551,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"  token_env: {github_metadata_config.token_env}")
         print(f"  output_dir: {render_user_path(github_metadata_config.output_dir)}")
         print(f"  resource_type: {github_metadata_config.resource_type}")
-        print(f"  state: {github_metadata_config.state}")
+        if github_metadata_config.resource_type != "release":
+            print(f"  state: {github_metadata_config.state}")
         if github_metadata_config.since is not None:
             print(f"  since: {github_metadata_config.since}")
         if github_metadata_config.max_items is not None:
@@ -2547,34 +2572,36 @@ def main(argv: Sequence[str] | None = None) -> int:
             exit_with_cli_error(str(exc), command="github_metadata")
 
         print("\nPlan: GitHub metadata run")
-        resource_label = (
-            "issue" if github_metadata_config.resource_type == "issue" else "pull_request"
-        )
-        resource_count_label = (
-            "issues_planned"
-            if github_metadata_config.resource_type == "issue"
-            else "pull_requests_planned"
-        )
+        if github_metadata_config.resource_type == "issue":
+            resource_label = "issue"
+            resource_count_label = "issues_planned"
+        elif github_metadata_config.resource_type == "pull_request":
+            resource_label = "pull_request"
+            resource_count_label = "pull_requests_planned"
+        else:
+            resource_label = "release"
+            resource_count_label = "releases_planned"
         print(f"  resource_type: {github_metadata_config.resource_type}")
         print(f"  {resource_count_label}: {len(records)}")
 
-        record_markdowns: dict[int, str] = {}
+        record_markdowns: dict[str, str] = {}
         github_manifest_entries: list[dict[str, object]] = []
         github_written_output_paths: list[Path] = []
         for record in records:
-            normalized_record = {
-                "repo": record.repo,
-                "number": record.number,
-                "title": record.title,
-                "state": record.state,
-                "author": record.author,
-                "created_at": record.created_at,
-                "updated_at": record.updated_at,
-                "source_url": record.source_url,
-                "body": record.body,
-            }
             if github_metadata_config.resource_type == "issue":
                 assert isinstance(record, GitHubIssue)
+                record_identifier = record.number
+                normalized_record = {
+                    "repo": record.repo,
+                    "number": record.number,
+                    "title": record.title,
+                    "state": record.state,
+                    "author": record.author,
+                    "created_at": record.created_at,
+                    "updated_at": record.updated_at,
+                    "source_url": record.source_url,
+                    "body": record.body,
+                }
                 if record.comments:
                     normalized_record["comments"] = [
                         {
@@ -2586,17 +2613,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                         for comment in record.comments
                     ]
                 markdown = normalize_issue_to_markdown(normalized_record)
-            else:
-                markdown = normalize_pull_request_to_markdown(normalized_record)
-            output_path = github_metadata_markdown_path(
-                github_metadata_config.output_dir,
-                github_metadata_config.resource_type,
-                record.number,
-            )
-            record_markdowns[record.number] = markdown
-            github_written_output_paths.append(output_path)
-            github_manifest_entries.append(
-                {
+                manifest_entry = {
                     "canonical_id": record.canonical_id,
                     "source_url": record.source_url,
                     "title": record.title,
@@ -2608,6 +2625,77 @@ def main(argv: Sequence[str] | None = None) -> int:
                     "updated_at": record.updated_at,
                     "author": record.author,
                     "content_hash": hashlib.sha256(markdown.encode("utf-8")).hexdigest(),
+                }
+            elif github_metadata_config.resource_type == "pull_request":
+                assert isinstance(record, GitHubPullRequest)
+                record_identifier = record.number
+                normalized_record = {
+                    "repo": record.repo,
+                    "number": record.number,
+                    "title": record.title,
+                    "state": record.state,
+                    "author": record.author,
+                    "created_at": record.created_at,
+                    "updated_at": record.updated_at,
+                    "source_url": record.source_url,
+                    "body": record.body,
+                }
+                markdown = normalize_pull_request_to_markdown(normalized_record)
+                manifest_entry = {
+                    "canonical_id": record.canonical_id,
+                    "source_url": record.source_url,
+                    "title": record.title,
+                    "repo": record.repo,
+                    "resource_type": github_metadata_config.resource_type,
+                    "number": record.number,
+                    "state": record.state,
+                    "created_at": record.created_at,
+                    "updated_at": record.updated_at,
+                    "author": record.author,
+                    "content_hash": hashlib.sha256(markdown.encode("utf-8")).hexdigest(),
+                }
+            else:
+                assert isinstance(record, GitHubRelease)
+                record_identifier = record.release_id
+                normalized_record = {
+                    "repo": record.repo,
+                    "release_id": record.release_id,
+                    "tag_name": record.tag_name,
+                    "title": record.title,
+                    "author": record.author,
+                    "created_at": record.created_at,
+                    "published_at": record.published_at,
+                    "draft": record.draft,
+                    "prerelease": record.prerelease,
+                    "source_url": record.source_url,
+                    "body": record.body,
+                }
+                markdown = normalize_release_to_markdown(normalized_record)
+                manifest_entry = {
+                    "canonical_id": record.canonical_id,
+                    "source_url": record.source_url,
+                    "title": record.title,
+                    "repo": record.repo,
+                    "resource_type": github_metadata_config.resource_type,
+                    "release_id": record.release_id,
+                    "tag_name": record.tag_name,
+                    "created_at": record.created_at,
+                    "published_at": record.published_at,
+                    "author": record.author,
+                    "draft": record.draft,
+                    "prerelease": record.prerelease,
+                    "content_hash": hashlib.sha256(markdown.encode("utf-8")).hexdigest(),
+                }
+            output_path = github_metadata_markdown_path(
+                github_metadata_config.output_dir,
+                github_metadata_config.resource_type,
+                record_identifier,
+            )
+            record_markdowns[record.canonical_id] = markdown
+            github_written_output_paths.append(output_path)
+            github_manifest_entries.append(
+                {
+                    **manifest_entry,
                     "output_path": output_path.relative_to(
                         Path(github_metadata_config.output_dir)
                     ).as_posix(),
@@ -2625,7 +2713,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         ]
 
         for record, output_path in zip(records, github_written_output_paths, strict=True):
-            print(f"\n  {resource_label}: #{record.number}")
+            if isinstance(record, GitHubRelease):
+                print(f"\n  {resource_label}: {record.tag_name}")
+            else:
+                print(f"\n  {resource_label}: #{record.number}")
             print(f"  title: {record.title}")
             print(f"  source_url: {record.source_url}")
             print(f"  Artifact path: {render_user_path(output_path)}")
@@ -2650,11 +2741,14 @@ def main(argv: Sequence[str] | None = None) -> int:
 
         try:
             for record in records:
+                record_identifier = (
+                    record.release_id if isinstance(record, GitHubRelease) else record.number
+                )
                 write_github_metadata_markdown(
                     github_metadata_config.output_dir,
                     github_metadata_config.resource_type,
-                    record.number,
-                    record_markdowns[record.number],
+                    record_identifier,
+                    record_markdowns[record.canonical_id],
                 )
             manifest = write_manifest(
                 github_metadata_config.output_dir,

--- a/src/knowledge_adapters/github_metadata/client.py
+++ b/src/knowledge_adapters/github_metadata/client.py
@@ -78,6 +78,29 @@ class GitHubPullRequest:
         return f"github_metadata:{self.host}:{self.repo}:pull_request:{self.number}"
 
 
+@dataclass(frozen=True)
+class GitHubRelease:
+    """One normalized GitHub release record."""
+
+    repo: str
+    host: str
+    release_id: int
+    tag_name: str
+    title: str
+    author: str | None
+    created_at: str
+    published_at: str | None
+    source_url: str
+    body: str
+    draft: bool
+    prerelease: bool
+
+    @property
+    def canonical_id(self) -> str:
+        """Return the release canonical ID."""
+        return f"github_metadata:{self.host}:{self.repo}:release:{self.release_id}"
+
+
 class GitHubMetadataRequestError(RuntimeError):
     """Stable request failure for github_metadata API reads."""
 
@@ -223,6 +246,19 @@ def pull_request_list_api_url(
     )
 
 
+def release_list_api_url(
+    *,
+    api_root: str,
+    owner: str,
+    repo_name: str,
+) -> str:
+    """Build the first repository releases API URL."""
+    encoded_owner = parse.quote(owner, safe="")
+    encoded_repo = parse.quote(repo_name, safe="")
+    query = parse.urlencode({"per_page": _PAGE_SIZE})
+    return f"{api_root.rstrip('/')}/repos/{encoded_owner}/{encoded_repo}/releases?{query}"
+
+
 def list_repository_issues(
     *,
     repo: str,
@@ -364,6 +400,75 @@ def list_repository_pull_requests(
     return ordered_pull_requests[:normalized_max_items]
 
 
+def list_repository_releases(
+    *,
+    repo: str,
+    token_env: str,
+    base_url: str | None = None,
+    since: str | None = None,
+    max_items: int | None = None,
+) -> tuple[GitHubRelease, ...]:
+    """List normalized releases for one repository through the REST API."""
+    owner, repo_name, normalized_repo = validate_repo(repo)
+    normalized_since = validate_since(since)
+    normalized_max_items = validate_max_items(max_items)
+    base_urls = resolve_base_urls(base_url)
+    token_env_name, token = resolve_token(token_env)
+
+    next_url: str | None = release_list_api_url(
+        api_root=base_urls.api_root,
+        owner=owner,
+        repo_name=repo_name,
+    )
+    seen_urls: set[str] = set()
+    releases: list[GitHubRelease] = []
+    while next_url is not None:
+        if next_url in seen_urls:
+            raise ValueError("Response error: repeated GitHub releases pagination URL.")
+        seen_urls.add(next_url)
+
+        payload, link_header = _request_json_list(
+            next_url,
+            token=token,
+            token_env=token_env_name,
+            repo=normalized_repo,
+            api_root=base_urls.api_root,
+        )
+        for item in payload:
+            releases.append(
+                _map_release(
+                    item,
+                    repo=normalized_repo,
+                    owner=owner,
+                    repo_name=repo_name,
+                    base_urls=base_urls,
+                )
+            )
+        next_url = _next_link_url(link_header)
+
+    ordered_releases = tuple(
+        sorted(
+            releases,
+            key=lambda release: (
+                "" if release.published_at is None else release.published_at,
+                release.tag_name,
+                release.release_id,
+            ),
+        )
+    )
+    if normalized_since is not None:
+        since_cutoff = _parse_timestamp(normalized_since)
+        ordered_releases = tuple(
+            release
+            for release in ordered_releases
+            if release.published_at is not None
+            and _parse_timestamp(release.published_at) >= since_cutoff
+        )
+    if normalized_max_items is None:
+        return ordered_releases
+    return ordered_releases[:normalized_max_items]
+
+
 def _map_issue(
     payload: dict[str, object],
     *,
@@ -460,6 +565,59 @@ def _map_pull_request(
     )
 
 
+def _map_release(
+    payload: dict[str, object],
+    *,
+    repo: str,
+    owner: str,
+    repo_name: str,
+    base_urls: GitHubMetadataBaseUrls,
+) -> GitHubRelease:
+    release_id = payload.get("id")
+    if not isinstance(release_id, int) or isinstance(release_id, bool):
+        raise ValueError("Response error: invalid release id.")
+
+    tag_name = _require_string(payload, "tag_name")
+    created_at = _require_string(payload, "created_at")
+    published_at = _optional_string(payload, "published_at")
+    title = _optional_string(payload, "name") or ""
+    draft = _require_bool(payload, "draft")
+    prerelease = _require_bool(payload, "prerelease")
+    body_value = payload.get("body")
+    if body_value is None:
+        body = ""
+    elif isinstance(body_value, str):
+        body = body_value
+    else:
+        raise ValueError("Response error: invalid release body.")
+
+    user = payload.get("user")
+    author: str | None = None
+    if isinstance(user, dict):
+        login = user.get("login")
+        if isinstance(login, str) and login:
+            author = login
+
+    encoded_owner = parse.quote(owner, safe="")
+    encoded_repo = parse.quote(repo_name, safe="")
+    encoded_tag = parse.quote(tag_name, safe="")
+    source_url = f"{base_urls.web_root}/{encoded_owner}/{encoded_repo}/releases/tag/{encoded_tag}"
+    return GitHubRelease(
+        repo=repo,
+        host=base_urls.host,
+        release_id=release_id,
+        tag_name=tag_name,
+        title=title,
+        author=author,
+        created_at=created_at,
+        published_at=published_at,
+        source_url=source_url,
+        body=body,
+        draft=draft,
+        prerelease=prerelease,
+    )
+
+
 def issue_comments_api_url(
     *,
     api_root: str,
@@ -553,6 +711,22 @@ def _map_issue_comment(payload: dict[str, object]) -> GitHubIssueComment:
 def _require_string(payload: dict[str, object], key: str) -> str:
     value = payload.get(key)
     if not isinstance(value, str):
+        raise ValueError(f"Response error: missing or invalid {key}.")
+    return value
+
+
+def _optional_string(payload: dict[str, object], key: str) -> str | None:
+    value = payload.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError(f"Response error: missing or invalid {key}.")
+    return value
+
+
+def _require_bool(payload: dict[str, object], key: str) -> bool:
+    value = payload.get(key)
+    if not isinstance(value, bool):
         raise ValueError(f"Response error: missing or invalid {key}.")
     return value
 

--- a/src/knowledge_adapters/github_metadata/config.py
+++ b/src/knowledge_adapters/github_metadata/config.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-SUPPORTED_RESOURCE_TYPES = frozenset({"issue", "pull_request"})
+SUPPORTED_RESOURCE_TYPES = frozenset({"issue", "pull_request", "release"})
 
 
 @dataclass(frozen=True)

--- a/src/knowledge_adapters/github_metadata/normalize.py
+++ b/src/knowledge_adapters/github_metadata/normalize.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping
 
 EMPTY_BODY_MARKER = "(empty issue body)"
 EMPTY_PULL_REQUEST_BODY_MARKER = "(empty pull request body)"
+EMPTY_RELEASE_BODY_MARKER = "(empty release body)"
 EMPTY_COMMENT_BODY_MARKER = "(empty issue comment body)"
 
 
@@ -29,6 +30,60 @@ def normalize_pull_request_to_markdown(pull_request: Mapping[str, object]) -> st
         empty_body_marker=EMPTY_PULL_REQUEST_BODY_MARKER,
         include_comments=False,
     )
+
+
+def normalize_release_to_markdown(release: Mapping[str, object]) -> str:
+    """Normalize one release payload into deterministic markdown."""
+    release_id_value = release.get("release_id")
+    if not isinstance(release_id_value, int) or isinstance(release_id_value, bool):
+        raise ValueError("release_id must be an integer.")
+    tag_name_value = release.get("tag_name")
+    if not isinstance(tag_name_value, str):
+        raise ValueError("tag_name must be a string.")
+    title_value = release.get("title", "")
+    if not isinstance(title_value, str):
+        raise ValueError("title must be a string.")
+    draft_value = release.get("draft")
+    if not isinstance(draft_value, bool):
+        raise ValueError("draft must be a boolean.")
+    prerelease_value = release.get("prerelease")
+    if not isinstance(prerelease_value, bool):
+        raise ValueError("prerelease must be a boolean.")
+
+    author = release.get("author")
+    author_text = "" if author is None else str(author)
+    created_at = str(release.get("created_at", ""))
+    published_at = release.get("published_at")
+    published_at_text = "" if published_at is None else str(published_at)
+    source_url = str(release.get("source_url", ""))
+    repo = str(release.get("repo", ""))
+    body = str(release.get("body") or "").rstrip("\n")
+    body_text = body if body else EMPTY_RELEASE_BODY_MARKER
+    heading = (
+        f"# Release {tag_name_value}: {title_value}"
+        if title_value
+        else f"# Release {tag_name_value}"
+    )
+
+    return f"""{heading}
+
+## Metadata
+- repo: {repo}
+- resource_type: release
+- release_id: {release_id_value}
+- tag_name: {tag_name_value}
+- title: {title_value}
+- author: {author_text}
+- created_at: {created_at}
+- published_at: {published_at_text}
+- draft: {str(draft_value).lower()}
+- prerelease: {str(prerelease_value).lower()}
+- source_url: {source_url}
+
+## Body
+
+{body_text}
+"""
 
 
 def _normalize_record_to_markdown(

--- a/src/knowledge_adapters/github_metadata/writer.py
+++ b/src/knowledge_adapters/github_metadata/writer.py
@@ -7,28 +7,29 @@ from pathlib import Path
 _RESOURCE_DIRECTORIES = {
     "issue": "issues",
     "pull_request": "pull_requests",
+    "release": "releases",
 }
 
 
-def markdown_path(output_dir: str, resource_type: str, number: int) -> Path:
+def markdown_path(output_dir: str, resource_type: str, identifier: int | str) -> Path:
     """Return the deterministic markdown path for one GitHub metadata record."""
     try:
         directory = _RESOURCE_DIRECTORIES[resource_type]
     except KeyError as exc:
         raise ValueError(f"Unsupported github_metadata resource_type: {resource_type!r}.") from exc
-    return Path(output_dir) / directory / f"{number}.md"
+    return Path(output_dir) / directory / f"{identifier}.md"
 
 
 def write_markdown(
     output_dir: str,
     resource_type: str,
-    number: int,
+    identifier: int | str,
     markdown: str,
     *,
     dry_run: bool = False,
 ) -> Path:
     """Write normalized GitHub metadata markdown to a deterministic local path."""
-    output_path = markdown_path(output_dir, resource_type, number)
+    output_path = markdown_path(output_dir, resource_type, identifier)
 
     if dry_run:
         return output_path

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -47,7 +47,8 @@ def test_top_level_help_introduces_shared_cli_flow(tmp_path: Path) -> None:
         "Normalize selected UTF-8 text files from a Git repository into shared artifacts." in stdout
     )
     assert (
-        "Normalize GitHub issue or pull request metadata from one repository into shared artifacts."
+        "Normalize GitHub issue, pull request, or release metadata from one repository "
+        "into shared artifacts."
         in stdout
     )
     assert "Normalize one local UTF-8 text file into shared artifacts." in stdout
@@ -171,16 +172,19 @@ def test_github_metadata_cli_help_includes_resource_type_guidance(tmp_path: Path
     stdout = normalize_whitespace(result.stdout)
 
     assert result.returncode == 0, result.stderr
-    assert "Fetch issues or pull requests from one GitHub or GitHub Enterprise repository" in stdout
+    assert (
+        "Fetch issues, pull requests, or releases from one GitHub or GitHub Enterprise repository"
+        in stdout
+    )
     assert "Issue mode filters out pull requests returned by the issues endpoint." in stdout
-    assert "under issues/ or pull_requests/." in stdout
+    assert "under issues/, pull_requests/, or releases/." in stdout
     assert "Issue comments can be included optionally in issue mode." in stdout
-    assert "Pull request comments, releases, timelines, reactions, reviews, checks" in stdout
+    assert "Pull request comments, release assets, changelog generation, timelines" in stdout
     assert "--repo OWNER/NAME" in stdout
     assert "--base-url BASE_URL" in stdout
     assert "--token-env ENV_VAR" in stdout
     assert "--output-dir DIR" in stdout
-    assert "--resource-type {issue,pull_request}" in stdout
+    assert "--resource-type {issue,pull_request,release}" in stdout
     assert "--state {open,closed,all}" in stdout
     assert "--since SINCE" in stdout
     assert "--max-items N" in stdout

--- a/tests/test_github_metadata.py
+++ b/tests/test_github_metadata.py
@@ -16,12 +16,15 @@ from knowledge_adapters.github_metadata.client import (
     issue_list_api_url,
     list_repository_issues,
     list_repository_pull_requests,
+    list_repository_releases,
     pull_request_list_api_url,
+    release_list_api_url,
     resolve_base_urls,
 )
 from knowledge_adapters.github_metadata.normalize import (
     EMPTY_BODY_MARKER,
     EMPTY_PULL_REQUEST_BODY_MARKER,
+    EMPTY_RELEASE_BODY_MARKER,
 )
 from tests.cli_output_assertions import (
     assert_dry_run_summary,
@@ -126,6 +129,33 @@ def _issue_comment(
     return payload
 
 
+def _release(
+    release_id: int,
+    *,
+    tag_name: str | None = None,
+    title: str | None = None,
+    body: str | None = "Release body",
+    author: str | None = "alice",
+    created_at: str | None = None,
+    published_at: str | None = None,
+    draft: bool = False,
+    prerelease: bool = False,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "id": release_id,
+        "tag_name": tag_name or f"v{release_id}.0.0",
+        "name": title,
+        "created_at": created_at or f"2026-04-{release_id:02d}T00:00:00Z",
+        "published_at": published_at or f"2026-04-{release_id:02d}T01:00:00Z",
+        "body": body,
+        "draft": draft,
+        "prerelease": prerelease,
+    }
+    if author is not None:
+        payload["user"] = {"login": author}
+    return payload
+
+
 def _install_fake_urlopen(
     monkeypatch: MonkeyPatch,
     responses: Mapping[str, _FakeGitHubResponse],
@@ -158,6 +188,14 @@ def test_github_metadata_resolves_github_and_ghe_base_urls() -> None:
             state="open",
         )
         == "https://api.github.com/repos/octo/project/pulls?state=open&per_page=100"
+    )
+    assert (
+        release_list_api_url(
+            api_root=github_urls.api_root,
+            owner="octo",
+            repo_name="project",
+        )
+        == "https://api.github.com/repos/octo/project/releases?per_page=100"
     )
 
     ghe_web_urls = resolve_base_urls("https://github.example.com")
@@ -272,6 +310,71 @@ def test_github_metadata_pull_requests_paginate_filter_since_and_limit(
     assert [pull_request.canonical_id for pull_request in pull_requests] == [
         "github_metadata:github.com:octo/project:pull_request:2",
         "github_metadata:github.com:octo/project:pull_request:4",
+    ]
+
+
+def test_github_metadata_releases_paginate_filter_since_order_and_limit(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GH_TOKEN", "secret-token")
+    first_url = release_list_api_url(
+        api_root="https://api.github.com",
+        owner="octo",
+        repo_name="project",
+    )
+    second_url = "https://api.github.com/repos/octo/project/releases?per_page=100&page=2"
+    fake_urlopen = _install_fake_urlopen(
+        monkeypatch,
+        {
+            first_url: _FakeGitHubResponse(
+                [
+                    _release(
+                        9,
+                        tag_name="v2.0.0",
+                        title="Major release",
+                        published_at="2026-04-09T01:00:00Z",
+                    ),
+                    _release(
+                        4,
+                        tag_name="v1.0.0",
+                        title="Initial release",
+                        published_at="2026-04-04T01:00:00Z",
+                    ),
+                ],
+                headers={"Link": f'<{second_url}>; rel="next"'},
+            ),
+            second_url: _FakeGitHubResponse(
+                [
+                    _release(
+                        7,
+                        tag_name="v1.1.0",
+                        title="Feature release",
+                        published_at="2026-04-07T01:00:00Z",
+                    ),
+                    _release(
+                        6,
+                        tag_name="v0.9.0",
+                        title="Old prerelease",
+                        published_at="2025-12-31T23:59:59Z",
+                        prerelease=True,
+                    ),
+                ]
+            ),
+        },
+    )
+
+    releases = list_repository_releases(
+        repo="octo/project",
+        token_env="GH_TOKEN",
+        since="2026-01-01T00:00:00Z",
+        max_items=2,
+    )
+
+    assert fake_urlopen.calls == [first_url, second_url]
+    assert [release.tag_name for release in releases] == ["v1.0.0", "v1.1.0"]
+    assert [release.canonical_id for release in releases] == [
+        "github_metadata:github.com:octo/project:release:4",
+        "github_metadata:github.com:octo/project:release:7",
     ]
 
 
@@ -663,6 +766,149 @@ def test_github_metadata_cli_writes_pull_request_artifacts_and_manifest(
             "author": None,
             "content_hash": hashlib.sha256(pr_8_markdown.encode("utf-8")).hexdigest(),
             "output_path": "pull_requests/8.md",
+        },
+    ]
+
+
+def test_github_metadata_cli_writes_release_artifacts_and_manifest(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("GH_TOKEN", "secret-token")
+    first_url = release_list_api_url(
+        api_root="https://api.github.com",
+        owner="octo",
+        repo_name="project",
+    )
+    second_url = "https://api.github.com/repos/octo/project/releases?per_page=100&page=2"
+    fake_urlopen = _install_fake_urlopen(
+        monkeypatch,
+        {
+            first_url: _FakeGitHubResponse(
+                [
+                    _release(
+                        9,
+                        tag_name="v2.0.0",
+                        title="Major release",
+                        body="Release notes for v2.\n",
+                        published_at="2026-04-09T01:00:00Z",
+                    )
+                ],
+                headers={"Link": f'<{second_url}>; rel="next"'},
+            ),
+            second_url: _FakeGitHubResponse(
+                [
+                    _release(
+                        4,
+                        tag_name="v1.0.0",
+                        title="Initial release",
+                        body=None,
+                        author=None,
+                        published_at="2026-04-04T01:00:00Z",
+                    ),
+                    _release(
+                        7,
+                        tag_name="v1.1.0",
+                        title="Feature release",
+                        body="Release notes for v1.1.\n",
+                        published_at="2026-04-07T01:00:00Z",
+                        prerelease=True,
+                    ),
+                ]
+            ),
+        },
+    )
+    output_dir = tmp_path / "out"
+
+    exit_code = main(
+        [
+            "github_metadata",
+            "--repo",
+            "octo/project",
+            "--token-env",
+            "GH_TOKEN",
+            "--resource-type",
+            "release",
+            "--output-dir",
+            str(output_dir),
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "resource_type: release" in captured.out
+    assert "releases_planned: 3" in captured.out
+    assert "state:" not in captured.out
+    assert "Release notes for v2." not in captured.out
+    assert_write_summary(captured.out, wrote=3, skipped=0)
+    assert fake_urlopen.calls == [first_url, second_url]
+
+    release_4_path = output_dir / "releases" / "4.md"
+    release_7_path = output_dir / "releases" / "7.md"
+    release_9_path = output_dir / "releases" / "9.md"
+    assert release_4_path.exists()
+    assert release_7_path.exists()
+    assert release_9_path.exists()
+    release_4_markdown = release_4_path.read_text(encoding="utf-8")
+    release_7_markdown = release_7_path.read_text(encoding="utf-8")
+    release_9_markdown = release_9_path.read_text(encoding="utf-8")
+    assert "# Release v1.0.0: Initial release" in release_4_markdown
+    assert "- published_at: 2026-04-04T01:00:00Z" in release_4_markdown
+    assert "- prerelease: true" in release_7_markdown
+    assert "Release notes for v2." in release_9_markdown
+    assert EMPTY_RELEASE_BODY_MARKER in release_4_markdown
+
+    manifest_payload = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
+    assert isinstance(manifest_payload["generated_at"], str)
+    assert manifest_payload["files"] == [
+        {
+            "canonical_id": "github_metadata:github.com:octo/project:release:4",
+            "source_url": "https://github.com/octo/project/releases/tag/v1.0.0",
+            "title": "Initial release",
+            "repo": "octo/project",
+            "resource_type": "release",
+            "release_id": 4,
+            "tag_name": "v1.0.0",
+            "created_at": "2026-04-04T00:00:00Z",
+            "published_at": "2026-04-04T01:00:00Z",
+            "author": None,
+            "draft": False,
+            "prerelease": False,
+            "content_hash": hashlib.sha256(release_4_markdown.encode("utf-8")).hexdigest(),
+            "output_path": "releases/4.md",
+        },
+        {
+            "canonical_id": "github_metadata:github.com:octo/project:release:7",
+            "source_url": "https://github.com/octo/project/releases/tag/v1.1.0",
+            "title": "Feature release",
+            "repo": "octo/project",
+            "resource_type": "release",
+            "release_id": 7,
+            "tag_name": "v1.1.0",
+            "created_at": "2026-04-07T00:00:00Z",
+            "published_at": "2026-04-07T01:00:00Z",
+            "author": "alice",
+            "draft": False,
+            "prerelease": True,
+            "content_hash": hashlib.sha256(release_7_markdown.encode("utf-8")).hexdigest(),
+            "output_path": "releases/7.md",
+        },
+        {
+            "canonical_id": "github_metadata:github.com:octo/project:release:9",
+            "source_url": "https://github.com/octo/project/releases/tag/v2.0.0",
+            "title": "Major release",
+            "repo": "octo/project",
+            "resource_type": "release",
+            "release_id": 9,
+            "tag_name": "v2.0.0",
+            "created_at": "2026-04-09T00:00:00Z",
+            "published_at": "2026-04-09T01:00:00Z",
+            "author": "alice",
+            "draft": False,
+            "prerelease": False,
+            "content_hash": hashlib.sha256(release_9_markdown.encode("utf-8")).hexdigest(),
+            "output_path": "releases/9.md",
         },
     ]
 

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -187,11 +187,55 @@ runs:
     )
 
 
+def test_load_run_config_supports_github_metadata_release_resource_type(tmp_path: Path) -> None:
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: repo-releases
+    type: github_metadata
+    repo: octo/project
+    resource_type: release
+    token_env: GH_TOKEN
+    since: 2026-01-01T00:00:00Z
+    max_items: 10
+    output_dir: ./artifacts/github/repo-releases
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    run_config = load_run_config(config_path)
+
+    assert run_config.runs == (
+        ConfiguredRun(
+            name="repo-releases",
+            run_type="github_metadata",
+            argv=(
+                "github_metadata",
+                "--repo",
+                "octo/project",
+                "--token-env",
+                "GH_TOKEN",
+                "--output-dir",
+                str((tmp_path / "artifacts" / "github" / "repo-releases").resolve()),
+                "--resource-type",
+                "release",
+                "--since",
+                "2026-01-01T00:00:00Z",
+                "--max-items",
+                "10",
+            ),
+            dry_run=False,
+        ),
+    )
+
+
 @pytest.mark.parametrize(
     ("field_block", "expected_fragment"),
     [
         ("state: merged", "unsupported 'state' value"),
-        ("resource_type: release", "unsupported 'resource_type' value"),
+        ("resource_type: milestone", "unsupported 'resource_type' value"),
         ("max_items: 0", "'max_items' to a positive integer"),
     ],
 )


### PR DESCRIPTION
Summary
- add `release` as a selectable `github_metadata` resource type across CLI and run-config inputs
- fetch GitHub and GHE releases through the existing REST pagination pattern and normalize deterministic release artifacts
- cover release selection, pagination, ordering, rendering, and manifest output while preserving existing issue and pull request behavior

Testing
- `make check`

Closes #182