### PR TITLE
chore: ignore egg-info artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ runs.yaml
 # Python
 __pycache__/
 *.pyc
+*.egg-info/
 
 # Virtual environments
 .venv/


### PR DESCRIPTION
Summary
- ignore `*.egg-info/` artifacts in `.gitignore`
- prevent editable install metadata generated by editable installs from being tracked as local build output

Testing
- make check