### PR TITLE
feat: add stale-aware bundle handling

### DIFF
--- a/runs.example.yaml
+++ b/runs.example.yaml
@@ -45,3 +45,12 @@ runs:
     # client_key_file: ./certs/confluence-client.key
     # Optional TLS override for an internal CA.
     # ca_bundle: ./certs/internal-ca.pem
+
+  # Optional bundle example. stale_mode is only applied when input manifests
+  # include explicit stale-artifact metadata.
+  - name: eng-space-tree-bundle
+    type: bundle
+    inputs:
+      - ./artifacts/confluence/eng-space-tree
+    output: ./artifacts/bundles/eng-space-tree.md
+    stale_mode: flag

--- a/src/knowledge_adapters/bundle.py
+++ b/src/knowledge_adapters/bundle.py
@@ -14,6 +14,7 @@ from knowledge_adapters.manifest import manifest_path
 
 BundleOrder = Literal["canonical_id", "manifest", "input"]
 HeaderMode = Literal["minimal", "full"]
+StaleMode = Literal["include", "exclude", "flag"]
 
 DEFAULT_BUNDLE_ORDER: BundleOrder = "canonical_id"
 BUNDLE_ORDER_CHOICES: tuple[BundleOrder, ...] = ("canonical_id", "manifest", "input")
@@ -28,6 +29,13 @@ HEADER_MODE_CHOICES: tuple[HeaderMode, ...] = ("minimal", "full")
 HEADER_MODE_LABELS: dict[HeaderMode, str] = {
     "minimal": "title plus source URL",
     "full": "title, source URL, canonical_id, and optional manifest metadata",
+}
+DEFAULT_STALE_MODE: StaleMode = "include"
+STALE_MODE_CHOICES: tuple[StaleMode, ...] = ("include", "exclude", "flag")
+STALE_MODE_LABELS: dict[StaleMode, str] = {
+    "include": "include stale artifacts when explicit stale metadata is present",
+    "exclude": "exclude stale artifacts when explicit stale metadata is present",
+    "flag": "include and mark stale artifacts when explicit stale metadata is present",
 }
 BUNDLE_SECTION_SEPARATOR = "\n\n---\n\n"
 
@@ -45,6 +53,7 @@ class BundleArtifact:
     ref: str | None
     content_hash: str | None
     artifact_path: Path
+    is_stale: bool = False
 
 
 @dataclass(frozen=True)
@@ -57,6 +66,11 @@ class BundlePlan:
     filtered_out_count: int = 0
     unchanged_count: int = 0
     baseline_manifest: Path | None = None
+    stale_metadata_available: bool = False
+    stale_artifact_count: int = 0
+    stale_artifacts_excluded_count: int = 0
+    stale_artifacts_flagged_count: int = 0
+    stale_mode: StaleMode = DEFAULT_STALE_MODE
 
 
 @dataclass(frozen=True)
@@ -111,6 +125,29 @@ class _BaselineManifestEntry:
     artifact_path: Path
 
 
+@dataclass(frozen=True)
+class _LoadedBundleManifest:
+    """Bundle artifacts plus optional explicit stale metadata from one manifest."""
+
+    artifacts: tuple[BundleArtifact, ...]
+    stale_metadata_available: bool
+    stale_artifact_count: int
+
+
+@dataclass(frozen=True)
+class _ExplicitStaleEntry:
+    """One explicitly reported stale artifact from manifest metadata."""
+
+    canonical_id: str
+    output_path: str
+    source_url: str | None
+    title: str | None
+    fetched_at: str | None
+    path: str | None
+    ref: str | None
+    content_hash: str | None
+
+
 def describe_bundle_order(order: BundleOrder) -> str:
     """Return the human-readable description for one bundle ordering mode."""
     return BUNDLE_ORDER_LABELS[order]
@@ -121,6 +158,11 @@ def describe_header_mode(mode: HeaderMode) -> str:
     return HEADER_MODE_LABELS[mode]
 
 
+def describe_stale_mode(mode: StaleMode) -> str:
+    """Return the human-readable description for one stale handling mode."""
+    return STALE_MODE_LABELS[mode]
+
+
 def load_bundle_plan(
     inputs: Sequence[str | Path],
     *,
@@ -129,11 +171,17 @@ def load_bundle_plan(
     exclude_patterns: Sequence[str] = (),
     changed_only: bool = False,
     baseline_manifest: str | Path | None = None,
+    stale_mode: StaleMode = DEFAULT_STALE_MODE,
 ) -> BundlePlan:
     """Load artifacts from output directories or manifest files."""
     if order not in BUNDLE_ORDER_CHOICES:
         raise ValueError(
             f"Unsupported bundle order {order!r}. Choose one of: {', '.join(BUNDLE_ORDER_CHOICES)}."
+        )
+    if stale_mode not in STALE_MODE_CHOICES:
+        raise ValueError(
+            f"Unsupported stale mode {stale_mode!r}. "
+            f"Choose one of: {', '.join(STALE_MODE_CHOICES)}."
         )
     if changed_only and baseline_manifest is None:
         raise ValueError("Bundle --changed-only requires --baseline-manifest.")
@@ -144,12 +192,19 @@ def load_bundle_plan(
     artifacts_by_id: dict[str, BundleArtifact] = {}
     artifact_positions: dict[str, _BundleArtifactPosition] = {}
     duplicate_canonical_ids: list[str] = []
+    stale_metadata_available = False
+    stale_artifact_count = 0
 
     for input_index, raw_input in enumerate(inputs):
         manifest = _resolve_manifest_input(raw_input)
         manifests.append(manifest)
         manifest_index = len(manifests) - 1
-        for manifest_entry_index, artifact in enumerate(_load_bundle_artifacts(manifest)):
+        loaded_manifest = _load_bundle_artifacts(manifest)
+        stale_metadata_available = (
+            stale_metadata_available or loaded_manifest.stale_metadata_available
+        )
+        stale_artifact_count += loaded_manifest.stale_artifact_count
+        for manifest_entry_index, artifact in enumerate(loaded_manifest.artifacts):
             if artifact.canonical_id in artifacts_by_id:
                 duplicate_canonical_ids.append(artifact.canonical_id)
                 continue
@@ -181,6 +236,16 @@ def load_bundle_plan(
         include_patterns=include_patterns,
         exclude_patterns=exclude_patterns,
     )
+    selected_artifacts, stale_artifacts_excluded_count = _handle_stale_bundle_artifacts(
+        selected_artifacts,
+        stale_metadata_available=stale_metadata_available,
+        stale_mode=stale_mode,
+    )
+    stale_artifacts_flagged_count = (
+        sum(1 for artifact in selected_artifacts if artifact.is_stale)
+        if stale_metadata_available and stale_mode == "flag"
+        else 0
+    )
 
     return BundlePlan(
         manifests=tuple(manifests),
@@ -189,6 +254,11 @@ def load_bundle_plan(
         filtered_out_count=filtered_out_count,
         unchanged_count=unchanged_count,
         baseline_manifest=baseline_manifest_path,
+        stale_metadata_available=stale_metadata_available,
+        stale_artifact_count=stale_artifact_count,
+        stale_artifacts_excluded_count=stale_artifacts_excluded_count,
+        stale_artifacts_flagged_count=stale_artifacts_flagged_count,
+        stale_mode=stale_mode,
     )
 
 
@@ -196,10 +266,11 @@ def render_bundle_markdown(
     artifacts: Sequence[BundleArtifact],
     *,
     header_mode: HeaderMode = DEFAULT_HEADER_MODE,
+    stale_mode: StaleMode = DEFAULT_STALE_MODE,
 ) -> str:
     """Render bundle output with stable separators and metadata lines."""
     return _render_bundle_sections_markdown(
-        render_bundle_sections(artifacts, header_mode=header_mode)
+        render_bundle_sections(artifacts, header_mode=header_mode, stale_mode=stale_mode)
     )
 
 
@@ -207,12 +278,18 @@ def render_bundle_sections(
     artifacts: Sequence[BundleArtifact],
     *,
     header_mode: HeaderMode = DEFAULT_HEADER_MODE,
+    stale_mode: StaleMode = DEFAULT_STALE_MODE,
 ) -> tuple[BundleSection, ...]:
     """Render bundle output as stable artifact-level sections."""
     if header_mode not in HEADER_MODE_CHOICES:
         raise ValueError(
             f"Unsupported bundle header mode {header_mode!r}. "
             f"Choose one of: {', '.join(HEADER_MODE_CHOICES)}."
+        )
+    if stale_mode not in STALE_MODE_CHOICES:
+        raise ValueError(
+            f"Unsupported stale mode {stale_mode!r}. "
+            f"Choose one of: {', '.join(STALE_MODE_CHOICES)}."
         )
 
     sections: list[BundleSection] = []
@@ -225,6 +302,7 @@ def render_bundle_sections(
                     artifact,
                     content=content,
                     header_mode=header_mode,
+                    flag_stale=stale_mode == "flag",
                 ),
             )
         )
@@ -306,7 +384,7 @@ def _resolve_manifest_input(raw_input: str | Path) -> Path:
     return resolved_path
 
 
-def _load_bundle_artifacts(manifest: Path) -> tuple[BundleArtifact, ...]:
+def _load_bundle_artifacts(manifest: Path) -> _LoadedBundleManifest:
     try:
         payload = json.loads(manifest.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
@@ -316,6 +394,10 @@ def _load_bundle_artifacts(manifest: Path) -> tuple[BundleArtifact, ...]:
     if not isinstance(files, list):
         raise ValueError(f"Bundle manifest {manifest} is invalid: expected a files list.")
 
+    stale_entries = _load_explicit_stale_entries(payload, manifest=manifest)
+    stale_entry_keys = frozenset(
+        (entry.canonical_id, entry.output_path) for entry in stale_entries
+    )
     artifacts: list[BundleArtifact] = []
     manifest_ids: set[str] = set()
     manifest_output_paths: set[str] = set()
@@ -333,6 +415,7 @@ def _load_bundle_artifacts(manifest: Path) -> tuple[BundleArtifact, ...]:
         path = _optional_manifest_string(entry, "path", manifest=manifest)
         ref = _optional_manifest_string(entry, "ref", manifest=manifest)
         content_hash = _optional_manifest_string(entry, "content_hash", manifest=manifest)
+        entry_stale = _optional_manifest_bool(entry, "stale", manifest=manifest)
         if not isinstance(canonical_id, str) or not isinstance(source_url, str):
             raise ValueError(
                 f"Bundle manifest {manifest} is invalid: files entries must include "
@@ -358,6 +441,10 @@ def _load_bundle_artifacts(manifest: Path) -> tuple[BundleArtifact, ...]:
 
         manifest_ids.add(canonical_id)
         manifest_output_paths.add(output_path)
+        is_stale = (
+            entry_stale is True
+            or (canonical_id, output_path) in stale_entry_keys
+        )
         artifacts.append(
             BundleArtifact(
                 canonical_id=canonical_id,
@@ -369,10 +456,47 @@ def _load_bundle_artifacts(manifest: Path) -> tuple[BundleArtifact, ...]:
                 ref=ref,
                 content_hash=content_hash,
                 artifact_path=(manifest.parent / output_path).resolve(),
+                is_stale=is_stale,
             )
         )
 
-    return tuple(artifacts)
+    for stale_entry in stale_entries:
+        canonical_id = stale_entry.canonical_id
+        output_path = stale_entry.output_path
+        if canonical_id in manifest_ids or output_path in manifest_output_paths:
+            continue
+
+        if stale_entry.source_url is None:
+            continue
+
+        manifest_ids.add(canonical_id)
+        manifest_output_paths.add(output_path)
+        artifacts.append(
+            BundleArtifact(
+                canonical_id=canonical_id,
+                source_url=stale_entry.source_url,
+                title=stale_entry.title,
+                output_path=output_path,
+                fetched_at=stale_entry.fetched_at,
+                path=stale_entry.path,
+                ref=stale_entry.ref,
+                content_hash=stale_entry.content_hash,
+                artifact_path=(manifest.parent / output_path).resolve(),
+                is_stale=True,
+            )
+        )
+
+    per_entry_stale_count = sum(
+        1
+        for artifact in artifacts
+        if artifact.is_stale
+        and (artifact.canonical_id, artifact.output_path) not in stale_entry_keys
+    )
+    return _LoadedBundleManifest(
+        artifacts=tuple(artifacts),
+        stale_metadata_available=bool(stale_entries) or per_entry_stale_count > 0,
+        stale_artifact_count=len(stale_entry_keys) + per_entry_stale_count,
+    )
 
 
 def _load_baseline_manifest_entries(manifest: Path) -> dict[str, _BaselineManifestEntry]:
@@ -472,12 +596,15 @@ def _render_bundle_header_lines(
     artifact: BundleArtifact,
     *,
     header_mode: HeaderMode,
+    flag_stale: bool,
 ) -> tuple[str, ...]:
     title = artifact.title or artifact.canonical_id
     lines = [
         f"## {title}",
         f"source_url: {artifact.source_url}",
     ]
+    if flag_stale and artifact.is_stale:
+        lines.append("stale: true")
     if header_mode == "minimal":
         return tuple(lines)
     if header_mode == "full":
@@ -502,10 +629,15 @@ def _render_bundle_section_markdown(
     *,
     content: str,
     header_mode: HeaderMode,
+    flag_stale: bool,
 ) -> str:
     return "\n".join(
         (
-            *_render_bundle_header_lines(artifact, header_mode=header_mode),
+            *_render_bundle_header_lines(
+                artifact,
+                header_mode=header_mode,
+                flag_stale=flag_stale,
+            ),
             "",
             content.rstrip("\n"),
         )
@@ -624,6 +756,26 @@ def _filter_bundle_artifacts(
     return tuple(selected_artifacts), filtered_out_count
 
 
+def _handle_stale_bundle_artifacts(
+    artifacts: Sequence[BundleArtifact],
+    *,
+    stale_metadata_available: bool,
+    stale_mode: StaleMode,
+) -> tuple[tuple[BundleArtifact, ...], int]:
+    if not stale_metadata_available or stale_mode != "exclude":
+        return tuple(artifacts), 0
+
+    selected_artifacts: list[BundleArtifact] = []
+    excluded_count = 0
+    for artifact in artifacts:
+        if artifact.is_stale:
+            excluded_count += 1
+            continue
+        selected_artifacts.append(artifact)
+
+    return tuple(selected_artifacts), excluded_count
+
+
 def _artifact_matches_patterns(
     artifact: BundleArtifact,
     patterns: Sequence[str],
@@ -639,6 +791,71 @@ def _artifact_matches_patterns(
         for pattern in patterns
         for value in artifact_values
     )
+
+
+def _load_explicit_stale_entries(
+    payload: object,
+    *,
+    manifest: Path,
+) -> tuple[_ExplicitStaleEntry, ...]:
+    if not isinstance(payload, dict) or "stale_artifacts" not in payload:
+        return ()
+
+    stale_artifacts = payload.get("stale_artifacts")
+    if not isinstance(stale_artifacts, list):
+        raise ValueError(
+            f"Bundle manifest {manifest} is invalid: stale_artifacts must be a list."
+        )
+
+    entries: list[_ExplicitStaleEntry] = []
+    seen_keys: set[tuple[str, str]] = set()
+    for entry in stale_artifacts:
+        if not isinstance(entry, dict):
+            raise ValueError(
+                f"Bundle manifest {manifest} is invalid: stale_artifacts entries "
+                "must be objects."
+            )
+        canonical_id = entry.get("canonical_id")
+        output_path = entry.get("output_path")
+        if not isinstance(canonical_id, str) or not isinstance(output_path, str):
+            raise ValueError(
+                f"Bundle manifest {manifest} is invalid: stale_artifacts entries must "
+                "include string canonical_id and output_path values."
+            )
+        key = (canonical_id, output_path)
+        if key in seen_keys:
+            continue
+        seen_keys.add(key)
+        entries.append(
+            _ExplicitStaleEntry(
+                canonical_id=canonical_id,
+                output_path=output_path,
+                source_url=_optional_manifest_string(entry, "source_url", manifest=manifest),
+                title=_optional_manifest_string(entry, "title", manifest=manifest),
+                fetched_at=_optional_manifest_string(entry, "fetched_at", manifest=manifest),
+                path=_optional_manifest_string(entry, "path", manifest=manifest),
+                ref=_optional_manifest_string(entry, "ref", manifest=manifest),
+                content_hash=_optional_manifest_string(entry, "content_hash", manifest=manifest),
+            )
+        )
+
+    return tuple(entries)
+
+
+def _optional_manifest_bool(
+    entry: dict[str, object],
+    field_name: str,
+    *,
+    manifest: Path,
+) -> bool | None:
+    value = entry.get(field_name)
+    if value is None:
+        return None
+    if not isinstance(value, bool):
+        raise ValueError(
+            f"Bundle manifest {manifest} is invalid: {field_name} values must be booleans."
+        )
+    return value
 
 
 def _optional_manifest_string(

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -17,9 +17,13 @@ from knowledge_adapters.bundle import (
     BUNDLE_ORDER_CHOICES,
     DEFAULT_BUNDLE_ORDER,
     DEFAULT_HEADER_MODE,
+    DEFAULT_STALE_MODE,
     HEADER_MODE_CHOICES,
+    STALE_MODE_CHOICES,
+    StaleMode,
     describe_bundle_order,
     describe_header_mode,
+    describe_stale_mode,
 )
 from knowledge_adapters.confluence.auth import SUPPORTED_AUTH_METHODS, resolve_tls_inputs
 
@@ -142,11 +146,15 @@ BUNDLE_HELP_EXAMPLES = """Examples:
   knowledge-adapters bundle ./artifacts --header-mode minimal --output ./bundle.md
   knowledge-adapters bundle ./artifacts --include "team-*" --exclude "*draft*" --output ./bundle.md
   knowledge-adapters bundle ./artifacts --max-bytes 250000 --output ./bundle.md
+  knowledge-adapters bundle ./artifacts --stale-mode flag --output ./bundle.md
   knowledge-adapters bundle ./artifacts --changed-only \\
     --baseline-manifest ./prior/manifest.json --output ./bundle.md
 """
 
 _WRITE_SUMMARY_RE = re.compile(r"Summary: wrote (?P<wrote>\d+), skipped (?P<skipped>\d+)")
+_BUNDLE_SUMMARY_RE = re.compile(
+    r"Summary: bundled (?P<bundled>\d+)(?:, .*?skipped (?P<skipped>\d+) duplicates)?"
+)
 _DRY_RUN_SUMMARY_RE = re.compile(
     r"Summary: would write (?P<wrote>\d+), would skip (?P<skipped>\d+)"
 )
@@ -684,6 +692,8 @@ def build_parser() -> argparse.ArgumentParser:
             "artifacts start included. Exclude filters apply after include matching and "
             "win on conflicts. With --changed-only, a baseline manifest is used to keep "
             "only artifacts with new canonical_id values or changed content_hash values. "
+            "With --stale-mode, explicit stale metadata in bundle manifests can include, "
+            "exclude, or flag stale artifacts without inferring stale state from disk. "
             "With --max-bytes, bundle output is split into deterministic numbered "
             "markdown files and sections are kept intact when possible."
         ),
@@ -766,6 +776,17 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "Prior manifest.json to compare by canonical_id and content_hash when "
             "--changed-only is set."
+        ),
+    )
+    bundle_parser.add_argument(
+        "--stale-mode",
+        choices=STALE_MODE_CHOICES,
+        default=DEFAULT_STALE_MODE,
+        help=(
+            "How to handle artifacts marked by explicit stale metadata: include keeps "
+            "the default bundle behavior; exclude skips stale artifacts; flag includes "
+            "stale artifacts with a visible stale marker. Ignored when no stale "
+            "metadata is available."
         ),
     )
 
@@ -899,6 +920,14 @@ def _parse_multi_run_summary(output: str) -> MultiRunSummary:
             dry_run=True,
             wrote=int(match.group("wrote")),
             skipped=int(match.group("skipped")),
+        )
+
+    if match := _BUNDLE_SUMMARY_RE.search(output):
+        skipped = match.group("skipped")
+        return MultiRunSummary(
+            dry_run=False,
+            wrote=int(match.group("bundled")),
+            skipped=int(skipped) if skipped is not None else 0,
         )
 
     dry_run_write_match = _DRY_RUN_BLOCK_WRITE_RE.search(output)
@@ -2194,18 +2223,24 @@ def main(argv: Sequence[str] | None = None) -> int:
                 exclude_patterns=args.exclude,
                 changed_only=args.changed_only,
                 baseline_manifest=args.baseline_manifest,
+                stale_mode=args.stale_mode,
             )
             split_bundle_plan: SplitBundlePlan | None = None
             bundle_markdown: str | None = None
+            effective_stale_mode: StaleMode = (
+                args.stale_mode if bundle_plan.stale_metadata_available else "include"
+            )
             if args.max_bytes is None:
                 bundle_markdown = render_bundle_markdown(
                     bundle_plan.artifacts,
                     header_mode=args.header_mode,
+                    stale_mode=effective_stale_mode,
                 )
             else:
                 sections = render_bundle_sections(
                     bundle_plan.artifacts,
                     header_mode=args.header_mode,
+                    stale_mode=effective_stale_mode,
                 )
                 split_bundle_plan = plan_split_bundle(
                     args.output,
@@ -2230,6 +2265,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             print("  changed_only: true")
             if bundle_plan.baseline_manifest is not None:
                 print(f"  baseline_manifest: {render_user_path(bundle_plan.baseline_manifest)}")
+        if bundle_plan.stale_metadata_available:
+            print(f"  stale_mode: {describe_stale_mode(args.stale_mode)}")
 
         print("\nPlan: Bundle run")
         for manifest in bundle_plan.manifests:
@@ -2246,6 +2283,17 @@ def main(argv: Sequence[str] | None = None) -> int:
                 print(f"  exclude: {pattern}")
         if args.include or args.exclude:
             print(f"  artifacts_filtered_out: {bundle_plan.filtered_out_count}")
+        if bundle_plan.stale_metadata_available:
+            print(f"  stale_artifacts: {bundle_plan.stale_artifact_count}")
+            if args.stale_mode == "exclude":
+                print(f"  stale_artifacts_excluded: {bundle_plan.stale_artifacts_excluded_count}")
+            elif args.stale_mode == "flag":
+                print(f"  stale_artifacts_flagged: {bundle_plan.stale_artifacts_flagged_count}")
+            else:
+                stale_included_count = sum(
+                    1 for artifact in bundle_plan.artifacts if artifact.is_stale
+                )
+                print(f"  stale_artifacts_included: {stale_included_count}")
         if split_bundle_plan is not None:
             print(f"  output_files: {len(split_bundle_plan.output_files)}")
             if split_bundle_plan.oversized_sections:

--- a/src/knowledge_adapters/run_config.py
+++ b/src/knowledge_adapters/run_config.py
@@ -9,6 +9,14 @@ from pathlib import Path
 
 import yaml  # type: ignore[import-untyped]
 
+from knowledge_adapters.bundle import (
+    BUNDLE_ORDER_CHOICES,
+    DEFAULT_BUNDLE_ORDER,
+    DEFAULT_HEADER_MODE,
+    DEFAULT_STALE_MODE,
+    HEADER_MODE_CHOICES,
+    STALE_MODE_CHOICES,
+)
 from knowledge_adapters.confluence.auth import CONFLUENCE_CA_BUNDLE_ENV, SUPPORTED_AUTH_METHODS
 from knowledge_adapters.confluence.config import validate_explicit_tls_paths
 from knowledge_adapters.confluence.resolve import (
@@ -19,12 +27,14 @@ from knowledge_adapters.confluence.resolve import (
 )
 from knowledge_adapters.github_metadata.config import SUPPORTED_RESOURCE_TYPES
 
-SUPPORTED_RUN_TYPES = frozenset({"confluence", "git_repo", "github_metadata", "local_files"})
+SUPPORTED_RUN_TYPES = frozenset(
+    {"bundle", "confluence", "git_repo", "github_metadata", "local_files"}
+)
 _SUPPORTED_CONFLUENCE_CLIENT_MODES = frozenset({"real", "stub"})
 _SUPPORTED_GITHUB_METADATA_STATES = frozenset({"open", "closed", "all"})
 _SUPPORTED_GITHUB_METADATA_RESOURCE_TYPES = SUPPORTED_RESOURCE_TYPES
 
-_COMMON_REQUIRED_KEYS = frozenset({"name", "type", "output_dir"})
+_COMMON_REQUIRED_KEYS = frozenset({"name", "type"})
 _CONFLUENCE_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
     {
         "auth_method",
@@ -37,15 +47,33 @@ _CONFLUENCE_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
         "dry_run",
         "enabled",
         "max_depth",
+        "output_dir",
         "space_key",
         "space_url",
         "target",
         "tree",
     }
 )
-_LOCAL_FILES_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset({"dry_run", "enabled", "file_path"})
+_BUNDLE_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
+    {
+        "baseline_manifest",
+        "changed_only",
+        "enabled",
+        "exclude",
+        "header_mode",
+        "include",
+        "inputs",
+        "max_bytes",
+        "order",
+        "output",
+        "stale_mode",
+    }
+)
+_LOCAL_FILES_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
+    {"dry_run", "enabled", "file_path", "output_dir"}
+)
 _GIT_REPO_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
-    {"dry_run", "enabled", "exclude", "include", "ref", "repo_url", "subdir"}
+    {"dry_run", "enabled", "exclude", "include", "output_dir", "ref", "repo_url", "subdir"}
 )
 _GITHUB_METADATA_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
     {
@@ -54,6 +82,7 @@ _GITHUB_METADATA_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
         "enabled",
         "include_issue_comments",
         "max_items",
+        "output_dir",
         "repo",
         "resource_type",
         "since",
@@ -201,6 +230,23 @@ def _parse_run(
             run_type=run_type,
             argv=argv,
             dry_run=dry_run,
+            enabled=enabled,
+        )
+
+    if run_type == "bundle":
+        argv = _build_bundle_argv(run_config, name=name, config_path=config_path)
+        enabled = _optional_bool(
+            run_config,
+            "enabled",
+            index=index,
+            config_path=config_path,
+            default=True,
+        )
+        return ConfiguredRun(
+            name=name,
+            run_type=run_type,
+            argv=argv,
+            dry_run=False,
             enabled=enabled,
         )
 
@@ -431,6 +477,121 @@ def _build_confluence_argv(
                 "greater than or equal to 0."
             )
         argv.extend(["--max-depth", str(max_depth)])
+
+    return tuple(argv)
+
+
+def _build_bundle_argv(
+    run_config: dict[str, object],
+    *,
+    name: str,
+    config_path: Path,
+) -> tuple[str, ...]:
+    _reject_unknown_keys(
+        run_config,
+        allowed_keys=_BUNDLE_ALLOWED_KEYS,
+        name=name,
+        config_path=config_path,
+    )
+    index = _run_index(name=name, config_path=config_path)
+    inputs = tuple(
+        _resolve_path_string(input_path, config_path=config_path)
+        for input_path in _required_string_sequence(
+            run_config,
+            "inputs",
+            index=index,
+            config_path=config_path,
+        )
+    )
+    output = _resolve_path_string(
+        _require_string(run_config, "output", index=index, config_path=config_path),
+        config_path=config_path,
+    )
+    argv: list[str] = [
+        "bundle",
+        *inputs,
+        "--output",
+        output,
+    ]
+
+    max_bytes = run_config.get("max_bytes")
+    if max_bytes is not None:
+        if isinstance(max_bytes, bool) or not isinstance(max_bytes, int) or max_bytes < 1:
+            raise ValueError(
+                f"Run {name!r} in {config_path} must set 'max_bytes' to a positive integer."
+            )
+        argv.extend(["--max-bytes", str(max_bytes)])
+
+    order = _optional_string(run_config, "order", index=index, config_path=config_path)
+    if order is not None:
+        if order not in BUNDLE_ORDER_CHOICES:
+            supported_values = " or ".join(repr(value) for value in BUNDLE_ORDER_CHOICES)
+            raise ValueError(
+                f"Run {name!r} in {config_path} has unsupported 'order' value "
+                f"{order!r}. Use {supported_values}."
+            )
+        if order != DEFAULT_BUNDLE_ORDER:
+            argv.extend(["--order", order])
+
+    header_mode = _optional_string(run_config, "header_mode", index=index, config_path=config_path)
+    if header_mode is not None:
+        if header_mode not in HEADER_MODE_CHOICES:
+            supported_values = " or ".join(repr(value) for value in HEADER_MODE_CHOICES)
+            raise ValueError(
+                f"Run {name!r} in {config_path} has unsupported 'header_mode' value "
+                f"{header_mode!r}. Use {supported_values}."
+            )
+        if header_mode != DEFAULT_HEADER_MODE:
+            argv.extend(["--header-mode", header_mode])
+
+    stale_mode = _optional_string(run_config, "stale_mode", index=index, config_path=config_path)
+    if stale_mode is not None:
+        if stale_mode not in STALE_MODE_CHOICES:
+            supported_values = " or ".join(repr(value) for value in STALE_MODE_CHOICES)
+            raise ValueError(
+                f"Run {name!r} in {config_path} has unsupported 'stale_mode' value "
+                f"{stale_mode!r}. Use {supported_values}."
+            )
+        if stale_mode != DEFAULT_STALE_MODE:
+            argv.extend(["--stale-mode", stale_mode])
+
+    for include_pattern in _optional_string_sequence(
+        run_config,
+        "include",
+        index=index,
+        config_path=config_path,
+    ):
+        argv.extend(["--include", include_pattern])
+    for exclude_pattern in _optional_string_sequence(
+        run_config,
+        "exclude",
+        index=index,
+        config_path=config_path,
+    ):
+        argv.extend(["--exclude", exclude_pattern])
+
+    changed_only = _optional_bool(
+        run_config,
+        "changed_only",
+        index=index,
+        config_path=config_path,
+        default=False,
+    )
+    baseline_manifest = _optional_string(
+        run_config,
+        "baseline_manifest",
+        index=index,
+        config_path=config_path,
+    )
+    if changed_only:
+        argv.append("--changed-only")
+    if baseline_manifest is not None:
+        argv.extend(
+            [
+                "--baseline-manifest",
+                _resolve_path_string(baseline_manifest, config_path=config_path),
+            ]
+        )
 
     return tuple(argv)
 
@@ -731,6 +892,27 @@ def _optional_string_sequence(
             )
         normalized_values.append(item.strip())
     return tuple(normalized_values)
+
+
+def _required_string_sequence(
+    run_config: dict[str, object],
+    key: str,
+    *,
+    index: int | str,
+    config_path: Path,
+) -> tuple[str, ...]:
+    if key not in run_config:
+        raise ValueError(
+            f"Run {index!r} in {config_path} must define {key!r} as a non-empty string "
+            "or list of non-empty strings."
+        )
+
+    return _optional_string_sequence(
+        run_config,
+        key,
+        index=index,
+        config_path=config_path,
+    )
 
 
 def _optional_bool(

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -4,12 +4,16 @@ import json
 from pathlib import Path
 
 import pytest
+from pytest import CaptureFixture
 
 from knowledge_adapters.bundle import (
     DEFAULT_BUNDLE_ORDER,
     DEFAULT_HEADER_MODE,
+    DEFAULT_STALE_MODE,
     ORDERING_RULE,
+    StaleMode,
     describe_bundle_order,
+    describe_stale_mode,
     load_bundle_plan,
     plan_split_bundle,
     render_bundle_markdown,
@@ -17,6 +21,7 @@ from knowledge_adapters.bundle import (
     write_bundle,
     write_split_bundle,
 )
+from knowledge_adapters.cli import main
 
 
 def _write_output_dir(
@@ -24,6 +29,7 @@ def _write_output_dir(
     *,
     files: list[dict[str, object]],
     artifact_contents: dict[str, str],
+    stale_artifacts: list[dict[str, object]] | None = None,
 ) -> Path:
     (output_dir / "pages").mkdir(parents=True, exist_ok=True)
     for relative_path, content in artifact_contents.items():
@@ -32,17 +38,13 @@ def _write_output_dir(
         artifact_path.write_text(content, encoding="utf-8")
 
     manifest = output_dir / "manifest.json"
-    manifest.write_text(
-        json.dumps(
-            {
-                "generated_at": "2026-04-24T00:00:00Z",
-                "files": files,
-            },
-            indent=2,
-        )
-        + "\n",
-        encoding="utf-8",
-    )
+    payload: dict[str, object] = {
+        "generated_at": "2026-04-24T00:00:00Z",
+        "files": files,
+    }
+    if stale_artifacts is not None:
+        payload["stale_artifacts"] = stale_artifacts
+    manifest.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
     return manifest
 
 
@@ -351,6 +353,193 @@ def test_load_bundle_plan_changed_only_treats_missing_baseline_file_as_changed(
 
     assert [artifact.canonical_id for artifact in plan.artifacts] == ["alpha"]
     assert plan.unchanged_count == 0
+
+
+def test_bundle_stale_mode_is_ignored_without_explicit_stale_metadata(tmp_path: Path) -> None:
+    output_dir = tmp_path / "artifacts"
+    _write_output_dir(
+        output_dir,
+        files=[
+            {
+                "canonical_id": "alpha",
+                "source_url": "https://example.com/alpha",
+                "output_path": "pages/alpha.md",
+                "title": "Alpha",
+            }
+        ],
+        artifact_contents={
+            "pages/alpha.md": "# Alpha\n\nAlpha content.\n",
+        },
+    )
+
+    default_plan = load_bundle_plan((output_dir,))
+    flagged_plan = load_bundle_plan((output_dir,), stale_mode="flag")
+
+    assert DEFAULT_STALE_MODE == "include"
+    assert default_plan.stale_metadata_available is False
+    assert flagged_plan.stale_metadata_available is False
+    assert default_plan.stale_artifact_count == 0
+    assert [artifact.canonical_id for artifact in flagged_plan.artifacts] == ["alpha"]
+    assert render_bundle_markdown(flagged_plan.artifacts, stale_mode="flag") == (
+        render_bundle_markdown(default_plan.artifacts)
+    )
+
+
+@pytest.mark.parametrize(
+    ("stale_mode", "expected_ids", "expected_excluded", "expected_flagged"),
+    [
+        ("include", ["alpha", "legacy"], 0, 0),
+        ("exclude", ["alpha"], 1, 0),
+        ("flag", ["alpha", "legacy"], 0, 1),
+    ],
+)
+def test_load_bundle_plan_handles_explicit_stale_metadata_by_mode(
+    tmp_path: Path,
+    stale_mode: StaleMode,
+    expected_ids: list[str],
+    expected_excluded: int,
+    expected_flagged: int,
+) -> None:
+    output_dir = tmp_path / "artifacts"
+    _write_output_dir(
+        output_dir,
+        files=[
+            {
+                "canonical_id": "alpha",
+                "source_url": "https://example.com/alpha",
+                "output_path": "pages/alpha.md",
+                "title": "Alpha",
+            }
+        ],
+        stale_artifacts=[
+            {
+                "canonical_id": "legacy",
+                "source_url": "https://example.com/legacy",
+                "output_path": "pages/legacy.md",
+                "title": "Legacy",
+            }
+        ],
+        artifact_contents={
+            "pages/alpha.md": "# Alpha\n\nAlpha content.\n",
+            "pages/legacy.md": "# Legacy\n\nLegacy content.\n",
+        },
+    )
+
+    first_plan = load_bundle_plan((output_dir,), stale_mode=stale_mode)
+    second_plan = load_bundle_plan((output_dir,), stale_mode=stale_mode)
+
+    assert first_plan.stale_metadata_available is True
+    assert first_plan.stale_artifact_count == 1
+    assert first_plan.stale_artifacts_excluded_count == expected_excluded
+    assert first_plan.stale_artifacts_flagged_count == expected_flagged
+    assert [artifact.canonical_id for artifact in first_plan.artifacts] == expected_ids
+    assert [artifact.canonical_id for artifact in second_plan.artifacts] == expected_ids
+    assert render_bundle_markdown(
+        first_plan.artifacts,
+        stale_mode=stale_mode,
+    ) == render_bundle_markdown(
+        second_plan.artifacts,
+        stale_mode=stale_mode,
+    )
+
+
+def test_render_bundle_markdown_flags_stale_artifacts_when_requested(tmp_path: Path) -> None:
+    output_dir = tmp_path / "artifacts"
+    _write_output_dir(
+        output_dir,
+        files=[
+            {
+                "canonical_id": "alpha",
+                "source_url": "https://example.com/alpha",
+                "output_path": "pages/alpha.md",
+                "title": "Alpha",
+            },
+            {
+                "canonical_id": "legacy",
+                "source_url": "https://example.com/legacy",
+                "output_path": "pages/legacy.md",
+                "title": "Legacy",
+                "stale": True,
+            },
+        ],
+        artifact_contents={
+            "pages/alpha.md": "# Alpha\n\nAlpha content.\n",
+            "pages/legacy.md": "# Legacy\n\nLegacy content.\n",
+        },
+    )
+
+    plan = load_bundle_plan((output_dir,), stale_mode="flag")
+
+    assert render_bundle_markdown(plan.artifacts, stale_mode="flag") == (
+        """## Alpha
+source_url: https://example.com/alpha
+canonical_id: alpha
+
+# Alpha
+
+Alpha content.
+
+---
+
+## Legacy
+source_url: https://example.com/legacy
+stale: true
+canonical_id: legacy
+
+# Legacy
+
+Legacy content.
+"""
+    )
+
+
+def test_bundle_cli_reports_stale_handling_when_metadata_is_available(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    output_dir = tmp_path / "artifacts"
+    bundle_path = tmp_path / "bundle.md"
+    _write_output_dir(
+        output_dir,
+        files=[
+            {
+                "canonical_id": "alpha",
+                "source_url": "https://example.com/alpha",
+                "output_path": "pages/alpha.md",
+                "title": "Alpha",
+            },
+            {
+                "canonical_id": "legacy",
+                "source_url": "https://example.com/legacy",
+                "output_path": "pages/legacy.md",
+                "title": "Legacy",
+                "stale": True,
+            },
+        ],
+        artifact_contents={
+            "pages/alpha.md": "# Alpha\n",
+            "pages/legacy.md": "# Legacy\n",
+        },
+    )
+
+    exit_code = main(
+        [
+            "bundle",
+            str(output_dir),
+            "--output",
+            str(bundle_path),
+            "--stale-mode",
+            "exclude",
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert describe_stale_mode("exclude") in captured.out
+    assert "stale_artifacts: 1" in captured.out
+    assert "stale_artifacts_excluded: 1" in captured.out
+    assert "Summary: bundled 1, skipped 0 duplicates" in captured.out
+    assert "Legacy" not in bundle_path.read_text(encoding="utf-8")
 
 
 def test_load_bundle_plan_changed_only_requires_baseline_manifest(tmp_path: Path) -> None:

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -80,6 +80,48 @@ runs:
     )
 
 
+def test_load_run_config_supports_bundle_stale_mode(tmp_path: Path) -> None:
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: stale-review-bundle
+    type: bundle
+    inputs:
+      - ./artifacts/confluence/docs-tree
+    output: ./bundles/docs-tree.md
+    stale_mode: flag
+    header_mode: minimal
+    include:
+      - "pages/*"
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    run_config = load_run_config(config_path)
+
+    assert run_config.runs == (
+        ConfiguredRun(
+            name="stale-review-bundle",
+            run_type="bundle",
+            argv=(
+                "bundle",
+                str((tmp_path / "artifacts" / "confluence" / "docs-tree").resolve()),
+                "--output",
+                str((tmp_path / "bundles" / "docs-tree.md").resolve()),
+                "--header-mode",
+                "minimal",
+                "--stale-mode",
+                "flag",
+                "--include",
+                "pages/*",
+            ),
+            dry_run=False,
+        ),
+    )
+
+
 def test_load_run_config_supports_git_repo_filters_and_ref(tmp_path: Path) -> None:
     repo_dir = tmp_path / "repo"
     repo_dir.mkdir()


### PR DESCRIPTION
Summary
- add opt-in bundle stale modes: include, exclude, and flag
- consume only explicit stale metadata from manifests (`stale_artifacts` or per-entry `stale: true`) and avoid filesystem-based stale inference
- report stale artifact counts and handling in bundle plans
- support bundle entries in runs.yaml, including optional stale_mode configuration
- document a bundle stale_mode example in runs.example.yaml

Default behavior
- unchanged: stale-mode defaults to include, and stale handling is ignored when no explicit stale metadata is available

Testing
- make check

Closes #156