### PR TITLE
docs: clarify AGENTS.md precedence over codex-workflow guidance

### DIFF
--- a/docs/codex-workflow.md
+++ b/docs/codex-workflow.md
@@ -28,7 +28,8 @@ Use extra care before asking Codex to drive:
 ## Repo-Specific Working Agreement
 
 `AGENTS.md` is the canonical source for task completion requirements in this
-repo. In practice, that means:
+repo. If there is any overlap or inconsistency, `AGENTS.md` takes precedence.
+In practice, that means:
 
 1. start from `main` and work on a new branch
 2. keep the branch scoped to one PR-sized change


### PR DESCRIPTION
Summary
- add a single-sentence clarification in `docs/codex-workflow.md` that `AGENTS.md` takes precedence when guidance overlaps or conflicts
- keep the change intentionally minimal to prevent drift between guidance and execution rules

Testing
- make check