### PR TITLE
feat: add named runs.yaml bundle definitions

### DIFF
--- a/runs.example.yaml
+++ b/runs.example.yaml
@@ -54,3 +54,13 @@ runs:
       - ./artifacts/confluence/eng-space-tree
     output: ./artifacts/bundles/eng-space-tree.md
     stale_mode: flag
+
+# Optional named bundle definitions resolve inputs from existing run names.
+# These bundle definitions do not execute the referenced runs automatically.
+bundles:
+  - name: review-pack
+    runs:
+      - team-notes
+      - eng-space-tree
+    output: ./artifacts/bundles/review-pack.md
+    header_mode: minimal

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -143,6 +143,7 @@ BUNDLE_HELP_EXAMPLES = """Examples:
   knowledge-adapters bundle ./artifacts/confluence --output ./bundle.md
   knowledge-adapters bundle ./artifacts/a ./artifacts/b --output ./bundle.md
   knowledge-adapters bundle ./artifacts/manifest.json --output ./bundle.md
+  knowledge-adapters bundle --config ./runs.yaml --bundle review-pack
   knowledge-adapters bundle ./artifacts --header-mode minimal --output ./bundle.md
   knowledge-adapters bundle ./artifacts --include "team-*" --exclude "*draft*" --output ./bundle.md
   knowledge-adapters bundle ./artifacts --max-bytes 250000 --output ./bundle.md
@@ -681,36 +682,54 @@ def build_parser() -> argparse.ArgumentParser:
         "bundle",
         help="Combine existing artifacts into one prompt-ready markdown file.",
         description=(
-            "Combine existing artifacts into one prompt-ready markdown file. Accept one "
-            "or more output directories or manifest files as input. Bundle output keeps "
-            "the original artifacts unchanged, removes duplicate canonical_id entries by "
-            "keeping the first artifact discovered from the provided inputs, and orders "
-            "the final sections using the selected deterministic ordering mode. Header "
-            "modes control how much manifest metadata appears above each document. Optional "
-            "glob-style include and exclude filters match canonical_id, title, "
-            "output_path, and source_url. If no --include filters are provided, all "
-            "artifacts start included. Exclude filters apply after include matching and "
-            "win on conflicts. With --changed-only, a baseline manifest is used to keep "
-            "only artifacts with new canonical_id values or changed content_hash values. "
-            "With --stale-mode, explicit stale metadata in bundle manifests can include, "
-            "exclude, or flag stale artifacts without inferring stale state from disk. "
-            "With --max-bytes, bundle output is split into deterministic numbered "
-            "markdown files and sections are kept intact when possible."
+            "Combine existing artifacts into one prompt-ready markdown file. Use either "
+            "direct input paths or a named bundle from runs.yaml. Direct input mode "
+            "accepts one or more output directories or manifest files as input. Bundle "
+            "output keeps the original artifacts unchanged, removes duplicate "
+            "canonical_id entries by keeping the first artifact discovered from the "
+            "provided inputs, and orders the final sections using the selected "
+            "deterministic ordering mode. Header modes control how much manifest "
+            "metadata appears above each document. Optional glob-style include and "
+            "exclude filters match canonical_id, title, output_path, and source_url. "
+            "If no --include filters are provided, all artifacts start included. "
+            "Exclude filters apply after include matching and win on conflicts. With "
+            "--changed-only, a baseline manifest is used to keep only artifacts with "
+            "new canonical_id values or changed content_hash values. With --stale-mode, "
+            "explicit stale metadata in bundle manifests can include, exclude, or flag "
+            "stale artifacts without inferring stale state from disk. With --max-bytes, "
+            "bundle output is split into deterministic numbered markdown files and "
+            "sections are kept intact when possible."
         ),
         epilog=BUNDLE_HELP_EXAMPLES,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     bundle_parser.add_argument(
         "inputs",
-        nargs="+",
+        nargs="*",
         metavar="INPUT",
-        help="One or more adapter output directories or manifest files to bundle.",
+        help=(
+            "One or more adapter output directories or manifest files to bundle. "
+            "Omit when using --config and --bundle."
+        ),
+    )
+    bundle_parser.add_argument(
+        "--config",
+        metavar="RUNS_YAML",
+        help="Load a named bundle definition from runs.yaml. Requires --bundle.",
+    )
+    bundle_parser.add_argument(
+        "--bundle",
+        dest="bundle_name",
+        metavar="NAME",
+        help="Named bundle entry to render from --config. Requires --config.",
     )
     bundle_parser.add_argument(
         "--output",
-        required=True,
         metavar="FILE",
-        help="Markdown file to write with the bundled artifact content.",
+        help=(
+            "Markdown file to write with the bundled artifact content. Required for "
+            "direct input mode; named bundles use their configured output."
+        ),
     )
     bundle_parser.add_argument(
         "--max-bytes",
@@ -2203,8 +2222,65 @@ def main(argv: Sequence[str] | None = None) -> int:
             write_bundle,
             write_split_bundle,
         )
+        from knowledge_adapters.run_config import load_run_config, select_bundle
 
-        output_path_input = Path(args.output).expanduser()
+        named_bundle_mode = args.config is not None or args.bundle_name is not None
+        if named_bundle_mode:
+            if args.config is None or args.bundle_name is None:
+                exit_with_cli_error(
+                    "Named bundle mode requires both --config and --bundle.",
+                    command="bundle",
+                )
+            if args.inputs:
+                exit_with_cli_error(
+                    "Named bundle mode does not accept direct INPUT paths.",
+                    command="bundle",
+                )
+            if args.output is not None:
+                exit_with_cli_error(
+                    "Named bundle mode uses the bundle output from runs.yaml and does not "
+                    "accept --output.",
+                    command="bundle",
+                )
+            try:
+                run_config = load_run_config(args.config)
+                configured_bundle = select_bundle(run_config, name=args.bundle_name)
+            except ValueError as exc:
+                exit_with_cli_error(str(exc), command="bundle")
+            bundle_inputs = configured_bundle.inputs
+            bundle_output = configured_bundle.output
+            bundle_max_bytes = configured_bundle.max_bytes
+            bundle_order = configured_bundle.order
+            bundle_header_mode = configured_bundle.header_mode
+            bundle_include = configured_bundle.include_patterns
+            bundle_exclude = configured_bundle.exclude_patterns
+            bundle_changed_only = configured_bundle.changed_only
+            bundle_baseline_manifest = configured_bundle.baseline_manifest
+            bundle_stale_mode = configured_bundle.stale_mode
+        else:
+            if not args.inputs:
+                exit_with_cli_error(
+                    "Direct bundle mode requires one or more INPUT paths or use --config "
+                    "and --bundle for a named bundle.",
+                    command="bundle",
+                )
+            if args.output is None:
+                exit_with_cli_error(
+                    "Direct bundle mode requires --output.",
+                    command="bundle",
+                )
+            bundle_inputs = tuple(args.inputs)
+            bundle_output = args.output
+            bundle_max_bytes = args.max_bytes
+            bundle_order = args.order
+            bundle_header_mode = args.header_mode
+            bundle_include = tuple(args.include)
+            bundle_exclude = tuple(args.exclude)
+            bundle_changed_only = args.changed_only
+            bundle_baseline_manifest = args.baseline_manifest
+            bundle_stale_mode = args.stale_mode
+
+        output_path_input = Path(bundle_output).expanduser()
         output_path = output_path_input.resolve()
         if output_path_input.exists() and output_path_input.is_dir():
             exit_with_cli_error(
@@ -2217,77 +2293,80 @@ def main(argv: Sequence[str] | None = None) -> int:
 
         try:
             bundle_plan = load_bundle_plan(
-                args.inputs,
-                order=args.order,
-                include_patterns=args.include,
-                exclude_patterns=args.exclude,
-                changed_only=args.changed_only,
-                baseline_manifest=args.baseline_manifest,
-                stale_mode=args.stale_mode,
+                bundle_inputs,
+                order=bundle_order,
+                include_patterns=bundle_include,
+                exclude_patterns=bundle_exclude,
+                changed_only=bundle_changed_only,
+                baseline_manifest=bundle_baseline_manifest,
+                stale_mode=bundle_stale_mode,
             )
             split_bundle_plan: SplitBundlePlan | None = None
             bundle_markdown: str | None = None
             effective_stale_mode: StaleMode = (
-                args.stale_mode if bundle_plan.stale_metadata_available else "include"
+                bundle_stale_mode if bundle_plan.stale_metadata_available else "include"
             )
-            if args.max_bytes is None:
+            if bundle_max_bytes is None:
                 bundle_markdown = render_bundle_markdown(
                     bundle_plan.artifacts,
-                    header_mode=args.header_mode,
+                    header_mode=bundle_header_mode,
                     stale_mode=effective_stale_mode,
                 )
             else:
                 sections = render_bundle_sections(
                     bundle_plan.artifacts,
-                    header_mode=args.header_mode,
+                    header_mode=bundle_header_mode,
                     stale_mode=effective_stale_mode,
                 )
                 split_bundle_plan = plan_split_bundle(
-                    args.output,
+                    bundle_output,
                     sections,
-                    max_bytes=args.max_bytes,
+                    max_bytes=bundle_max_bytes,
                 )
         except ValueError as exc:
             exit_with_cli_error(str(exc), command="bundle")
 
         print("Bundle command invoked")
-        print(f"  inputs: {len(args.inputs)}")
-        print(f"  output: {render_user_path(args.output)}")
-        if args.max_bytes is not None:
-            print(f"  max_bytes: {args.max_bytes}")
-        print(f"  ordering: {describe_bundle_order(args.order)}")
-        print(f"  header_mode: {describe_header_mode(args.header_mode)}")
-        if args.include:
-            print(f"  include_filters: {len(args.include)}")
-        if args.exclude:
-            print(f"  exclude_filters: {len(args.exclude)}")
-        if args.changed_only:
+        if named_bundle_mode:
+            print(f"  config_path: {render_user_path(run_config.config_path)}")
+            print(f"  bundle: {configured_bundle.name}")
+        print(f"  inputs: {len(bundle_inputs)}")
+        print(f"  output: {render_user_path(bundle_output)}")
+        if bundle_max_bytes is not None:
+            print(f"  max_bytes: {bundle_max_bytes}")
+        print(f"  ordering: {describe_bundle_order(bundle_order)}")
+        print(f"  header_mode: {describe_header_mode(bundle_header_mode)}")
+        if bundle_include:
+            print(f"  include_filters: {len(bundle_include)}")
+        if bundle_exclude:
+            print(f"  exclude_filters: {len(bundle_exclude)}")
+        if bundle_changed_only:
             print("  changed_only: true")
             if bundle_plan.baseline_manifest is not None:
                 print(f"  baseline_manifest: {render_user_path(bundle_plan.baseline_manifest)}")
         if bundle_plan.stale_metadata_available:
-            print(f"  stale_mode: {describe_stale_mode(args.stale_mode)}")
+            print(f"  stale_mode: {describe_stale_mode(bundle_stale_mode)}")
 
         print("\nPlan: Bundle run")
         for manifest in bundle_plan.manifests:
             print(f"  manifest: {render_user_path(manifest)}")
         print(f"  artifacts_selected: {len(bundle_plan.artifacts)}")
         print(f"  duplicates_skipped: {len(bundle_plan.duplicate_canonical_ids)}")
-        if args.changed_only:
+        if bundle_changed_only:
             print(f"  unchanged_skipped: {bundle_plan.unchanged_count}")
-        if args.include:
-            for pattern in args.include:
+        if bundle_include:
+            for pattern in bundle_include:
                 print(f"  include: {pattern}")
-        if args.exclude:
-            for pattern in args.exclude:
+        if bundle_exclude:
+            for pattern in bundle_exclude:
                 print(f"  exclude: {pattern}")
-        if args.include or args.exclude:
+        if bundle_include or bundle_exclude:
             print(f"  artifacts_filtered_out: {bundle_plan.filtered_out_count}")
         if bundle_plan.stale_metadata_available:
             print(f"  stale_artifacts: {bundle_plan.stale_artifact_count}")
-            if args.stale_mode == "exclude":
+            if bundle_stale_mode == "exclude":
                 print(f"  stale_artifacts_excluded: {bundle_plan.stale_artifacts_excluded_count}")
-            elif args.stale_mode == "flag":
+            elif bundle_stale_mode == "flag":
                 print(f"  stale_artifacts_flagged: {bundle_plan.stale_artifacts_flagged_count}")
             else:
                 stale_included_count = sum(
@@ -2302,20 +2381,20 @@ def main(argv: Sequence[str] | None = None) -> int:
                     print(
                         "  oversized: "
                         f"{oversized_section.canonical_id} "
-                        f"({oversized_section.byte_count} bytes > {args.max_bytes} max)"
+                        f"({oversized_section.byte_count} bytes > {bundle_max_bytes} max)"
                     )
         print("  action: write")
 
         try:
             if split_bundle_plan is None:
                 assert bundle_markdown is not None
-                written_bundle = write_bundle(args.output, bundle_markdown)
+                written_bundle = write_bundle(bundle_output, bundle_markdown)
                 written_split_bundle = None
             else:
                 written_split_bundle = write_split_bundle(split_bundle_plan)
                 written_bundle = None
         except OSError as exc:
-            exit_with_bundle_output_error(args.output, exc=exc)
+            exit_with_bundle_output_error(bundle_output, exc=exc)
 
         if written_split_bundle is None:
             assert written_bundle is not None
@@ -2328,14 +2407,14 @@ def main(argv: Sequence[str] | None = None) -> int:
                     f"{render_user_path(output_file.path)} "
                     f"({output_file.artifact_count} artifacts, {output_file.byte_count} bytes)"
                 )
-        if args.changed_only:
+        if bundle_changed_only:
             print(
                 "\nSummary: bundled "
                 f"{len(bundle_plan.artifacts)}, skipped "
                 f"{bundle_plan.unchanged_count} unchanged, skipped "
                 f"{len(bundle_plan.duplicate_canonical_ids)} duplicates"
             )
-        elif args.include or args.exclude:
+        elif bundle_include or bundle_exclude:
             print(
                 "\nSummary: bundled "
                 f"{len(bundle_plan.artifacts)}, filtered out "

--- a/src/knowledge_adapters/run_config.py
+++ b/src/knowledge_adapters/run_config.py
@@ -16,6 +16,9 @@ from knowledge_adapters.bundle import (
     DEFAULT_STALE_MODE,
     HEADER_MODE_CHOICES,
     STALE_MODE_CHOICES,
+    BundleOrder,
+    HeaderMode,
+    StaleMode,
 )
 from knowledge_adapters.confluence.auth import CONFLUENCE_CA_BUNDLE_ENV, SUPPORTED_AUTH_METHODS
 from knowledge_adapters.confluence.config import validate_explicit_tls_paths
@@ -35,6 +38,19 @@ _SUPPORTED_GITHUB_METADATA_STATES = frozenset({"open", "closed", "all"})
 _SUPPORTED_GITHUB_METADATA_RESOURCE_TYPES = SUPPORTED_RESOURCE_TYPES
 
 _COMMON_REQUIRED_KEYS = frozenset({"name", "type"})
+_BUNDLE_OPTION_KEYS = frozenset(
+    {
+        "baseline_manifest",
+        "changed_only",
+        "exclude",
+        "header_mode",
+        "include",
+        "max_bytes",
+        "order",
+        "output",
+        "stale_mode",
+    }
+)
 _CONFLUENCE_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
     {
         "auth_method",
@@ -54,21 +70,10 @@ _CONFLUENCE_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
         "tree",
     }
 )
-_BUNDLE_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
-    {
-        "baseline_manifest",
-        "changed_only",
-        "enabled",
-        "exclude",
-        "header_mode",
-        "include",
-        "inputs",
-        "max_bytes",
-        "order",
-        "output",
-        "stale_mode",
-    }
+_BUNDLE_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | _BUNDLE_OPTION_KEYS | frozenset(
+    {"enabled", "inputs"}
 )
+_NAMED_BUNDLE_ALLOWED_KEYS = _BUNDLE_OPTION_KEYS | frozenset({"name", "runs"})
 _LOCAL_FILES_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
     {"dry_run", "enabled", "file_path", "output_dir"}
 )
@@ -104,11 +109,29 @@ class ConfiguredRun:
 
 
 @dataclass(frozen=True)
+class ConfiguredBundle:
+    """One named bundle definition described in a config file."""
+
+    name: str
+    inputs: tuple[str, ...]
+    output: str
+    max_bytes: int | None = None
+    order: BundleOrder = DEFAULT_BUNDLE_ORDER
+    header_mode: HeaderMode = DEFAULT_HEADER_MODE
+    include_patterns: tuple[str, ...] = ()
+    exclude_patterns: tuple[str, ...] = ()
+    changed_only: bool = False
+    baseline_manifest: str | None = None
+    stale_mode: StaleMode = DEFAULT_STALE_MODE
+
+
+@dataclass(frozen=True)
 class RunConfig:
     """Validated multi-run config."""
 
     config_path: Path
     runs: tuple[ConfiguredRun, ...]
+    bundles: tuple[ConfiguredBundle, ...] = ()
 
 
 def load_run_config(
@@ -142,17 +165,44 @@ def load_run_config(
             f"Config file {resolved_config_path} must define a non-empty top-level 'runs:' list."
         )
 
-    return RunConfig(
-        config_path=resolved_config_path,
-        runs=tuple(
-            _parse_run(
-                run_config,
+    configured_runs = tuple(
+        _parse_run(
+            run_config,
+            index=index,
+            config_path=resolved_config_path,
+            no_confluence_ca_bundle=no_confluence_ca_bundle,
+        )
+        for index, run_config in enumerate(runs, start=1)
+    )
+
+    configured_bundles: tuple[ConfiguredBundle, ...] = ()
+    if "bundles" in raw_config:
+        raw_bundles = raw_config.get("bundles")
+        if not isinstance(raw_bundles, list) or not raw_bundles:
+            raise ValueError(
+                f"Config file {resolved_config_path} must define top-level 'bundles:' "
+                "as a non-empty list when provided."
+            )
+
+        configured_runs_by_name = _configured_runs_by_name(
+            configured_runs,
+            config_path=resolved_config_path,
+        )
+        configured_bundles = tuple(
+            _parse_named_bundle(
+                bundle_config,
                 index=index,
                 config_path=resolved_config_path,
-                no_confluence_ca_bundle=no_confluence_ca_bundle,
+                configured_runs_by_name=configured_runs_by_name,
             )
-            for index, run_config in enumerate(runs, start=1)
-        ),
+            for index, bundle_config in enumerate(raw_bundles, start=1)
+        )
+        _reject_duplicate_bundle_names(configured_bundles, config_path=resolved_config_path)
+
+    return RunConfig(
+        config_path=resolved_config_path,
+        runs=configured_runs,
+        bundles=configured_bundles,
     )
 
 
@@ -180,6 +230,25 @@ def select_runs(
         configured_run
         for configured_run in run_config.runs
         if configured_run.name in selected_names
+    )
+
+
+def select_bundle(run_config: RunConfig, *, name: str) -> ConfiguredBundle:
+    """Select one named bundle definition by name."""
+    if not run_config.bundles:
+        raise ValueError(
+            f"Config file {run_config.config_path} does not define any top-level named "
+            "bundles. Add a 'bundles:' list or use direct bundle inputs."
+        )
+
+    for configured_bundle in run_config.bundles:
+        if configured_bundle.name == name:
+            return configured_bundle
+
+    available = ", ".join(repr(configured_bundle.name) for configured_bundle in run_config.bundles)
+    raise ValueError(
+        f"Unknown bundle name {name!r} in {run_config.config_path}. "
+        f"Available bundle names: {available}."
     )
 
 
@@ -503,16 +572,73 @@ def _build_bundle_argv(
             config_path=config_path,
         )
     )
+    configured_bundle = _parse_configured_bundle(
+        run_config,
+        name=name,
+        config_path=config_path,
+        inputs=inputs,
+    )
+    return _configured_bundle_to_argv(configured_bundle)
+
+
+def _parse_named_bundle(
+    bundle_config: object,
+    *,
+    index: int,
+    config_path: Path,
+    configured_runs_by_name: dict[str, ConfiguredRun],
+) -> ConfiguredBundle:
+    if not isinstance(bundle_config, dict):
+        raise ValueError(
+            f"Bundle #{index} in {config_path} must be a mapping with name, runs, and output."
+        )
+
+    name = bundle_config.get("name")
+    if not isinstance(name, str) or not name.strip():
+        raise ValueError(
+            f"Bundle #{index} in {config_path} must define a non-empty string for 'name'."
+        )
+    normalized_name = name.strip()
+    _reject_unknown_keys(
+        bundle_config,
+        allowed_keys=_NAMED_BUNDLE_ALLOWED_KEYS,
+        name=normalized_name,
+        config_path=config_path,
+    )
+    run_names = _named_bundle_run_names(
+        bundle_config,
+        name=normalized_name,
+        config_path=config_path,
+    )
+    inputs = tuple(
+        _resolve_named_bundle_input(
+            configured_runs_by_name.get(run_name),
+            run_name=run_name,
+            bundle_name=normalized_name,
+            config_path=config_path,
+        )
+        for run_name in run_names
+    )
+    return _parse_configured_bundle(
+        bundle_config,
+        name=normalized_name,
+        config_path=config_path,
+        inputs=inputs,
+    )
+
+
+def _parse_configured_bundle(
+    run_config: dict[str, object],
+    *,
+    name: str,
+    config_path: Path,
+    inputs: tuple[str, ...],
+) -> ConfiguredBundle:
+    index = _run_index(name=name, config_path=config_path)
     output = _resolve_path_string(
         _require_string(run_config, "output", index=index, config_path=config_path),
         config_path=config_path,
     )
-    argv: list[str] = [
-        "bundle",
-        *inputs,
-        "--output",
-        output,
-    ]
 
     max_bytes = run_config.get("max_bytes")
     if max_bytes is not None:
@@ -520,9 +646,9 @@ def _build_bundle_argv(
             raise ValueError(
                 f"Run {name!r} in {config_path} must set 'max_bytes' to a positive integer."
             )
-        argv.extend(["--max-bytes", str(max_bytes)])
 
     order = _optional_string(run_config, "order", index=index, config_path=config_path)
+    resolved_order: BundleOrder = DEFAULT_BUNDLE_ORDER
     if order is not None:
         if order not in BUNDLE_ORDER_CHOICES:
             supported_values = " or ".join(repr(value) for value in BUNDLE_ORDER_CHOICES)
@@ -530,10 +656,10 @@ def _build_bundle_argv(
                 f"Run {name!r} in {config_path} has unsupported 'order' value "
                 f"{order!r}. Use {supported_values}."
             )
-        if order != DEFAULT_BUNDLE_ORDER:
-            argv.extend(["--order", order])
+        resolved_order = order
 
     header_mode = _optional_string(run_config, "header_mode", index=index, config_path=config_path)
+    resolved_header_mode: HeaderMode = DEFAULT_HEADER_MODE
     if header_mode is not None:
         if header_mode not in HEADER_MODE_CHOICES:
             supported_values = " or ".join(repr(value) for value in HEADER_MODE_CHOICES)
@@ -541,10 +667,10 @@ def _build_bundle_argv(
                 f"Run {name!r} in {config_path} has unsupported 'header_mode' value "
                 f"{header_mode!r}. Use {supported_values}."
             )
-        if header_mode != DEFAULT_HEADER_MODE:
-            argv.extend(["--header-mode", header_mode])
+        resolved_header_mode = header_mode
 
     stale_mode = _optional_string(run_config, "stale_mode", index=index, config_path=config_path)
+    resolved_stale_mode: StaleMode = DEFAULT_STALE_MODE
     if stale_mode is not None:
         if stale_mode not in STALE_MODE_CHOICES:
             supported_values = " or ".join(repr(value) for value in STALE_MODE_CHOICES)
@@ -552,24 +678,20 @@ def _build_bundle_argv(
                 f"Run {name!r} in {config_path} has unsupported 'stale_mode' value "
                 f"{stale_mode!r}. Use {supported_values}."
             )
-        if stale_mode != DEFAULT_STALE_MODE:
-            argv.extend(["--stale-mode", stale_mode])
+        resolved_stale_mode = stale_mode
 
-    for include_pattern in _optional_string_sequence(
+    include_patterns = _optional_string_sequence(
         run_config,
         "include",
         index=index,
         config_path=config_path,
-    ):
-        argv.extend(["--include", include_pattern])
-    for exclude_pattern in _optional_string_sequence(
+    )
+    exclude_patterns = _optional_string_sequence(
         run_config,
         "exclude",
         index=index,
         config_path=config_path,
-    ):
-        argv.extend(["--exclude", exclude_pattern])
-
+    )
     changed_only = _optional_bool(
         run_config,
         "changed_only",
@@ -583,17 +705,158 @@ def _build_bundle_argv(
         index=index,
         config_path=config_path,
     )
-    if changed_only:
+    resolved_baseline_manifest = (
+        _resolve_path_string(baseline_manifest, config_path=config_path)
+        if baseline_manifest is not None
+        else None
+    )
+
+    return ConfiguredBundle(
+        name=name,
+        inputs=inputs,
+        output=output,
+        max_bytes=max_bytes,
+        order=resolved_order,
+        header_mode=resolved_header_mode,
+        include_patterns=include_patterns,
+        exclude_patterns=exclude_patterns,
+        changed_only=changed_only,
+        baseline_manifest=resolved_baseline_manifest,
+        stale_mode=resolved_stale_mode,
+    )
+
+
+def _configured_bundle_to_argv(configured_bundle: ConfiguredBundle) -> tuple[str, ...]:
+    argv: list[str] = [
+        "bundle",
+        *configured_bundle.inputs,
+        "--output",
+        configured_bundle.output,
+    ]
+    if configured_bundle.max_bytes is not None:
+        argv.extend(["--max-bytes", str(configured_bundle.max_bytes)])
+    if configured_bundle.order != DEFAULT_BUNDLE_ORDER:
+        argv.extend(["--order", configured_bundle.order])
+    if configured_bundle.header_mode != DEFAULT_HEADER_MODE:
+        argv.extend(["--header-mode", configured_bundle.header_mode])
+    if configured_bundle.stale_mode != DEFAULT_STALE_MODE:
+        argv.extend(["--stale-mode", configured_bundle.stale_mode])
+    for include_pattern in configured_bundle.include_patterns:
+        argv.extend(["--include", include_pattern])
+    for exclude_pattern in configured_bundle.exclude_patterns:
+        argv.extend(["--exclude", exclude_pattern])
+    if configured_bundle.changed_only:
         argv.append("--changed-only")
-    if baseline_manifest is not None:
-        argv.extend(
-            [
-                "--baseline-manifest",
-                _resolve_path_string(baseline_manifest, config_path=config_path),
-            ]
+    if configured_bundle.baseline_manifest is not None:
+        argv.extend(["--baseline-manifest", configured_bundle.baseline_manifest])
+    return tuple(argv)
+
+
+def _configured_runs_by_name(
+    configured_runs: tuple[ConfiguredRun, ...],
+    *,
+    config_path: Path,
+) -> dict[str, ConfiguredRun]:
+    runs_by_name: dict[str, ConfiguredRun] = {}
+    duplicate_names: list[str] = []
+    for configured_run in configured_runs:
+        if configured_run.name in runs_by_name:
+            if configured_run.name not in duplicate_names:
+                duplicate_names.append(configured_run.name)
+            continue
+        runs_by_name[configured_run.name] = configured_run
+    if duplicate_names:
+        duplicates = ", ".join(repr(name) for name in duplicate_names)
+        raise ValueError(
+            f"Config file {config_path} must use unique run names when defining top-level "
+            f"bundles. Duplicate run names: {duplicates}."
+        )
+    return runs_by_name
+
+
+def _reject_duplicate_bundle_names(
+    configured_bundles: tuple[ConfiguredBundle, ...],
+    *,
+    config_path: Path,
+) -> None:
+    seen_names: set[str] = set()
+    duplicate_names: list[str] = []
+    for configured_bundle in configured_bundles:
+        if configured_bundle.name in seen_names:
+            if configured_bundle.name not in duplicate_names:
+                duplicate_names.append(configured_bundle.name)
+            continue
+        seen_names.add(configured_bundle.name)
+    if duplicate_names:
+        duplicates = ", ".join(repr(name) for name in duplicate_names)
+        raise ValueError(
+            f"Config file {config_path} contains duplicate bundle names: {duplicates}."
         )
 
-    return tuple(argv)
+
+def _named_bundle_run_names(
+    bundle_config: dict[str, object],
+    *,
+    name: str,
+    config_path: Path,
+) -> tuple[str, ...]:
+    raw_run_names = bundle_config.get("runs")
+    if raw_run_names is None:
+        raise ValueError(
+            f"Bundle {name!r} in {config_path} must define 'runs' as a non-empty string "
+            "or list of non-empty strings."
+        )
+    if isinstance(raw_run_names, str):
+        normalized_name = raw_run_names.strip()
+        if not normalized_name:
+            raise ValueError(
+                f"Bundle {name!r} in {config_path} must define 'runs' as a non-empty string "
+                "or list of non-empty strings."
+            )
+        return (normalized_name,)
+    if not isinstance(raw_run_names, list) or not raw_run_names:
+        raise ValueError(
+            f"Bundle {name!r} in {config_path} must define 'runs' as a non-empty string "
+            "or list of non-empty strings."
+        )
+
+    normalized_names: list[str] = []
+    for run_name in raw_run_names:
+        if not isinstance(run_name, str) or not run_name.strip():
+            raise ValueError(
+                f"Bundle {name!r} in {config_path} must define 'runs' as a non-empty string "
+                "or list of non-empty strings."
+            )
+        normalized_names.append(run_name.strip())
+    return tuple(normalized_names)
+
+
+def _resolve_named_bundle_input(
+    configured_run: ConfiguredRun | None,
+    *,
+    run_name: str,
+    bundle_name: str,
+    config_path: Path,
+) -> str:
+    if configured_run is None:
+        raise ValueError(
+            f"Bundle {bundle_name!r} in {config_path} references unknown run name "
+            f"{run_name!r}."
+        )
+    resolved_output_dir = _argv_flag_value(configured_run.argv, "--output-dir")
+    if resolved_output_dir is None:
+        raise ValueError(
+            f"Bundle {bundle_name!r} in {config_path} references run {run_name!r}, but "
+            "that run has no resolvable output directory or manifest path for bundling."
+        )
+    return resolved_output_dir
+
+
+def _argv_flag_value(argv: tuple[str, ...], flag: str) -> str | None:
+    for index, value in enumerate(argv):
+        if value == flag and index + 1 < len(argv):
+            return argv[index + 1]
+    return None
 
 
 def _resolve_configured_ca_bundle(

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -542,6 +542,159 @@ def test_bundle_cli_reports_stale_handling_when_metadata_is_available(
     assert "Legacy" not in bundle_path.read_text(encoding="utf-8")
 
 
+def test_bundle_cli_renders_named_bundle_from_config_for_one_run(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    output_dir = tmp_path / "artifacts" / "team-notes"
+    _write_output_dir(
+        output_dir,
+        files=[
+            {
+                "canonical_id": "team-notes",
+                "source_url": "https://example.com/team-notes",
+                "output_path": "pages/team-notes.md",
+                "title": "Team Notes",
+            }
+        ],
+        artifact_contents={
+            "pages/team-notes.md": "# Team Notes\n\nShip it.\n",
+        },
+    )
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: team-notes
+    type: local_files
+    file_path: ./inputs/team-notes.txt
+    output_dir: ./artifacts/team-notes
+bundles:
+  - name: review-pack
+    runs: team-notes
+    output: ./bundles/review-pack.md
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    exit_code = main(["bundle", "--config", str(config_path), "--bundle", "review-pack"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "bundle: review-pack" in captured.out
+    assert "config_path:" in captured.out
+    bundle_path = tmp_path / "bundles" / "review-pack.md"
+    assert bundle_path.exists()
+    assert "Team Notes" in bundle_path.read_text(encoding="utf-8")
+
+
+def test_bundle_cli_renders_named_bundle_from_config_with_multiple_runs_and_options(
+    tmp_path: Path,
+) -> None:
+    output_a = tmp_path / "artifacts" / "a"
+    output_b = tmp_path / "artifacts" / "b"
+    _write_output_dir(
+        output_a,
+        files=[
+            {
+                "canonical_id": "gamma",
+                "source_url": "https://example.com/gamma",
+                "output_path": "pages/gamma.md",
+                "title": "Gamma",
+            },
+            {
+                "canonical_id": "draft",
+                "source_url": "https://example.com/draft",
+                "output_path": "pages/draft.md",
+                "title": "Draft",
+            },
+        ],
+        artifact_contents={
+            "pages/gamma.md": "# Gamma\n\nGamma content.\n",
+            "pages/draft.md": "# Draft\n\nDraft content.\n",
+        },
+    )
+    _write_output_dir(
+        output_b,
+        files=[
+            {
+                "canonical_id": "alpha",
+                "source_url": "https://example.com/alpha",
+                "output_path": "pages/alpha.md",
+                "title": "Alpha",
+            }
+        ],
+        artifact_contents={
+            "pages/alpha.md": "# Alpha\n\nAlpha content.\n",
+        },
+    )
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: run-a
+    type: local_files
+    file_path: ./inputs/a.txt
+    output_dir: ./artifacts/a
+  - name: run-b
+    type: local_files
+    file_path: ./inputs/b.txt
+    output_dir: ./artifacts/b
+bundles:
+  - name: review-pack
+    runs:
+      - run-a
+      - run-b
+    output: ./bundles/review-pack.md
+    order: input
+    header_mode: minimal
+    exclude:
+      - draft
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    exit_code = main(["bundle", "--config", str(config_path), "--bundle", "review-pack"])
+
+    assert exit_code == 0
+    bundle_path = tmp_path / "bundles" / "review-pack.md"
+    bundle_text = bundle_path.read_text(encoding="utf-8")
+    assert bundle_text.startswith("## Gamma\n")
+    assert "\n---\n\n## Alpha\n" in bundle_text
+    assert "## Draft\n" not in bundle_text
+    assert "canonical_id:" not in bundle_text
+
+
+def test_bundle_cli_rejects_unknown_named_bundle_name(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: team-notes
+    type: local_files
+    file_path: ./inputs/team-notes.txt
+    output_dir: ./artifacts/team-notes
+bundles:
+  - name: review-pack
+    runs: team-notes
+    output: ./bundles/review-pack.md
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit, match="2"):
+        main(["bundle", "--config", str(config_path), "--bundle", "missing-bundle"])
+
+    captured = capsys.readouterr()
+    assert "Unknown bundle name 'missing-bundle'" in captured.err
+
+
 def test_load_bundle_plan_changed_only_requires_baseline_manifest(tmp_path: Path) -> None:
     output_dir = tmp_path / "artifacts"
     _write_output_dir(

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -9,7 +9,13 @@ from pytest import CaptureFixture, MonkeyPatch
 
 import knowledge_adapters.cli as cli
 from knowledge_adapters.cli import main
-from knowledge_adapters.run_config import ConfiguredRun, load_run_config, select_runs
+from knowledge_adapters.run_config import (
+    ConfiguredBundle,
+    ConfiguredRun,
+    load_run_config,
+    select_bundle,
+    select_runs,
+)
 
 
 class _FakeHTTPResponse:
@@ -120,6 +126,117 @@ runs:
             dry_run=False,
         ),
     )
+
+
+def test_load_run_config_supports_named_bundle_referencing_one_run(tmp_path: Path) -> None:
+    config_path = tmp_path / "runs.yaml"
+    baseline_manifest = tmp_path / "baseline" / "manifest.json"
+    config_path.write_text(
+        f"""
+runs:
+  - name: team-notes
+    type: local_files
+    file_path: ./inputs/team-notes.txt
+    output_dir: ./artifacts/local/team-notes
+bundles:
+  - name: review-pack
+    runs: team-notes
+    output: ./bundles/review-pack.md
+    max_bytes: 250000
+    order: input
+    header_mode: minimal
+    include:
+      - "team-*"
+    exclude:
+      - "*draft*"
+    changed_only: true
+    baseline_manifest: {baseline_manifest}
+    stale_mode: flag
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    run_config = load_run_config(config_path)
+
+    assert run_config.bundles == (
+        ConfiguredBundle(
+            name="review-pack",
+            inputs=(str((tmp_path / "artifacts" / "local" / "team-notes").resolve()),),
+            output=str((tmp_path / "bundles" / "review-pack.md").resolve()),
+            max_bytes=250000,
+            order="input",
+            header_mode="minimal",
+            include_patterns=("team-*",),
+            exclude_patterns=("*draft*",),
+            changed_only=True,
+            baseline_manifest=str(baseline_manifest),
+            stale_mode="flag",
+        ),
+    )
+
+
+def test_load_run_config_supports_named_bundle_referencing_multiple_runs(tmp_path: Path) -> None:
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: team-notes
+    type: local_files
+    file_path: ./inputs/team-notes.txt
+    output_dir: ./artifacts/local/team-notes
+  - name: docs-tree
+    type: confluence
+    base_url: https://example.com/wiki
+    target: "12345"
+    output_dir: ./artifacts/confluence/docs-tree
+bundles:
+  - name: merged-review
+    runs:
+      - team-notes
+      - docs-tree
+    output: ./bundles/merged-review.md
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    run_config = load_run_config(config_path)
+
+    assert run_config.bundles == (
+        ConfiguredBundle(
+            name="merged-review",
+            inputs=(
+                str((tmp_path / "artifacts" / "local" / "team-notes").resolve()),
+                str((tmp_path / "artifacts" / "confluence" / "docs-tree").resolve()),
+            ),
+            output=str((tmp_path / "bundles" / "merged-review.md").resolve()),
+        ),
+    )
+
+
+def test_load_run_config_rejects_unknown_named_bundle_run_reference(tmp_path: Path) -> None:
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: team-notes
+    type: local_files
+    file_path: ./inputs/team-notes.txt
+    output_dir: ./artifacts/local/team-notes
+bundles:
+  - name: review-pack
+    runs:
+      - team-notes
+      - missing-run
+    output: ./bundles/review-pack.md
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="references unknown run name 'missing-run'"):
+        load_run_config(config_path)
 
 
 def test_load_run_config_supports_git_repo_filters_and_ref(tmp_path: Path) -> None:
@@ -552,6 +669,30 @@ runs:
         select_runs(run_config, only_names=("missing-run",))
 
 
+def test_select_bundle_rejects_unknown_named_bundle(tmp_path: Path) -> None:
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: team-notes
+    type: local_files
+    file_path: ./notes.txt
+    output_dir: ./artifacts
+bundles:
+  - name: review-pack
+    runs: team-notes
+    output: ./bundles/review-pack.md
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    run_config = load_run_config(config_path)
+
+    with pytest.raises(ValueError, match="Unknown bundle name 'missing-bundle'"):
+        select_bundle(run_config, name="missing-bundle")
+
+
 @pytest.mark.parametrize(
     ("field_name", "field_block", "expected_fragment"),
     [
@@ -711,6 +852,38 @@ runs:
             "last_modified": "1970-01-01T00:00:00Z",
         }
     ]
+
+
+def test_run_command_executes_explicit_input_bundle_run(tmp_path: Path) -> None:
+    source_file = tmp_path / "inputs" / "team-notes.txt"
+    source_file.parent.mkdir(parents=True)
+    source_file.write_text("Ship it.\n", encoding="utf-8")
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: team-notes
+    type: local_files
+    file_path: ./inputs/team-notes.txt
+    output_dir: ./artifacts/local/team-notes
+  - name: team-notes-bundle
+    type: bundle
+    inputs:
+      - ./artifacts/local/team-notes
+    output: ./bundles/team-notes.md
+    header_mode: minimal
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    exit_code = main(["run", str(config_path)])
+
+    assert exit_code == 0
+    bundle_path = tmp_path / "bundles" / "team-notes.md"
+    assert bundle_path.exists()
+    assert "## team-notes.txt" in bundle_path.read_text(encoding="utf-8")
+    assert "Ship it." in bundle_path.read_text(encoding="utf-8")
 
 
 def test_run_command_skips_disabled_runs_by_default(


### PR DESCRIPTION
Summary
- add top-level bundles definitions in runs.yaml that resolve bundle inputs from existing named runs
- add knowledge-adapters bundle --config/--bundle support while preserving direct bundle INPUT usage
- keep explicit-input type: bundle runs supported and cover both config-driven and direct bundle paths with tests

Testing
- make check

Closes #151