### PR TITLE
test: add Confluence stub integration coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,28 @@ After `make dev`, the repo-local CLI entrypoint for this checkout is:
 .venv/bin/knowledge-adapters
 ```
 
+## Integration Tests
+
+Use the normal fast local loop when you are iterating on unit, contract, and
+CLI behavior that does not need a live subprocess:
+
+```bash
+.venv/bin/pytest -m "not integration"
+```
+
+Run the integration slice explicitly when you want to exercise real adapter
+wiring against the local Confluence stub:
+
+```bash
+.venv/bin/pytest -m integration
+```
+
+These integration tests start [`tools/confluence_stub/app.py`](./tools/confluence_stub/app.py)
+locally with `uvicorn`, talk only to `localhost`, and use committed stub data
+from [`tools/confluence_stub/data/pages.json`](./tools/confluence_stub/data/pages.json)
+so the responses stay deterministic and do not require real Confluence
+credentials.
+
 Common commands:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ where = ["src"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+markers = [
+  "integration: local integration tests that exercise real adapter wiring against deterministic stubs",
+]
 
 [tool.ruff]
 line-length = 100

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for local deterministic adapter wiring."""

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -5,21 +5,16 @@ import subprocess
 import sys
 import time
 from collections.abc import Iterator
-from dataclasses import dataclass
 from pathlib import Path
 from urllib import request
 from urllib.error import HTTPError, URLError
 
 import pytest
 
+from tests.integration.helpers import ConfluenceStubServer
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 STUB_DIR = REPO_ROOT / "tools" / "confluence_stub"
-
-
-@dataclass(frozen=True)
-class ConfluenceStubServer:
-    base_url: str
-    log_path: Path
 
 
 def _find_available_port() -> int:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import socket
+import subprocess
+import sys
+import time
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from urllib import request
+from urllib.error import HTTPError, URLError
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+STUB_DIR = REPO_ROOT / "tools" / "confluence_stub"
+
+
+@dataclass(frozen=True)
+class ConfluenceStubServer:
+    base_url: str
+    log_path: Path
+
+
+def _find_available_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _read_log_excerpt(log_path: Path) -> str:
+    if not log_path.exists():
+        return "(no stub log output)"
+
+    log_text = log_path.read_text(encoding="utf-8").strip()
+    if not log_text:
+        return "(stub produced no log output)"
+    return log_text
+
+
+def _wait_for_stub_ready(
+    base_url: str,
+    process: subprocess.Popen[str],
+    *,
+    log_path: Path,
+    timeout_seconds: float = 10.0,
+) -> None:
+    deadline = time.monotonic() + timeout_seconds
+    readiness_url = f"{base_url}/rest/api/content"
+
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise RuntimeError(
+                "Confluence stub exited before becoming ready.\n"
+                f"Stub log:\n{_read_log_excerpt(log_path)}"
+            )
+
+        try:
+            with request.urlopen(readiness_url, timeout=0.2) as response:
+                if response.status == 200:
+                    return
+        except (HTTPError, URLError):
+            pass
+
+        time.sleep(0.1)
+
+    raise RuntimeError(
+        "Timed out waiting for the Confluence stub to become ready.\n"
+        f"Stub log:\n{_read_log_excerpt(log_path)}"
+    )
+
+
+@pytest.fixture
+def confluence_stub_server(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Iterator[ConfluenceStubServer]:
+    log_dir = tmp_path_factory.mktemp("confluence-stub")
+    log_path = log_dir / "uvicorn.log"
+    port = _find_available_port()
+
+    with log_path.open("w", encoding="utf-8") as log_file:
+        process = subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "uvicorn",
+                "app:app",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                str(port),
+            ],
+            cwd=STUB_DIR,
+            stdout=log_file,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        base_url = f"http://127.0.0.1:{port}"
+        _wait_for_stub_ready(base_url, process, log_path=log_path)
+        try:
+            yield ConfluenceStubServer(base_url=base_url, log_path=log_path)
+        finally:
+            if process.poll() is None:
+                process.terminate()
+                try:
+                    process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait(timeout=5)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class ConfluenceStubServer:
+    base_url: str
+    log_path: Path

--- a/tests/integration/test_confluence_stub_integration.py
+++ b/tests/integration/test_confluence_stub_integration.py
@@ -12,7 +12,7 @@ from tests.artifact_assertions import (
     assert_markdown_document,
     manifest_file,
 )
-from tests.integration.conftest import ConfluenceStubServer
+from tests.integration.helpers import ConfluenceStubServer
 
 
 def _confluence_argv(
@@ -128,6 +128,9 @@ def test_confluence_cli_reuses_fetch_cache_on_second_fetch(
     assert "cache_misses: 1" in first_run.out
     assert len(list(cache_dir.rglob("page.json"))) == 1
 
+    # Downgrade the local manifest to simulate stale local metadata while the
+    # remote summary still matches the cached full payload. That forces the
+    # real summary-plus-full-fetch path on the second run and verifies cache reuse.
     _set_manifest_page_version(output_dir, page_version=0)
 
     second_exit_code = main(

--- a/tests/integration/test_confluence_stub_integration.py
+++ b/tests/integration/test_confluence_stub_integration.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pytest import CaptureFixture, MonkeyPatch
+
+from knowledge_adapters.cli import main
+from tests.artifact_assertions import (
+    assert_manifest_entries,
+    assert_markdown_document,
+    manifest_file,
+)
+from tests.integration.conftest import ConfluenceStubServer
+
+
+def _confluence_argv(
+    base_url: str,
+    output_dir: Path,
+    *,
+    fetch_cache_dir: Path | None = None,
+) -> list[str]:
+    argv = [
+        "confluence",
+        "--client-mode",
+        "real",
+        "--base-url",
+        base_url,
+        "--target",
+        "12345",
+        "--output-dir",
+        str(output_dir),
+    ]
+    if fetch_cache_dir is not None:
+        argv.extend(["--fetch-cache-dir", str(fetch_cache_dir)])
+    return argv
+
+
+def _load_manifest(output_dir: Path) -> dict[str, object]:
+    payload = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def _set_manifest_page_version(output_dir: Path, *, page_version: int) -> None:
+    manifest = _load_manifest(output_dir)
+    files = manifest.get("files")
+    assert isinstance(files, list)
+    assert len(files) == 1
+    entry = files[0]
+    assert isinstance(entry, dict)
+    entry["page_version"] = page_version
+    (output_dir / "manifest.json").write_text(
+        f"{json.dumps(manifest, indent=2)}\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.integration
+def test_confluence_cli_writes_stub_page_through_real_client_path(
+    tmp_path: Path,
+    confluence_stub_server: ConfluenceStubServer,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "stub-token")
+    output_dir = tmp_path / "artifacts"
+
+    exit_code = main(_confluence_argv(confluence_stub_server.base_url, output_dir))
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "Summary: wrote 1, skipped 0" in captured.out
+
+    page_path = output_dir / "pages" / "12345.md"
+    assert_markdown_document(
+        page_path.read_text(encoding="utf-8"),
+        title="Test Page",
+        metadata={
+            "source": "confluence",
+            "canonical_id": "12345",
+            "parent_id": "",
+            "source_url": f"{confluence_stub_server.base_url}/pages/viewpage.action?pageId=12345",
+            "fetched_at": "",
+            "updated_at": "",
+            "adapter": "confluence",
+        },
+        content="Hello world",
+    )
+    assert_manifest_entries(
+        output_dir / "manifest.json",
+        files=[
+            manifest_file(
+                canonical_id="12345",
+                source_url=f"{confluence_stub_server.base_url}/pages/viewpage.action?pageId=12345",
+                output_path="pages/12345.md",
+                title="Test Page",
+                page_version=1,
+                last_modified="2026-04-20T12:34:56Z",
+            )
+        ],
+    )
+
+
+@pytest.mark.integration
+def test_confluence_cli_reuses_fetch_cache_on_second_fetch(
+    tmp_path: Path,
+    confluence_stub_server: ConfluenceStubServer,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "stub-token")
+    output_dir = tmp_path / "artifacts"
+    cache_dir = tmp_path / "cache"
+
+    first_exit_code = main(
+        _confluence_argv(
+            confluence_stub_server.base_url,
+            output_dir,
+            fetch_cache_dir=cache_dir,
+        )
+    )
+
+    assert first_exit_code == 0
+    first_run = capsys.readouterr()
+    assert "cache_hits: 0" in first_run.out
+    assert "cache_misses: 1" in first_run.out
+    assert len(list(cache_dir.rglob("page.json"))) == 1
+
+    _set_manifest_page_version(output_dir, page_version=0)
+
+    second_exit_code = main(
+        _confluence_argv(
+            confluence_stub_server.base_url,
+            output_dir,
+            fetch_cache_dir=cache_dir,
+        )
+    )
+
+    assert second_exit_code == 0
+    second_run = capsys.readouterr()
+    assert "Summary: wrote 1, skipped 0" in second_run.out
+    assert "cache_hits: 1" in second_run.out
+    assert "cache_misses: 0" in second_run.out


### PR DESCRIPTION
Summary
- add a pytest integration marker and a small tests/integration layout for local stub-backed coverage
- start the local Confluence stub with uvicorn in a fixture and wait on a deterministic readiness request
- cover one end-to-end real-client write path and one fetch-cache hit path against the local stub
- document fast vs integration pytest commands in the README

Testing
- make check
- .venv/bin/pytest -m "not integration"
- .venv/bin/pytest -m integration