### PR TITLE
feat: add Confluence traversal cache

### DIFF
--- a/runs.example.yaml
+++ b/runs.example.yaml
@@ -42,6 +42,8 @@ runs:
     max_depth: 1
     # client_mode: real
     # auth_method: client-cert-env
+    # Optional traversal cache for repeated large tree listing runs.
+    # tree_cache_dir: ./.cache/confluence-tree
     # client_cert_file: ./certs/confluence-client.crt
     # client_key_file: ./certs/confluence-client.key
     # Optional TLS override for an internal CA.

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -169,6 +169,7 @@ _CONFLUENCE_REAL_ONLY_INPUT_FLAGS = (
     "--client-cert-file",
     "--client-key-file",
     "--fetch-cache-dir",
+    "--tree-cache-dir",
 )
 
 
@@ -428,6 +429,13 @@ def build_parser() -> argparse.ArgumentParser:
         "--fetch-cache-dir",
         help=(
             "Opt-in directory for caching raw Confluence full-page fetch payloads. "
+            "Disabled when omitted."
+        ),
+    )
+    confluence_parser.add_argument(
+        "--tree-cache-dir",
+        help=(
+            "Opt-in directory for caching Confluence traversal listing results. "
             "Disabled when omitted."
         ),
     )
@@ -1253,6 +1261,10 @@ def main(argv: Sequence[str] | None = None) -> int:
             validate_space_key,
         )
         from knowledge_adapters.confluence.traversal import TreeWalkProgress, walk_pages
+        from knowledge_adapters.confluence.tree_cache import (
+            ConfluenceTreeCache,
+            prepare_tree_cache_dir,
+        )
         from knowledge_adapters.confluence.writer import markdown_path, write_markdown
         from knowledge_adapters.manifest import (
             build_manifest_entry,
@@ -1276,6 +1288,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             client_cert_file=args.client_cert_file,
             client_key_file=args.client_key_file,
             fetch_cache_dir=args.fetch_cache_dir,
+            tree_cache_dir=args.tree_cache_dir,
             client_mode=args.client_mode,
             auth_method=args.auth_method,
             debug=args.debug,
@@ -1298,6 +1311,15 @@ def main(argv: Sequence[str] | None = None) -> int:
             try:
                 fetch_cache = ConfluenceFetchCache(
                     prepare_fetch_cache_dir(confluence_config.fetch_cache_dir),
+                    base_url=confluence_config.base_url,
+                )
+            except ValueError as exc:
+                exit_with_cli_error(str(exc), command="confluence")
+        tree_cache: ConfluenceTreeCache | None = None
+        if confluence_config.tree_cache_dir is not None:
+            try:
+                tree_cache = ConfluenceTreeCache(
+                    prepare_tree_cache_dir(confluence_config.tree_cache_dir),
                     base_url=confluence_config.base_url,
                 )
             except ValueError as exc:
@@ -1437,20 +1459,31 @@ def main(argv: Sequence[str] | None = None) -> int:
             def selected_list_child_page_ids(
                 resolved_target: ResolvedTarget,
             ) -> list[str]:
-                return list_real_child_page_ids(
-                    resolved_target,
-                    base_url=confluence_config.base_url,
-                    auth_method=confluence_config.auth_method,
-                    **real_client_tls_kwargs(),
-                )
+                def fetch_listing() -> list[str]:
+                    return list_real_child_page_ids(
+                        resolved_target,
+                        base_url=confluence_config.base_url,
+                        auth_method=confluence_config.auth_method,
+                        **real_client_tls_kwargs(),
+                    )
+
+                page_id = resolved_target.page_id
+                if tree_cache is None or not page_id:
+                    return fetch_listing()
+                return tree_cache.get_child_page_ids(page_id, fetch_listing)
 
             def selected_list_space_page_ids(space_key: str) -> list[str]:
-                return list_real_space_page_ids(
-                    space_key,
-                    base_url=confluence_config.base_url,
-                    auth_method=confluence_config.auth_method,
-                    **real_client_tls_kwargs(),
-                )
+                def fetch_listing() -> list[str]:
+                    return list_real_space_page_ids(
+                        space_key,
+                        base_url=confluence_config.base_url,
+                        auth_method=confluence_config.auth_method,
+                        **real_client_tls_kwargs(),
+                    )
+
+                if tree_cache is None:
+                    return fetch_listing()
+                return tree_cache.get_space_page_ids(space_key, fetch_listing)
         else:
             selected_fetch_page = fetch_page
             selected_fetch_page_summary = fetch_page
@@ -1650,6 +1683,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             if fetch_cache is not None:
                 summary_lines.append(f"    cache_hits: {fetch_cache.stats.hits}")
                 summary_lines.append(f"    cache_misses: {fetch_cache.stats.misses}")
+            if tree_cache is not None:
+                summary_lines.append(f"    tree_cache_hits: {tree_cache.stats.hits}")
+                summary_lines.append(f"    tree_cache_misses: {tree_cache.stats.misses}")
             print("  Summary:")
             for line in summary_lines:
                 print(line)
@@ -1672,6 +1708,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             if fetch_cache is not None:
                 print(f"  cache_hits: {fetch_cache.stats.hits}")
                 print(f"  cache_misses: {fetch_cache.stats.misses}")
+            if tree_cache is not None:
+                print(f"  tree_cache_hits: {tree_cache.stats.hits}")
+                print(f"  tree_cache_misses: {tree_cache.stats.misses}")
             print(f"  pages_written: {write_count}")
             print(f"  pages_skipped: {skip_count}")
 

--- a/src/knowledge_adapters/confluence/config.py
+++ b/src/knowledge_adapters/confluence/config.py
@@ -22,6 +22,7 @@ class ConfluenceConfig:
     client_cert_file: str | None = None
     client_key_file: str | None = None
     fetch_cache_dir: str | None = None
+    tree_cache_dir: str | None = None
     client_mode: str = "stub"
     auth_method: str = "bearer-env"
     debug: bool = False

--- a/src/knowledge_adapters/confluence/tree_cache.py
+++ b/src/knowledge_adapters/confluence/tree_cache.py
@@ -1,0 +1,198 @@
+"""Opt-in traversal cache for Confluence listing discovery."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+CACHE_SCHEMA_VERSION = 1
+_ENTRY_FILENAME = "listing.json"
+
+
+@dataclass
+class ConfluenceTreeCacheStats:
+    """Run-scoped traversal cache counters."""
+
+    hits: int = 0
+    misses: int = 0
+
+
+def _hash_value(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _normal_base_url(base_url: str) -> str:
+    return base_url.rstrip("/")
+
+
+def prepare_tree_cache_dir(path_value: str) -> Path:
+    """Validate and create the configured traversal cache root."""
+    cache_dir = Path(path_value).expanduser().resolve()
+    if cache_dir.exists() and not cache_dir.is_dir():
+        raise ValueError(
+            f"Confluence traversal cache path is not a directory: {cache_dir}. "
+            "Verify --tree-cache-dir and use a directory path."
+        )
+
+    try:
+        cache_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise ValueError(
+            f"Could not create Confluence traversal cache directory {cache_dir}: {exc}."
+        ) from exc
+
+    return cache_dir
+
+
+class ConfluenceTreeCache:
+    """Best-effort cache for Confluence traversal listing results."""
+
+    def __init__(self, root_dir: Path, *, base_url: str) -> None:
+        self._root_dir = root_dir
+        self._base_url = _normal_base_url(base_url)
+        self.stats = ConfluenceTreeCacheStats()
+
+    def get_child_page_ids(
+        self,
+        parent_page_id: str,
+        fetch_listing: Callable[[], list[str]],
+    ) -> list[str]:
+        """Return cached child page IDs, or fetch and best-effort cache them."""
+        return self._get_listing(
+            kind="child",
+            key_name="parent_page_id",
+            key_value=parent_page_id,
+            fetch_listing=fetch_listing,
+        )
+
+    def get_space_page_ids(
+        self,
+        space_key: str,
+        fetch_listing: Callable[[], list[str]],
+    ) -> list[str]:
+        """Return cached space page IDs, or fetch and best-effort cache them."""
+        return self._get_listing(
+            kind="space",
+            key_name="space_key",
+            key_value=space_key,
+            fetch_listing=fetch_listing,
+        )
+
+    def _get_listing(
+        self,
+        *,
+        kind: str,
+        key_name: str,
+        key_value: str,
+        fetch_listing: Callable[[], list[str]],
+    ) -> list[str]:
+        try:
+            page_ids = self._read_listing(kind=kind, key_name=key_name, key_value=key_value)
+        except (OSError, ValueError, TypeError, json.JSONDecodeError):
+            self.stats.misses += 1
+        else:
+            self.stats.hits += 1
+            return page_ids
+
+        page_ids = fetch_listing()
+        self._store_listing(
+            kind=kind,
+            key_name=key_name,
+            key_value=key_value,
+            page_ids=page_ids,
+        )
+        return page_ids
+
+    def _entry_path(self, *, kind: str, key_value: str) -> Path:
+        return (
+            self._root_dir
+            / "confluence"
+            / _hash_value(self._base_url)
+            / "traversal"
+            / kind
+            / _hash_value(key_value)
+            / _ENTRY_FILENAME
+        )
+
+    def _read_listing(self, *, kind: str, key_name: str, key_value: str) -> list[str]:
+        entry = json.loads(
+            self._entry_path(kind=kind, key_value=key_value).read_text(encoding="utf-8")
+        )
+        if not isinstance(entry, dict):
+            raise ValueError("invalid cache entry")
+        return self._validate_entry(
+            _as_str_object_dict(entry),
+            kind=kind,
+            key_name=key_name,
+            key_value=key_value,
+        )
+
+    def _store_listing(
+        self,
+        *,
+        kind: str,
+        key_name: str,
+        key_value: str,
+        page_ids: list[str],
+    ) -> None:
+        entry: dict[str, object] = {
+            "cache_schema_version": CACHE_SCHEMA_VERSION,
+            "base_url": self._base_url,
+            "kind": kind,
+            key_name: key_value,
+            "page_ids": list(page_ids),
+        }
+
+        try:
+            self._write_entry(kind=kind, key_value=key_value, entry=entry)
+        except (OSError, TypeError, ValueError):
+            return
+
+    def _write_entry(self, *, kind: str, key_value: str, entry: Mapping[str, object]) -> None:
+        entry_path = self._entry_path(kind=kind, key_value=key_value)
+        entry_path.parent.mkdir(parents=True, exist_ok=True)
+        temporary_path = entry_path.with_suffix(".tmp")
+        serialized_entry = f"{json.dumps(entry, indent=2, sort_keys=True)}\n"
+        temporary_path.write_text(serialized_entry, encoding="utf-8")
+        os.replace(temporary_path, entry_path)
+
+    def _validate_entry(
+        self,
+        entry: Mapping[str, object],
+        *,
+        kind: str,
+        key_name: str,
+        key_value: str,
+    ) -> list[str]:
+        if entry.get("cache_schema_version") != CACHE_SCHEMA_VERSION:
+            raise ValueError("cache schema mismatch")
+        if entry.get("base_url") != self._base_url:
+            raise ValueError("base_url mismatch")
+        if entry.get("kind") != kind:
+            raise ValueError("listing kind mismatch")
+        if entry.get(key_name) != key_value:
+            raise ValueError("listing key mismatch")
+
+        page_ids = entry.get("page_ids")
+        if not isinstance(page_ids, list):
+            raise ValueError("invalid cached listing")
+        result: list[str] = []
+        for page_id in page_ids:
+            if not isinstance(page_id, str) or not page_id:
+                raise ValueError("invalid cached page ID")
+            result.append(page_id)
+        return result
+
+
+def _as_str_object_dict(value: dict[Any, Any]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, item in value.items():
+        if not isinstance(key, str):
+            raise ValueError("invalid cache entry")
+        result[key] = item
+    return result

--- a/src/knowledge_adapters/run_config.py
+++ b/src/knowledge_adapters/run_config.py
@@ -69,6 +69,7 @@ _CONFLUENCE_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
         "space_url",
         "target",
         "tree",
+        "tree_cache_dir",
     }
 )
 _BUNDLE_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | _BUNDLE_OPTION_KEYS | frozenset(
@@ -542,6 +543,20 @@ def _build_confluence_argv(
             [
                 "--fetch-cache-dir",
                 _resolve_path_string(fetch_cache_dir, config_path=config_path),
+            ]
+        )
+
+    tree_cache_dir = _optional_string(
+        run_config,
+        "tree_cache_dir",
+        index=index,
+        config_path=config_path,
+    )
+    if tree_cache_dir is not None:
+        argv.extend(
+            [
+                "--tree-cache-dir",
+                _resolve_path_string(tree_cache_dir, config_path=config_path),
             ]
         )
 

--- a/tests/test_confluence_real_traversal_contract.py
+++ b/tests/test_confluence_real_traversal_contract.py
@@ -382,6 +382,235 @@ def test_real_space_mode_discovers_pages_and_writes_in_lexical_order(
     assert "Summary: wrote 3, skipped 0" in output
 
 
+def test_real_tree_runs_without_traversal_cache_by_default(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    exit_code, _output_dir, _page_fetch_counts, child_list_calls = _run_real_recursive_cli(
+        tmp_path,
+        monkeypatch,
+        max_depth=1,
+    )
+
+    assert exit_code == 0
+    assert child_list_calls == ["100"]
+    output = capsys.readouterr().out
+    assert "tree_cache_hits" not in output
+    assert "tree_cache_misses" not in output
+
+
+def test_real_tree_reuses_cached_child_page_listing(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    from knowledge_adapters.confluence import client as client_module
+
+    pages = _real_pages()
+    cache_dir = tmp_path / "cache"
+    child_list_calls: list[str] = []
+
+    def stub_real_fetch(
+        target: ResolvedTarget,
+        *,
+        base_url: str = "https://example.com/wiki",
+        auth_method: str = "bearer-env",
+        ca_bundle: str | None = None,
+        client_cert_file: str | None = None,
+        client_key_file: str | None = None,
+    ) -> dict[str, object]:
+        del base_url, auth_method, ca_bundle, client_cert_file, client_key_file
+        return dict(pages[str(target.page_id)])
+
+    def stub_child_id_discovery(*args: object, **kwargs: object) -> list[str]:
+        parent_id = _called_page_id(args, kwargs)
+        child_list_calls.append(parent_id)
+        return ["200", "300"]
+
+    monkeypatch.setattr(client_module, "fetch_real_page", stub_real_fetch, raising=False)
+    monkeypatch.setattr(
+        client_module,
+        "list_real_child_page_ids",
+        stub_child_id_discovery,
+        raising=False,
+    )
+
+    first_output_dir = tmp_path / "first"
+    assert (
+        main(
+            [
+                *_real_tree_argv(first_output_dir, max_depth=1),
+                "--tree-cache-dir",
+                str(cache_dir),
+            ]
+        )
+        == 0
+    )
+    first_output = capsys.readouterr().out
+    assert "tree_cache_hits: 0" in first_output
+    assert "tree_cache_misses: 1" in first_output
+
+    second_output_dir = tmp_path / "second"
+    assert (
+        main(
+            [
+                *_real_tree_argv(second_output_dir, max_depth=1),
+                "--tree-cache-dir",
+                str(cache_dir),
+            ]
+        )
+        == 0
+    )
+
+    assert child_list_calls == ["100"]
+    second_output = capsys.readouterr().out
+    assert "tree_cache_hits: 1" in second_output
+    assert "tree_cache_misses: 0" in second_output
+
+
+def test_real_tree_cache_write_failure_does_not_fail_run(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    from knowledge_adapters.confluence import client as client_module
+    from knowledge_adapters.confluence.tree_cache import ConfluenceTreeCache
+
+    pages = _real_pages()
+    child_list_calls: list[str] = []
+
+    def stub_real_fetch(
+        target: ResolvedTarget,
+        *,
+        base_url: str = "https://example.com/wiki",
+        auth_method: str = "bearer-env",
+        ca_bundle: str | None = None,
+        client_cert_file: str | None = None,
+        client_key_file: str | None = None,
+    ) -> dict[str, object]:
+        del base_url, auth_method, ca_bundle, client_cert_file, client_key_file
+        return dict(pages[str(target.page_id)])
+
+    def stub_child_id_discovery(*args: object, **kwargs: object) -> list[str]:
+        parent_id = _called_page_id(args, kwargs)
+        child_list_calls.append(parent_id)
+        return ["200", "300"]
+
+    def raise_write_error(
+        self: ConfluenceTreeCache,
+        *,
+        kind: str,
+        key_value: str,
+        entry: object,
+    ) -> None:
+        del self, kind, key_value, entry
+        raise OSError("synthetic write failure")
+
+    monkeypatch.setattr(client_module, "fetch_real_page", stub_real_fetch, raising=False)
+    monkeypatch.setattr(
+        client_module,
+        "list_real_child_page_ids",
+        stub_child_id_discovery,
+        raising=False,
+    )
+    monkeypatch.setattr(ConfluenceTreeCache, "_write_entry", raise_write_error)
+
+    assert (
+        main(
+            [
+                *_real_tree_argv(tmp_path / "out", max_depth=1),
+                "--tree-cache-dir",
+                str(tmp_path / "cache"),
+            ]
+        )
+        == 0
+    )
+
+    assert child_list_calls == ["100"]
+    output = capsys.readouterr().out
+    assert "Summary: wrote 3, skipped 0" in output
+    assert "tree_cache_hits: 0" in output
+    assert "tree_cache_misses: 1" in output
+
+
+def test_real_space_reuses_cached_space_page_listing(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    from knowledge_adapters.confluence import client as client_module
+
+    pages = _real_pages()
+    cache_dir = tmp_path / "cache"
+    space_list_calls: list[str] = []
+
+    def stub_real_fetch(
+        target: ResolvedTarget,
+        *,
+        base_url: str = "https://example.com/wiki",
+        auth_method: str = "bearer-env",
+        ca_bundle: str | None = None,
+        client_cert_file: str | None = None,
+        client_key_file: str | None = None,
+    ) -> dict[str, object]:
+        del base_url, auth_method, ca_bundle, client_cert_file, client_key_file
+        return dict(pages[str(target.page_id)])
+
+    def stub_space_discovery(
+        space_key: str,
+        *,
+        base_url: str = "https://example.com/wiki",
+        auth_method: str = "bearer-env",
+        ca_bundle: str | None = None,
+        client_cert_file: str | None = None,
+        client_key_file: str | None = None,
+    ) -> list[str]:
+        del base_url, auth_method, ca_bundle, client_cert_file, client_key_file
+        space_list_calls.append(space_key)
+        return ["300", "100", "200"]
+
+    monkeypatch.setattr(client_module, "fetch_real_page", stub_real_fetch, raising=False)
+    monkeypatch.setattr(
+        client_module,
+        "list_real_space_page_ids",
+        stub_space_discovery,
+        raising=False,
+    )
+
+    first_output_dir = tmp_path / "first"
+    assert (
+        main(
+            [
+                *_real_space_argv(first_output_dir),
+                "--tree-cache-dir",
+                str(cache_dir),
+            ]
+        )
+        == 0
+    )
+    first_output = capsys.readouterr().out
+    assert "tree_cache_hits: 0" in first_output
+    assert "tree_cache_misses: 1" in first_output
+
+    second_output_dir = tmp_path / "second"
+    assert (
+        main(
+            [
+                *_real_space_argv(second_output_dir),
+                "--tree-cache-dir",
+                str(cache_dir),
+            ]
+        )
+        == 0
+    )
+
+    assert space_list_calls == ["ENG"]
+    second_output = capsys.readouterr().out
+    assert "tree_cache_hits: 1" in second_output
+    assert "tree_cache_misses: 0" in second_output
+
+
 def test_real_space_dry_run_reports_space_summary_and_planned_actions(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,

--- a/tests/test_confluence_tree_cache.py
+++ b/tests/test_confluence_tree_cache.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pytest import MonkeyPatch
+
+from knowledge_adapters.confluence.tree_cache import (
+    ConfluenceTreeCache,
+    prepare_tree_cache_dir,
+)
+
+
+def test_tree_cache_miss_fetches_and_stores_listing(tmp_path: Path) -> None:
+    cache = ConfluenceTreeCache(tmp_path / "cache", base_url="https://example.com/wiki/")
+    fetch_calls = 0
+
+    def fetch_listing() -> list[str]:
+        nonlocal fetch_calls
+        fetch_calls += 1
+        return ["200", "300"]
+
+    assert cache.get_child_page_ids("100", fetch_listing) == ["200", "300"]
+
+    assert fetch_calls == 1
+    assert cache.stats.hits == 0
+    assert cache.stats.misses == 1
+    assert list((tmp_path / "cache").rglob("listing.json"))
+
+
+def test_tree_cache_hit_returns_cached_child_listing(tmp_path: Path) -> None:
+    cache = ConfluenceTreeCache(tmp_path / "cache", base_url="https://example.com/wiki")
+
+    assert cache.get_child_page_ids("100", lambda: ["200"]) == ["200"]
+    assert cache.get_child_page_ids("100", lambda: pytest.fail("unexpected fetch")) == ["200"]
+
+    assert cache.stats.hits == 1
+    assert cache.stats.misses == 1
+
+
+def test_tree_cache_corrupt_entry_falls_back_to_fetch(tmp_path: Path) -> None:
+    cache = ConfluenceTreeCache(tmp_path / "cache", base_url="https://example.com/wiki")
+    assert cache.get_child_page_ids("100", lambda: ["200"]) == ["200"]
+    listing_path = next((tmp_path / "cache").rglob("listing.json"))
+    listing_path.write_text("{not valid json", encoding="utf-8")
+
+    assert cache.get_child_page_ids("100", lambda: ["300"]) == ["300"]
+
+    assert cache.stats.hits == 0
+    assert cache.stats.misses == 2
+
+
+def test_tree_cache_write_failure_does_not_fail_lookup(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    cache = ConfluenceTreeCache(tmp_path / "cache", base_url="https://example.com/wiki")
+
+    def raise_write_error(
+        self: ConfluenceTreeCache,
+        *,
+        kind: str,
+        key_value: str,
+        entry: object,
+    ) -> None:
+        del self, kind, key_value, entry
+        raise OSError("synthetic write failure")
+
+    monkeypatch.setattr(ConfluenceTreeCache, "_write_entry", raise_write_error)
+
+    assert cache.get_child_page_ids("100", lambda: ["200"]) == ["200"]
+    assert cache.stats.hits == 0
+    assert cache.stats.misses == 1
+
+
+def test_prepare_tree_cache_dir_rejects_file_path(tmp_path: Path) -> None:
+    cache_path = tmp_path / "cache-file"
+    cache_path.write_text("not a directory", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Verify --tree-cache-dir"):
+        prepare_tree_cache_dir(str(cache_path))

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -43,6 +43,7 @@ runs:
     target: "12345"
     output_dir: ./artifacts/confluence/docs-home
     fetch_cache_dir: ./.cache/confluence-fetches
+    tree_cache_dir: ./.cache/confluence-tree
   - name: team-notes
     type: local_files
     file_path: ./inputs/team-notes.txt
@@ -70,6 +71,8 @@ runs:
                 str((tmp_path / "artifacts" / "confluence" / "docs-home").resolve()),
                 "--fetch-cache-dir",
                 str((tmp_path / ".cache" / "confluence-fetches").resolve()),
+                "--tree-cache-dir",
+                str((tmp_path / ".cache" / "confluence-tree").resolve()),
             ),
             dry_run=False,
         ),


### PR DESCRIPTION
Summary
- add an opt-in --tree-cache-dir / tree_cache_dir traversal cache for Confluence listing discovery
- cache only space page listings and child page ID listings, namespaced by normalized base URL and separate from fetch cache/artifacts/manifests/bundles
- fail open on missing/corrupt entries and best-effort write failures, while reporting tree_cache_hits and tree_cache_misses when enabled
- default behavior is unchanged when traversal cache is not configured

Testing
- make check

Closes #198