### PR TITLE
fix: require --tree when using --max-depth

### DIFF
--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -1376,6 +1376,11 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "--target, --space-key, or --space-url is required.",
                 command="confluence",
             )
+        if explicit_max_depth and not confluence_config.tree:
+            exit_with_cli_error(
+                "--max-depth requires --tree.",
+                command="confluence",
+            )
         try:
             validate_explicit_tls_paths(
                 ca_bundle=None if confluence_config.no_ca_bundle else confluence_config.ca_bundle,

--- a/tests/test_normalize_writer.py
+++ b/tests/test_normalize_writer.py
@@ -594,6 +594,33 @@ def test_confluence_cli_rejects_negative_max_depth(
     ) in captured.err
 
 
+def test_confluence_cli_requires_tree_when_max_depth_is_explicit(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    output_dir = tmp_path / "out"
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(
+            [
+                "confluence",
+                "--base-url",
+                "https://example.com/wiki",
+                "--target",
+                "12345",
+                "--output-dir",
+                str(output_dir),
+                "--max-depth",
+                "1",
+            ]
+        )
+
+    assert exc_info.value.code == 2
+
+    captured = capsys.readouterr()
+    assert "knowledge-adapters confluence: error: --max-depth requires --tree.\n" in captured.err
+
+
 def test_confluence_cli_reports_invalid_output_dir(
     tmp_path: Path,
     capsys: CaptureFixture[str],


### PR DESCRIPTION
Summary
- reject explicit --max-depth usage unless --tree is also set
- prevent the prior silent no-op behavior when --max-depth was provided alone
- add CLI coverage for the new validation while preserving existing behavior when --tree is present

Testing
- make check