### PR TITLE
feat: report progress during confluence listing pagination

### DIFF
--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -1469,6 +1469,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                         resolved_target,
                         base_url=confluence_config.base_url,
                         auth_method=confluence_config.auth_method,
+                        progress_callback=_print_discovered_pages_progress,
                         **real_client_tls_kwargs(),
                     )
 
@@ -1483,6 +1484,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                         space_key,
                         base_url=confluence_config.base_url,
                         auth_method=confluence_config.auth_method,
+                        progress_callback=_print_discovered_pages_progress,
                         **real_client_tls_kwargs(),
                     )
 
@@ -1728,9 +1730,12 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "use --client-mode real to discover descendants from Confluence."
             )
 
+        def _print_discovered_pages_progress(discovered_pages: int) -> None:
+            print(f"discovered_pages: {discovered_pages}")
+
         def _print_tree_walk_progress(progress: TreeWalkProgress) -> None:
             if progress.periodic:
-                print(f"discovered_pages: {progress.discovered_pages}")
+                _print_discovered_pages_progress(progress.discovered_pages)
                 return
             print(
                 "Tree progress: "

--- a/src/knowledge_adapters/confluence/client.py
+++ b/src/knowledge_adapters/confluence/client.py
@@ -6,11 +6,13 @@ import json
 import os
 import socket
 import ssl
+from collections.abc import Callable
 from urllib import parse, request
 from urllib.error import HTTPError, URLError
 
 from knowledge_adapters.confluence.auth import build_request_auth
 from knowledge_adapters.confluence.models import ResolvedTarget
+from knowledge_adapters.confluence.traversal import DISCOVERY_PROGRESS_INTERVAL
 
 
 class ConfluenceRequestError(RuntimeError):
@@ -28,6 +30,9 @@ class ConfluenceRequestError(RuntimeError):
         self.request_url = request_url
         self.auth_method = auth_method
         self.underlying_error = underlying_error
+
+
+DiscoveryProgressCallback = Callable[[int], None]
 
 
 def fetch_page(target: ResolvedTarget) -> dict[str, object]:
@@ -245,6 +250,26 @@ def _next_page_url(payload: dict[str, object], *, base_url: str) -> str | None:
     if not isinstance(next_url, str) or not next_url:
         return None
     return _absolute_api_url(base_url, next_url)
+
+
+def _report_periodic_discovery_progress(
+    discovered_pages: int,
+    *,
+    last_reported_pages: int,
+    progress_callback: DiscoveryProgressCallback | None,
+) -> int:
+    if progress_callback is None:
+        return last_reported_pages
+
+    next_threshold = max(
+        DISCOVERY_PROGRESS_INTERVAL,
+        last_reported_pages + DISCOVERY_PROGRESS_INTERVAL,
+    )
+    while next_threshold <= discovered_pages:
+        progress_callback(next_threshold)
+        last_reported_pages = next_threshold
+        next_threshold += DISCOVERY_PROGRESS_INTERVAL
+    return last_reported_pages
 
 
 def _sanitize_debug_value(value: str) -> str:
@@ -468,6 +493,7 @@ def list_real_child_page_ids(
     no_ca_bundle: bool = False,
     client_cert_file: str | None = None,
     client_key_file: str | None = None,
+    progress_callback: DiscoveryProgressCallback | None = None,
 ) -> list[str]:
     """List direct child page IDs for one Confluence page in real mode."""
     page_id = target.page_id
@@ -482,7 +508,13 @@ def list_real_child_page_ids(
         client_cert_file=client_cert_file,
         client_key_file=client_key_file,
     )
-    return _map_child_page_ids(raw_payload)
+    child_page_ids = _map_child_page_ids(raw_payload)
+    _report_periodic_discovery_progress(
+        len(set(child_page_ids)),
+        last_reported_pages=0,
+        progress_callback=progress_callback,
+    )
+    return child_page_ids
 
 
 def list_real_space_page_ids(
@@ -495,6 +527,7 @@ def list_real_space_page_ids(
     client_cert_file: str | None = None,
     client_key_file: str | None = None,
     page_limit: int = 100,
+    progress_callback: DiscoveryProgressCallback | None = None,
 ) -> list[str]:
     """List all page IDs in one Confluence space in deterministic order."""
     if not space_key:
@@ -508,6 +541,7 @@ def list_real_space_page_ids(
     )
     page_ids: set[str] = set()
     seen_page_urls: set[str] = set()
+    last_reported_pages = 0
     while next_url is not None:
         if next_url in seen_page_urls:
             raise ValueError("Response error: repeated space page-list pagination URL.")
@@ -522,6 +556,11 @@ def list_real_space_page_ids(
             client_key_file=client_key_file,
         )
         page_ids.update(_map_content_page_ids(raw_payload))
+        last_reported_pages = _report_periodic_discovery_progress(
+            len(page_ids),
+            last_reported_pages=last_reported_pages,
+            progress_callback=progress_callback,
+        )
         next_url = _next_page_url(raw_payload, base_url=base_url)
 
     return sorted(page_ids)

--- a/tests/confluence/test_client.py
+++ b/tests/confluence/test_client.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import json
+from typing import Literal
+
+from pytest import MonkeyPatch
+
+from knowledge_adapters.confluence.client import (
+    list_real_child_page_ids,
+    list_real_space_page_ids,
+)
+from knowledge_adapters.confluence.models import ResolvedTarget
+
+
+class _FakeHTTPResponse:
+    def __init__(self, payload: dict[str, object], *, status: int = 200) -> None:
+        self.status = status
+        self._payload = payload
+
+    def __enter__(self) -> _FakeHTTPResponse:
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> Literal[False]:
+        return False
+
+    def read(self) -> bytes:
+        return json.dumps(self._payload).encode("utf-8")
+
+    def getcode(self) -> int:
+        return self.status
+
+
+def _real_target(page_id: str = "12345") -> ResolvedTarget:
+    return ResolvedTarget(
+        raw_value=page_id,
+        page_id=page_id,
+        page_url=None,
+    )
+
+
+def _valid_child_list_payload(*, child_page_ids: list[str]) -> dict[str, object]:
+    return {
+        "results": [
+            {
+                "id": child_page_id,
+            }
+            for child_page_id in child_page_ids
+        ]
+    }
+
+
+def _valid_space_page_list_payload(
+    *,
+    page_ids: list[str],
+    next_url: str | None = None,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "results": [{"id": page_id, "type": "page"} for page_id in page_ids]
+    }
+    if next_url is not None:
+        payload["_links"] = {"next": next_url}
+    return payload
+
+
+def test_real_child_list_reports_periodic_progress_for_large_results(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    progress_updates: list[int] = []
+
+    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *args, **kwargs: _FakeHTTPResponse(
+            _valid_child_list_payload(
+                child_page_ids=[str(page_id) for page_id in range(200, 1201)]
+            )
+        ),
+    )
+
+    child_page_ids = list_real_child_page_ids(
+        _real_target(),
+        base_url="https://example.com/wiki",
+        auth_method="bearer-env",
+        progress_callback=progress_updates.append,
+    )
+
+    assert len(child_page_ids) == 1001
+    assert progress_updates == [500, 1000]
+
+
+def test_real_child_list_does_not_report_progress_for_small_results(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    progress_updates: list[int] = []
+
+    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *args, **kwargs: _FakeHTTPResponse(
+            _valid_child_list_payload(child_page_ids=["200", "300", "300"])
+        ),
+    )
+
+    list_real_child_page_ids(
+        _real_target(),
+        base_url="https://example.com/wiki",
+        auth_method="bearer-env",
+        progress_callback=progress_updates.append,
+    )
+
+    assert progress_updates == []
+
+
+def test_real_space_page_list_reports_periodic_progress_during_pagination(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    progress_updates: list[int] = []
+    payloads = [
+        _valid_space_page_list_payload(
+            page_ids=[str(page_id) for page_id in range(1, 401)],
+            next_url="/wiki/rest/api/content?spaceKey=ENG&type=page&start=400&limit=400",
+        ),
+        _valid_space_page_list_payload(
+            page_ids=[str(page_id) for page_id in range(401, 801)],
+            next_url="/wiki/rest/api/content?spaceKey=ENG&type=page&start=800&limit=400",
+        ),
+        _valid_space_page_list_payload(
+            page_ids=[str(page_id) for page_id in range(801, 1101)]
+        ),
+    ]
+
+    def fake_urlopen(*args: object, **kwargs: object) -> _FakeHTTPResponse:
+        del args, kwargs
+        return _FakeHTTPResponse(payloads.pop(0))
+
+    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    page_ids = list_real_space_page_ids(
+        "ENG",
+        base_url="https://example.com/wiki",
+        auth_method="bearer-env",
+        page_limit=400,
+        progress_callback=progress_updates.append,
+    )
+
+    assert len(page_ids) == 1100
+    assert progress_updates == [500, 1000]
+
+
+def test_real_space_page_list_does_not_report_progress_for_small_runs(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    progress_updates: list[int] = []
+
+    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *args, **kwargs: _FakeHTTPResponse(
+            _valid_space_page_list_payload(page_ids=["100", "200"])
+        ),
+    )
+
+    list_real_space_page_ids(
+        "ENG",
+        base_url="https://example.com/wiki",
+        auth_method="bearer-env",
+        progress_callback=progress_updates.append,
+    )
+
+    assert progress_updates == []

--- a/tests/confluence/test_traversal_real.py
+++ b/tests/confluence/test_traversal_real.py
@@ -204,6 +204,7 @@ def _run_real_recursive_cli(
     *,
     pages: dict[str, dict[str, object]] | None = None,
     children_by_parent: dict[str, ChildDiscoveryResult] | None = None,
+    listing_progress_counts_by_parent: dict[str, list[int]] | None = None,
     target: str = "100",
     max_depth: int,
     dry_run: bool = False,
@@ -240,6 +241,10 @@ def _run_real_recursive_cli(
     def stub_child_id_discovery(*args: object, **kwargs: object) -> list[str]:
         parent_id = _called_page_id(args, kwargs)
         child_list_calls.append(parent_id)
+        progress_callback = kwargs.get("progress_callback")
+        if callable(progress_callback):
+            for discovered_pages in (listing_progress_counts_by_parent or {}).get(parent_id, []):
+                progress_callback(discovered_pages)
 
         result = children_by_parent[parent_id]
         if isinstance(result, Exception):
@@ -316,8 +321,16 @@ def _run_real_space_cli(
         ca_bundle: str | None = None,
         client_cert_file: str | None = None,
         client_key_file: str | None = None,
+        progress_callback: object | None = None,
     ) -> list[str]:
-        del base_url, auth_method, ca_bundle, client_cert_file, client_key_file
+        del (
+            base_url,
+            auth_method,
+            ca_bundle,
+            client_cert_file,
+            client_key_file,
+            progress_callback,
+        )
         space_list_calls.append(space_key)
         return list(discovered_page_ids or [])
 
@@ -577,8 +590,16 @@ def test_real_space_reuses_cached_space_page_listing(
         ca_bundle: str | None = None,
         client_cert_file: str | None = None,
         client_key_file: str | None = None,
+        progress_callback: object | None = None,
     ) -> list[str]:
-        del base_url, auth_method, ca_bundle, client_cert_file, client_key_file
+        del (
+            base_url,
+            auth_method,
+            ca_bundle,
+            client_cert_file,
+            client_key_file,
+            progress_callback,
+        )
         space_list_calls.append(space_key)
         return ["300", "100", "200"]
 
@@ -970,6 +991,49 @@ def test_real_tree_reports_periodic_discovery_progress_for_large_runs(
     assert "    would_skip: 0" in output
     assert "  pages_in_tree: 1001 (root + descendants)" in output
     assert "    pages_in_plan: 1001 (root 1, descendants 1000)" in output
+
+
+def test_real_tree_reports_listing_progress_before_depth_progress(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    pages = {
+        str(page_id): {
+            "canonical_id": str(page_id),
+            "title": f"Page {page_id}",
+            "source_url": f"https://example.com/wiki/pages/{page_id}",
+            "content": f"Content for {page_id}.",
+            "page_version": page_id,
+            "last_modified": "2026-04-20T00:00:00Z",
+        }
+        for page_id in range(100, 1101)
+    }
+    children_by_parent: dict[str, ChildDiscoveryResult] = {
+        "100": [str(page_id) for page_id in range(101, 1101)],
+    }
+    children_by_parent.update({str(page_id): [] for page_id in range(101, 1101)})
+
+    exit_code, _output_dir, _page_fetch_counts, _child_list_calls = _run_real_recursive_cli(
+        tmp_path,
+        monkeypatch,
+        pages=pages,
+        children_by_parent=children_by_parent,
+        listing_progress_counts_by_parent={"100": [500, 1000]},
+        max_depth=1,
+        dry_run=True,
+    )
+
+    assert exit_code == 0
+
+    output = capsys.readouterr().out
+    assert "Tree progress: depth 0, discovered 1, fetched 1, planned 1" in output
+    assert "discovered_pages: 500" in output
+    assert "discovered_pages: 1000" in output
+    assert "Tree progress: depth 1, discovered 1001, fetched 1001, planned 1001" in output
+    assert output.index("discovered_pages: 500") < output.index(
+        "Tree progress: depth 1, discovered 1001, fetched 1001, planned 1001"
+    )
 
 
 def test_real_tree_orders_pages_breadth_first_then_lexical_without_parent_adjacency(

--- a/tests/test_confluence_real_client_contract.py
+++ b/tests/test_confluence_real_client_contract.py
@@ -4,6 +4,7 @@ import io
 import json
 import re
 import ssl
+from collections.abc import Callable
 from email.message import Message
 from pathlib import Path
 from typing import Any, Literal, cast
@@ -99,6 +100,7 @@ def _list_real_child_page_ids(
     ca_bundle: str | None = None,
     client_cert_file: str | None = None,
     client_key_file: str | None = None,
+    progress_callback: Callable[[int], None] | None = None,
 ) -> list[str]:
     from knowledge_adapters.confluence import client as client_module
 
@@ -110,6 +112,7 @@ def _list_real_child_page_ids(
         ca_bundle=ca_bundle,
         client_cert_file=client_cert_file,
         client_key_file=client_key_file,
+        progress_callback=progress_callback,
     )
     return cast(list[str], child_page_ids)
 
@@ -123,6 +126,7 @@ def _list_real_space_page_ids(
     client_cert_file: str | None = None,
     client_key_file: str | None = None,
     page_limit: int = 100,
+    progress_callback: Callable[[int], None] | None = None,
 ) -> list[str]:
     from knowledge_adapters.confluence import client as client_module
 
@@ -135,6 +139,7 @@ def _list_real_space_page_ids(
         client_cert_file=client_cert_file,
         client_key_file=client_key_file,
         page_limit=page_limit,
+        progress_callback=progress_callback,
     )
     return cast(list[str], page_ids)
 
@@ -1094,6 +1099,51 @@ def test_real_child_list_maps_valid_confluence_response_into_child_page_ids(
     assert child_page_ids == ["200", "300", "300"]
 
 
+def test_real_child_list_reports_periodic_progress_for_large_results(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    progress_updates: list[int] = []
+
+    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *args, **kwargs: _FakeHTTPResponse(
+            _valid_child_list_payload(
+                child_page_ids=[str(page_id) for page_id in range(200, 1201)]
+            )
+        ),
+    )
+
+    child_page_ids = _list_real_child_page_ids(
+        _real_target(),
+        progress_callback=progress_updates.append,
+    )
+
+    assert len(child_page_ids) == 1001
+    assert progress_updates == [500, 1000]
+
+
+def test_real_child_list_does_not_report_progress_for_small_results(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    progress_updates: list[int] = []
+
+    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *args, **kwargs: _FakeHTTPResponse(
+            _valid_child_list_payload(child_page_ids=["200", "300", "300"])
+        ),
+    )
+
+    _list_real_child_page_ids(
+        _real_target(),
+        progress_callback=progress_updates.append,
+    )
+
+    assert progress_updates == []
+
+
 def test_real_child_list_ignores_extra_irrelevant_fields_in_valid_response(
     monkeypatch: MonkeyPatch,
 ) -> None:
@@ -1151,6 +1201,62 @@ def test_real_space_page_list_paginates_and_returns_lexical_page_ids(
         "https://example.com/wiki/rest/api/content?spaceKey=ENG&type=page&start=0&limit=2",
         "https://example.com/wiki/rest/api/content?spaceKey=ENG&type=page&start=2&limit=2",
     ]
+
+
+def test_real_space_page_list_reports_periodic_progress_during_pagination(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    progress_updates: list[int] = []
+    payloads = [
+        _valid_space_page_list_payload(
+            page_ids=[str(page_id) for page_id in range(1, 401)],
+            next_url="/wiki/rest/api/content?spaceKey=ENG&type=page&start=400&limit=400",
+        ),
+        _valid_space_page_list_payload(
+            page_ids=[str(page_id) for page_id in range(401, 801)],
+            next_url="/wiki/rest/api/content?spaceKey=ENG&type=page&start=800&limit=400",
+        ),
+        _valid_space_page_list_payload(
+            page_ids=[str(page_id) for page_id in range(801, 1101)]
+        ),
+    ]
+
+    def fake_urlopen(*args: object, **kwargs: object) -> _FakeHTTPResponse:
+        del args, kwargs
+        return _FakeHTTPResponse(payloads.pop(0))
+
+    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    page_ids = _list_real_space_page_ids(
+        "ENG",
+        page_limit=400,
+        progress_callback=progress_updates.append,
+    )
+
+    assert len(page_ids) == 1100
+    assert progress_updates == [500, 1000]
+
+
+def test_real_space_page_list_does_not_report_progress_for_small_runs(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    progress_updates: list[int] = []
+
+    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *args, **kwargs: _FakeHTTPResponse(
+            _valid_space_page_list_payload(page_ids=["100", "200"])
+        ),
+    )
+
+    _list_real_space_page_ids(
+        "ENG",
+        progress_callback=progress_updates.append,
+    )
+
+    assert progress_updates == []
 
 
 def test_real_space_page_list_rejects_non_page_content(

--- a/tests/test_confluence_real_client_contract.py
+++ b/tests/test_confluence_real_client_contract.py
@@ -4,7 +4,6 @@ import io
 import json
 import re
 import ssl
-from collections.abc import Callable
 from email.message import Message
 from pathlib import Path
 from typing import Any, Literal, cast
@@ -100,7 +99,6 @@ def _list_real_child_page_ids(
     ca_bundle: str | None = None,
     client_cert_file: str | None = None,
     client_key_file: str | None = None,
-    progress_callback: Callable[[int], None] | None = None,
 ) -> list[str]:
     from knowledge_adapters.confluence import client as client_module
 
@@ -112,7 +110,6 @@ def _list_real_child_page_ids(
         ca_bundle=ca_bundle,
         client_cert_file=client_cert_file,
         client_key_file=client_key_file,
-        progress_callback=progress_callback,
     )
     return cast(list[str], child_page_ids)
 
@@ -126,7 +123,6 @@ def _list_real_space_page_ids(
     client_cert_file: str | None = None,
     client_key_file: str | None = None,
     page_limit: int = 100,
-    progress_callback: Callable[[int], None] | None = None,
 ) -> list[str]:
     from knowledge_adapters.confluence import client as client_module
 
@@ -139,7 +135,6 @@ def _list_real_space_page_ids(
         client_cert_file=client_cert_file,
         client_key_file=client_key_file,
         page_limit=page_limit,
-        progress_callback=progress_callback,
     )
     return cast(list[str], page_ids)
 
@@ -1099,51 +1094,6 @@ def test_real_child_list_maps_valid_confluence_response_into_child_page_ids(
     assert child_page_ids == ["200", "300", "300"]
 
 
-def test_real_child_list_reports_periodic_progress_for_large_results(
-    monkeypatch: MonkeyPatch,
-) -> None:
-    progress_updates: list[int] = []
-
-    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
-    monkeypatch.setattr(
-        "urllib.request.urlopen",
-        lambda *args, **kwargs: _FakeHTTPResponse(
-            _valid_child_list_payload(
-                child_page_ids=[str(page_id) for page_id in range(200, 1201)]
-            )
-        ),
-    )
-
-    child_page_ids = _list_real_child_page_ids(
-        _real_target(),
-        progress_callback=progress_updates.append,
-    )
-
-    assert len(child_page_ids) == 1001
-    assert progress_updates == [500, 1000]
-
-
-def test_real_child_list_does_not_report_progress_for_small_results(
-    monkeypatch: MonkeyPatch,
-) -> None:
-    progress_updates: list[int] = []
-
-    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
-    monkeypatch.setattr(
-        "urllib.request.urlopen",
-        lambda *args, **kwargs: _FakeHTTPResponse(
-            _valid_child_list_payload(child_page_ids=["200", "300", "300"])
-        ),
-    )
-
-    _list_real_child_page_ids(
-        _real_target(),
-        progress_callback=progress_updates.append,
-    )
-
-    assert progress_updates == []
-
-
 def test_real_child_list_ignores_extra_irrelevant_fields_in_valid_response(
     monkeypatch: MonkeyPatch,
 ) -> None:
@@ -1201,62 +1151,6 @@ def test_real_space_page_list_paginates_and_returns_lexical_page_ids(
         "https://example.com/wiki/rest/api/content?spaceKey=ENG&type=page&start=0&limit=2",
         "https://example.com/wiki/rest/api/content?spaceKey=ENG&type=page&start=2&limit=2",
     ]
-
-
-def test_real_space_page_list_reports_periodic_progress_during_pagination(
-    monkeypatch: MonkeyPatch,
-) -> None:
-    progress_updates: list[int] = []
-    payloads = [
-        _valid_space_page_list_payload(
-            page_ids=[str(page_id) for page_id in range(1, 401)],
-            next_url="/wiki/rest/api/content?spaceKey=ENG&type=page&start=400&limit=400",
-        ),
-        _valid_space_page_list_payload(
-            page_ids=[str(page_id) for page_id in range(401, 801)],
-            next_url="/wiki/rest/api/content?spaceKey=ENG&type=page&start=800&limit=400",
-        ),
-        _valid_space_page_list_payload(
-            page_ids=[str(page_id) for page_id in range(801, 1101)]
-        ),
-    ]
-
-    def fake_urlopen(*args: object, **kwargs: object) -> _FakeHTTPResponse:
-        del args, kwargs
-        return _FakeHTTPResponse(payloads.pop(0))
-
-    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
-    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
-
-    page_ids = _list_real_space_page_ids(
-        "ENG",
-        page_limit=400,
-        progress_callback=progress_updates.append,
-    )
-
-    assert len(page_ids) == 1100
-    assert progress_updates == [500, 1000]
-
-
-def test_real_space_page_list_does_not_report_progress_for_small_runs(
-    monkeypatch: MonkeyPatch,
-) -> None:
-    progress_updates: list[int] = []
-
-    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
-    monkeypatch.setattr(
-        "urllib.request.urlopen",
-        lambda *args, **kwargs: _FakeHTTPResponse(
-            _valid_space_page_list_payload(page_ids=["100", "200"])
-        ),
-    )
-
-    _list_real_space_page_ids(
-        "ENG",
-        progress_callback=progress_updates.append,
-    )
-
-    assert progress_updates == []
 
 
 def test_real_space_page_list_rejects_non_page_content(


### PR DESCRIPTION
Summary
- report periodic `discovered_pages: <count>` updates during Confluence listing so large runs show progress before traversal fetches begin
- reuse the existing discovered-pages cadence and label so this complements #206 without changing traversal, fetch, or cache behavior
- add focused contract and CLI coverage for large listing progress, small-run quiet output, and traversal-progress compatibility

Testing
- make check

Closes #210