### PR TITLE
test: add Confluence tree traversal stub integration coverage

### DIFF
--- a/tests/integration/test_confluence_stub.py
+++ b/tests/integration/test_confluence_stub.py
@@ -37,6 +37,29 @@ def _confluence_argv(
     return argv
 
 
+def _confluence_tree_argv(
+    base_url: str,
+    output_dir: Path,
+    *,
+    target: str,
+    max_depth: int,
+) -> list[str]:
+    return [
+        "confluence",
+        "--client-mode",
+        "real",
+        "--base-url",
+        base_url,
+        "--target",
+        target,
+        "--tree",
+        "--max-depth",
+        str(max_depth),
+        "--output-dir",
+        str(output_dir),
+    ]
+
+
 def _load_manifest(output_dir: Path) -> dict[str, object]:
     payload = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
     assert isinstance(payload, dict)
@@ -146,3 +169,84 @@ def test_confluence_cli_reuses_fetch_cache_on_second_fetch(
     assert "Summary: wrote 1, skipped 0" in second_run.out
     assert "cache_hits: 1" in second_run.out
     assert "cache_misses: 0" in second_run.out
+
+
+@pytest.mark.integration
+def test_confluence_cli_traverses_tree_through_real_client_path(
+    tmp_path: Path,
+    confluence_stub_server: ConfluenceStubServer,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "stub-token")
+    output_dir = tmp_path / "artifacts"
+
+    exit_code = main(
+        _confluence_tree_argv(
+            confluence_stub_server.base_url,
+            output_dir,
+            target="12345",
+            max_depth=1,
+        )
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "pages_in_tree: 2 (root + descendants)" in captured.out
+    assert "Summary: wrote 2, skipped 0" in captured.out
+
+    root_page_path = output_dir / "pages" / "12345.md"
+    child_page_path = output_dir / "pages" / "23456.md"
+    assert_markdown_document(
+        root_page_path.read_text(encoding="utf-8"),
+        title="Test Page",
+        metadata={
+            "source": "confluence",
+            "canonical_id": "12345",
+            "parent_id": "",
+            "source_url": f"{confluence_stub_server.base_url}/pages/viewpage.action?pageId=12345",
+            "fetched_at": "",
+            "updated_at": "",
+            "adapter": "confluence",
+        },
+        content="Hello world",
+    )
+    assert_markdown_document(
+        child_page_path.read_text(encoding="utf-8"),
+        title="Child Page",
+        metadata={
+            "source": "confluence",
+            "canonical_id": "23456",
+            "parent_id": "",
+            "source_url": f"{confluence_stub_server.base_url}/pages/viewpage.action?pageId=23456",
+            "fetched_at": "",
+            "updated_at": "",
+            "adapter": "confluence",
+        },
+        content="Child page content",
+    )
+
+    manifest = _load_manifest(output_dir)
+    assert manifest["root_page_id"] == "12345"
+    assert manifest["max_depth"] == 1
+    assert_manifest_entries(
+        manifest,
+        files=[
+            manifest_file(
+                canonical_id="12345",
+                source_url=f"{confluence_stub_server.base_url}/pages/viewpage.action?pageId=12345",
+                output_path="pages/12345.md",
+                title="Test Page",
+                page_version=1,
+                last_modified="2026-04-20T12:34:56Z",
+            ),
+            manifest_file(
+                canonical_id="23456",
+                source_url=f"{confluence_stub_server.base_url}/pages/viewpage.action?pageId=23456",
+                output_path="pages/23456.md",
+                title="Child Page",
+                page_version=2,
+                last_modified="2026-04-20T12:45:00Z",
+            ),
+        ],
+    )

--- a/tools/confluence_stub/app.py
+++ b/tools/confluence_stub/app.py
@@ -16,6 +16,7 @@ class Page:
     version: int
     last_modified: str
     content: str
+    child_page_ids: tuple[str, ...]
 
 
 app = FastAPI(title="Confluence Stub")
@@ -36,6 +37,7 @@ def _load_pages() -> list[Page]:
         version = raw_page.get("version")
         last_modified = raw_page.get("last_modified")
         content = raw_page.get("content")
+        child_page_ids = raw_page.get("child_page_ids", [])
         if not isinstance(page_id, str) or not page_id:
             raise ValueError("Each stub page must include a non-empty string id.")
         if not isinstance(title, str) or not title:
@@ -46,6 +48,13 @@ def _load_pages() -> list[Page]:
             raise ValueError(f"Stub page {page_id} must include a non-empty last_modified.")
         if not isinstance(content, str):
             raise ValueError(f"Stub page {page_id} must include string content.")
+        if not isinstance(child_page_ids, list) or any(
+            not isinstance(child_page_id, str) or not child_page_id
+            for child_page_id in child_page_ids
+        ):
+            raise ValueError(
+                f"Stub page {page_id} must include child_page_ids as a list of strings."
+            )
 
         pages.append(
             Page(
@@ -54,6 +63,7 @@ def _load_pages() -> list[Page]:
                 version=version,
                 last_modified=last_modified,
                 content=content,
+                child_page_ids=tuple(child_page_ids),
             )
         )
 
@@ -151,3 +161,16 @@ def get_page(
         version=version,
         last_modified=last_modified,
     )
+
+
+@app.get("/rest/api/content/{page_id}/child/page")
+def list_child_pages(
+    page_id: str,
+    request: Request,
+) -> dict[str, object]:
+    page = _find_page(page_id)
+    child_pages = [_find_page(child_page_id) for child_page_id in page.child_page_ids]
+    return {
+        "results": [_summary_payload(request, child_page) for child_page in child_pages],
+        "size": len(child_pages),
+    }

--- a/tools/confluence_stub/data/pages.json
+++ b/tools/confluence_stub/data/pages.json
@@ -4,6 +4,15 @@
     "title": "Test Page",
     "version": 1,
     "last_modified": "2026-04-20T12:34:56Z",
-    "content": "Hello world"
+    "content": "Hello world",
+    "child_page_ids": ["23456"]
+  },
+  {
+    "id": "23456",
+    "title": "Child Page",
+    "version": 2,
+    "last_modified": "2026-04-20T12:45:00Z",
+    "content": "Child page content",
+    "child_page_ids": []
   }
 ]


### PR DESCRIPTION
Summary
- add a minimal child-page listing path to the local Confluence stub
- extend the stub data with one deterministic parent/child page pair
- add one real-client integration test covering `--tree --max-depth 1` end to end

Testing
- make smoke
- make check