### PR TITLE
Improve large-run progress output ergonomics

### DIFF
--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -207,6 +207,37 @@ class _TeeStream:
             stream.flush()
 
 
+class _ProgressLineRenderer:
+    """Render deterministic progress lines, using carriage return only for TTYs."""
+
+    def __init__(self, stream: TextIO) -> None:
+        self._stream = stream
+        self._has_pending_tty_line = False
+
+    def render(self, text: str) -> None:
+        if self._is_tty():
+            self._stream.write(f"\r{text}")
+            self._stream.flush()
+            self._has_pending_tty_line = True
+            return
+
+        print(text, file=self._stream)
+
+    def finish(self) -> None:
+        if not self._has_pending_tty_line:
+            return
+
+        self._stream.write("\n")
+        self._stream.flush()
+        self._has_pending_tty_line = False
+
+    def _is_tty(self) -> bool:
+        isatty = getattr(self._stream, "isatty", None)
+        if not callable(isatty):
+            return False
+        return bool(isatty())
+
+
 def _parse_confluence_auth_method(value: str) -> str:
     """Parse and validate a supported Confluence auth method."""
     normalized_value = value.strip()
@@ -1730,13 +1761,19 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "use --client-mode real to discover descendants from Confluence."
             )
 
+        progress_renderer = _ProgressLineRenderer(sys.stdout)
+
+        def _finish_progress_line() -> None:
+            progress_renderer.finish()
+
         def _print_discovered_pages_progress(discovered_pages: int) -> None:
-            print(f"discovered_pages: {discovered_pages}")
+            progress_renderer.render(f"discovered_pages: {discovered_pages}")
 
         def _print_tree_walk_progress(progress: TreeWalkProgress) -> None:
             if progress.periodic:
                 _print_discovered_pages_progress(progress.discovered_pages)
                 return
+            _finish_progress_line()
             print(
                 "Tree progress: "
                 f"depth {progress.depth}, "
@@ -1766,6 +1803,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             print(f"Space progress: discovery started, space_key {resolved_space_key}")
             try:
                 discovered_page_ids = sorted(set(selected_list_space_page_ids(resolved_space_key)))
+                _finish_progress_line()
                 print(
                     "Space progress: "
                     f"discovered {len(discovered_page_ids)} pages, "
@@ -1792,12 +1830,14 @@ def main(argv: Sequence[str] | None = None) -> int:
                             f"planned {len(discovered_page_ids)}"
                         )
             except (RuntimeError, ValueError) as exc:
+                _finish_progress_line()
                 exit_with_cli_error(
                     str(exc),
                     command="confluence",
                     debug_lines=_confluence_debug_lines(exc),
                 )
 
+            _finish_progress_line()
             _print_confluence_invocation()
             space_page_records: list[tuple[dict[str, object], Path, PageSyncDecision, str]] = []
             for page in pages:
@@ -1992,6 +2032,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                         progress_callback=_print_tree_walk_progress,
                     )
                 except (RuntimeError, ValueError) as exc:
+                    _finish_progress_line()
                     exit_with_cli_error(
                         str(exc),
                         command="confluence",
@@ -2005,6 +2046,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     list_child_page_ids=selected_list_child_page_ids,
                     progress_callback=_print_tree_walk_progress,
                 )
+            _finish_progress_line()
             _print_confluence_invocation()
             page_records: list[tuple[dict[str, object], Path, PageSyncDecision, str]] = []
             for page in pages:

--- a/tests/confluence/test_traversal_real.py
+++ b/tests/confluence/test_traversal_real.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 from typing import cast
 
@@ -984,6 +985,7 @@ def test_real_tree_reports_periodic_discovery_progress_for_large_runs(
     assert exit_code == 0
 
     output = capsys.readouterr().out
+    assert "\r" not in output
     assert "discovered_pages: 500" in output
     assert "discovered_pages: 1000" in output
     assert "  Summary:" in output
@@ -991,6 +993,50 @@ def test_real_tree_reports_periodic_discovery_progress_for_large_runs(
     assert "    would_skip: 0" in output
     assert "  pages_in_tree: 1001 (root + descendants)" in output
     assert "    pages_in_plan: 1001 (root 1, descendants 1000)" in output
+
+
+def test_real_tree_uses_carriage_return_progress_for_tty_stdout(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    pages = {
+        str(page_id): {
+            "canonical_id": str(page_id),
+            "title": f"Page {page_id}",
+            "source_url": f"https://example.com/wiki/pages/{page_id}",
+            "content": f"Content for {page_id}.",
+            "page_version": page_id,
+            "last_modified": "2026-04-20T00:00:00Z",
+        }
+        for page_id in range(100, 1101)
+    }
+    children_by_parent: dict[str, ChildDiscoveryResult] = {
+        "100": [str(page_id) for page_id in range(101, 1101)],
+    }
+    children_by_parent.update({str(page_id): [] for page_id in range(101, 1101)})
+
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+
+    exit_code, _output_dir, _page_fetch_counts, _child_list_calls = _run_real_recursive_cli(
+        tmp_path,
+        monkeypatch,
+        pages=pages,
+        children_by_parent=children_by_parent,
+        max_depth=1,
+        dry_run=True,
+    )
+
+    assert exit_code == 0
+
+    output = capsys.readouterr().out
+    assert "\rdiscovered_pages: 500" in output
+    assert (
+        "\rdiscovered_pages: 1000\n"
+        "Tree progress: depth 1, discovered 1001, fetched 1001, planned 1001"
+        in output
+    )
+    assert output.endswith("\n")
 
 
 def test_real_tree_reports_listing_progress_before_depth_progress(


### PR DESCRIPTION
Summary
- add a tiny TTY-aware renderer for periodic discovered_pages progress updates
- preserve deterministic line-based progress output for non-TTY runs and captured logs
- ensure inline TTY progress hands off cleanly to the next newline-terminated message

Testing
- make check
- make smoke

Closes #215