### PR TITLE
Suppress per-item output by default; add --verbose

### DIFF
--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -171,6 +171,7 @@ _CONFLUENCE_REAL_ONLY_INPUT_FLAGS = (
     "--fetch-cache-dir",
     "--tree-cache-dir",
 )
+_VERBOSE_HELP = "Show per-item write/skip details that are hidden by default."
 
 
 @dataclass(frozen=True)
@@ -427,6 +428,19 @@ def build_parser() -> argparse.ArgumentParser:
         epilog=TOP_LEVEL_HELP_EXAMPLES,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help=_VERBOSE_HELP,
+    )
+
+    def add_verbose_argument(subparser: argparse.ArgumentParser) -> None:
+        subparser.add_argument(
+            "--verbose",
+            action="store_true",
+            default=argparse.SUPPRESS,
+            help=_VERBOSE_HELP,
+        )
 
     subparsers = parser.add_subparsers(dest="command", required=True)
 
@@ -453,6 +467,7 @@ def build_parser() -> argparse.ArgumentParser:
         epilog=CONFLUENCE_HELP_EXAMPLES,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
+    add_verbose_argument(confluence_parser)
     confluence_parser.add_argument(
         "--base-url",
         required=True,
@@ -593,6 +608,7 @@ def build_parser() -> argparse.ArgumentParser:
         epilog=LOCAL_FILES_HELP_EXAMPLES,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
+    add_verbose_argument(local_files_parser)
     local_files_parser.add_argument(
         "--file-path",
         required=True,
@@ -633,6 +649,7 @@ def build_parser() -> argparse.ArgumentParser:
         epilog=GIT_REPO_HELP_EXAMPLES,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
+    add_verbose_argument(git_repo_parser)
     git_repo_parser.add_argument(
         "--repo-url",
         required=True,
@@ -704,6 +721,7 @@ def build_parser() -> argparse.ArgumentParser:
         epilog=GITHUB_METADATA_HELP_EXAMPLES,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
+    add_verbose_argument(github_metadata_parser)
     github_metadata_parser.add_argument(
         "--repo",
         required=True,
@@ -803,6 +821,7 @@ def build_parser() -> argparse.ArgumentParser:
         epilog=BUNDLE_HELP_EXAMPLES,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
+    add_verbose_argument(bundle_parser)
     bundle_parser.add_argument(
         "inputs",
         nargs="*",
@@ -921,6 +940,7 @@ def build_parser() -> argparse.ArgumentParser:
         epilog=RUN_HELP_EXAMPLES,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
+    add_verbose_argument(run_parser)
     run_parser.add_argument(
         "config_path",
         metavar="RUNS_YAML",
@@ -1105,12 +1125,15 @@ def _effective_configured_run_argv(
     run_type: str,
     argv: Sequence[str],
     debug: bool,
+    verbose: bool,
 ) -> tuple[str, ...]:
     """Apply safe top-level run overrides before invoking a configured run."""
     effective_argv = tuple(argv)
-    if not debug or run_type != "confluence" or "--debug" in effective_argv:
-        return effective_argv
-    return (*effective_argv, "--debug")
+    if debug and run_type == "confluence" and "--debug" not in effective_argv:
+        effective_argv = (*effective_argv, "--debug")
+    if verbose and "--verbose" not in effective_argv:
+        effective_argv = (*effective_argv, "--verbose")
+    return effective_argv
 
 
 def _execute_configured_run(
@@ -1129,6 +1152,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     raw_argv = tuple(sys.argv[1:] if argv is None else argv)
     parser = build_parser()
     args = parser.parse_args(raw_argv)
+    verbose = bool(args.verbose)
 
     if args.command == "run":
         from knowledge_adapters.run_config import load_run_config, select_runs
@@ -1177,6 +1201,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 run_type=configured_run.run_type,
                 argv=configured_run.argv,
                 debug=args.debug,
+                verbose=verbose,
             )
             display_command = shlex.join(("knowledge-adapters", *effective_argv))
             print(
@@ -1973,12 +1998,13 @@ def main(argv: Sequence[str] | None = None) -> int:
                     discovered_count=len(discovered_page_ids),
                 )
                 print_stale_artifacts(confluence_config.output_dir, stale_artifacts)
-                for _page, output_path, page_decision, action in space_page_records:
-                    _print(
-                        "  would "
-                        f"{action} {_display_output_path(output_path)} "
-                        f"({_format_page_sync_decision(page_decision)})"
-                    )
+                if verbose:
+                    for _page, output_path, page_decision, action in space_page_records:
+                        _print(
+                            "  would "
+                            f"{action} {_display_output_path(output_path)} "
+                            f"({_format_page_sync_decision(page_decision)})"
+                        )
                 print_dry_run_complete()
                 return 0
 
@@ -2040,11 +2066,12 @@ def main(argv: Sequence[str] | None = None) -> int:
             try:
                 for page, output_path, page_decision, action in space_page_records:
                     if action == "skip":
-                        _print(
-                            "\nSkipped: "
-                            f"{_display_output_path(output_path)} "
-                            f"({_format_page_sync_decision(page_decision)})"
-                        )
+                        if verbose:
+                            _print(
+                                "\nSkipped: "
+                                f"{_display_output_path(output_path)} "
+                                f"({_format_page_sync_decision(page_decision)})"
+                            )
                         continue
 
                     page_to_write = space_pages_to_write[str(page.get("canonical_id") or "")]
@@ -2054,11 +2081,12 @@ def main(argv: Sequence[str] | None = None) -> int:
                         str(page_to_write.get("canonical_id") or ""),
                         markdown,
                     )
-                    _print(
-                        "\nWrote: "
-                        f"{_display_output_path(output_path)} "
-                        f"({_format_page_sync_decision(page_decision)})"
-                    )
+                    if verbose:
+                        _print(
+                            "\nWrote: "
+                            f"{_display_output_path(output_path)} "
+                            f"({_format_page_sync_decision(page_decision)})"
+                        )
 
                 manifest = write_manifest(confluence_config.output_dir, files)
             except OSError as exc:
@@ -2182,12 +2210,13 @@ def main(argv: Sequence[str] | None = None) -> int:
                     stale_count=len(stale_artifacts),
                 )
                 print_stale_artifacts(confluence_config.output_dir, stale_artifacts)
-                for _page, output_path, page_decision, action in page_records:
-                    _print(
-                        "  would "
-                        f"{action} {_display_output_path(output_path)} "
-                        f"({_format_page_sync_decision(page_decision)})"
-                    )
+                if verbose:
+                    for _page, output_path, page_decision, action in page_records:
+                        _print(
+                            "  would "
+                            f"{action} {_display_output_path(output_path)} "
+                            f"({_format_page_sync_decision(page_decision)})"
+                        )
                 print_dry_run_complete()
                 return 0
 
@@ -2249,11 +2278,12 @@ def main(argv: Sequence[str] | None = None) -> int:
             try:
                 for page, output_path, page_decision, action in page_records:
                     if action == "skip":
-                        _print(
-                            "\nSkipped: "
-                            f"{_display_output_path(output_path)} "
-                            f"({_format_page_sync_decision(page_decision)})"
-                        )
+                        if verbose:
+                            _print(
+                                "\nSkipped: "
+                                f"{_display_output_path(output_path)} "
+                                f"({_format_page_sync_decision(page_decision)})"
+                            )
                         continue
 
                     page_to_write = pages_to_write[str(page.get("canonical_id") or "")]
@@ -2263,11 +2293,12 @@ def main(argv: Sequence[str] | None = None) -> int:
                         str(page_to_write.get("canonical_id") or ""),
                         markdown,
                     )
-                    _print(
-                        "\nWrote: "
-                        f"{_display_output_path(output_path)} "
-                        f"({_format_page_sync_decision(page_decision)})"
-                    )
+                    if verbose:
+                        _print(
+                            "\nWrote: "
+                            f"{_display_output_path(output_path)} "
+                            f"({_format_page_sync_decision(page_decision)})"
+                        )
 
                 manifest = write_manifest_with_context(
                     confluence_config.output_dir,
@@ -2386,17 +2417,19 @@ def main(argv: Sequence[str] | None = None) -> int:
                     page_id,
                     markdown,
                 )
-                _print(
-                    "\nWrote: "
-                    f"{_display_output_path(output_path)} "
-                    f"({_format_page_sync_decision(page_decision)})"
-                )
+                if verbose:
+                    _print(
+                        "\nWrote: "
+                        f"{_display_output_path(output_path)} "
+                        f"({_format_page_sync_decision(page_decision)})"
+                    )
             else:
-                _print(
-                    "\nSkipped: "
-                    f"{_display_output_path(output_path)} "
-                    f"({_format_page_sync_decision(page_decision)})"
-                )
+                if verbose:
+                    _print(
+                        "\nSkipped: "
+                        f"{_display_output_path(output_path)} "
+                        f"({_format_page_sync_decision(page_decision)})"
+                    )
 
             manifest = write_manifest(
                 confluence_config.output_dir,

--- a/tests/confluence/test_traversal.py
+++ b/tests/confluence/test_traversal.py
@@ -58,6 +58,7 @@ def _run_recursive_cli(
     target: str = "100",
     max_depth: int,
     dry_run: bool = False,
+    verbose: bool = False,
     fail_on_ids: set[str] | None = None,
 ) -> tuple[int, Path, dict[str, int]]:
     pages = pages or _synthetic_pages()
@@ -88,6 +89,8 @@ def _run_recursive_cli(
     ]
     if dry_run:
         argv.append("--dry-run")
+    if verbose:
+        argv.append("--verbose")
 
     exit_code = main(argv)
     return exit_code, output_dir, fetch_counts
@@ -267,6 +270,7 @@ def test_recursive_dry_run_reports_unique_planned_outputs_without_writing(
         monkeypatch,
         max_depth=2,
         dry_run=True,
+        verbose=True,
     )
 
     assert exit_code == 0

--- a/tests/confluence/test_traversal_incremental.py
+++ b/tests/confluence/test_traversal_incremental.py
@@ -67,6 +67,7 @@ def _run_recursive_cli(
     target: str = "100",
     max_depth: int = 1,
     dry_run: bool = False,
+    verbose: bool = False,
 ) -> tuple[int, Path]:
     pages = pages or _synthetic_pages()
 
@@ -90,6 +91,8 @@ def _run_recursive_cli(
     ]
     if dry_run:
         argv.append("--dry-run")
+    if verbose:
+        argv.append("--verbose")
 
     return main(argv), output_dir
 
@@ -167,6 +170,7 @@ def test_incremental_dry_run_without_manifest_marks_all_pages_as_write(
         tmp_path,
         monkeypatch,
         dry_run=True,
+        verbose=True,
     )
 
     assert exit_code == 0
@@ -266,6 +270,7 @@ def test_incremental_dry_run_uses_manifest_identity_and_file_existence_for_skip(
         tmp_path,
         monkeypatch,
         dry_run=True,
+        verbose=True,
     )
 
     assert exit_code == 0
@@ -316,6 +321,7 @@ def test_incremental_dry_run_reports_both_would_write_and_would_skip_without_wri
         tmp_path,
         monkeypatch,
         dry_run=True,
+        verbose=True,
     )
 
     assert exit_code == 0
@@ -414,6 +420,7 @@ def test_incremental_normal_run_manifest_includes_written_and_skipped_pages(
         tmp_path,
         monkeypatch,
         dry_run=False,
+        verbose=True,
     )
 
     assert exit_code == 0
@@ -455,6 +462,7 @@ def test_incremental_normal_run_rewrites_pages_when_source_metadata_changes(
         tmp_path,
         monkeypatch,
         dry_run=False,
+        verbose=True,
     )
 
     assert exit_code == 0
@@ -642,6 +650,7 @@ def test_incremental_normal_run_handles_larger_mixed_write_and_skip_set(
         monkeypatch,
         pages=pages,
         max_depth=1,
+        verbose=True,
     )
 
     assert exit_code == 0
@@ -713,6 +722,7 @@ def test_incremental_dry_run_rewrites_pages_from_older_manifests_without_source_
         tmp_path,
         monkeypatch,
         dry_run=True,
+        verbose=True,
     )
 
     assert exit_code == 0
@@ -866,6 +876,7 @@ def test_incremental_dry_run_reports_last_modified_rewrite_reason(
         tmp_path,
         monkeypatch,
         dry_run=True,
+        verbose=True,
     )
 
     assert exit_code == 0

--- a/tests/confluence/test_traversal_real.py
+++ b/tests/confluence/test_traversal_real.py
@@ -20,6 +20,7 @@ def _real_tree_argv(
     target: str = "100",
     max_depth: int,
     dry_run: bool = False,
+    verbose: bool = False,
 ) -> list[str]:
     argv = [
         "confluence",
@@ -37,6 +38,8 @@ def _real_tree_argv(
     ]
     if dry_run:
         argv.append("--dry-run")
+    if verbose:
+        argv.append("--verbose")
     return argv
 
 
@@ -45,8 +48,9 @@ def _real_space_argv(
     *,
     space_flag: str = "--space-key",
     space_value: str = "ENG",
+    verbose: bool = False,
 ) -> list[str]:
-    return [
+    argv = [
         "confluence",
         "--base-url",
         "https://example.com/wiki",
@@ -57,6 +61,9 @@ def _real_space_argv(
         "--client-mode",
         "real",
     ]
+    if verbose:
+        argv.append("--verbose")
+    return argv
 
 
 def _load_manifest(output_dir: Path) -> dict[str, object]:
@@ -703,7 +710,7 @@ def test_real_space_dry_run_reports_space_summary_and_planned_actions(
     )
 
     output_dir = tmp_path / "out"
-    exit_code = main([*_real_space_argv(output_dir), "--dry-run"])
+    exit_code = main([*_real_space_argv(output_dir, verbose=True), "--dry-run"])
 
     assert exit_code == 0
     assert not (output_dir / "manifest.json").exists()
@@ -920,7 +927,7 @@ def test_real_tree_incremental_run_skips_full_page_fetch_for_unchanged_pages(
         raising=False,
     )
 
-    exit_code = main(_real_tree_argv(output_dir, max_depth=1))
+    exit_code = main(_real_tree_argv(output_dir, max_depth=1, verbose=True))
 
     assert exit_code == 0
     assert full_fetch_counts == {"300": 1}
@@ -1020,7 +1027,7 @@ def test_real_tree_fetch_progress_uses_carriage_return_for_tty_stdout(
     )
     monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
 
-    exit_code = main(_real_tree_argv(output_dir, max_depth=1))
+    exit_code = main(_real_tree_argv(output_dir, max_depth=1, verbose=True))
 
     assert exit_code == 0
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -185,6 +185,7 @@ def test_confluence_cli_renders_symlinked_output_paths_consistently(
             "12345",
             "--output-dir",
             str(output_dir_arg),
+            "--verbose",
         ]
     )
 
@@ -247,6 +248,7 @@ def test_confluence_cli_full_flow_keeps_dry_run_and_write_artifacts_in_sync(
             target_url,
             "--output-dir",
             str(output_dir),
+            "--verbose",
         ]
     )
 

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1103,7 +1103,7 @@ def test_confluence_cli_smoke_uses_installed_entrypoint_with_default_stub_client
     assert "resolved_page_id: 12345" in result.stdout
     assert "Artifact:" in result.stdout
     assert "auth_method:" not in result.stdout
-    assert "Wrote:" in result.stdout
+    assert "Wrote:" not in result.stdout
     assert_write_summary(result.stdout, wrote=1, skipped=0)
     assert "Manifest:" in result.stdout
     assert f"Write complete. Artifacts created under {tmp_path / 'artifacts'}" in result.stdout

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -1162,7 +1162,40 @@ runs:
     assert "dry_run_runs: 1" in captured.out
     assert "would_write: 1" in captured.out
     assert "would_skip: 0" in captured.out
+    assert "pages/12345.md" not in captured.out
     assert not (tmp_path / "artifacts").exists()
+
+
+def test_run_command_verbose_preserves_nested_confluence_per_item_output(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: docs-tree
+    type: confluence
+    base_url: https://example.com/wiki
+    target: "12345"
+    output_dir: ./artifacts/confluence/docs-tree
+    tree: true
+    max_depth: 1
+    dry_run: true
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    exit_code = main(["run", "--verbose", str(config_path)])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "Run summary: would write 1, would skip 0" in captured.out
+    assert (
+        f"would write {tmp_path / 'artifacts' / 'confluence' / 'docs-tree' / 'pages' / '12345.md'}"
+        in captured.out
+    )
 
 
 def test_run_command_preserves_nested_adapter_error_details(


### PR DESCRIPTION
Summary
- add a CLI --verbose flag and pass it through config-driven runs
- hide Confluence per-page write/skip detail by default while keeping progress, plans, summaries, lifecycle messages, and errors visible
- update direct and run-mode tests for quiet defaults and verbose opt-in

Testing
- make check
- make smoke