### PR TITLE
[codex] add Confluence cache control flags

### DIFF
--- a/adapters/confluence/README.md
+++ b/adapters/confluence/README.md
@@ -87,6 +87,10 @@ Out of the box, the default Confluence CLI:
 - supports an opt-in real client path with `--client-mode real` for
   contract-tested live page fetches and breadth-first tree traversal using
   `bearer-env` or `client-cert-env` auth
+- supports opt-in fetch and traversal caches with explicit cache controls:
+  `--force-refresh` bypasses configured cache reads while still writing fresh
+  entries, and `--clear-cache` clears only configured Confluence cache subtrees
+  before the run starts
 - keeps `stub` and `real` modes on the same CLI flow and artifact layout, with
   only the content source changing between modes
 - keeps dry-run and write messaging aligned across `stub` and `real`, including

--- a/runs.example.yaml
+++ b/runs.example.yaml
@@ -28,6 +28,8 @@ runs:
     # client_mode: real
     # auth_method: bearer-env
     # fetch_cache_dir: ./.cache/knowledge-adapters
+    # force_refresh: true
+    # clear_cache: true
     # dry_run: true
     # Optional TLS override for an internal CA.
     # ca_bundle: ./certs/internal-ca.pem
@@ -44,6 +46,8 @@ runs:
     # auth_method: client-cert-env
     # Optional traversal cache for repeated large tree listing runs.
     # tree_cache_dir: ./.cache/confluence-tree
+    # force_refresh: true
+    # clear_cache: true
     # client_cert_file: ./certs/confluence-client.crt
     # client_key_file: ./certs/confluence-client.key
     # Optional TLS override for an internal CA.

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -542,6 +542,22 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     confluence_parser.add_argument(
+        "--force-refresh",
+        action="store_true",
+        help=(
+            "Bypass existing Confluence fetch and traversal cache reads for this run. "
+            "Configured caches still receive fresh entries."
+        ),
+    )
+    confluence_parser.add_argument(
+        "--clear-cache",
+        action="store_true",
+        help=(
+            "Delete configured Confluence fetch and traversal cache contents before "
+            "the run starts. Only configured cache directories are affected."
+        ),
+    )
+    confluence_parser.add_argument(
         "--client-mode",
         choices=("stub", "real"),
         default="stub",
@@ -1359,6 +1375,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         from knowledge_adapters.confluence.fetch_cache import (
             ConfluenceFetchCache,
+            clear_fetch_cache_entries,
             prepare_fetch_cache_dir,
         )
         from knowledge_adapters.confluence.incremental import (
@@ -1375,6 +1392,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         from knowledge_adapters.confluence.traversal import TreeWalkProgress, walk_pages
         from knowledge_adapters.confluence.tree_cache import (
             ConfluenceTreeCache,
+            clear_tree_cache_entries,
             prepare_tree_cache_dir,
         )
         from knowledge_adapters.confluence.writer import markdown_path, write_markdown
@@ -1401,6 +1419,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             client_key_file=args.client_key_file,
             fetch_cache_dir=args.fetch_cache_dir,
             tree_cache_dir=args.tree_cache_dir,
+            force_refresh=args.force_refresh,
+            clear_cache=args.clear_cache,
             client_mode=args.client_mode,
             auth_method=args.auth_method,
             debug=args.debug,
@@ -1418,24 +1438,6 @@ def main(argv: Sequence[str] | None = None) -> int:
                 ),
                 command="confluence",
             )
-        fetch_cache: ConfluenceFetchCache | None = None
-        if confluence_config.fetch_cache_dir is not None:
-            try:
-                fetch_cache = ConfluenceFetchCache(
-                    prepare_fetch_cache_dir(confluence_config.fetch_cache_dir),
-                    base_url=confluence_config.base_url,
-                )
-            except ValueError as exc:
-                exit_with_cli_error(str(exc), command="confluence")
-        tree_cache: ConfluenceTreeCache | None = None
-        if confluence_config.tree_cache_dir is not None:
-            try:
-                tree_cache = ConfluenceTreeCache(
-                    prepare_tree_cache_dir(confluence_config.tree_cache_dir),
-                    base_url=confluence_config.base_url,
-                )
-            except ValueError as exc:
-                exit_with_cli_error(str(exc), command="confluence")
         if confluence_config.max_depth < 0:
             exit_with_cli_error(
                 "--max-depth must be greater than or equal to 0.",
@@ -1516,6 +1518,74 @@ def main(argv: Sequence[str] | None = None) -> int:
                     str(exc),
                     command="confluence",
                 )
+
+        cache_control_lines: list[str] = []
+        if confluence_config.force_refresh:
+            if (
+                confluence_config.fetch_cache_dir is None
+                and confluence_config.tree_cache_dir is None
+            ):
+                cache_control_lines.append(
+                    "force_refresh: requested, but no cache dirs are configured; "
+                    "cache reads are already disabled"
+                )
+            else:
+                cache_control_lines.append(
+                    "force_refresh: enabled; configured cache reads will be bypassed"
+                )
+        if (
+            confluence_config.clear_cache
+            and confluence_config.fetch_cache_dir is None
+            and confluence_config.tree_cache_dir is None
+        ):
+            cache_control_lines.append(
+                "clear_cache: requested, but no cache dirs are configured; nothing to clear"
+            )
+
+        fetch_cache: ConfluenceFetchCache | None = None
+        if confluence_config.fetch_cache_dir is not None:
+            try:
+                prepared_fetch_cache_dir = prepare_fetch_cache_dir(
+                    confluence_config.fetch_cache_dir
+                )
+                if confluence_config.clear_cache:
+                    cleared = clear_fetch_cache_entries(
+                        prepared_fetch_cache_dir,
+                        base_url=confluence_config.base_url,
+                    )
+                    cache_control_lines.append(
+                        "fetch_cache: cleared configured entries"
+                        if cleared
+                        else "fetch_cache: no configured entries to clear"
+                    )
+                fetch_cache = ConfluenceFetchCache(
+                    prepared_fetch_cache_dir,
+                    base_url=confluence_config.base_url,
+                    force_refresh=confluence_config.force_refresh,
+                )
+            except (OSError, ValueError) as exc:
+                exit_with_cli_error(str(exc), command="confluence")
+        tree_cache: ConfluenceTreeCache | None = None
+        if confluence_config.tree_cache_dir is not None:
+            try:
+                prepared_tree_cache_dir = prepare_tree_cache_dir(confluence_config.tree_cache_dir)
+                if confluence_config.clear_cache:
+                    cleared = clear_tree_cache_entries(
+                        prepared_tree_cache_dir,
+                        base_url=confluence_config.base_url,
+                    )
+                    cache_control_lines.append(
+                        "tree_cache: cleared configured entries"
+                        if cleared
+                        else "tree_cache: no configured entries to clear"
+                    )
+                tree_cache = ConfluenceTreeCache(
+                    prepared_tree_cache_dir,
+                    base_url=confluence_config.base_url,
+                    force_refresh=confluence_config.force_refresh,
+                )
+            except (OSError, ValueError) as exc:
+                exit_with_cli_error(str(exc), command="confluence")
 
         selected_fetch_page: Callable[[ResolvedTarget], dict[str, object]]
         selected_fetch_page_summary: Callable[[ResolvedTarget], dict[str, object]]
@@ -1671,6 +1741,10 @@ def main(argv: Sequence[str] | None = None) -> int:
                 )
                 _print(f"  fetch_scope: {fetch_scope}")
             _print(f"  run_mode: {run_mode}")
+            if cache_control_lines:
+                _print("  cache_control:")
+                for line in cache_control_lines:
+                    _print(f"    {line}")
             if confluence_config.tree:
                 max_depth = str(confluence_config.max_depth)
                 if confluence_config.dry_run:

--- a/src/knowledge_adapters/confluence/config.py
+++ b/src/knowledge_adapters/confluence/config.py
@@ -23,6 +23,8 @@ class ConfluenceConfig:
     client_key_file: str | None = None
     fetch_cache_dir: str | None = None
     tree_cache_dir: str | None = None
+    force_refresh: bool = False
+    clear_cache: bool = False
     client_mode: str = "stub"
     auth_method: str = "bearer-env"
     debug: bool = False

--- a/src/knowledge_adapters/confluence/fetch_cache.py
+++ b/src/knowledge_adapters/confluence/fetch_cache.py
@@ -105,7 +105,6 @@ class ConfluenceFetchCache:
     def load_page(self, canonical_id: str) -> dict[str, object] | None:
         """Return a mapped cached page when metadata and payload are valid."""
         if self._force_refresh:
-            self.stats.misses += 1
             return None
 
         metadata = self._metadata_by_id.get(canonical_id)

--- a/src/knowledge_adapters/confluence/fetch_cache.py
+++ b/src/knowledge_adapters/confluence/fetch_cache.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import shutil
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -61,12 +62,25 @@ def prepare_fetch_cache_dir(path_value: str) -> Path:
     return cache_dir
 
 
+def clear_fetch_cache_entries(root_dir: Path, *, base_url: str) -> bool:
+    """Delete known fetch-cache entries under the configured cache root."""
+    cache_subtree = _fetch_cache_subtree(root_dir, base_url=base_url)
+    if not cache_subtree.exists():
+        return False
+    if cache_subtree.is_symlink() or not cache_subtree.is_dir():
+        cache_subtree.unlink()
+        return True
+    shutil.rmtree(cache_subtree)
+    return True
+
+
 class ConfluenceFetchCache:
     """Best-effort cache for raw Confluence full-page payloads."""
 
-    def __init__(self, root_dir: Path, *, base_url: str) -> None:
+    def __init__(self, root_dir: Path, *, base_url: str, force_refresh: bool = False) -> None:
         self._root_dir = root_dir
         self._base_url = _normal_base_url(base_url)
+        self._force_refresh = force_refresh
         self._metadata_by_id: dict[str, _PageMetadata] = {}
         self.stats = ConfluenceFetchCacheStats()
 
@@ -90,6 +104,10 @@ class ConfluenceFetchCache:
 
     def load_page(self, canonical_id: str) -> dict[str, object] | None:
         """Return a mapped cached page when metadata and payload are valid."""
+        if self._force_refresh:
+            self.stats.misses += 1
+            return None
+
         metadata = self._metadata_by_id.get(canonical_id)
         if metadata is None:
             self.stats.misses += 1
@@ -138,10 +156,7 @@ class ConfluenceFetchCache:
 
     def _entry_path(self, canonical_id: str) -> Path:
         return (
-            self._root_dir
-            / "confluence"
-            / _hash_value(self._base_url)
-            / "pages"
+            _fetch_cache_subtree(self._root_dir, base_url=self._base_url)
             / _hash_value(canonical_id)
             / _ENTRY_FILENAME
         )
@@ -215,3 +230,7 @@ def _as_str_object_dict(value: dict[Any, Any]) -> dict[str, object]:
             raise ValueError("invalid cached payload")
         result[key] = item
     return result
+
+
+def _fetch_cache_subtree(root_dir: Path, *, base_url: str) -> Path:
+    return root_dir / "confluence" / _hash_value(_normal_base_url(base_url)) / "pages"

--- a/src/knowledge_adapters/confluence/tree_cache.py
+++ b/src/knowledge_adapters/confluence/tree_cache.py
@@ -105,9 +105,7 @@ class ConfluenceTreeCache:
         key_value: str,
         fetch_listing: Callable[[], list[str]],
     ) -> list[str]:
-        if self._force_refresh:
-            self.stats.misses += 1
-        else:
+        if not self._force_refresh:
             try:
                 page_ids = self._read_listing(kind=kind, key_name=key_name, key_value=key_value)
             except (OSError, ValueError, TypeError, json.JSONDecodeError):

--- a/src/knowledge_adapters/confluence/tree_cache.py
+++ b/src/knowledge_adapters/confluence/tree_cache.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import shutil
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -49,12 +50,25 @@ def prepare_tree_cache_dir(path_value: str) -> Path:
     return cache_dir
 
 
+def clear_tree_cache_entries(root_dir: Path, *, base_url: str) -> bool:
+    """Delete known traversal-cache entries under the configured cache root."""
+    cache_subtree = _tree_cache_subtree(root_dir, base_url=base_url)
+    if not cache_subtree.exists():
+        return False
+    if cache_subtree.is_symlink() or not cache_subtree.is_dir():
+        cache_subtree.unlink()
+        return True
+    shutil.rmtree(cache_subtree)
+    return True
+
+
 class ConfluenceTreeCache:
     """Best-effort cache for Confluence traversal listing results."""
 
-    def __init__(self, root_dir: Path, *, base_url: str) -> None:
+    def __init__(self, root_dir: Path, *, base_url: str, force_refresh: bool = False) -> None:
         self._root_dir = root_dir
         self._base_url = _normal_base_url(base_url)
+        self._force_refresh = force_refresh
         self.stats = ConfluenceTreeCacheStats()
 
     def get_child_page_ids(
@@ -91,13 +105,16 @@ class ConfluenceTreeCache:
         key_value: str,
         fetch_listing: Callable[[], list[str]],
     ) -> list[str]:
-        try:
-            page_ids = self._read_listing(kind=kind, key_name=key_name, key_value=key_value)
-        except (OSError, ValueError, TypeError, json.JSONDecodeError):
+        if self._force_refresh:
             self.stats.misses += 1
         else:
-            self.stats.hits += 1
-            return page_ids
+            try:
+                page_ids = self._read_listing(kind=kind, key_name=key_name, key_value=key_value)
+            except (OSError, ValueError, TypeError, json.JSONDecodeError):
+                self.stats.misses += 1
+            else:
+                self.stats.hits += 1
+                return page_ids
 
         page_ids = fetch_listing()
         self._store_listing(
@@ -110,10 +127,7 @@ class ConfluenceTreeCache:
 
     def _entry_path(self, *, kind: str, key_value: str) -> Path:
         return (
-            self._root_dir
-            / "confluence"
-            / _hash_value(self._base_url)
-            / "traversal"
+            _tree_cache_subtree(self._root_dir, base_url=self._base_url)
             / kind
             / _hash_value(key_value)
             / _ENTRY_FILENAME
@@ -196,3 +210,7 @@ def _as_str_object_dict(value: dict[Any, Any]) -> dict[str, object]:
             raise ValueError("invalid cache entry")
         result[key] = item
     return result
+
+
+def _tree_cache_subtree(root_dir: Path, *, base_url: str) -> Path:
+    return root_dir / "confluence" / _hash_value(_normal_base_url(base_url)) / "traversal"

--- a/src/knowledge_adapters/run_config.py
+++ b/src/knowledge_adapters/run_config.py
@@ -59,10 +59,12 @@ _CONFLUENCE_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
         "client_mode",
         "client_cert_file",
         "client_key_file",
+        "clear_cache",
         "debug",
         "dry_run",
         "enabled",
         "fetch_cache_dir",
+        "force_refresh",
         "max_depth",
         "output_dir",
         "space_key",
@@ -559,6 +561,23 @@ def _build_confluence_argv(
                 _resolve_path_string(tree_cache_dir, config_path=config_path),
             ]
         )
+
+    if _optional_bool(
+        run_config,
+        "force_refresh",
+        index=index,
+        config_path=config_path,
+        default=False,
+    ):
+        argv.append("--force-refresh")
+    if _optional_bool(
+        run_config,
+        "clear_cache",
+        index=index,
+        config_path=config_path,
+        default=False,
+    ):
+        argv.append("--clear-cache")
 
     if _optional_bool(run_config, "debug", index=index, config_path=config_path, default=False):
         argv.append("--debug")

--- a/tests/confluence/test_fetch_cache.py
+++ b/tests/confluence/test_fetch_cache.py
@@ -111,7 +111,7 @@ def test_fetch_cache_force_refresh_bypasses_cached_payload(tmp_path: Path) -> No
 
     assert cache.load_page("12345") is None
     assert cache.stats.hits == 0
-    assert cache.stats.misses == 1
+    assert cache.stats.misses == 0
 
 
 def test_clear_fetch_cache_entries_removes_only_fetch_subtree(tmp_path: Path) -> None:
@@ -210,7 +210,7 @@ def test_confluence_force_refresh_bypasses_fetch_cache_hit(
     captured = capsys.readouterr()
     assert "force_refresh: enabled; configured cache reads will be bypassed" in captured.out
     assert "cache_hits: 0" in captured.out
-    assert "cache_misses: 1" in captured.out
+    assert "cache_misses: 0" in captured.out
     output = (output_dir / "pages" / "12345.md").read_text(encoding="utf-8")
     assert "Fresh content." in output
     assert "Cached content." not in output

--- a/tests/confluence/test_fetch_cache.py
+++ b/tests/confluence/test_fetch_cache.py
@@ -9,6 +9,7 @@ from knowledge_adapters.cli import main
 from knowledge_adapters.confluence.client import map_real_page_payload
 from knowledge_adapters.confluence.fetch_cache import (
     ConfluenceFetchCache,
+    clear_fetch_cache_entries,
     prepare_fetch_cache_dir,
 )
 from knowledge_adapters.manifest import build_manifest_entry, write_manifest
@@ -18,6 +19,8 @@ def _confluence_argv(
     output_dir: Path,
     *,
     fetch_cache_dir: Path | None = None,
+    force_refresh: bool = False,
+    clear_cache: bool = False,
 ) -> list[str]:
     argv = [
         "confluence",
@@ -32,6 +35,10 @@ def _confluence_argv(
     ]
     if fetch_cache_dir is not None:
         argv.extend(["--fetch-cache-dir", str(fetch_cache_dir)])
+    if force_refresh:
+        argv.append("--force-refresh")
+    if clear_cache:
+        argv.append("--clear-cache")
     return argv
 
 
@@ -92,6 +99,38 @@ def _cache_entry_path(cache_dir: Path) -> Path:
     return next(cache_dir.rglob("page.json"))
 
 
+def test_fetch_cache_force_refresh_bypasses_cached_payload(tmp_path: Path) -> None:
+    cache = ConfluenceFetchCache(
+        prepare_fetch_cache_dir(str(tmp_path / "cache")),
+        base_url="https://example.com/wiki",
+        force_refresh=True,
+    )
+    cached_payload = _raw_payload(content="<p>Cached.</p>")
+    cache.record_metadata(map_real_page_payload(cached_payload, "12345"))
+    cache.store_page(map_real_page_payload(cached_payload, "12345"), cached_payload)
+
+    assert cache.load_page("12345") is None
+    assert cache.stats.hits == 0
+    assert cache.stats.misses == 1
+
+
+def test_clear_fetch_cache_entries_removes_only_fetch_subtree(tmp_path: Path) -> None:
+    cache_dir = tmp_path / "cache"
+    _store_cached_payload(cache_dir, _raw_payload())
+    entry_path = _cache_entry_path(cache_dir)
+    traversal_sibling = entry_path.parents[2] / "traversal" / "child" / "abc" / "listing.json"
+    traversal_sibling.parent.mkdir(parents=True)
+    traversal_sibling.write_text("{}", encoding="utf-8")
+
+    assert clear_fetch_cache_entries(
+        prepare_fetch_cache_dir(str(cache_dir)),
+        base_url="https://example.com/wiki",
+    )
+
+    assert not entry_path.exists()
+    assert traversal_sibling.exists()
+
+
 def test_confluence_fetch_cache_disabled_keeps_output_unchanged(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -143,6 +182,68 @@ def test_confluence_fetch_cache_hit_uses_cached_raw_payload(
     assert "Hello from Confluence." in (output_dir / "pages" / "12345.md").read_text(
         encoding="utf-8"
     )
+
+
+def test_confluence_force_refresh_bypasses_fetch_cache_hit(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    output_dir = tmp_path / "out"
+    cache_dir = tmp_path / "cache"
+    _write_prior_manifest(output_dir, page_version=6)
+    _store_cached_payload(cache_dir, _raw_payload(content="<p>Cached content.</p>"))
+    requests: list[str] = []
+
+    def request_json(api_url: str, **_kwargs: object) -> dict[str, object]:
+        requests.append(api_url)
+        return _raw_payload(content="<p>Fresh content.</p>")
+
+    monkeypatch.setattr("knowledge_adapters.confluence.client._request_json", request_json)
+
+    exit_code = main(
+        _confluence_argv(output_dir, fetch_cache_dir=cache_dir, force_refresh=True)
+    )
+
+    assert exit_code == 0
+    assert len(requests) == 2
+    captured = capsys.readouterr()
+    assert "force_refresh: enabled; configured cache reads will be bypassed" in captured.out
+    assert "cache_hits: 0" in captured.out
+    assert "cache_misses: 1" in captured.out
+    output = (output_dir / "pages" / "12345.md").read_text(encoding="utf-8")
+    assert "Fresh content." in output
+    assert "Cached content." not in output
+
+
+def test_confluence_clear_cache_removes_stale_fetch_entry_before_run(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    output_dir = tmp_path / "out"
+    cache_dir = tmp_path / "cache"
+    _write_prior_manifest(output_dir, page_version=6)
+    _store_cached_payload(cache_dir, _raw_payload(content="<p>Stale cached content.</p>"))
+    requests: list[str] = []
+
+    def request_json(api_url: str, **_kwargs: object) -> dict[str, object]:
+        requests.append(api_url)
+        return _raw_payload(content="<p>Fresh content.</p>")
+
+    monkeypatch.setattr("knowledge_adapters.confluence.client._request_json", request_json)
+
+    exit_code = main(_confluence_argv(output_dir, fetch_cache_dir=cache_dir, clear_cache=True))
+
+    assert exit_code == 0
+    assert len(requests) == 2
+    captured = capsys.readouterr()
+    assert "fetch_cache: cleared configured entries" in captured.out
+    assert "cache_hits: 0" in captured.out
+    assert "cache_misses: 1" in captured.out
+    output = (output_dir / "pages" / "12345.md").read_text(encoding="utf-8")
+    assert "Fresh content." in output
+    assert "Stale cached content." not in output
 
 
 def test_confluence_fetch_cache_miss_on_metadata_mismatch(

--- a/tests/confluence/test_traversal_real.py
+++ b/tests/confluence/test_traversal_real.py
@@ -576,6 +576,152 @@ def test_real_tree_reuses_cached_child_page_listing(
     assert "tree_cache_misses: 0" in second_output
 
 
+def test_real_tree_force_refresh_bypasses_traversal_cache_hit(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    from knowledge_adapters.confluence import client as client_module
+
+    pages = _real_pages()
+    cache_dir = tmp_path / "cache"
+    child_list_calls: list[str] = []
+
+    def stub_real_fetch(
+        target: ResolvedTarget,
+        *,
+        base_url: str = "https://example.com/wiki",
+        auth_method: str = "bearer-env",
+        ca_bundle: str | None = None,
+        client_cert_file: str | None = None,
+        client_key_file: str | None = None,
+    ) -> dict[str, object]:
+        del base_url, auth_method, ca_bundle, client_cert_file, client_key_file
+        return dict(pages[str(target.page_id)])
+
+    def stub_child_id_discovery(*args: object, **kwargs: object) -> list[str]:
+        parent_id = _called_page_id(args, kwargs)
+        child_list_calls.append(parent_id)
+        return ["200", "300"]
+
+    monkeypatch.setattr(client_module, "fetch_real_page", stub_real_fetch, raising=False)
+    monkeypatch.setattr(
+        client_module,
+        "list_real_child_page_ids",
+        stub_child_id_discovery,
+        raising=False,
+    )
+
+    assert (
+        main(
+            [
+                *_real_tree_argv(tmp_path / "first", max_depth=1),
+                "--tree-cache-dir",
+                str(cache_dir),
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    assert (
+        main(
+            [
+                *_real_tree_argv(tmp_path / "second", max_depth=1),
+                "--tree-cache-dir",
+                str(cache_dir),
+                "--force-refresh",
+            ]
+        )
+        == 0
+    )
+
+    assert child_list_calls == ["100", "100"]
+    second_output = capsys.readouterr().out
+    assert "force_refresh: enabled; configured cache reads will be bypassed" in second_output
+    assert "tree_cache_hits: 0" in second_output
+    assert "tree_cache_misses: 1" in second_output
+
+
+def test_real_tree_clear_cache_removes_stale_traversal_entry_before_run(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    from knowledge_adapters.confluence import client as client_module
+
+    pages = _real_pages()
+    cache_dir = tmp_path / "cache"
+    child_list_calls: list[str] = []
+
+    def stub_real_fetch(
+        target: ResolvedTarget,
+        *,
+        base_url: str = "https://example.com/wiki",
+        auth_method: str = "bearer-env",
+        ca_bundle: str | None = None,
+        client_cert_file: str | None = None,
+        client_key_file: str | None = None,
+    ) -> dict[str, object]:
+        del base_url, auth_method, ca_bundle, client_cert_file, client_key_file
+        return dict(pages[str(target.page_id)])
+
+    def stale_child_id_discovery(*args: object, **kwargs: object) -> list[str]:
+        parent_id = _called_page_id(args, kwargs)
+        child_list_calls.append(parent_id)
+        return ["200"]
+
+    monkeypatch.setattr(client_module, "fetch_real_page", stub_real_fetch, raising=False)
+    monkeypatch.setattr(
+        client_module,
+        "list_real_child_page_ids",
+        stale_child_id_discovery,
+        raising=False,
+    )
+    assert (
+        main(
+            [
+                *_real_tree_argv(tmp_path / "priming", max_depth=1),
+                "--tree-cache-dir",
+                str(cache_dir),
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    def fresh_child_id_discovery(*args: object, **kwargs: object) -> list[str]:
+        parent_id = _called_page_id(args, kwargs)
+        child_list_calls.append(parent_id)
+        return ["300"]
+
+    monkeypatch.setattr(
+        client_module,
+        "list_real_child_page_ids",
+        fresh_child_id_discovery,
+        raising=False,
+    )
+    assert (
+        main(
+            [
+                *_real_tree_argv(tmp_path / "out", max_depth=1),
+                "--tree-cache-dir",
+                str(cache_dir),
+                "--clear-cache",
+            ]
+        )
+        == 0
+    )
+
+    assert child_list_calls == ["100", "100"]
+    output = capsys.readouterr().out
+    assert "tree_cache: cleared configured entries" in output
+    assert "tree_cache_hits: 0" in output
+    assert "tree_cache_misses: 1" in output
+    manifest = _load_manifest(tmp_path / "out")
+    assert [file["canonical_id"] for file in _manifest_files(manifest)] == ["100", "300"]
+
+
 def test_real_tree_cache_write_failure_does_not_fail_run(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,

--- a/tests/confluence/test_traversal_real.py
+++ b/tests/confluence/test_traversal_real.py
@@ -640,7 +640,7 @@ def test_real_tree_force_refresh_bypasses_traversal_cache_hit(
     second_output = capsys.readouterr().out
     assert "force_refresh: enabled; configured cache reads will be bypassed" in second_output
     assert "tree_cache_hits: 0" in second_output
-    assert "tree_cache_misses: 1" in second_output
+    assert "tree_cache_misses: 0" in second_output
 
 
 def test_real_tree_clear_cache_removes_stale_traversal_entry_before_run(

--- a/tests/confluence/test_tree_cache.py
+++ b/tests/confluence/test_tree_cache.py
@@ -7,6 +7,7 @@ from pytest import MonkeyPatch
 
 from knowledge_adapters.confluence.tree_cache import (
     ConfluenceTreeCache,
+    clear_tree_cache_entries,
     prepare_tree_cache_dir,
 )
 
@@ -36,6 +37,40 @@ def test_tree_cache_hit_returns_cached_child_listing(tmp_path: Path) -> None:
 
     assert cache.stats.hits == 1
     assert cache.stats.misses == 1
+
+
+def test_tree_cache_force_refresh_bypasses_cached_listing(tmp_path: Path) -> None:
+    cache_dir = tmp_path / "cache"
+    priming_cache = ConfluenceTreeCache(cache_dir, base_url="https://example.com/wiki")
+    assert priming_cache.get_child_page_ids("100", lambda: ["200"]) == ["200"]
+
+    cache = ConfluenceTreeCache(
+        cache_dir,
+        base_url="https://example.com/wiki",
+        force_refresh=True,
+    )
+
+    assert cache.get_child_page_ids("100", lambda: ["300"]) == ["300"]
+    assert cache.stats.hits == 0
+    assert cache.stats.misses == 1
+
+
+def test_clear_tree_cache_entries_removes_only_traversal_subtree(tmp_path: Path) -> None:
+    cache_dir = tmp_path / "cache"
+    cache = ConfluenceTreeCache(cache_dir, base_url="https://example.com/wiki")
+    assert cache.get_child_page_ids("100", lambda: ["200"]) == ["200"]
+    listing_path = next(cache_dir.rglob("listing.json"))
+    fetch_sibling = listing_path.parents[3] / "pages" / "abc" / "page.json"
+    fetch_sibling.parent.mkdir(parents=True)
+    fetch_sibling.write_text("{}", encoding="utf-8")
+
+    assert clear_tree_cache_entries(
+        prepare_tree_cache_dir(str(cache_dir)),
+        base_url="https://example.com/wiki",
+    )
+
+    assert not listing_path.exists()
+    assert fetch_sibling.exists()
 
 
 def test_tree_cache_corrupt_entry_falls_back_to_fetch(tmp_path: Path) -> None:

--- a/tests/confluence/test_tree_cache.py
+++ b/tests/confluence/test_tree_cache.py
@@ -52,7 +52,7 @@ def test_tree_cache_force_refresh_bypasses_cached_listing(tmp_path: Path) -> Non
 
     assert cache.get_child_page_ids("100", lambda: ["300"]) == ["300"]
     assert cache.stats.hits == 0
-    assert cache.stats.misses == 1
+    assert cache.stats.misses == 0
 
 
 def test_clear_tree_cache_entries_removes_only_traversal_subtree(tmp_path: Path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -99,6 +99,39 @@ def test_confluence_cli_dry_run_reports_output_without_writing(
     assert "# stub-page-12345" in captured.out
 
 
+def test_confluence_cache_control_without_cache_dirs_is_explicit_noop(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    output_dir = tmp_path / "out"
+
+    exit_code = main(
+        [
+            "confluence",
+            "--base-url",
+            "https://example.com/wiki",
+            "--target",
+            "12345",
+            "--output-dir",
+            str(output_dir),
+            "--force-refresh",
+            "--clear-cache",
+            "--dry-run",
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "cache_control:" in captured.out
+    assert (
+        "force_refresh: requested, but no cache dirs are configured; "
+        "cache reads are already disabled"
+    ) in captured.out
+    assert (
+        "clear_cache: requested, but no cache dirs are configured; nothing to clear"
+    ) in captured.out
+
+
 def test_confluence_cli_dry_run_reports_same_resolved_target_details_for_full_url_input(
     tmp_path: Path,
     capsys: CaptureFixture[str],

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -136,6 +136,8 @@ runs:
     output_dir: ./artifacts/confluence/docs-home
     fetch_cache_dir: ./.cache/confluence-fetches
     tree_cache_dir: ./.cache/confluence-tree
+    force_refresh: true
+    clear_cache: true
   - name: team-notes
     type: local_files
     file_path: ./inputs/team-notes.txt
@@ -165,6 +167,8 @@ runs:
                 str((tmp_path / ".cache" / "confluence-fetches").resolve()),
                 "--tree-cache-dir",
                 str((tmp_path / ".cache" / "confluence-tree").resolve()),
+                "--force-refresh",
+                "--clear-cache",
             ),
             dry_run=False,
         ),


### PR DESCRIPTION
## Summary

- Add explicit Confluence `--force-refresh` and `--clear-cache` flags for configured fetch and traversal caches.
- Keep cache behavior local to the fetch and traversal cache modules, including scoped clear helpers for known cache subtrees only.
- Add equivalent `runs.yaml` keys, examples, docs notes, and coverage for bypass, clear, visible CLI output, and no-cache-dir safety.

Closes #205.

## Validation

- `make check`