### PR TITLE
Add Confluence run metrics

### DIFF
--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -1382,6 +1382,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             PageSyncDecision,
             classify_page_sync,
         )
+        from knowledge_adapters.confluence.metrics import ConfluenceRunMetrics
         from knowledge_adapters.confluence.models import ResolvedTarget
         from knowledge_adapters.confluence.normalize import normalize_to_markdown
         from knowledge_adapters.confluence.resolve import (
@@ -1587,6 +1588,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             except (OSError, ValueError) as exc:
                 exit_with_cli_error(str(exc), command="confluence")
 
+        run_metrics = ConfluenceRunMetrics()
         selected_fetch_page: Callable[[ResolvedTarget], dict[str, object]]
         selected_fetch_page_summary: Callable[[ResolvedTarget], dict[str, object]]
         selected_list_child_page_ids: Callable[[ResolvedTarget], list[str]] | None = None
@@ -1604,49 +1606,55 @@ def main(argv: Sequence[str] | None = None) -> int:
                 return kwargs
 
             def selected_fetch_page(resolved_target: ResolvedTarget) -> dict[str, object]:
-                if fetch_cache is None:
-                    return fetch_real_page(
+                with run_metrics.time_fetch():
+                    if fetch_cache is None:
+                        run_metrics.record_page_fetch_request()
+                        return fetch_real_page(
+                            resolved_target,
+                            base_url=confluence_config.base_url,
+                            auth_method=confluence_config.auth_method,
+                            **real_client_tls_kwargs(),
+                        )
+
+                    page_id = resolved_target.page_id
+                    if page_id:
+                        cached_page = fetch_cache.load_page(page_id)
+                        if cached_page is not None:
+                            return cached_page
+
+                    run_metrics.record_page_fetch_request()
+                    raw_payload = fetch_real_page_raw(
                         resolved_target,
                         base_url=confluence_config.base_url,
                         auth_method=confluence_config.auth_method,
                         **real_client_tls_kwargs(),
                     )
-
-                page_id = resolved_target.page_id
-                if page_id:
-                    cached_page = fetch_cache.load_page(page_id)
-                    if cached_page is not None:
-                        return cached_page
-
-                raw_payload = fetch_real_page_raw(
-                    resolved_target,
-                    base_url=confluence_config.base_url,
-                    auth_method=confluence_config.auth_method,
-                    **real_client_tls_kwargs(),
-                )
-                if not page_id:
-                    raise ValueError("Response error: canonical_id mismatch.")
-                page = map_real_page_payload(raw_payload, page_id)
-                fetch_cache.store_page(page, raw_payload)
-                return page
+                    if not page_id:
+                        raise ValueError("Response error: canonical_id mismatch.")
+                    page = map_real_page_payload(raw_payload, page_id)
+                    fetch_cache.store_page(page, raw_payload)
+                    return page
 
             def selected_fetch_page_summary(
                 resolved_target: ResolvedTarget,
             ) -> dict[str, object]:
-                page = fetch_real_page_summary(
-                    resolved_target,
-                    base_url=confluence_config.base_url,
-                    auth_method=confluence_config.auth_method,
-                    **real_client_tls_kwargs(),
-                )
-                if fetch_cache is not None:
-                    fetch_cache.record_metadata(page)
-                return page
+                with run_metrics.time_fetch():
+                    run_metrics.record_page_fetch_request()
+                    page = fetch_real_page_summary(
+                        resolved_target,
+                        base_url=confluence_config.base_url,
+                        auth_method=confluence_config.auth_method,
+                        **real_client_tls_kwargs(),
+                    )
+                    if fetch_cache is not None:
+                        fetch_cache.record_metadata(page)
+                    return page
 
             def selected_list_child_page_ids(
                 resolved_target: ResolvedTarget,
             ) -> list[str]:
                 def fetch_listing() -> list[str]:
+                    run_metrics.record_listing_request()
                     return list_real_child_page_ids(
                         resolved_target,
                         base_url=confluence_config.base_url,
@@ -1656,12 +1664,14 @@ def main(argv: Sequence[str] | None = None) -> int:
                     )
 
                 page_id = resolved_target.page_id
-                if tree_cache is None or not page_id:
-                    return fetch_listing()
-                return tree_cache.get_child_page_ids(page_id, fetch_listing)
+                with run_metrics.time_discovery():
+                    if tree_cache is None or not page_id:
+                        return fetch_listing()
+                    return tree_cache.get_child_page_ids(page_id, fetch_listing)
 
             def selected_list_space_page_ids(space_key: str) -> list[str]:
                 def fetch_listing() -> list[str]:
+                    run_metrics.record_listing_request()
                     return list_real_space_page_ids(
                         space_key,
                         base_url=confluence_config.base_url,
@@ -1670,12 +1680,17 @@ def main(argv: Sequence[str] | None = None) -> int:
                         **real_client_tls_kwargs(),
                     )
 
-                if tree_cache is None:
-                    return fetch_listing()
-                return tree_cache.get_space_page_ids(space_key, fetch_listing)
+                with run_metrics.time_discovery():
+                    if tree_cache is None:
+                        return fetch_listing()
+                    return tree_cache.get_space_page_ids(space_key, fetch_listing)
         else:
-            selected_fetch_page = fetch_page
-            selected_fetch_page_summary = fetch_page
+            def selected_fetch_page(resolved_target: ResolvedTarget) -> dict[str, object]:
+                with run_metrics.time_fetch():
+                    run_metrics.record_page_fetch_request()
+                    return fetch_page(resolved_target)
+
+            selected_fetch_page_summary = selected_fetch_page
 
         progress_renderer = _ProgressLineRenderer(sys.stdout)
         progress_stdout = _ProgressAwareStream(sys.stdout, progress_renderer)
@@ -1862,6 +1877,40 @@ def main(argv: Sequence[str] | None = None) -> int:
                 _print()
                 _print(markdown)
 
+        def _format_metric_seconds(seconds: float) -> str:
+            return f"{seconds:.3f}"
+
+        def _refresh_run_metric_cache_stats() -> None:
+            if fetch_cache is None:
+                run_metrics.record_fetch_cache_stats(hits=0, misses=0)
+                return
+            run_metrics.record_fetch_cache_stats(
+                hits=fetch_cache.stats.hits,
+                misses=fetch_cache.stats.misses,
+            )
+
+        def _print_confluence_run_metrics(*, indent: str) -> None:
+            _refresh_run_metric_cache_stats()
+            metric_indent = f"{indent}  "
+            _print(f"{indent}run_metrics:")
+            _print(f"{metric_indent}listing_requests: {run_metrics.listing_requests}")
+            _print(f"{metric_indent}pages_discovered: {run_metrics.pages_discovered}")
+            _print(
+                f"{metric_indent}discovery_seconds: "
+                f"{_format_metric_seconds(run_metrics.discovery_seconds)}"
+            )
+            _print(f"{metric_indent}page_fetch_requests: {run_metrics.page_fetch_requests}")
+            _print(f"{metric_indent}fetch_cache_hits: {run_metrics.fetch_cache_hits}")
+            _print(f"{metric_indent}fetch_cache_misses: {run_metrics.fetch_cache_misses}")
+            _print(
+                f"{metric_indent}fetch_cache_saved_requests: "
+                f"{run_metrics.fetch_cache_saved_requests}"
+            )
+            _print(
+                f"{metric_indent}fetch_seconds: "
+                f"{_format_metric_seconds(run_metrics.fetch_seconds)}"
+            )
+
         def _print_confluence_dry_run_summary(
             *,
             mode: str,
@@ -1907,6 +1956,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             _print("  Summary:")
             for line in summary_lines:
                 _print(line)
+            _print_confluence_run_metrics(indent="    ")
 
         def _print_confluence_write_summary(
             *,
@@ -1931,6 +1981,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 _print(f"  tree_cache_misses: {tree_cache.stats.misses}")
             _print(f"  pages_written: {write_count}")
             _print(f"  pages_skipped: {skip_count}")
+            _print_confluence_run_metrics(indent="  ")
 
         def _print_stub_tree_mode_note() -> None:
             if not (confluence_config.tree and confluence_config.client_mode == "stub"):
@@ -1991,6 +2042,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             _print(f"Space progress: discovery started, space_key {resolved_space_key}")
             try:
                 discovered_page_ids = sorted(set(selected_list_space_page_ids(resolved_space_key)))
+                run_metrics.record_pages_discovered(len(discovered_page_ids))
                 _render_final_discovered_pages_progress(len(discovered_page_ids))
                 _print(
                     "Space progress: "
@@ -2238,6 +2290,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     list_child_page_ids=selected_list_child_page_ids,
                     progress_callback=_print_tree_walk_progress,
                 )
+            run_metrics.record_pages_discovered(len(pages))
             _finish_progress_line()
             _print_confluence_invocation()
             page_records: list[tuple[dict[str, object], Path, PageSyncDecision, str]] = []
@@ -2440,6 +2493,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 
         _print_confluence_invocation()
         page_id = str(page["canonical_id"])
+        run_metrics.record_pages_discovered(1)
         output_path = markdown_path(confluence_config.output_dir, page_id)
         manifest_output_path = manifest_path(confluence_config.output_dir)
         page_decision = classify_page_sync(

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -1607,8 +1607,8 @@ def main(argv: Sequence[str] | None = None) -> int:
 
             def selected_fetch_page(resolved_target: ResolvedTarget) -> dict[str, object]:
                 with run_metrics.time_fetch():
+                    run_metrics.record_page_fetch_request()
                     if fetch_cache is None:
-                        run_metrics.record_page_fetch_request()
                         return fetch_real_page(
                             resolved_target,
                             base_url=confluence_config.base_url,
@@ -1622,7 +1622,6 @@ def main(argv: Sequence[str] | None = None) -> int:
                         if cached_page is not None:
                             return cached_page
 
-                    run_metrics.record_page_fetch_request()
                     raw_payload = fetch_real_page_raw(
                         resolved_target,
                         base_url=confluence_config.base_url,
@@ -1639,7 +1638,6 @@ def main(argv: Sequence[str] | None = None) -> int:
                 resolved_target: ResolvedTarget,
             ) -> dict[str, object]:
                 with run_metrics.time_fetch():
-                    run_metrics.record_page_fetch_request()
                     page = fetch_real_page_summary(
                         resolved_target,
                         base_url=confluence_config.base_url,
@@ -1690,7 +1688,11 @@ def main(argv: Sequence[str] | None = None) -> int:
                     run_metrics.record_page_fetch_request()
                     return fetch_page(resolved_target)
 
-            selected_fetch_page_summary = selected_fetch_page
+            def selected_fetch_page_summary(
+                resolved_target: ResolvedTarget,
+            ) -> dict[str, object]:
+                with run_metrics.time_fetch():
+                    return fetch_page(resolved_target)
 
         progress_renderer = _ProgressLineRenderer(sys.stdout)
         progress_stdout = _ProgressAwareStream(sys.stdout, progress_renderer)

--- a/src/knowledge_adapters/confluence/metrics.py
+++ b/src/knowledge_adapters/confluence/metrics.py
@@ -1,0 +1,55 @@
+"""Run-scoped metrics for Confluence adapter executions."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+
+
+@dataclass
+class ConfluenceRunMetrics:
+    """Lightweight counters and timers for one Confluence CLI run."""
+
+    listing_requests: int = 0
+    pages_discovered: int = 0
+    discovery_seconds: float = 0.0
+    page_fetch_requests: int = 0
+    fetch_cache_hits: int = 0
+    fetch_cache_misses: int = 0
+    fetch_seconds: float = 0.0
+
+    @property
+    def fetch_cache_saved_requests(self) -> int:
+        """Return full-page fetch requests avoided by cache hits."""
+        return self.fetch_cache_hits
+
+    def record_listing_request(self) -> None:
+        self.listing_requests += 1
+
+    def record_page_fetch_request(self) -> None:
+        self.page_fetch_requests += 1
+
+    def record_pages_discovered(self, count: int) -> None:
+        self.pages_discovered = count
+
+    def record_fetch_cache_stats(self, *, hits: int, misses: int) -> None:
+        self.fetch_cache_hits = hits
+        self.fetch_cache_misses = misses
+
+    @contextmanager
+    def time_discovery(self) -> Iterator[None]:
+        started_at = time.monotonic()
+        try:
+            yield
+        finally:
+            self.discovery_seconds += time.monotonic() - started_at
+
+    @contextmanager
+    def time_fetch(self) -> Iterator[None]:
+        started_at = time.monotonic()
+        try:
+            yield
+        finally:
+            self.fetch_seconds += time.monotonic() - started_at

--- a/tests/confluence/test_fetch_cache.py
+++ b/tests/confluence/test_fetch_cache.py
@@ -229,7 +229,7 @@ def test_confluence_force_refresh_bypasses_fetch_cache_hit(
     assert "force_refresh: enabled; configured cache reads will be bypassed" in captured.out
     assert "cache_hits: 0" in captured.out
     assert "cache_misses: 0" in captured.out
-    assert "page_fetch_requests: 2" in captured.out
+    assert "page_fetch_requests: 1" in captured.out
     assert "fetch_cache_hits: 0" in captured.out
     assert "fetch_cache_misses: 0" in captured.out
     assert "fetch_cache_saved_requests: 0" in captured.out
@@ -263,7 +263,7 @@ def test_confluence_clear_cache_removes_stale_fetch_entry_before_run(
     assert "fetch_cache: cleared configured entries" in captured.out
     assert "cache_hits: 0" in captured.out
     assert "cache_misses: 1" in captured.out
-    assert "page_fetch_requests: 2" in captured.out
+    assert "page_fetch_requests: 1" in captured.out
     assert "fetch_cache_hits: 0" in captured.out
     assert "fetch_cache_misses: 1" in captured.out
     assert "fetch_cache_saved_requests: 0" in captured.out

--- a/tests/confluence/test_fetch_cache.py
+++ b/tests/confluence/test_fetch_cache.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -99,6 +100,10 @@ def _cache_entry_path(cache_dir: Path) -> Path:
     return next(cache_dir.rglob("page.json"))
 
 
+def _assert_seconds_metric(output: str, name: str) -> None:
+    assert re.search(rf"{name}: \d+\.\d{{3}}", output) is not None
+
+
 def test_fetch_cache_force_refresh_bypasses_cached_payload(tmp_path: Path) -> None:
     cache = ConfluenceFetchCache(
         prepare_fetch_cache_dir(str(tmp_path / "cache")),
@@ -149,8 +154,17 @@ def test_confluence_fetch_cache_disabled_keeps_output_unchanged(
     assert exit_code == 0
     assert len(requests) == 1
     captured = capsys.readouterr()
-    assert "cache_hits:" not in captured.out
-    assert "cache_misses:" not in captured.out
+    assert "\n  cache_hits:" not in captured.out
+    assert "\n  cache_misses:" not in captured.out
+    assert "run_metrics:" in captured.out
+    assert "listing_requests: 0" in captured.out
+    assert "pages_discovered: 1" in captured.out
+    assert "page_fetch_requests: 1" in captured.out
+    assert "fetch_cache_hits: 0" in captured.out
+    assert "fetch_cache_misses: 0" in captured.out
+    assert "fetch_cache_saved_requests: 0" in captured.out
+    _assert_seconds_metric(captured.out, "discovery_seconds")
+    _assert_seconds_metric(captured.out, "fetch_seconds")
 
 
 def test_confluence_fetch_cache_hit_uses_cached_raw_payload(
@@ -179,6 +193,10 @@ def test_confluence_fetch_cache_hit_uses_cached_raw_payload(
     captured = capsys.readouterr()
     assert "cache_hits: 1" in captured.out
     assert "cache_misses: 0" in captured.out
+    assert "page_fetch_requests: 1" in captured.out
+    assert "fetch_cache_hits: 1" in captured.out
+    assert "fetch_cache_misses: 0" in captured.out
+    assert "fetch_cache_saved_requests: 1" in captured.out
     assert "Hello from Confluence." in (output_dir / "pages" / "12345.md").read_text(
         encoding="utf-8"
     )
@@ -211,6 +229,10 @@ def test_confluence_force_refresh_bypasses_fetch_cache_hit(
     assert "force_refresh: enabled; configured cache reads will be bypassed" in captured.out
     assert "cache_hits: 0" in captured.out
     assert "cache_misses: 0" in captured.out
+    assert "page_fetch_requests: 2" in captured.out
+    assert "fetch_cache_hits: 0" in captured.out
+    assert "fetch_cache_misses: 0" in captured.out
+    assert "fetch_cache_saved_requests: 0" in captured.out
     output = (output_dir / "pages" / "12345.md").read_text(encoding="utf-8")
     assert "Fresh content." in output
     assert "Cached content." not in output
@@ -241,6 +263,10 @@ def test_confluence_clear_cache_removes_stale_fetch_entry_before_run(
     assert "fetch_cache: cleared configured entries" in captured.out
     assert "cache_hits: 0" in captured.out
     assert "cache_misses: 1" in captured.out
+    assert "page_fetch_requests: 2" in captured.out
+    assert "fetch_cache_hits: 0" in captured.out
+    assert "fetch_cache_misses: 1" in captured.out
+    assert "fetch_cache_saved_requests: 0" in captured.out
     output = (output_dir / "pages" / "12345.md").read_text(encoding="utf-8")
     assert "Fresh content." in output
     assert "Stale cached content." not in output

--- a/tests/confluence/test_traversal_real.py
+++ b/tests/confluence/test_traversal_real.py
@@ -418,6 +418,12 @@ def test_real_space_mode_discovers_pages_and_writes_in_lexical_order(
     assert "pages_discovered: 3" in output
     assert "pages_planned: 3" in output
     assert "Summary: wrote 3, skipped 0" in output
+    assert "run_metrics:" in output
+    assert "listing_requests: 1" in output
+    assert "page_fetch_requests: 3" in output
+    assert "fetch_cache_hits: 0" in output
+    assert "fetch_cache_misses: 0" in output
+    assert "fetch_cache_saved_requests: 0" in output
 
 
 def test_real_space_fetch_progress_uses_carriage_return_for_tty_stdout(
@@ -1009,6 +1015,7 @@ def test_space_mode_rejects_invalid_space_url_shape(
 def test_real_tree_depth_semantics_use_separate_page_fetch_and_child_discovery(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
     max_depth: int,
     expected_ids: list[str],
     expected_fetch_counts: dict[str, int],
@@ -1028,6 +1035,13 @@ def test_real_tree_depth_semantics_use_separate_page_fetch_and_child_discovery(
     assert [entry["canonical_id"] for entry in _manifest_files(payload)] == expected_ids
     assert page_fetch_counts == expected_fetch_counts
     assert child_list_calls == expected_child_calls
+    output = capsys.readouterr().out
+    assert "run_metrics:" in output
+    assert f"listing_requests: {len(expected_child_calls)}" in output
+    assert f"pages_discovered: {len(expected_ids)}" in output
+    assert f"page_fetch_requests: {len(expected_fetch_counts)}" in output
+    assert "fetch_cache_hits: 0" in output
+    assert "fetch_cache_misses: 0" in output
 
 
 def test_real_tree_incremental_run_skips_full_page_fetch_for_unchanged_pages(

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1105,6 +1105,13 @@ def test_confluence_cli_smoke_uses_installed_entrypoint_with_default_stub_client
     assert "auth_method:" not in result.stdout
     assert "Wrote:" not in result.stdout
     assert_write_summary(result.stdout, wrote=1, skipped=0)
+    assert "run_metrics:" in result.stdout
+    assert "listing_requests: 0" in result.stdout
+    assert "pages_discovered: 1" in result.stdout
+    assert "page_fetch_requests: 1" in result.stdout
+    assert "fetch_cache_hits: 0" in result.stdout
+    assert "fetch_cache_misses: 0" in result.stdout
+    assert "fetch_cache_saved_requests: 0" in result.stdout
     assert "Manifest:" in result.stdout
     assert f"Write complete. Artifacts created under {tmp_path / 'artifacts'}" in result.stdout
 


### PR DESCRIPTION
Summary
- Add a lightweight Confluence run metrics object for listing/page-fetch counters and monotonic phase timing.
- Print concise `run_metrics` blocks after existing Confluence dry-run and write summaries while preserving existing cache summary lines.
- Cover discovery, fetch, and fetch-cache hit/miss metrics in CLI, traversal, and cache tests.

Testing
- `make check`

Closes #213