### PR TITLE
[codex] Add optional Confluence request pacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,23 @@ CONFLUENCE_BEARER_TOKEN=... knowledge-adapters confluence \
 If that real-mode dry run looks right, rerun it without `--dry-run` to write
 the live-fetched artifact and manifest.
 
+Optional request pacing is available only when you opt in. Use
+`--request-delay-ms` to require a minimum delay between live Confluence API
+request starts, or `--max-requests-per-second` to cap the request rate. If both
+are set, the slower interval wins. The first live request is immediate, and
+cache hits do not sleep.
+
+```bash
+CONFLUENCE_BEARER_TOKEN=... knowledge-adapters confluence \
+  --client-mode real \
+  --auth-method bearer-env \
+  --base-url https://example.com/wiki \
+  --target 12345 \
+  --output-dir ./artifacts \
+  --request-delay-ms 250 \
+  --max-requests-per-second 2
+```
+
 ## Confluence Authentication Examples
 
 Bearer token via `CONFLUENCE_BEARER_TOKEN`:
@@ -175,6 +192,8 @@ runs:
     output_dir: ./artifacts/confluence/docs-home-bearer
     client_mode: real
     auth_method: bearer-env
+    request_delay_ms: 250
+    max_requests_per_second: 2
     dry_run: true
 
   - name: docs-home-mtls
@@ -588,6 +607,10 @@ In v1, `--client-mode real` supports both single-page fetches and real breadth-f
 tree traversal with `--tree` and `--max-depth`, using `bearer-env` auth and
 optional client certificates or `client-cert-env` auth. This opt-in path is
 contract-tested, but not fully live-validated across Confluence environments.
+
+For slower real-mode runs, add `--request-delay-ms` or
+`--max-requests-per-second`. When both are present, the CLI uses whichever option
+produces the longer interval between live Confluence API request starts.
 
 For certificate-based auth, set `CONFLUENCE_CLIENT_CERT_FILE` to a combined PEM
 file, or set `CONFLUENCE_CLIENT_CERT_FILE` plus `CONFLUENCE_CLIENT_KEY_FILE` for

--- a/adapters/confluence/README.md
+++ b/adapters/confluence/README.md
@@ -51,6 +51,11 @@ real` plus an auth method:
 - `client-cert-env` via `CONFLUENCE_CLIENT_CERT_FILE` plus optional
   `CONFLUENCE_CLIENT_KEY_FILE`
 
+Real-mode request pacing is optional. Add `--request-delay-ms` or
+`--max-requests-per-second` to slow live Confluence API calls during page
+fetches and listing/discovery. If both are provided, the slower interval between
+request starts is used.
+
 Treat tree mode as a follow-on step. With the default `stub` client, `--tree`
 still plans only the resolved root page because no child pages are discovered.
 
@@ -91,6 +96,8 @@ Out of the box, the default Confluence CLI:
   `--force-refresh` bypasses configured cache reads while still writing fresh
   entries, and `--clear-cache` clears only configured Confluence cache subtrees
   before the run starts
+- supports opt-in real-client request pacing with `--request-delay-ms` and
+  `--max-requests-per-second`
 - keeps `stub` and `real` modes on the same CLI flow and artifact layout, with
   only the content source changing between modes
 - keeps dry-run and write messaging aligned across `stub` and `real`, including
@@ -125,6 +132,7 @@ runtime rather than committed:
 - target page URL or page ID
 - output directory
 - optional fetch mode and limits
+- optional real-client request pacing
 
 ## Design and Contract Docs
 

--- a/docs/confluence-real-client.md
+++ b/docs/confluence-real-client.md
@@ -333,7 +333,7 @@ The following are explicitly out of scope for v1:
 - broader auth abstractions or multi-provider auth systems
 - attachments
 - comments
-- pagination or rate-limit sophistication
+- adaptive rate-limit sophistication beyond explicit operator pacing
 - macro fidelity improvements
 - write-path refactors
 - manifest schema changes

--- a/docs/confluence-real-traversal.md
+++ b/docs/confluence-real-traversal.md
@@ -293,7 +293,7 @@ Live validation against a real Confluence instance may be useful for developer c
 
 The following are explicitly out of scope for this phase:
 
-- pagination or rate-limit sophistication
+- adaptive rate-limit sophistication beyond explicit operator pacing
 - retries, backoff, or resume behavior
 - attachments
 - comments

--- a/runs.example.yaml
+++ b/runs.example.yaml
@@ -27,6 +27,10 @@ runs:
     # Real mode with bearer auth from CONFLUENCE_BEARER_TOKEN.
     # client_mode: real
     # auth_method: bearer-env
+    # Optional request pacing for live Confluence API calls. If both are set,
+    # the slower interval between request starts is used.
+    # request_delay_ms: 250
+    # max_requests_per_second: 2
     # fetch_cache_dir: ./.cache/knowledge-adapters
     # force_refresh: true
     # clear_cache: true
@@ -44,6 +48,9 @@ runs:
     max_depth: 1
     # client_mode: real
     # auth_method: client-cert-env
+    # Optional request pacing for live Confluence API calls.
+    # request_delay_ms: 250
+    # max_requests_per_second: 2
     # Optional traversal cache for repeated large tree listing runs.
     # tree_cache_dir: ./.cache/confluence-tree
     # force_refresh: true

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import io
+import math
 import re
 import shlex
 import sys
@@ -170,6 +171,8 @@ _CONFLUENCE_REAL_ONLY_INPUT_FLAGS = (
     "--client-key-file",
     "--fetch-cache-dir",
     "--tree-cache-dir",
+    "--request-delay-ms",
+    "--max-requests-per-second",
 )
 _VERBOSE_HELP = "Show per-item write/skip details that are hidden by default."
 
@@ -183,13 +186,14 @@ class MultiRunSummary:
     skipped: int
 
 
-class RealClientTLSKwargs(TypedDict, total=False):
+class RealClientKwargs(TypedDict, total=False):
     """Keyword arguments shared by Confluence real-client calls."""
 
     ca_bundle: str | None
     no_ca_bundle: bool
     client_cert_file: str | None
     client_key_file: str | None
+    request_pacer: Callable[[], None]
 
 
 class _TeeStream:
@@ -331,6 +335,32 @@ def _parse_positive_int(value: str) -> int:
 
     if parsed_value < 1:
         raise argparse.ArgumentTypeError("expected a positive integer.")
+
+    return parsed_value
+
+
+def _parse_non_negative_int(value: str) -> int:
+    """Parse a non-negative integer CLI value."""
+    try:
+        parsed_value = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("expected a non-negative integer.") from exc
+
+    if parsed_value < 0:
+        raise argparse.ArgumentTypeError("expected a non-negative integer.")
+
+    return parsed_value
+
+
+def _parse_positive_float(value: str) -> float:
+    """Parse a finite positive numeric CLI value."""
+    try:
+        parsed_value = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("expected a positive number.") from exc
+
+    if not math.isfinite(parsed_value) or parsed_value <= 0:
+        raise argparse.ArgumentTypeError("expected a positive number.")
 
     return parsed_value
 
@@ -539,6 +569,24 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "Opt-in directory for caching Confluence traversal listing results. "
             "Disabled when omitted."
+        ),
+    )
+    confluence_parser.add_argument(
+        "--request-delay-ms",
+        type=_parse_non_negative_int,
+        metavar="MS",
+        help=(
+            "Opt-in minimum delay between live Confluence API request starts, in "
+            "milliseconds. Defaults to no pacing."
+        ),
+    )
+    confluence_parser.add_argument(
+        "--max-requests-per-second",
+        type=_parse_positive_float,
+        metavar="N",
+        help=(
+            "Opt-in maximum live Confluence API request rate. When combined with "
+            "--request-delay-ms, the slower interval is used."
         ),
     )
     confluence_parser.add_argument(
@@ -1385,6 +1433,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         from knowledge_adapters.confluence.metrics import ConfluenceRunMetrics
         from knowledge_adapters.confluence.models import ResolvedTarget
         from knowledge_adapters.confluence.normalize import normalize_to_markdown
+        from knowledge_adapters.confluence.pacing import build_confluence_request_pacer
         from knowledge_adapters.confluence.resolve import (
             resolve_target_for_base_url,
             space_key_from_url_for_base_url,
@@ -1428,6 +1477,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             dry_run=args.dry_run,
             tree=args.tree,
             max_depth=args.max_depth,
+            request_delay_ms=args.request_delay_ms,
+            max_requests_per_second=args.max_requests_per_second,
         )
         output_dir_input = Path(confluence_config.output_dir).expanduser()
         output_dir = output_dir_input.resolve()
@@ -1589,20 +1640,27 @@ def main(argv: Sequence[str] | None = None) -> int:
                 exit_with_cli_error(str(exc), command="confluence")
 
         run_metrics = ConfluenceRunMetrics()
+        request_pacer = build_confluence_request_pacer(
+            request_delay_ms=confluence_config.request_delay_ms,
+            max_requests_per_second=confluence_config.max_requests_per_second,
+        )
+        request_pace = request_pacer.pace if request_pacer is not None else None
         selected_fetch_page: Callable[[ResolvedTarget], dict[str, object]]
         selected_fetch_page_summary: Callable[[ResolvedTarget], dict[str, object]]
         selected_list_child_page_ids: Callable[[ResolvedTarget], list[str]] | None = None
         selected_list_space_page_ids: Callable[[str], list[str]] | None = None
         if confluence_config.client_mode == "real":
 
-            def real_client_tls_kwargs() -> RealClientTLSKwargs:
-                kwargs = RealClientTLSKwargs(
+            def real_client_kwargs() -> RealClientKwargs:
+                kwargs = RealClientKwargs(
                     ca_bundle=confluence_config.ca_bundle,
                     client_cert_file=confluence_config.client_cert_file,
                     client_key_file=confluence_config.client_key_file,
                 )
                 if confluence_config.no_ca_bundle:
                     kwargs["no_ca_bundle"] = True
+                if request_pace is not None:
+                    kwargs["request_pacer"] = request_pace
                 return kwargs
 
             def selected_fetch_page(resolved_target: ResolvedTarget) -> dict[str, object]:
@@ -1613,7 +1671,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                             resolved_target,
                             base_url=confluence_config.base_url,
                             auth_method=confluence_config.auth_method,
-                            **real_client_tls_kwargs(),
+                            **real_client_kwargs(),
                         )
 
                     page_id = resolved_target.page_id
@@ -1626,7 +1684,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                         resolved_target,
                         base_url=confluence_config.base_url,
                         auth_method=confluence_config.auth_method,
-                        **real_client_tls_kwargs(),
+                        **real_client_kwargs(),
                     )
                     if not page_id:
                         raise ValueError("Response error: canonical_id mismatch.")
@@ -1642,7 +1700,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                         resolved_target,
                         base_url=confluence_config.base_url,
                         auth_method=confluence_config.auth_method,
-                        **real_client_tls_kwargs(),
+                        **real_client_kwargs(),
                     )
                     if fetch_cache is not None:
                         fetch_cache.record_metadata(page)
@@ -1658,7 +1716,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                         base_url=confluence_config.base_url,
                         auth_method=confluence_config.auth_method,
                         progress_callback=_print_discovered_pages_progress,
-                        **real_client_tls_kwargs(),
+                        **real_client_kwargs(),
                     )
 
                 page_id = resolved_target.page_id
@@ -1675,7 +1733,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                         base_url=confluence_config.base_url,
                         auth_method=confluence_config.auth_method,
                         progress_callback=_print_discovered_pages_progress,
-                        **real_client_tls_kwargs(),
+                        **real_client_kwargs(),
                     )
 
                 with run_metrics.time_discovery():

--- a/src/knowledge_adapters/confluence/client.py
+++ b/src/knowledge_adapters/confluence/client.py
@@ -33,6 +33,7 @@ class ConfluenceRequestError(RuntimeError):
 
 
 DiscoveryProgressCallback = Callable[[int], None]
+RequestPacer = Callable[[], None]
 
 
 def fetch_page(target: ResolvedTarget) -> dict[str, object]:
@@ -369,6 +370,7 @@ def _request_json(
     no_ca_bundle: bool = False,
     client_cert_file: str | None = None,
     client_key_file: str | None = None,
+    request_pacer: RequestPacer | None = None,
 ) -> dict[str, object]:
     request_auth = build_request_auth(
         auth_method,
@@ -383,6 +385,8 @@ def _request_json(
     )
 
     try:
+        if request_pacer is not None:
+            request_pacer()
         with request.urlopen(api_request, context=request_auth.ssl_context) as response:
             raw_payload = json.loads(response.read().decode("utf-8"))
     except (HTTPError, URLError) as exc:
@@ -410,6 +414,7 @@ def fetch_real_page_raw(
     no_ca_bundle: bool = False,
     client_cert_file: str | None = None,
     client_key_file: str | None = None,
+    request_pacer: RequestPacer | None = None,
 ) -> dict[str, object]:
     """Fetch one raw Confluence full-page payload through the real client path."""
     page_id = target.page_id
@@ -423,6 +428,7 @@ def fetch_real_page_raw(
         no_ca_bundle=no_ca_bundle,
         client_cert_file=client_cert_file,
         client_key_file=client_key_file,
+        request_pacer=request_pacer,
     )
 
 
@@ -440,6 +446,7 @@ def fetch_real_page(
     no_ca_bundle: bool = False,
     client_cert_file: str | None = None,
     client_key_file: str | None = None,
+    request_pacer: RequestPacer | None = None,
 ) -> dict[str, object]:
     """Fetch one Confluence page through the opt-in real client path."""
     page_id = target.page_id
@@ -454,6 +461,7 @@ def fetch_real_page(
         no_ca_bundle=no_ca_bundle,
         client_cert_file=client_cert_file,
         client_key_file=client_key_file,
+        request_pacer=request_pacer,
     )
     return _map_real_page(raw_payload, page_id)
 
@@ -467,6 +475,7 @@ def fetch_real_page_summary(
     no_ca_bundle: bool = False,
     client_cert_file: str | None = None,
     client_key_file: str | None = None,
+    request_pacer: RequestPacer | None = None,
 ) -> dict[str, object]:
     """Fetch Confluence page metadata used for incremental sync decisions."""
     page_id = target.page_id
@@ -480,6 +489,7 @@ def fetch_real_page_summary(
         no_ca_bundle=no_ca_bundle,
         client_cert_file=client_cert_file,
         client_key_file=client_key_file,
+        request_pacer=request_pacer,
     )
     return _map_real_page_summary(raw_payload, page_id)
 
@@ -494,6 +504,7 @@ def list_real_child_page_ids(
     client_cert_file: str | None = None,
     client_key_file: str | None = None,
     progress_callback: DiscoveryProgressCallback | None = None,
+    request_pacer: RequestPacer | None = None,
 ) -> list[str]:
     """List direct child page IDs for one Confluence page in real mode."""
     page_id = target.page_id
@@ -507,6 +518,7 @@ def list_real_child_page_ids(
         no_ca_bundle=no_ca_bundle,
         client_cert_file=client_cert_file,
         client_key_file=client_key_file,
+        request_pacer=request_pacer,
     )
     child_page_ids = _map_child_page_ids(raw_payload)
     _report_periodic_discovery_progress(
@@ -528,6 +540,7 @@ def list_real_space_page_ids(
     client_key_file: str | None = None,
     page_limit: int = 100,
     progress_callback: DiscoveryProgressCallback | None = None,
+    request_pacer: RequestPacer | None = None,
 ) -> list[str]:
     """List all page IDs in one Confluence space in deterministic order."""
     if not space_key:
@@ -554,6 +567,7 @@ def list_real_space_page_ids(
             no_ca_bundle=no_ca_bundle,
             client_cert_file=client_cert_file,
             client_key_file=client_key_file,
+            request_pacer=request_pacer,
         )
         page_ids.update(_map_content_page_ids(raw_payload))
         last_reported_pages = _report_periodic_discovery_progress(

--- a/src/knowledge_adapters/confluence/config.py
+++ b/src/knowledge_adapters/confluence/config.py
@@ -31,6 +31,8 @@ class ConfluenceConfig:
     dry_run: bool = False
     tree: bool = False
     max_depth: int = 0
+    request_delay_ms: int | None = None
+    max_requests_per_second: float | None = None
 
 
 _TLS_INPUT_OPTION_NAMES = {

--- a/src/knowledge_adapters/confluence/pacing.py
+++ b/src/knowledge_adapters/confluence/pacing.py
@@ -1,0 +1,58 @@
+"""Optional request pacing for live Confluence API calls."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+
+@dataclass
+class ConfluenceRequestPacer:
+    """Enforce a minimum interval between real Confluence request starts."""
+
+    min_interval_seconds: float
+    monotonic: Callable[[], float] = time.monotonic
+    sleep: Callable[[float], None] = time.sleep
+    _last_request_started_at: float | None = field(default=None, init=False)
+
+    def pace(self) -> None:
+        now = self.monotonic()
+        if self._last_request_started_at is not None:
+            elapsed = now - self._last_request_started_at
+            remaining = self.min_interval_seconds - elapsed
+            if remaining > 0:
+                self.sleep(remaining)
+                now = self.monotonic()
+        self._last_request_started_at = now
+
+
+def request_pacing_interval_seconds(
+    *,
+    request_delay_ms: int | None,
+    max_requests_per_second: float | None,
+) -> float | None:
+    """Return the configured request interval, using the slower option when both are set."""
+    intervals: list[float] = []
+    if request_delay_ms is not None and request_delay_ms > 0:
+        intervals.append(request_delay_ms / 1000)
+    if max_requests_per_second is not None:
+        intervals.append(1 / max_requests_per_second)
+    if not intervals:
+        return None
+    return max(intervals)
+
+
+def build_confluence_request_pacer(
+    *,
+    request_delay_ms: int | None,
+    max_requests_per_second: float | None,
+) -> ConfluenceRequestPacer | None:
+    """Build an optional Confluence request pacer from validated config values."""
+    interval_seconds = request_pacing_interval_seconds(
+        request_delay_ms=request_delay_ms,
+        max_requests_per_second=max_requests_per_second,
+    )
+    if interval_seconds is None:
+        return None
+    return ConfluenceRequestPacer(interval_seconds)

--- a/src/knowledge_adapters/run_config.py
+++ b/src/knowledge_adapters/run_config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import os
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -66,7 +67,9 @@ _CONFLUENCE_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
         "fetch_cache_dir",
         "force_refresh",
         "max_depth",
+        "max_requests_per_second",
         "output_dir",
+        "request_delay_ms",
         "space_key",
         "space_url",
         "target",
@@ -533,6 +536,24 @@ def _build_confluence_argv(
                 resolved_client_key_file,
             ]
         )
+
+    request_delay_ms = _optional_non_negative_int(
+        run_config,
+        "request_delay_ms",
+        index=index,
+        config_path=config_path,
+    )
+    if request_delay_ms is not None:
+        argv.extend(["--request-delay-ms", str(request_delay_ms)])
+
+    max_requests_per_second = _optional_positive_number(
+        run_config,
+        "max_requests_per_second",
+        index=index,
+        config_path=config_path,
+    )
+    if max_requests_per_second is not None:
+        argv.extend(["--max-requests-per-second", f"{max_requests_per_second:g}"])
 
     fetch_cache_dir = _optional_string(
         run_config,
@@ -1241,6 +1262,47 @@ def _optional_bool(
     if not isinstance(value, bool):
         raise ValueError(f"Run {index!r} in {config_path} must set {key!r} to true or false.")
     return value
+
+
+def _optional_non_negative_int(
+    run_config: dict[str, object],
+    key: str,
+    *,
+    index: int | str,
+    config_path: Path,
+) -> int | None:
+    if key not in run_config:
+        return None
+    value = run_config.get(key)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(
+            f"Run {index!r} in {config_path} must set {key!r} to an integer "
+            "greater than or equal to 0."
+        )
+    if value < 0:
+        raise ValueError(
+            f"Run {index!r} in {config_path} must set {key!r} to an integer "
+            "greater than or equal to 0."
+        )
+    return value
+
+
+def _optional_positive_number(
+    run_config: dict[str, object],
+    key: str,
+    *,
+    index: int | str,
+    config_path: Path,
+) -> float | None:
+    if key not in run_config:
+        return None
+    value = run_config.get(key)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"Run {index!r} in {config_path} must set {key!r} to a positive number.")
+    parsed_value = float(value)
+    if not math.isfinite(parsed_value) or parsed_value <= 0:
+        raise ValueError(f"Run {index!r} in {config_path} must set {key!r} to a positive number.")
+    return parsed_value
 
 
 def _resolve_path_string(value: str, *, config_path: Path) -> str:

--- a/tests/confluence/test_client.py
+++ b/tests/confluence/test_client.py
@@ -6,6 +6,8 @@ from typing import Literal
 from pytest import MonkeyPatch
 
 from knowledge_adapters.confluence.client import (
+    fetch_real_page,
+    fetch_real_page_summary,
     list_real_child_page_ids,
     list_real_space_page_ids,
 )
@@ -60,6 +62,22 @@ def _valid_space_page_list_payload(
     if next_url is not None:
         payload["_links"] = {"next": next_url}
     return payload
+
+
+def _valid_confluence_payload(page_id: str = "12345") -> dict[str, object]:
+    return {
+        "id": page_id,
+        "title": "Real Page",
+        "body": {"storage": {"value": "<p>Hello from Confluence.</p>"}},
+        "version": {
+            "number": 7,
+            "when": "2026-04-20T12:34:56Z",
+        },
+        "_links": {
+            "base": "https://example.com/wiki",
+            "webui": f"/spaces/ENG/pages/{page_id}",
+        },
+    }
 
 
 def test_real_child_list_reports_periodic_progress_for_large_results(
@@ -169,3 +187,119 @@ def test_real_space_page_list_does_not_report_progress_for_small_runs(
     )
 
     assert progress_updates == []
+
+
+def test_real_fetch_omits_pacing_by_default(monkeypatch: MonkeyPatch) -> None:
+    request_count = 0
+
+    def fake_urlopen(*args: object, **kwargs: object) -> _FakeHTTPResponse:
+        nonlocal request_count
+        del args, kwargs
+        request_count += 1
+        return _FakeHTTPResponse(_valid_confluence_payload())
+
+    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    page = fetch_real_page(
+        _real_target(),
+        base_url="https://example.com/wiki",
+        auth_method="bearer-env",
+    )
+
+    assert page["canonical_id"] == "12345"
+    assert request_count == 1
+
+
+def test_real_page_fetch_invokes_request_pacer(monkeypatch: MonkeyPatch) -> None:
+    pacer_calls: list[str] = []
+
+    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *args, **kwargs: _FakeHTTPResponse(_valid_confluence_payload()),
+    )
+
+    page = fetch_real_page(
+        _real_target(),
+        base_url="https://example.com/wiki",
+        auth_method="bearer-env",
+        request_pacer=lambda: pacer_calls.append("fetch"),
+    )
+
+    assert page["canonical_id"] == "12345"
+    assert pacer_calls == ["fetch"]
+
+
+def test_real_page_summary_fetch_invokes_request_pacer(monkeypatch: MonkeyPatch) -> None:
+    pacer_calls: list[str] = []
+
+    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *args, **kwargs: _FakeHTTPResponse(_valid_confluence_payload()),
+    )
+
+    page = fetch_real_page_summary(
+        _real_target(),
+        base_url="https://example.com/wiki",
+        auth_method="bearer-env",
+        request_pacer=lambda: pacer_calls.append("summary"),
+    )
+
+    assert page["canonical_id"] == "12345"
+    assert "content" not in page
+    assert pacer_calls == ["summary"]
+
+
+def test_real_child_listing_invokes_request_pacer(monkeypatch: MonkeyPatch) -> None:
+    pacer_calls: list[str] = []
+
+    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *args, **kwargs: _FakeHTTPResponse(
+            _valid_child_list_payload(child_page_ids=["200"])
+        ),
+    )
+
+    child_page_ids = list_real_child_page_ids(
+        _real_target(),
+        base_url="https://example.com/wiki",
+        auth_method="bearer-env",
+        request_pacer=lambda: pacer_calls.append("child-list"),
+    )
+
+    assert child_page_ids == ["200"]
+    assert pacer_calls == ["child-list"]
+
+
+def test_real_space_listing_invokes_request_pacer_for_each_page(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    pacer_calls: list[str] = []
+    payloads = [
+        _valid_space_page_list_payload(
+            page_ids=["300", "100"],
+            next_url="/wiki/rest/api/content?spaceKey=ENG&type=page&start=2&limit=2",
+        ),
+        _valid_space_page_list_payload(page_ids=["200"]),
+    ]
+
+    def fake_urlopen(*args: object, **kwargs: object) -> _FakeHTTPResponse:
+        del args, kwargs
+        return _FakeHTTPResponse(payloads.pop(0))
+
+    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    page_ids = list_real_space_page_ids(
+        "ENG",
+        base_url="https://example.com/wiki",
+        auth_method="bearer-env",
+        page_limit=2,
+        request_pacer=lambda: pacer_calls.append("space-list"),
+    )
+
+    assert page_ids == ["100", "200", "300"]
+    assert pacer_calls == ["space-list", "space-list"]

--- a/tests/confluence/test_pacing.py
+++ b/tests/confluence/test_pacing.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import pytest
+
+from knowledge_adapters.confluence.pacing import (
+    ConfluenceRequestPacer,
+    build_confluence_request_pacer,
+    request_pacing_interval_seconds,
+)
+
+
+def test_build_request_pacer_defaults_to_noop_when_unconfigured() -> None:
+    assert (
+        build_confluence_request_pacer(
+            request_delay_ms=None,
+            max_requests_per_second=None,
+        )
+        is None
+    )
+    assert (
+        build_confluence_request_pacer(
+            request_delay_ms=0,
+            max_requests_per_second=None,
+        )
+        is None
+    )
+
+
+def test_request_pacing_interval_uses_slower_option_when_both_are_set() -> None:
+    assert (
+        request_pacing_interval_seconds(
+            request_delay_ms=250,
+            max_requests_per_second=10,
+        )
+        == 0.25
+    )
+    assert (
+        request_pacing_interval_seconds(
+            request_delay_ms=10,
+            max_requests_per_second=2,
+        )
+        == 0.5
+    )
+
+
+def test_request_pacer_sleeps_between_request_starts() -> None:
+    now = 100.0
+    sleeps: list[float] = []
+
+    def monotonic() -> float:
+        return now
+
+    def sleep(seconds: float) -> None:
+        nonlocal now
+        sleeps.append(seconds)
+        now += seconds
+
+    pacer = ConfluenceRequestPacer(
+        min_interval_seconds=0.25,
+        monotonic=monotonic,
+        sleep=sleep,
+    )
+
+    pacer.pace()
+    now += 0.1
+    pacer.pace()
+    now += 0.25
+    pacer.pace()
+
+    assert sleeps == [pytest.approx(0.15)]

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1133,7 +1133,6 @@ def test_confluence_cli_smoke_uses_installed_entrypoint_with_default_stub_client
 Stub content for page 12345.
 """
     )
-
     payload = json.loads((tmp_path / "artifacts" / "manifest.json").read_text(encoding="utf-8"))
     assert payload["files"] == [
         {
@@ -1145,6 +1144,44 @@ Stub content for page 12345.
             "last_modified": "1970-01-01T00:00:00Z",
         }
     ]
+
+
+def test_confluence_cli_rejects_invalid_request_delay(tmp_path: Path) -> None:
+    result = _run_cli(
+        tmp_path,
+        "confluence",
+        "--base-url",
+        "https://example.com/wiki",
+        "--target",
+        "12345",
+        "--output-dir",
+        "./artifacts",
+        "--request-delay-ms",
+        "-1",
+    )
+
+    assert result.returncode == 2
+    assert result.stdout == ""
+    assert "argument --request-delay-ms: expected a non-negative integer." in result.stderr
+
+
+def test_confluence_cli_rejects_invalid_max_requests_per_second(tmp_path: Path) -> None:
+    result = _run_cli(
+        tmp_path,
+        "confluence",
+        "--base-url",
+        "https://example.com/wiki",
+        "--target",
+        "12345",
+        "--output-dir",
+        "./artifacts",
+        "--max-requests-per-second",
+        "0",
+    )
+
+    assert result.returncode == 2
+    assert result.stdout == ""
+    assert "argument --max-requests-per-second: expected a positive number." in result.stderr
 
 
 def test_confluence_cli_tree_dry_run_with_stub_client_reports_discovery_limit(
@@ -1283,6 +1320,9 @@ def test_confluence_help_lists_supported_auth_methods_and_examples(
     assert "same resolve, plan, and write flow" in stdout
     assert "'real' fetches from Confluence" in stdout
     assert "--auth-method AUTH_METHOD" in stdout
+    assert "--request-delay-ms MS" in stdout
+    assert "--max-requests-per-second N" in stdout
+    assert "the slower interval is used" in stdout
     assert "contract-tested live fetches" in stdout
     assert "The CLI resolves either input into one canonical page" in stdout
     assert "source URL for artifact and manifest reporting" in stdout

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -134,6 +134,8 @@ runs:
     base_url: https://example.com/wiki
     target: "12345"
     output_dir: ./artifacts/confluence/docs-home
+    request_delay_ms: 250
+    max_requests_per_second: 2.5
     fetch_cache_dir: ./.cache/confluence-fetches
     tree_cache_dir: ./.cache/confluence-tree
     force_refresh: true
@@ -163,6 +165,10 @@ runs:
                 "12345",
                 "--output-dir",
                 str((tmp_path / "artifacts" / "confluence" / "docs-home").resolve()),
+                "--request-delay-ms",
+                "250",
+                "--max-requests-per-second",
+                "2.5",
                 "--fetch-cache-dir",
                 str((tmp_path / ".cache" / "confluence-fetches").resolve()),
                 "--tree-cache-dir",
@@ -807,6 +813,26 @@ bundles:
             "auth_method",
             "auth_method: oauth",
             "unsupported 'auth_method' value 'oauth'",
+        ),
+        (
+            "request_delay_ms",
+            "request_delay_ms: -1",
+            "must set 'request_delay_ms' to an integer greater than or equal to 0",
+        ),
+        (
+            "request_delay_ms",
+            "request_delay_ms: 1.5",
+            "must set 'request_delay_ms' to an integer greater than or equal to 0",
+        ),
+        (
+            "max_requests_per_second",
+            "max_requests_per_second: 0",
+            "must set 'max_requests_per_second' to a positive number",
+        ),
+        (
+            "max_requests_per_second",
+            "max_requests_per_second: fast",
+            "must set 'max_requests_per_second' to a positive number",
         ),
     ],
 )


### PR DESCRIPTION
## Summary
- Add explicit opt-in Confluence request pacing via `--request-delay-ms` and `--max-requests-per-second`, plus `runs.yaml` keys.
- Apply a shared pacer to real Confluence page fetches, metadata fetches, child listing, and paginated space discovery; cache hits remain immediate.
- Document the deterministic combination rule: when both options are set, the slower interval between live request starts is used.

Fixes #214

## Validation
- `make check` (Ruff, mypy, and 356 tests)

## Residual risks
- Pacing is intentionally local and process-level only; it does not coordinate across parallel operator runs or detect server-side throttling automatically.