### PR TITLE
fix: align Confluence run config validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ This repository follows the shared workflow defined in the
 - Workflow rules: `ai-workflow-playbook/docs/`
 
 Use the playbook for general workflow rules. Follow this AGENTS.md for
-repo-specific behavior when they differ.
+repo-specific execution details where they are more specific.
 
 ---
 
@@ -118,6 +118,8 @@ If `gh` is required but unavailable, explicitly report it instead of stopping ea
 Pull requests must:
 
 - target `main`
+- be ready for review when implementation is complete and `make check` passes,
+  unless draft status is explicitly requested
 - include a clear summary of changes
 - include a testing/verification section
 

--- a/src/knowledge_adapters/run_config.py
+++ b/src/knowledge_adapters/run_config.py
@@ -615,6 +615,10 @@ def _build_confluence_argv(
                 f"Run {name!r} in {config_path} must set 'max_depth' to an integer "
                 "greater than or equal to 0."
             )
+        if not tree:
+            raise ValueError(
+                f"Run {name!r} in {config_path} must set 'tree' when using 'max_depth'."
+            )
         argv.extend(["--max-depth", str(max_depth)])
 
     return tuple(argv)

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -904,6 +904,26 @@ runs:
         load_run_config(config_path)
 
 
+def test_load_run_config_requires_tree_for_confluence_max_depth(tmp_path: Path) -> None:
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: docs-home
+    type: confluence
+    base_url: https://example.com/wiki
+    target: "12345"
+    output_dir: ./artifacts/confluence/docs-home
+    max_depth: 1
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="must set 'tree' when using 'max_depth'"):
+        load_run_config(config_path)
+
+
 def test_run_command_executes_multiple_runs_in_sequence(
     tmp_path: Path,
     capsys: CaptureFixture[str],


### PR DESCRIPTION
## Summary of findings
- AGENTS.md already pointed to the playbook, but its wording implied repo-local rules could differ from shared workflow guidance.
- Confluence `runs.yaml` mapped request pacing, cache controls, and traversal settings to CLI flags, but `max_depth` without `tree` was only rejected later by the CLI path.

## What was fixed
- Clarified that AGENTS.md provides repo-specific execution details where they are more specific than the playbook.
- Made `runs.yaml` reject Confluence `max_depth` unless `tree` is enabled, matching CLI validation behavior.
- Added focused run-config coverage for that parity case.
- Added the ready-for-review PR default to AGENTS.md for completed, validated work.

## Intentionally left unchanged
- No non-Confluence adapters were changed.
- No new run-config schema concepts or abstractions were added.
- Existing cache controls and pacing key names were left unchanged because they already map cleanly to CLI flags.

## Validation
- Passed: `.venv/bin/pytest tests/test_run_config.py::test_load_run_config_requires_tree_for_confluence_max_depth`.
- Passed: `make check` (Ruff, mypy, 357 tests).
- Passed: `git diff --check`.

## Residual gaps
- Low: parity was checked for the requested Confluence pacing, cache, and traversal settings; broader adapter parity was intentionally out of scope.
