### PR TITLE
[codex] Add Confluence real-run request summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ Optional request pacing is available only when you opt in. Use
 request starts, or `--max-requests-per-second` to cap the request rate. If both
 are set, the slower interval wins. The first live request is immediate, and
 cache hits do not sleep.
+Real-mode summaries include a `request_summary` block with live API request
+counts, timing, effective request rate, and pacing status.
 
 ```bash
 CONFLUENCE_BEARER_TOKEN=... knowledge-adapters confluence \

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import inspect
 import io
 import math
 import re
@@ -1653,41 +1652,17 @@ def main(argv: Sequence[str] | None = None) -> int:
         selected_list_space_page_ids: Callable[[str], list[str]] | None = None
         if confluence_config.client_mode == "real":
 
-            def supports_keyword_argument(
-                callable_object: Callable[..., object],
-                name: str,
-                *,
-                allow_var_keyword: bool = True,
-            ) -> bool:
-                try:
-                    signature = inspect.signature(callable_object)
-                except (TypeError, ValueError):
-                    return False
-                return any(
-                    (
-                        allow_var_keyword
-                        and parameter.kind is inspect.Parameter.VAR_KEYWORD
-                    )
-                    or parameter.name == name
-                    for parameter in signature.parameters.values()
-                )
-
-            def real_client_kwargs(callable_object: Callable[..., object]) -> RealClientKwargs:
+            def real_client_kwargs() -> RealClientKwargs:
                 kwargs = RealClientKwargs(
                     ca_bundle=confluence_config.ca_bundle,
                     client_cert_file=confluence_config.client_cert_file,
                     client_key_file=confluence_config.client_key_file,
+                    request_counter=run_metrics.record_live_api_request,
                 )
                 if confluence_config.no_ca_bundle:
                     kwargs["no_ca_bundle"] = True
-                if request_pace is not None and supports_keyword_argument(
-                    callable_object, "request_pacer"
-                ):
+                if request_pace is not None:
                     kwargs["request_pacer"] = request_pace
-                if supports_keyword_argument(
-                    callable_object, "request_counter", allow_var_keyword=False
-                ):
-                    kwargs["request_counter"] = run_metrics.record_live_api_request
                 return kwargs
 
             def selected_fetch_page(resolved_target: ResolvedTarget) -> dict[str, object]:
@@ -1698,7 +1673,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                             resolved_target,
                             base_url=confluence_config.base_url,
                             auth_method=confluence_config.auth_method,
-                            **real_client_kwargs(fetch_real_page),
+                            **real_client_kwargs(),
                         )
 
                     page_id = resolved_target.page_id
@@ -1711,7 +1686,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                         resolved_target,
                         base_url=confluence_config.base_url,
                         auth_method=confluence_config.auth_method,
-                        **real_client_kwargs(fetch_real_page_raw),
+                        **real_client_kwargs(),
                     )
                     if not page_id:
                         raise ValueError("Response error: canonical_id mismatch.")
@@ -1727,7 +1702,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                         resolved_target,
                         base_url=confluence_config.base_url,
                         auth_method=confluence_config.auth_method,
-                        **real_client_kwargs(fetch_real_page_summary),
+                        **real_client_kwargs(),
                     )
                     if fetch_cache is not None:
                         fetch_cache.record_metadata(page)
@@ -1743,7 +1718,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                         base_url=confluence_config.base_url,
                         auth_method=confluence_config.auth_method,
                         progress_callback=_print_discovered_pages_progress,
-                        **real_client_kwargs(list_real_child_page_ids),
+                        **real_client_kwargs(),
                     )
 
                 page_id = resolved_target.page_id
@@ -1760,7 +1735,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                         base_url=confluence_config.base_url,
                         auth_method=confluence_config.auth_method,
                         progress_callback=_print_discovered_pages_progress,
-                        **real_client_kwargs(list_real_space_page_ids),
+                        **real_client_kwargs(),
                     )
 
                 with run_metrics.time_discovery():

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import inspect
 import io
 import math
 import re
@@ -194,6 +195,7 @@ class RealClientKwargs(TypedDict, total=False):
     client_cert_file: str | None
     client_key_file: str | None
     request_pacer: Callable[[], None]
+    request_counter: Callable[[], None]
 
 
 class _TeeStream:
@@ -1651,7 +1653,26 @@ def main(argv: Sequence[str] | None = None) -> int:
         selected_list_space_page_ids: Callable[[str], list[str]] | None = None
         if confluence_config.client_mode == "real":
 
-            def real_client_kwargs() -> RealClientKwargs:
+            def supports_keyword_argument(
+                callable_object: Callable[..., object],
+                name: str,
+                *,
+                allow_var_keyword: bool = True,
+            ) -> bool:
+                try:
+                    signature = inspect.signature(callable_object)
+                except (TypeError, ValueError):
+                    return False
+                return any(
+                    (
+                        allow_var_keyword
+                        and parameter.kind is inspect.Parameter.VAR_KEYWORD
+                    )
+                    or parameter.name == name
+                    for parameter in signature.parameters.values()
+                )
+
+            def real_client_kwargs(callable_object: Callable[..., object]) -> RealClientKwargs:
                 kwargs = RealClientKwargs(
                     ca_bundle=confluence_config.ca_bundle,
                     client_cert_file=confluence_config.client_cert_file,
@@ -1659,20 +1680,25 @@ def main(argv: Sequence[str] | None = None) -> int:
                 )
                 if confluence_config.no_ca_bundle:
                     kwargs["no_ca_bundle"] = True
-                if request_pace is not None:
+                if request_pace is not None and supports_keyword_argument(
+                    callable_object, "request_pacer"
+                ):
                     kwargs["request_pacer"] = request_pace
+                if supports_keyword_argument(
+                    callable_object, "request_counter", allow_var_keyword=False
+                ):
+                    kwargs["request_counter"] = run_metrics.record_live_api_request
                 return kwargs
 
             def selected_fetch_page(resolved_target: ResolvedTarget) -> dict[str, object]:
                 with run_metrics.time_fetch():
                     run_metrics.record_page_fetch_request()
                     if fetch_cache is None:
-                        run_metrics.record_live_api_request()
                         return fetch_real_page(
                             resolved_target,
                             base_url=confluence_config.base_url,
                             auth_method=confluence_config.auth_method,
-                            **real_client_kwargs(),
+                            **real_client_kwargs(fetch_real_page),
                         )
 
                     page_id = resolved_target.page_id
@@ -1681,12 +1707,11 @@ def main(argv: Sequence[str] | None = None) -> int:
                         if cached_page is not None:
                             return cached_page
 
-                    run_metrics.record_live_api_request()
                     raw_payload = fetch_real_page_raw(
                         resolved_target,
                         base_url=confluence_config.base_url,
                         auth_method=confluence_config.auth_method,
-                        **real_client_kwargs(),
+                        **real_client_kwargs(fetch_real_page_raw),
                     )
                     if not page_id:
                         raise ValueError("Response error: canonical_id mismatch.")
@@ -1698,12 +1723,11 @@ def main(argv: Sequence[str] | None = None) -> int:
                 resolved_target: ResolvedTarget,
             ) -> dict[str, object]:
                 with run_metrics.time_fetch():
-                    run_metrics.record_live_api_request()
                     page = fetch_real_page_summary(
                         resolved_target,
                         base_url=confluence_config.base_url,
                         auth_method=confluence_config.auth_method,
-                        **real_client_kwargs(),
+                        **real_client_kwargs(fetch_real_page_summary),
                     )
                     if fetch_cache is not None:
                         fetch_cache.record_metadata(page)
@@ -1714,13 +1738,12 @@ def main(argv: Sequence[str] | None = None) -> int:
             ) -> list[str]:
                 def fetch_listing() -> list[str]:
                     run_metrics.record_listing_request()
-                    run_metrics.record_live_api_request()
                     return list_real_child_page_ids(
                         resolved_target,
                         base_url=confluence_config.base_url,
                         auth_method=confluence_config.auth_method,
                         progress_callback=_print_discovered_pages_progress,
-                        **real_client_kwargs(),
+                        **real_client_kwargs(list_real_child_page_ids),
                     )
 
                 page_id = resolved_target.page_id
@@ -1732,13 +1755,12 @@ def main(argv: Sequence[str] | None = None) -> int:
             def selected_list_space_page_ids(space_key: str) -> list[str]:
                 def fetch_listing() -> list[str]:
                     run_metrics.record_listing_request()
-                    run_metrics.record_live_api_request()
                     return list_real_space_page_ids(
                         space_key,
                         base_url=confluence_config.base_url,
                         auth_method=confluence_config.auth_method,
                         progress_callback=_print_discovered_pages_progress,
-                        **real_client_kwargs(),
+                        **real_client_kwargs(list_real_space_page_ids),
                     )
 
                 with run_metrics.time_discovery():

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -1667,6 +1667,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 with run_metrics.time_fetch():
                     run_metrics.record_page_fetch_request()
                     if fetch_cache is None:
+                        run_metrics.record_live_api_request()
                         return fetch_real_page(
                             resolved_target,
                             base_url=confluence_config.base_url,
@@ -1680,6 +1681,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                         if cached_page is not None:
                             return cached_page
 
+                    run_metrics.record_live_api_request()
                     raw_payload = fetch_real_page_raw(
                         resolved_target,
                         base_url=confluence_config.base_url,
@@ -1696,6 +1698,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 resolved_target: ResolvedTarget,
             ) -> dict[str, object]:
                 with run_metrics.time_fetch():
+                    run_metrics.record_live_api_request()
                     page = fetch_real_page_summary(
                         resolved_target,
                         base_url=confluence_config.base_url,
@@ -1711,6 +1714,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             ) -> list[str]:
                 def fetch_listing() -> list[str]:
                     run_metrics.record_listing_request()
+                    run_metrics.record_live_api_request()
                     return list_real_child_page_ids(
                         resolved_target,
                         base_url=confluence_config.base_url,
@@ -1728,6 +1732,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             def selected_list_space_page_ids(space_key: str) -> list[str]:
                 def fetch_listing() -> list[str]:
                     run_metrics.record_listing_request()
+                    run_metrics.record_live_api_request()
                     return list_real_space_page_ids(
                         space_key,
                         base_url=confluence_config.base_url,
@@ -1940,6 +1945,33 @@ def main(argv: Sequence[str] | None = None) -> int:
         def _format_metric_seconds(seconds: float) -> str:
             return f"{seconds:.3f}"
 
+        def _format_metric_rate(rate: float | None) -> str:
+            if rate is None:
+                return "n/a"
+            return f"{rate:.3f}"
+
+        def _configured_pacing_source() -> str:
+            delay_interval = (
+                confluence_config.request_delay_ms / 1000
+                if confluence_config.request_delay_ms is not None
+                and confluence_config.request_delay_ms > 0
+                else None
+            )
+            rate_interval = (
+                1 / confluence_config.max_requests_per_second
+                if confluence_config.max_requests_per_second is not None
+                else None
+            )
+            if delay_interval is None:
+                return "max_requests_per_second"
+            if rate_interval is None:
+                return "request_delay_ms"
+            if delay_interval > rate_interval:
+                return "request_delay_ms"
+            if rate_interval > delay_interval:
+                return "max_requests_per_second"
+            return "request_delay_ms and max_requests_per_second"
+
         def _refresh_run_metric_cache_stats() -> None:
             if fetch_cache is None:
                 run_metrics.record_fetch_cache_stats(hits=0, misses=0)
@@ -1970,6 +2002,32 @@ def main(argv: Sequence[str] | None = None) -> int:
                 f"{metric_indent}fetch_seconds: "
                 f"{_format_metric_seconds(run_metrics.fetch_seconds)}"
             )
+
+        def _print_confluence_request_summary(*, indent: str) -> None:
+            if confluence_config.client_mode != "real":
+                return
+
+            metric_indent = f"{indent}  "
+            _print(f"{indent}request_summary:")
+            _print(f"{metric_indent}live_api_requests: {run_metrics.live_api_requests}")
+            _print(
+                f"{metric_indent}request_timing_seconds: "
+                f"{_format_metric_seconds(run_metrics.request_timing_seconds)}"
+            )
+            _print(
+                f"{metric_indent}effective_requests_per_second: "
+                f"{_format_metric_rate(run_metrics.effective_requests_per_second)}"
+            )
+            _print(
+                f"{metric_indent}pacing_enabled: "
+                f"{'true' if request_pacer is not None else 'false'}"
+            )
+            if request_pacer is not None:
+                _print(
+                    f"{metric_indent}pacing_interval_seconds: "
+                    f"{_format_metric_seconds(request_pacer.min_interval_seconds)}"
+                )
+                _print(f"{metric_indent}pacing_source: {_configured_pacing_source()}")
 
         def _print_confluence_dry_run_summary(
             *,
@@ -2017,6 +2075,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             for line in summary_lines:
                 _print(line)
             _print_confluence_run_metrics(indent="    ")
+            _print_confluence_request_summary(indent="    ")
 
         def _print_confluence_write_summary(
             *,
@@ -2042,6 +2101,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             _print(f"  pages_written: {write_count}")
             _print(f"  pages_skipped: {skip_count}")
             _print_confluence_run_metrics(indent="  ")
+            _print_confluence_request_summary(indent="  ")
 
         def _print_stub_tree_mode_note() -> None:
             if not (confluence_config.tree and confluence_config.client_mode == "stub"):

--- a/src/knowledge_adapters/confluence/client.py
+++ b/src/knowledge_adapters/confluence/client.py
@@ -34,6 +34,7 @@ class ConfluenceRequestError(RuntimeError):
 
 DiscoveryProgressCallback = Callable[[int], None]
 RequestPacer = Callable[[], None]
+RequestCounter = Callable[[], None]
 
 
 def fetch_page(target: ResolvedTarget) -> dict[str, object]:
@@ -371,6 +372,7 @@ def _request_json(
     client_cert_file: str | None = None,
     client_key_file: str | None = None,
     request_pacer: RequestPacer | None = None,
+    request_counter: RequestCounter | None = None,
 ) -> dict[str, object]:
     request_auth = build_request_auth(
         auth_method,
@@ -387,6 +389,8 @@ def _request_json(
     try:
         if request_pacer is not None:
             request_pacer()
+        if request_counter is not None:
+            request_counter()
         with request.urlopen(api_request, context=request_auth.ssl_context) as response:
             raw_payload = json.loads(response.read().decode("utf-8"))
     except (HTTPError, URLError) as exc:
@@ -415,6 +419,7 @@ def fetch_real_page_raw(
     client_cert_file: str | None = None,
     client_key_file: str | None = None,
     request_pacer: RequestPacer | None = None,
+    request_counter: RequestCounter | None = None,
 ) -> dict[str, object]:
     """Fetch one raw Confluence full-page payload through the real client path."""
     page_id = target.page_id
@@ -429,6 +434,7 @@ def fetch_real_page_raw(
         client_cert_file=client_cert_file,
         client_key_file=client_key_file,
         request_pacer=request_pacer,
+        request_counter=request_counter,
     )
 
 
@@ -447,6 +453,7 @@ def fetch_real_page(
     client_cert_file: str | None = None,
     client_key_file: str | None = None,
     request_pacer: RequestPacer | None = None,
+    request_counter: RequestCounter | None = None,
 ) -> dict[str, object]:
     """Fetch one Confluence page through the opt-in real client path."""
     page_id = target.page_id
@@ -462,6 +469,7 @@ def fetch_real_page(
         client_cert_file=client_cert_file,
         client_key_file=client_key_file,
         request_pacer=request_pacer,
+        request_counter=request_counter,
     )
     return _map_real_page(raw_payload, page_id)
 
@@ -476,6 +484,7 @@ def fetch_real_page_summary(
     client_cert_file: str | None = None,
     client_key_file: str | None = None,
     request_pacer: RequestPacer | None = None,
+    request_counter: RequestCounter | None = None,
 ) -> dict[str, object]:
     """Fetch Confluence page metadata used for incremental sync decisions."""
     page_id = target.page_id
@@ -490,6 +499,7 @@ def fetch_real_page_summary(
         client_cert_file=client_cert_file,
         client_key_file=client_key_file,
         request_pacer=request_pacer,
+        request_counter=request_counter,
     )
     return _map_real_page_summary(raw_payload, page_id)
 
@@ -505,6 +515,7 @@ def list_real_child_page_ids(
     client_key_file: str | None = None,
     progress_callback: DiscoveryProgressCallback | None = None,
     request_pacer: RequestPacer | None = None,
+    request_counter: RequestCounter | None = None,
 ) -> list[str]:
     """List direct child page IDs for one Confluence page in real mode."""
     page_id = target.page_id
@@ -519,6 +530,7 @@ def list_real_child_page_ids(
         client_cert_file=client_cert_file,
         client_key_file=client_key_file,
         request_pacer=request_pacer,
+        request_counter=request_counter,
     )
     child_page_ids = _map_child_page_ids(raw_payload)
     _report_periodic_discovery_progress(
@@ -541,6 +553,7 @@ def list_real_space_page_ids(
     page_limit: int = 100,
     progress_callback: DiscoveryProgressCallback | None = None,
     request_pacer: RequestPacer | None = None,
+    request_counter: RequestCounter | None = None,
 ) -> list[str]:
     """List all page IDs in one Confluence space in deterministic order."""
     if not space_key:
@@ -568,6 +581,7 @@ def list_real_space_page_ids(
             client_cert_file=client_cert_file,
             client_key_file=client_key_file,
             request_pacer=request_pacer,
+            request_counter=request_counter,
         )
         page_ids.update(_map_content_page_ids(raw_payload))
         last_reported_pages = _report_periodic_discovery_progress(

--- a/src/knowledge_adapters/confluence/metrics.py
+++ b/src/knowledge_adapters/confluence/metrics.py
@@ -19,11 +19,27 @@ class ConfluenceRunMetrics:
     fetch_cache_hits: int = 0
     fetch_cache_misses: int = 0
     fetch_seconds: float = 0.0
+    live_api_requests: int = 0
 
     @property
     def fetch_cache_saved_requests(self) -> int:
         """Return full-page fetch requests avoided by cache hits."""
         return self.fetch_cache_hits
+
+    @property
+    def request_timing_seconds(self) -> float:
+        """Return elapsed time tracked around live request paths."""
+        return self.discovery_seconds + self.fetch_seconds
+
+    @property
+    def effective_requests_per_second(self) -> float | None:
+        """Return live Confluence API request rate when it can be computed."""
+        if self.live_api_requests == 0 or self.request_timing_seconds <= 0:
+            return None
+        return self.live_api_requests / self.request_timing_seconds
+
+    def record_live_api_request(self) -> None:
+        self.live_api_requests += 1
 
     def record_listing_request(self) -> None:
         self.listing_requests += 1

--- a/tests/confluence/test_fetch_cache.py
+++ b/tests/confluence/test_fetch_cache.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import json
 import re
 from pathlib import Path
+from urllib.request import Request
 
 import pytest
 from pytest import CaptureFixture, MonkeyPatch
@@ -110,6 +112,20 @@ def _assert_seconds_metric(output: str, name: str) -> None:
     assert re.search(rf"{name}: \d+\.\d{{3}}", output) is not None
 
 
+class _FakeHTTPResponse:
+    def __init__(self, payload: dict[str, object]) -> None:
+        self._payload = payload
+
+    def __enter__(self) -> _FakeHTTPResponse:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        del args
+
+    def read(self) -> bytes:
+        return json.dumps(self._payload).encode("utf-8")
+
+
 def test_fetch_cache_force_refresh_bypasses_cached_payload(tmp_path: Path) -> None:
     cache = ConfluenceFetchCache(
         prepare_fetch_cache_dir(str(tmp_path / "cache")),
@@ -149,11 +165,12 @@ def test_confluence_fetch_cache_disabled_keeps_output_unchanged(
 ) -> None:
     requests: list[str] = []
 
-    def request_json(api_url: str, **_kwargs: object) -> dict[str, object]:
-        requests.append(api_url)
-        return _raw_payload()
+    def fake_urlopen(api_request: Request, **_kwargs: object) -> _FakeHTTPResponse:
+        requests.append(api_request.full_url)
+        return _FakeHTTPResponse(_raw_payload())
 
-    monkeypatch.setattr("knowledge_adapters.confluence.client._request_json", request_json)
+    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
 
     exit_code = main(_confluence_argv(tmp_path / "out"))
 
@@ -190,13 +207,15 @@ def test_confluence_fetch_cache_hit_uses_cached_raw_payload(
     _store_cached_payload(cache_dir, _raw_payload())
     requests: list[str] = []
 
-    def request_json(api_url: str, **_kwargs: object) -> dict[str, object]:
+    def fake_urlopen(api_request: Request, **_kwargs: object) -> _FakeHTTPResponse:
+        api_url = api_request.full_url
         requests.append(api_url)
         if "expand=version" in api_url:
-            return _raw_payload()
+            return _FakeHTTPResponse(_raw_payload())
         raise AssertionError("full page fetch should be satisfied by cache")
 
-    monkeypatch.setattr("knowledge_adapters.confluence.client._request_json", request_json)
+    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
 
     exit_code = main(_confluence_argv(output_dir, fetch_cache_dir=cache_dir))
 
@@ -223,11 +242,12 @@ def test_confluence_request_summary_reports_request_pacing(
 ) -> None:
     requests: list[str] = []
 
-    def request_json(api_url: str, **_kwargs: object) -> dict[str, object]:
-        requests.append(api_url)
-        return _raw_payload()
+    def fake_urlopen(api_request: Request, **_kwargs: object) -> _FakeHTTPResponse:
+        requests.append(api_request.full_url)
+        return _FakeHTTPResponse(_raw_payload())
 
-    monkeypatch.setattr("knowledge_adapters.confluence.client._request_json", request_json)
+    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
 
     exit_code = main(_confluence_argv(tmp_path / "out", request_delay_ms=250))
 

--- a/tests/confluence/test_fetch_cache.py
+++ b/tests/confluence/test_fetch_cache.py
@@ -22,6 +22,8 @@ def _confluence_argv(
     fetch_cache_dir: Path | None = None,
     force_refresh: bool = False,
     clear_cache: bool = False,
+    request_delay_ms: int | None = None,
+    max_requests_per_second: float | None = None,
 ) -> list[str]:
     argv = [
         "confluence",
@@ -40,6 +42,10 @@ def _confluence_argv(
         argv.append("--force-refresh")
     if clear_cache:
         argv.append("--clear-cache")
+    if request_delay_ms is not None:
+        argv.extend(["--request-delay-ms", str(request_delay_ms)])
+    if max_requests_per_second is not None:
+        argv.extend(["--max-requests-per-second", f"{max_requests_per_second:g}"])
     return argv
 
 
@@ -163,8 +169,14 @@ def test_confluence_fetch_cache_disabled_keeps_output_unchanged(
     assert "fetch_cache_hits: 0" in captured.out
     assert "fetch_cache_misses: 0" in captured.out
     assert "fetch_cache_saved_requests: 0" in captured.out
+    assert "request_summary:" in captured.out
+    assert "live_api_requests: 1" in captured.out
+    assert "effective_requests_per_second:" in captured.out
+    assert "pacing_enabled: false" in captured.out
+    assert "pacing_interval_seconds:" not in captured.out
     _assert_seconds_metric(captured.out, "discovery_seconds")
     _assert_seconds_metric(captured.out, "fetch_seconds")
+    _assert_seconds_metric(captured.out, "request_timing_seconds")
 
 
 def test_confluence_fetch_cache_hit_uses_cached_raw_payload(
@@ -197,9 +209,36 @@ def test_confluence_fetch_cache_hit_uses_cached_raw_payload(
     assert "fetch_cache_hits: 1" in captured.out
     assert "fetch_cache_misses: 0" in captured.out
     assert "fetch_cache_saved_requests: 1" in captured.out
+    assert "request_summary:" in captured.out
+    assert "live_api_requests: 1" in captured.out
     assert "Hello from Confluence." in (output_dir / "pages" / "12345.md").read_text(
         encoding="utf-8"
     )
+
+
+def test_confluence_request_summary_reports_request_pacing(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    requests: list[str] = []
+
+    def request_json(api_url: str, **_kwargs: object) -> dict[str, object]:
+        requests.append(api_url)
+        return _raw_payload()
+
+    monkeypatch.setattr("knowledge_adapters.confluence.client._request_json", request_json)
+
+    exit_code = main(_confluence_argv(tmp_path / "out", request_delay_ms=250))
+
+    assert exit_code == 0
+    assert len(requests) == 1
+    captured = capsys.readouterr()
+    assert "request_summary:" in captured.out
+    assert "live_api_requests: 1" in captured.out
+    assert "pacing_enabled: true" in captured.out
+    assert "pacing_interval_seconds: 0.250" in captured.out
+    assert "pacing_source: request_delay_ms" in captured.out
 
 
 def test_confluence_force_refresh_bypasses_fetch_cache_hit(

--- a/tests/confluence/test_traversal_real.py
+++ b/tests/confluence/test_traversal_real.py
@@ -5,6 +5,7 @@ import sys
 from collections.abc import Callable
 from pathlib import Path
 from typing import cast
+from urllib.request import Request
 
 import pytest
 from pytest import CaptureFixture, MonkeyPatch
@@ -922,6 +923,54 @@ def test_real_space_dry_run_reports_space_summary_and_planned_actions(
     assert "would write " in output
     assert "pages/100.md" in output
     assert "pages/200.md" in output
+
+
+def test_real_space_paginated_discovery_counts_each_live_request(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    payloads: list[dict[str, object]] = [
+        {
+            "results": [],
+            "_links": {
+                "next": "/wiki/rest/api/content?spaceKey=ENG&type=page&start=100&limit=100"
+            },
+        },
+        {"results": []},
+    ]
+    request_urls: list[str] = []
+
+    class FakeHTTPResponse:
+        def __init__(self, payload: dict[str, object]) -> None:
+            self._payload = payload
+
+        def __enter__(self) -> FakeHTTPResponse:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            del args
+
+        def read(self) -> bytes:
+            return json.dumps(self._payload).encode("utf-8")
+
+    def fake_urlopen(api_request: Request, **_kwargs: object) -> FakeHTTPResponse:
+        request_urls.append(api_request.full_url)
+        return FakeHTTPResponse(payloads.pop(0))
+
+    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    output_dir = tmp_path / "out"
+    exit_code = main([*_real_space_argv(output_dir), "--dry-run"])
+
+    assert exit_code == 0
+    assert len(request_urls) == 2
+    assert not payloads
+    output = capsys.readouterr().out
+    assert "request_summary:" in output
+    assert "listing_requests: 1" in output
+    assert "live_api_requests: 2" in output
 
 
 @pytest.mark.parametrize(

--- a/tests/confluence/test_traversal_real.py
+++ b/tests/confluence/test_traversal_real.py
@@ -239,8 +239,9 @@ def _run_real_recursive_cli(
         ca_bundle: str | None = None,
         client_cert_file: str | None = None,
         client_key_file: str | None = None,
+        **_client_kwargs: object,
     ) -> dict[str, object]:
-        del base_url, auth_method, ca_bundle, client_cert_file, client_key_file
+        del base_url, auth_method, ca_bundle, client_cert_file, client_key_file, _client_kwargs
 
         page_id = str(target.page_id)
         page_fetch_counts[page_id] = page_fetch_counts.get(page_id, 0) + 1
@@ -317,8 +318,9 @@ def _run_real_space_cli(
         ca_bundle: str | None = None,
         client_cert_file: str | None = None,
         client_key_file: str | None = None,
+        **_client_kwargs: object,
     ) -> dict[str, object]:
-        del base_url, auth_method, ca_bundle, client_cert_file, client_key_file
+        del base_url, auth_method, ca_bundle, client_cert_file, client_key_file, _client_kwargs
 
         page_id = str(target.page_id)
         page_fetch_counts[page_id] = page_fetch_counts.get(page_id, 0) + 1
@@ -333,6 +335,7 @@ def _run_real_space_cli(
         client_cert_file: str | None = None,
         client_key_file: str | None = None,
         progress_callback: object | None = None,
+        **_client_kwargs: object,
     ) -> list[str]:
         del (
             base_url,
@@ -340,6 +343,7 @@ def _run_real_space_cli(
             ca_bundle,
             client_cert_file,
             client_key_file,
+            _client_kwargs,
         )
         space_list_calls.append(space_key)
         if progress_callback is not None:
@@ -533,8 +537,9 @@ def test_real_tree_reuses_cached_child_page_listing(
         ca_bundle: str | None = None,
         client_cert_file: str | None = None,
         client_key_file: str | None = None,
+        **_client_kwargs: object,
     ) -> dict[str, object]:
-        del base_url, auth_method, ca_bundle, client_cert_file, client_key_file
+        del base_url, auth_method, ca_bundle, client_cert_file, client_key_file, _client_kwargs
         return dict(pages[str(target.page_id)])
 
     def stub_child_id_discovery(*args: object, **kwargs: object) -> list[str]:
@@ -602,8 +607,9 @@ def test_real_tree_force_refresh_bypasses_traversal_cache_hit(
         ca_bundle: str | None = None,
         client_cert_file: str | None = None,
         client_key_file: str | None = None,
+        **_client_kwargs: object,
     ) -> dict[str, object]:
-        del base_url, auth_method, ca_bundle, client_cert_file, client_key_file
+        del base_url, auth_method, ca_bundle, client_cert_file, client_key_file, _client_kwargs
         return dict(pages[str(target.page_id)])
 
     def stub_child_id_discovery(*args: object, **kwargs: object) -> list[str]:
@@ -669,8 +675,9 @@ def test_real_tree_clear_cache_removes_stale_traversal_entry_before_run(
         ca_bundle: str | None = None,
         client_cert_file: str | None = None,
         client_key_file: str | None = None,
+        **_client_kwargs: object,
     ) -> dict[str, object]:
-        del base_url, auth_method, ca_bundle, client_cert_file, client_key_file
+        del base_url, auth_method, ca_bundle, client_cert_file, client_key_file, _client_kwargs
         return dict(pages[str(target.page_id)])
 
     def stale_child_id_discovery(*args: object, **kwargs: object) -> list[str]:
@@ -748,8 +755,9 @@ def test_real_tree_cache_write_failure_does_not_fail_run(
         ca_bundle: str | None = None,
         client_cert_file: str | None = None,
         client_key_file: str | None = None,
+        **_client_kwargs: object,
     ) -> dict[str, object]:
-        del base_url, auth_method, ca_bundle, client_cert_file, client_key_file
+        del base_url, auth_method, ca_bundle, client_cert_file, client_key_file, _client_kwargs
         return dict(pages[str(target.page_id)])
 
     def stub_child_id_discovery(*args: object, **kwargs: object) -> list[str]:
@@ -813,8 +821,9 @@ def test_real_space_reuses_cached_space_page_listing(
         ca_bundle: str | None = None,
         client_cert_file: str | None = None,
         client_key_file: str | None = None,
+        **_client_kwargs: object,
     ) -> dict[str, object]:
-        del base_url, auth_method, ca_bundle, client_cert_file, client_key_file
+        del base_url, auth_method, ca_bundle, client_cert_file, client_key_file, _client_kwargs
         return dict(pages[str(target.page_id)])
 
     def stub_space_discovery(
@@ -826,6 +835,7 @@ def test_real_space_reuses_cached_space_page_listing(
         client_cert_file: str | None = None,
         client_key_file: str | None = None,
         progress_callback: object | None = None,
+        **_client_kwargs: object,
     ) -> list[str]:
         del (
             base_url,
@@ -834,6 +844,7 @@ def test_real_space_reuses_cached_space_page_listing(
             client_cert_file,
             client_key_file,
             progress_callback,
+            _client_kwargs,
         )
         space_list_calls.append(space_key)
         return ["300", "100", "200"]
@@ -896,8 +907,9 @@ def test_real_space_dry_run_reports_space_summary_and_planned_actions(
         ca_bundle: str | None = None,
         client_cert_file: str | None = None,
         client_key_file: str | None = None,
+        **_client_kwargs: object,
     ) -> dict[str, object]:
-        del base_url, auth_method, ca_bundle, client_cert_file, client_key_file
+        del base_url, auth_method, ca_bundle, client_cert_file, client_key_file, _client_kwargs
         return dict(pages[str(target.page_id)])
 
     monkeypatch.setattr(client_module, "fetch_real_page", stub_real_fetch, raising=False)
@@ -1139,8 +1151,9 @@ def test_real_tree_incremental_run_skips_full_page_fetch_for_unchanged_pages(
         ca_bundle: str | None = None,
         client_cert_file: str | None = None,
         client_key_file: str | None = None,
+        **_client_kwargs: object,
     ) -> dict[str, object]:
-        del base_url, auth_method, ca_bundle, client_cert_file, client_key_file
+        del base_url, auth_method, ca_bundle, client_cert_file, client_key_file, _client_kwargs
         page_id = str(target.page_id)
         full_fetch_counts[page_id] = full_fetch_counts.get(page_id, 0) + 1
         return dict(pages[page_id])
@@ -1153,8 +1166,9 @@ def test_real_tree_incremental_run_skips_full_page_fetch_for_unchanged_pages(
         ca_bundle: str | None = None,
         client_cert_file: str | None = None,
         client_key_file: str | None = None,
+        **_client_kwargs: object,
     ) -> dict[str, object]:
-        del base_url, auth_method, ca_bundle, client_cert_file, client_key_file
+        del base_url, auth_method, ca_bundle, client_cert_file, client_key_file, _client_kwargs
         page_id = str(target.page_id)
         summary_fetch_counts[page_id] = summary_fetch_counts.get(page_id, 0) + 1
         page = dict(pages[page_id])
@@ -1242,8 +1256,9 @@ def test_real_tree_fetch_progress_uses_carriage_return_for_tty_stdout(
         ca_bundle: str | None = None,
         client_cert_file: str | None = None,
         client_key_file: str | None = None,
+        **_client_kwargs: object,
     ) -> dict[str, object]:
-        del base_url, auth_method, ca_bundle, client_cert_file, client_key_file
+        del base_url, auth_method, ca_bundle, client_cert_file, client_key_file, _client_kwargs
         return dict(pages[str(target.page_id)])
 
     def stub_real_fetch_summary(
@@ -1254,8 +1269,9 @@ def test_real_tree_fetch_progress_uses_carriage_return_for_tty_stdout(
         ca_bundle: str | None = None,
         client_cert_file: str | None = None,
         client_key_file: str | None = None,
+        **_client_kwargs: object,
     ) -> dict[str, object]:
-        del base_url, auth_method, ca_bundle, client_cert_file, client_key_file
+        del base_url, auth_method, ca_bundle, client_cert_file, client_key_file, _client_kwargs
         page = dict(pages[str(target.page_id)])
         page.pop("content", None)
         return page
@@ -1746,8 +1762,9 @@ def test_real_tree_stops_without_writes_when_later_child_list_fails_after_partia
         ca_bundle: str | None = None,
         client_cert_file: str | None = None,
         client_key_file: str | None = None,
+        **_client_kwargs: object,
     ) -> dict[str, object]:
-        del base_url, auth_method, ca_bundle, client_cert_file, client_key_file
+        del base_url, auth_method, ca_bundle, client_cert_file, client_key_file, _client_kwargs
 
         page_id = str(target.page_id)
         page_fetch_counts[page_id] = page_fetch_counts.get(page_id, 0) + 1
@@ -1830,8 +1847,9 @@ def test_real_tree_stops_without_writes_when_later_page_fetch_fails_after_partia
         ca_bundle: str | None = None,
         client_cert_file: str | None = None,
         client_key_file: str | None = None,
+        **_client_kwargs: object,
     ) -> dict[str, object]:
-        del base_url, auth_method, ca_bundle, client_cert_file, client_key_file
+        del base_url, auth_method, ca_bundle, client_cert_file, client_key_file, _client_kwargs
 
         page_id = str(target.page_id)
         page_fetch_counts[page_id] = page_fetch_counts.get(page_id, 0) + 1

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1112,6 +1112,7 @@ def test_confluence_cli_smoke_uses_installed_entrypoint_with_default_stub_client
     assert "fetch_cache_hits: 0" in result.stdout
     assert "fetch_cache_misses: 0" in result.stdout
     assert "fetch_cache_saved_requests: 0" in result.stdout
+    assert "request_summary:" not in result.stdout
     assert "Manifest:" in result.stdout
     assert f"Write complete. Artifacts created under {tmp_path / 'artifacts'}" in result.stdout
 

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -62,8 +62,17 @@ def _patch_large_real_confluence_tree(monkeypatch: MonkeyPatch) -> None:
         no_ca_bundle: bool = False,
         client_cert_file: str | None = None,
         client_key_file: str | None = None,
+        **_client_kwargs: object,
     ) -> dict[str, object]:
-        del base_url, auth_method, ca_bundle, no_ca_bundle, client_cert_file, client_key_file
+        del (
+            base_url,
+            auth_method,
+            ca_bundle,
+            no_ca_bundle,
+            client_cert_file,
+            client_key_file,
+            _client_kwargs,
+        )
         return dict(pages[str(target.page_id)])
 
     def stub_child_id_discovery(
@@ -76,6 +85,7 @@ def _patch_large_real_confluence_tree(monkeypatch: MonkeyPatch) -> None:
         client_cert_file: str | None = None,
         client_key_file: str | None = None,
         progress_callback: Any = None,
+        **_client_kwargs: object,
     ) -> list[str]:
         del (
             base_url,
@@ -85,6 +95,7 @@ def _patch_large_real_confluence_tree(monkeypatch: MonkeyPatch) -> None:
             client_cert_file,
             client_key_file,
             progress_callback,
+            _client_kwargs,
         )
         return children_by_parent[str(target.page_id)]
 
@@ -1666,7 +1677,9 @@ def test_run_command_no_ca_bundle_flag_disables_env_and_config_ca_bundle(
 
     def stub_real_fetch(*args: object, **kwargs: object) -> dict[str, object]:
         del args
-        observed_kwargs.append(dict(kwargs))
+        observed = dict(kwargs)
+        assert callable(observed.pop("request_counter"))
+        observed_kwargs.append(observed)
         return {
             "canonical_id": "12345",
             "title": "Real Page",
@@ -1765,7 +1778,9 @@ def test_run_command_passes_confluence_tls_config_to_real_client(
 
     def stub_real_fetch(*args: object, **kwargs: object) -> dict[str, object]:
         del args
-        observed_kwargs.append(dict(kwargs))
+        observed = dict(kwargs)
+        assert callable(observed.pop("request_counter"))
+        observed_kwargs.append(observed)
         return {
             "canonical_id": "12345",
             "title": "Real Page",


### PR DESCRIPTION
## Summary

Adds a real-client-only Confluence `request_summary` section after run summaries so operators can inspect live API request behavior after a run. The section reports live API request count, tracked request timing, effective requests per second, and pacing status/configuration when enabled.

The live API count is recorded at the Confluence HTTP request boundary via `_request_json()`, so fetch-cache hits are not counted as full-page live requests while paginated discovery counts each HTTP page request. Stub-mode output does not gain the new request summary block.

## Validation

- `make check`
  - `ruff check .`: passed
  - `mypy .`: passed
  - `pytest`: 359 passed

## Residual Risks

Request timing and effective request rate use the existing run-scoped fetch/discovery timing windows, so they are intended as operator-facing run diagnostics rather than precise network-only telemetry.
