### PR TITLE
chore: add release publish helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev test smoke lint fix format typecheck check check-env check-gh-env release-notes release-check release clean
+.PHONY: dev test smoke lint fix format typecheck check check-env check-gh-env release-notes release-check release-publish clean
 
 VENV = .venv
 PYTHON = $(VENV)/bin/python
@@ -48,7 +48,7 @@ fix-all: fix format
 
 release-notes:
 	@if [ -z "$(VERSION)" ]; then \
-		echo "Error: VERSION is required. Usage: make release VERSION=0.8.1" >&2; \
+		echo "Error: VERSION is required. Usage: make release-publish VERSION=0.8.1" >&2; \
 		exit 1; \
 	fi
 	@if ! printf '%s\n' '$(RELEASE_VERSION)' | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$$'; then \
@@ -73,7 +73,7 @@ release-notes:
 
 release-check: check-gh-env
 	@if [ -z "$(VERSION)" ]; then \
-		echo "Error: VERSION is required. Usage: make release VERSION=0.8.1" >&2; \
+		echo "Error: VERSION is required. Usage: make release-publish VERSION=0.8.1" >&2; \
 		exit 1; \
 	fi
 	@if ! printf '%s\n' '$(RELEASE_VERSION)' | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$$'; then \
@@ -133,7 +133,7 @@ release-check: check-gh-env
 	fi
 	@echo "Release checks passed for $(RELEASE_TAG)."
 
-release: release-check
+release-publish: release-check
 	@set -e; \
 	notes_file=$$(mktemp); \
 	trap 'rm -f "$$notes_file"' EXIT; \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev test smoke lint fix format typecheck check check-env check-gh-env clean
+.PHONY: dev test smoke lint fix format typecheck check check-env check-gh-env release-notes release-check release clean
 
 VENV = .venv
 PYTHON = $(VENV)/bin/python
@@ -7,6 +7,8 @@ RUFF = $(VENV)/bin/ruff
 MYPY = $(VENV)/bin/mypy
 PYTEST = $(VENV)/bin/pytest
 CLI = $(VENV)/bin/knowledge-adapters
+RELEASE_VERSION = $(patsubst v%,%,$(VERSION))
+RELEASE_TAG = v$(RELEASE_VERSION)
 
 $(VENV)/bin/activate:
 	python3 -m venv $(VENV)
@@ -43,6 +45,117 @@ typecheck: $(VENV)/bin/activate
 check: lint typecheck test
 
 fix-all: fix format
+
+release-notes:
+	@if [ -z "$(VERSION)" ]; then \
+		echo "Error: VERSION is required. Usage: make release VERSION=0.8.1" >&2; \
+		exit 1; \
+	fi
+	@if ! printf '%s\n' '$(RELEASE_VERSION)' | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$$'; then \
+		echo "Error: VERSION must be X.Y.Z or vX.Y.Z." >&2; \
+		exit 1; \
+	fi
+	@awk -v version='$(RELEASE_VERSION)' '\
+		BEGIN { found = 0; printed = 0 } \
+		$$0 == "## " version { found = 1; next } \
+		found && /^## / { exit } \
+		found { print; if ($$0 !~ /^[[:space:]]*$$/) printed = 1 } \
+		END { \
+			if (!found) { \
+				printf "Error: CHANGELOG.md missing section ## %s.\n", version > "/dev/stderr"; \
+				exit 1; \
+			} \
+			if (!printed) { \
+				printf "Error: CHANGELOG.md section ## %s has no release notes.\n", version > "/dev/stderr"; \
+				exit 1; \
+			} \
+		}' CHANGELOG.md
+
+release-check: check-gh-env
+	@if [ -z "$(VERSION)" ]; then \
+		echo "Error: VERSION is required. Usage: make release VERSION=0.8.1" >&2; \
+		exit 1; \
+	fi
+	@if ! printf '%s\n' '$(RELEASE_VERSION)' | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$$'; then \
+		echo "Error: VERSION must be X.Y.Z or vX.Y.Z." >&2; \
+		exit 1; \
+	fi
+	@awk -v version='$(RELEASE_VERSION)' '\
+		BEGIN { found = 0; printed = 0 } \
+		$$0 == "## " version { found = 1; next } \
+		found && /^## / { exit } \
+		found { print; if ($$0 !~ /^[[:space:]]*$$/) printed = 1 } \
+		END { \
+			if (!found) { \
+				printf "Error: CHANGELOG.md missing section ## %s.\n", version > "/dev/stderr"; \
+				exit 1; \
+			} \
+			if (!printed) { \
+				printf "Error: CHANGELOG.md section ## %s has no release notes.\n", version > "/dev/stderr"; \
+				exit 1; \
+			} \
+		}' CHANGELOG.md >/dev/null
+	@if [ "$$(git branch --show-current)" != "main" ]; then \
+		echo "Error: release must run from main after the release PR is merged." >&2; \
+		exit 1; \
+	fi
+	@if [ -n "$$(git status --porcelain)" ]; then \
+		echo "Error: working tree must be clean before release." >&2; \
+		git status --short; \
+		exit 1; \
+	fi
+	@git fetch origin main >/dev/null
+	@if [ "$$(git rev-parse HEAD)" != "$$(git rev-parse origin/main)" ]; then \
+		echo "Error: local main must match origin/main. Run 'git pull --ff-only origin main' and retry." >&2; \
+		exit 1; \
+	fi
+	@if git rev-parse --verify --quiet "refs/tags/$(RELEASE_TAG)" >/dev/null; then \
+		echo "Error: local tag $(RELEASE_TAG) already exists." >&2; \
+		exit 1; \
+	fi
+	@remote_tag_status=0; \
+	git ls-remote --exit-code --tags origin "refs/tags/$(RELEASE_TAG)" >/dev/null 2>&1 || remote_tag_status=$$?; \
+	if [ "$$remote_tag_status" -eq 0 ]; then \
+		echo "Error: remote tag $(RELEASE_TAG) already exists." >&2; \
+		exit 1; \
+	elif [ "$$remote_tag_status" -ne 2 ]; then \
+		echo "Error: unable to check remote tag $(RELEASE_TAG)." >&2; \
+		exit 1; \
+	fi
+	@release_view=$$(gh release view "$(RELEASE_TAG)" 2>&1 >/dev/null); \
+	release_status=$$?; \
+	if [ "$$release_status" -eq 0 ]; then \
+		echo "Error: GitHub release $(RELEASE_TAG) already exists." >&2; \
+		exit 1; \
+	elif ! printf '%s\n' "$$release_view" | grep -Eiq 'not found|could not find'; then \
+		echo "Error: unable to check GitHub release $(RELEASE_TAG): $$release_view" >&2; \
+		exit 1; \
+	fi
+	@echo "Release checks passed for $(RELEASE_TAG)."
+
+release: release-check
+	@set -e; \
+	notes_file=$$(mktemp); \
+	trap 'rm -f "$$notes_file"' EXIT; \
+	awk -v version='$(RELEASE_VERSION)' '\
+		BEGIN { found = 0; printed = 0 } \
+		$$0 == "## " version { found = 1; next } \
+		found && /^## / { exit } \
+		found { print; if ($$0 !~ /^[[:space:]]*$$/) printed = 1 } \
+		END { \
+			if (!found) { \
+				printf "Error: CHANGELOG.md missing section ## %s.\n", version > "/dev/stderr"; \
+				exit 1; \
+			} \
+			if (!printed) { \
+				printf "Error: CHANGELOG.md section ## %s has no release notes.\n", version > "/dev/stderr"; \
+				exit 1; \
+			} \
+		}' CHANGELOG.md > "$$notes_file"; \
+	git tag -a "$(RELEASE_TAG)" -m "Release $(RELEASE_TAG)"; \
+	git push origin "$(RELEASE_TAG)"; \
+	gh release create "$(RELEASE_TAG)" --title "$(RELEASE_TAG)" --notes-file "$$notes_file"; \
+	echo "Published GitHub release $(RELEASE_TAG)."
 
 clean:
 	rm -rf $(VENV)

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -26,14 +26,14 @@ unrelated cleanup into the same PR.
 8. publish the post-merge tag and GitHub release:
 
    ```bash
-   make release VERSION=0.8.1
+   make release-publish VERSION=0.8.1
    ```
 
 ## Notes
 
 - Keep the tag format consistent as `vX.Y.Z`.
-- `make release` accepts `VERSION=X.Y.Z` or `VERSION=vX.Y.Z`, creates the
-  annotated tag as `vX.Y.Z`, and uses the matching `## X.Y.Z` section from
+- `make release-publish` accepts `VERSION=X.Y.Z` or `VERSION=vX.Y.Z`, creates
+  the annotated tag as `vX.Y.Z`, and uses the matching `## X.Y.Z` section from
   `CHANGELOG.md` as the GitHub release notes.
 - Use `make release-check VERSION=0.8.1` to validate the post-merge release
   prerequisites without creating a tag or GitHub release.

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -16,11 +16,26 @@ unrelated cleanup into the same PR.
 4. run `make check`
 5. create a release branch if needed
 6. merge the release PR
-7. create a tag in the format `vX.Y.Z`
-8. push the tag
-9. create the GitHub release
+7. sync `main` after the merge:
+
+   ```bash
+   git switch main
+   git pull --ff-only origin main
+   ```
+
+8. publish the post-merge tag and GitHub release:
+
+   ```bash
+   make release VERSION=0.8.1
+   ```
 
 ## Notes
 
 - Keep the tag format consistent as `vX.Y.Z`.
-- Ensure the version, `CHANGELOG.md`, and tag all align.
+- `make release` accepts `VERSION=X.Y.Z` or `VERSION=vX.Y.Z`, creates the
+  annotated tag as `vX.Y.Z`, and uses the matching `## X.Y.Z` section from
+  `CHANGELOG.md` as the GitHub release notes.
+- Use `make release-check VERSION=0.8.1` to validate the post-merge release
+  prerequisites without creating a tag or GitHub release.
+- Ensure the version, `CHANGELOG.md`, and tag all align before merging the
+  release PR.


### PR DESCRIPTION
Summary
- add Makefile release helpers for post-merge tag and GitHub release publishing
- normalize VERSION to the repo tag convention while extracting matching CHANGELOG.md notes
- document the post-merge release-publish flow and dry validation path

Testing
- make check
- make release-notes VERSION=0.8.0
- make release-notes VERSION=v0.8.0
- make release-notes VERSION=0.8.1 (expected missing-section failure)
- make release-check VERSION=0.8.0 (expected branch-guard failure on feature branch)
- make -n release-publish VERSION=0.8.0