### PR TITLE
[codex] Relax Confluence missing-page test assertion

### DIFF
--- a/tests/integration/test_confluence_stub.py
+++ b/tests/integration/test_confluence_stub.py
@@ -302,7 +302,7 @@ def test_confluence_cli_reports_missing_stub_page_without_traceback(
         env=env,
     )
 
-    assert result.returncode != 0
+    assert result.returncode == 2
     assert result.stdout == ""
     assert_contains_normalized(
         result.stderr,

--- a/tests/integration/test_confluence_stub.py
+++ b/tests/integration/test_confluence_stub.py
@@ -302,11 +302,11 @@ def test_confluence_cli_reports_missing_stub_page_without_traceback(
         env=env,
     )
 
-    assert result.returncode == 2
+    assert result.returncode != 0
     assert result.stdout == ""
-    assert (
-        result.stderr
-        == "knowledge-adapters confluence: error: Confluence page not found. Verify --target.\n"
+    assert_contains_normalized(
+        result.stderr,
+        "Confluence page not found. Verify --target.",
     )
     assert "Traceback" not in result.stdout
     assert "Traceback" not in result.stderr


### PR DESCRIPTION
## Summary
- Relax the missing Confluence stub page integration test so it asserts the key user-facing page-not-found message via normalized matching instead of full stderr equality.
- Keep the failure contract covered: non-zero exit, empty stdout, no Python traceback, no page artifact, and no manifest.

Fixes #236.

## Validation
- `make smoke` - 27 passed
- `make check` - ruff passed, mypy passed, 359 tests passed