### PR TITLE
Add deterministic adapter chaos test utilities

### DIFF
--- a/docs/chaos-testing.md
+++ b/docs/chaos-testing.md
@@ -1,0 +1,31 @@
+# Chaos Testing Utilities
+
+The repository includes deterministic, test/dev-only chaos helpers in
+`tests/chaos.py`. They let adapter tests exercise realistic failure behavior
+without credentials, live services, sleeps, or external network calls.
+
+Available Confluence HTTP scenarios:
+
+- `timeout`
+- `rate_limit`
+- `invalid_json`
+- `empty_response`
+- `partial_payload`
+
+Use the shared `confluence_chaos` fixture in tests that need to harden real
+client or CLI failure handling:
+
+```python
+from tests.chaos import AdapterChaosScenario
+
+
+def test_adapter_failure(confluence_chaos):
+    confluence_chaos(AdapterChaosScenario.TIMEOUT)
+
+    # Run the adapter path under test. urllib.request.urlopen is patched and
+    # CONFLUENCE_BEARER_TOKEN is set to a deterministic test value.
+```
+
+Keep chaos scenarios deterministic and local to tests. Do not add production
+chaos injection or scenarios that require live services, real credentials, or
+timing-sensitive assertions.

--- a/tests/chaos.py
+++ b/tests/chaos.py
@@ -1,0 +1,137 @@
+"""Deterministic chaos helpers for adapter tests.
+
+These helpers are test/dev-only seams for exercising adapter failure behavior
+without real services, credentials, sleeps, or external network calls. Prefer
+installing a named scenario in an adapter test over hand-rolling one-off HTTP
+stubs so failure coverage stays readable and repeatable.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from email.message import Message
+from enum import StrEnum
+from types import TracebackType
+from typing import Literal, Self
+from urllib.error import HTTPError, URLError
+from urllib.request import Request
+
+from pytest import MonkeyPatch
+
+
+class AdapterChaosScenario(StrEnum):
+    """Named deterministic adapter failure scenarios."""
+
+    TIMEOUT = "timeout"
+    RATE_LIMIT = "rate_limit"
+    INVALID_JSON = "invalid_json"
+    EMPTY_RESPONSE = "empty_response"
+    PARTIAL_PAYLOAD = "partial_payload"
+
+
+@dataclass(frozen=True)
+class ChaosHTTPResponse:
+    """Small urllib-compatible response for deterministic chaos tests."""
+
+    body: bytes
+    status: int = 200
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> Literal[False]:
+        del exc_type, exc, tb
+        return False
+
+    def read(self) -> bytes:
+        return self.body
+
+    def getcode(self) -> int:
+        return self.status
+
+
+@dataclass(frozen=True)
+class ConfluenceHTTPChaos:
+    """Install named chaos responses at the Confluence real-client HTTP seam."""
+
+    scenario: AdapterChaosScenario
+    page_id: str = "12345"
+    base_url: str = "https://example.com/wiki"
+    bearer_token: str = "chaos-test-token"
+
+    def install(self, monkeypatch: MonkeyPatch) -> None:
+        """Patch urllib and auth inputs for a deterministic Confluence test."""
+        monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", self.bearer_token)
+        monkeypatch.setattr("urllib.request.urlopen", self.urlopen)
+
+    def urlopen(self, request: object, *args: object, **kwargs: object) -> ChaosHTTPResponse:
+        """Return or raise the configured scenario as urllib.urlopen would."""
+        del args, kwargs
+
+        request_url = _request_url(request)
+        if self.scenario == AdapterChaosScenario.TIMEOUT:
+            raise URLError(TimeoutError("timed out"))
+        if self.scenario == AdapterChaosScenario.RATE_LIMIT:
+            headers = Message()
+            headers["Retry-After"] = "60"
+            raise HTTPError(
+                request_url,
+                429,
+                "Too Many Requests",
+                headers,
+                None,
+            )
+        if self.scenario == AdapterChaosScenario.INVALID_JSON:
+            return ChaosHTTPResponse(b'{"id": ')
+        if self.scenario == AdapterChaosScenario.EMPTY_RESPONSE:
+            return ChaosHTTPResponse(b"")
+        if self.scenario == AdapterChaosScenario.PARTIAL_PAYLOAD:
+            return ChaosHTTPResponse(json.dumps(_partial_page_payload(self)).encode("utf-8"))
+
+        raise AssertionError(f"Unhandled chaos scenario: {self.scenario}")
+
+
+def install_confluence_http_chaos(
+    monkeypatch: MonkeyPatch,
+    scenario: AdapterChaosScenario,
+    *,
+    page_id: str = "12345",
+    base_url: str = "https://example.com/wiki",
+) -> ConfluenceHTTPChaos:
+    """Install a Confluence chaos scenario and return the configured helper."""
+    chaos = ConfluenceHTTPChaos(
+        scenario=scenario,
+        page_id=page_id,
+        base_url=base_url,
+    )
+    chaos.install(monkeypatch)
+    return chaos
+
+
+def _request_url(request: object) -> str:
+    if isinstance(request, Request):
+        return request.full_url
+    if isinstance(request, str):
+        return request
+    return "https://example.com/unknown-chaos-request"
+
+
+def _partial_page_payload(chaos: ConfluenceHTTPChaos) -> dict[str, object]:
+    return {
+        "id": chaos.page_id,
+        "title": "Partial Chaos Page",
+        "version": {
+            "number": 1,
+            "when": "2026-04-20T12:34:56Z",
+        },
+        "_links": {
+            "base": chaos.base_url,
+            "webui": f"/spaces/CHAOS/pages/{chaos.page_id}",
+        },
+    }

--- a/tests/confluence/test_chaos.py
+++ b/tests/confluence/test_chaos.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+from pytest import CaptureFixture
+
+from knowledge_adapters.cli import main
+from knowledge_adapters.confluence.client import ConfluenceRequestError, fetch_real_page
+from knowledge_adapters.confluence.models import ResolvedTarget
+from tests.chaos import AdapterChaosScenario, ConfluenceHTTPChaos
+
+ConfluenceChaosInstaller = Callable[[AdapterChaosScenario], ConfluenceHTTPChaos]
+
+
+def _target(page_id: str = "12345") -> ResolvedTarget:
+    return ResolvedTarget(
+        raw_value=page_id,
+        page_id=page_id,
+        page_url=None,
+    )
+
+
+def _confluence_cli_argv(output_dir: Path) -> list[str]:
+    return [
+        "confluence",
+        "--base-url",
+        "https://example.com/wiki",
+        "--target",
+        "12345",
+        "--output-dir",
+        str(output_dir),
+        "--client-mode",
+        "real",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("scenario", "expected_message"),
+    [
+        (
+            AdapterChaosScenario.TIMEOUT,
+            "Confluence network request failed. Verify --base-url and network access.",
+        ),
+        (
+            AdapterChaosScenario.RATE_LIMIT,
+            "Confluence request failed (status 429). Verify --base-url and access.",
+        ),
+    ],
+)
+def test_confluence_chaos_request_failures_are_clear(
+    confluence_chaos: ConfluenceChaosInstaller,
+    scenario: AdapterChaosScenario,
+    expected_message: str,
+) -> None:
+    confluence_chaos(scenario)
+
+    with pytest.raises(ConfluenceRequestError) as exc_info:
+        fetch_real_page(
+            _target(),
+            base_url="https://example.com/wiki",
+            auth_method="bearer-env",
+        )
+
+    exc = exc_info.value
+    assert str(exc) == expected_message
+    assert exc.request_url == (
+        "https://example.com/wiki/rest/api/content/"
+        "12345?expand=body.storage,_links,version"
+    )
+    assert exc.auth_method == "bearer-env"
+
+
+@pytest.mark.parametrize(
+    ("scenario", "expected_message"),
+    [
+        (
+            AdapterChaosScenario.INVALID_JSON,
+            "Response error: invalid JSON payload.",
+        ),
+        (
+            AdapterChaosScenario.EMPTY_RESPONSE,
+            "Response error: invalid JSON payload.",
+        ),
+        (
+            AdapterChaosScenario.PARTIAL_PAYLOAD,
+            "Response error: missing content.",
+        ),
+    ],
+)
+def test_confluence_chaos_payload_failures_are_clear(
+    confluence_chaos: ConfluenceChaosInstaller,
+    scenario: AdapterChaosScenario,
+    expected_message: str,
+) -> None:
+    confluence_chaos(scenario)
+
+    with pytest.raises(ValueError, match=expected_message):
+        fetch_real_page(
+            _target(),
+            base_url="https://example.com/wiki",
+            auth_method="bearer-env",
+        )
+
+
+@pytest.mark.parametrize(
+    ("scenario", "expected_message"),
+    [
+        (
+            AdapterChaosScenario.TIMEOUT,
+            "Confluence network request failed. Verify --base-url and network access.",
+        ),
+        (
+            AdapterChaosScenario.RATE_LIMIT,
+            "Confluence request failed (status 429). Verify --base-url and access.",
+        ),
+        (
+            AdapterChaosScenario.INVALID_JSON,
+            "Response error: invalid JSON payload.",
+        ),
+        (
+            AdapterChaosScenario.EMPTY_RESPONSE,
+            "Response error: invalid JSON payload.",
+        ),
+        (
+            AdapterChaosScenario.PARTIAL_PAYLOAD,
+            "Response error: missing content.",
+        ),
+    ],
+)
+def test_confluence_cli_real_mode_surfaces_chaos_without_artifacts(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+    confluence_chaos: ConfluenceChaosInstaller,
+    scenario: AdapterChaosScenario,
+    expected_message: str,
+) -> None:
+    confluence_chaos(scenario)
+    output_dir = tmp_path / "out"
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(_confluence_cli_argv(output_dir))
+
+    assert exc_info.value.code == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == f"knowledge-adapters confluence: error: {expected_message}\n"
+    assert not (output_dir / "manifest.json").exists()
+    pages_dir = output_dir / "pages"
+    assert not pages_dir.exists() or list(pages_dir.glob("*.md")) == []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,26 @@
 """Shared pytest fixtures."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+from pytest import MonkeyPatch
+
+from tests.chaos import (
+    AdapterChaosScenario,
+    ConfluenceHTTPChaos,
+    install_confluence_http_chaos,
+)
+
+
+@pytest.fixture
+def confluence_chaos(
+    monkeypatch: MonkeyPatch,
+) -> Callable[[AdapterChaosScenario], ConfluenceHTTPChaos]:
+    """Install one deterministic Confluence HTTP chaos scenario for a test."""
+
+    def install(scenario: AdapterChaosScenario) -> ConfluenceHTTPChaos:
+        return install_confluence_http_chaos(monkeypatch, scenario)
+
+    return install


### PR DESCRIPTION
## Summary
- Add a test/dev-only Confluence HTTP chaos helper with named deterministic scenarios for timeout, rate limit, invalid JSON, empty response, and partial payload responses.
- Wire a shared `confluence_chaos` pytest fixture for future adapter hardening tests.
- Add focused Confluence real-client and CLI tests proving chaos cases fail cleanly without writing artifacts.
- Document the utility in `docs/chaos-testing.md`.

## Validation
- `make check` passed: ruff, mypy, and 369 pytest tests.

## Residual risks
- The helper currently targets the Confluence `urllib.request.urlopen` seam only; other adapters can add similarly scoped helpers later if they need chaos coverage.