### PR TITLE
Add chaos validation make targets

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -29,5 +29,8 @@ jobs:
       - name: Run smoke tests
         run: make smoke
 
+      - name: Run chaos canary
+        run: make chaos-random
+
       - name: Run checks
         run: make check

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev test smoke lint fix format typecheck check check-env check-gh-env release-notes release-check release-publish clean
+.PHONY: dev test smoke lint fix format typecheck check check-env check-gh-env chaos-random chaos-all release-notes release-check release-publish clean
 
 VENV = .venv
 PYTHON = $(VENV)/bin/python
@@ -9,6 +9,8 @@ PYTEST = $(VENV)/bin/pytest
 CLI = $(VENV)/bin/knowledge-adapters
 RELEASE_VERSION = $(patsubst v%,%,$(VERSION))
 RELEASE_TAG = v$(RELEASE_VERSION)
+CHAOS_SEED ?= $(shell date +%s)
+CHAOS_SCENARIO ?=
 
 $(VENV)/bin/activate:
 	python3 -m venv $(VENV)
@@ -29,6 +31,23 @@ test: $(VENV)/bin/activate
 
 smoke: $(VENV)/bin/activate
 	$(PYTEST) tests/test_cli_smoke.py
+
+chaos-random: $(VENV)/bin/activate
+	@set -e; \
+	seed="$(CHAOS_SEED)"; \
+	scenario="$(CHAOS_SCENARIO)"; \
+	if [ -z "$$scenario" ]; then \
+		scenario="$$(CHAOS_SEED="$$seed" $(PYTHON) -c 'import os; from tests.chaos import select_chaos_scenario; print(select_chaos_scenario(os.environ["CHAOS_SEED"]).value)')"; \
+	else \
+		CHAOS_SCENARIO="$$scenario" $(PYTHON) -c 'import os; from tests.chaos import AdapterChaosScenario; AdapterChaosScenario(os.environ["CHAOS_SCENARIO"])'; \
+	fi; \
+	echo "Chaos seed: $$seed"; \
+	echo "Chaos scenario: $$scenario"; \
+	echo "Rerun: make chaos-random CHAOS_SEED=$$seed CHAOS_SCENARIO=$$scenario"; \
+	$(PYTEST) -m chaos -k "$$scenario"
+
+chaos-all: $(VENV)/bin/activate
+	$(PYTEST) -m chaos
 
 lint: $(VENV)/bin/activate
 	$(RUFF) check .

--- a/docs/chaos-testing.md
+++ b/docs/chaos-testing.md
@@ -29,3 +29,29 @@ def test_adapter_failure(confluence_chaos):
 Keep chaos scenarios deterministic and local to tests. Do not add production
 chaos injection or scenarios that require live services, real credentials, or
 timing-sensitive assertions.
+
+## Running Chaos Validation
+
+Use `make chaos-random` for a cheap canary. It selects one scenario from the
+current chaos suite, prints the seed, prints the selected scenario, and then
+runs only the chaos tests for that scenario. Supplying the same seed selects the
+same scenario:
+
+```bash
+make chaos-random CHAOS_SEED=issue-247
+```
+
+When `chaos-random` runs, it also prints a rerun command that pins both values:
+
+```bash
+make chaos-random CHAOS_SEED=<printed-seed> CHAOS_SCENARIO=<printed-scenario>
+```
+
+Use that command to reproduce a random CI or local canary failure exactly.
+
+Use `make chaos-all` when you want the complete current chaos suite. That is the
+right target for local hardening before changing adapter failure behavior, and
+for scheduled automation that can spend more time on exhaustive chaos coverage.
+
+The pull request CI workflow runs `make chaos-random` as a quick signal while
+leaving `make check` as the repository's canonical validation path.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ where = ["src"]
 testpaths = ["tests"]
 markers = [
   "integration: local integration tests that exercise real adapter wiring against deterministic stubs",
+  "chaos: deterministic adapter chaos tests",
 ]
 
 [tool.ruff]

--- a/tests/chaos.py
+++ b/tests/chaos.py
@@ -9,6 +9,7 @@ stubs so failure coverage stays readable and repeatable.
 from __future__ import annotations
 
 import json
+import random
 from dataclasses import dataclass
 from email.message import Message
 from enum import StrEnum
@@ -28,6 +29,11 @@ class AdapterChaosScenario(StrEnum):
     INVALID_JSON = "invalid_json"
     EMPTY_RESPONSE = "empty_response"
     PARTIAL_PAYLOAD = "partial_payload"
+
+
+def select_chaos_scenario(seed: str) -> AdapterChaosScenario:
+    """Select one named chaos scenario deterministically from a seed."""
+    return random.Random(seed).choice(tuple(AdapterChaosScenario))
 
 
 @dataclass(frozen=True)

--- a/tests/confluence/test_chaos.py
+++ b/tests/confluence/test_chaos.py
@@ -9,9 +9,11 @@ from pytest import CaptureFixture
 from knowledge_adapters.cli import main
 from knowledge_adapters.confluence.client import ConfluenceRequestError, fetch_real_page
 from knowledge_adapters.confluence.models import ResolvedTarget
-from tests.chaos import AdapterChaosScenario, ConfluenceHTTPChaos
+from tests.chaos import AdapterChaosScenario, ConfluenceHTTPChaos, select_chaos_scenario
 
 ConfluenceChaosInstaller = Callable[[AdapterChaosScenario], ConfluenceHTTPChaos]
+
+pytestmark = pytest.mark.chaos
 
 
 def _target(page_id: str = "12345") -> ResolvedTarget:
@@ -149,3 +151,10 @@ def test_confluence_cli_real_mode_surfaces_chaos_without_artifacts(
     assert not (output_dir / "manifest.json").exists()
     pages_dir = output_dir / "pages"
     assert not pages_dir.exists() or list(pages_dir.glob("*.md")) == []
+
+
+def test_chaos_random_selection_is_seeded() -> None:
+    scenario = select_chaos_scenario("issue-247")
+
+    assert scenario == select_chaos_scenario("issue-247")
+    assert scenario in tuple(AdapterChaosScenario)


### PR DESCRIPTION
## Summary

- Add `make chaos-random` and `make chaos-all` targets for adapter chaos validation.
- Make `chaos-random` select one scenario deterministically from `CHAOS_SEED`, print the selected scenario, and print a pinned rerun command.
- Mark chaos tests with a `chaos` pytest marker, run the cheap chaos canary in the existing CI workflow, and document local, CI, and scheduled-use expectations.

## Scope check

- [x] This PR contains only one logical arc.

## Testing

- `make check`
- `make chaos-random`
- `make chaos-all`
- `make chaos-random CHAOS_SEED=1777502682 CHAOS_SCENARIO=partial_payload`

## Notes

- Residual risk: `make check` already includes these deterministic chaos tests via the normal pytest run, so the new CI canary is an additional cheap reporting signal rather than the only CI chaos coverage.

## Issue closure

Closes #247