### PR TITLE
[codex] Add adapter contract test scaffold

### DIFF
--- a/adapters/confluence/README.md
+++ b/adapters/confluence/README.md
@@ -139,6 +139,8 @@ runtime rather than committed:
 The following docs define intended behavior beyond the current default client:
 
 - [`docs/adapter-spec.md`](../../docs/adapter-spec.md): generic adapter contract
+- [`docs/adapter-contract-tests.md`](../../docs/adapter-contract-tests.md):
+  minimal test-only success invariants and failure-safety expectations
 - [`docs/confluence-recursive-fetch.md`](../../docs/confluence-recursive-fetch.md):
   recursive traversal semantics for `--tree` and `--max-depth`
 - [`docs/confluence-incremental-sync.md`](../../docs/confluence-incremental-sync.md):

--- a/docs/adapter-contract-tests.md
+++ b/docs/adapter-contract-tests.md
@@ -1,0 +1,41 @@
+# Adapter Invariant and Contract Tests
+
+Adapter contract tests are test-only checks for behavior that should stay stable
+as adapter coverage grows. They are intentionally smaller than a production
+schema or framework.
+
+## Success Invariants
+
+For adapters that write the repository's normalized markdown artifact shape,
+success tests should verify the artifact has:
+
+- a non-empty title
+- required metadata keys for source, canonical identity, source URL, and adapter
+- the current shared metadata slots: `parent_id`, `fetched_at`, and `updated_at`
+- a content section, with source-specific assertions for whether content may be
+  empty
+
+For manifest-backed adapters, success tests should verify:
+
+- `generated_at` is present
+- `files` is a list
+- each entry has non-empty `canonical_id`, `source_url`, and relative
+  `output_path`
+- source-specific fields, such as `title`, are asserted only when that adapter
+  already provides them
+
+The reusable helpers live in `tests/adapter_contracts.py`. Add coverage for a
+future adapter by writing a focused adapter test that runs a deterministic local
+fixture or stub, then calls the helpers against the written artifact and
+manifest. Do not require adapters with different output shapes to adopt these
+helpers until their shape is intentionally compatible.
+
+## Failure Safety
+
+Known failure paths should fail before writing partial adapter outputs when the
+repository already has a deterministic seam for the failure. Use
+`assert_no_partial_adapter_artifacts` for those cases.
+
+Keep these tests local and deterministic. They should not require live services,
+credentials, external network access, sleeps, or broad production validation
+changes.

--- a/docs/adapter-spec.md
+++ b/docs/adapter-spec.md
@@ -26,6 +26,13 @@ An adapter must:
 
 8. avoid embedding environment-specific details in the repo
 
+## Test Contracts
+
+Adapter invariant and contract tests live in the test suite, not in production
+validation code. See [`adapter-contract-tests.md`](adapter-contract-tests.md)
+for the current success and failure-safety expectations and how future adapters
+should add coverage.
+
 ## Runtime Inputs
 
 Adapters should accept, directly or indirectly, the following classes of input:

--- a/tests/adapter_contracts.py
+++ b/tests/adapter_contracts.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from tests.artifact_assertions import parse_markdown_document
+
+DEFAULT_MARKDOWN_METADATA_FIELDS = (
+    "source",
+    "canonical_id",
+    "parent_id",
+    "source_url",
+    "fetched_at",
+    "updated_at",
+    "adapter",
+)
+
+DEFAULT_MANIFEST_ENTRY_FIELDS = (
+    "canonical_id",
+    "source_url",
+    "output_path",
+)
+
+
+def assert_normalized_markdown_contract(
+    markdown: str,
+    *,
+    source: str,
+    adapter: str,
+    canonical_id: str,
+    source_url: str,
+    title: str | None = None,
+    content: str | None = None,
+    required_metadata_fields: Sequence[str] = DEFAULT_MARKDOWN_METADATA_FIELDS,
+) -> None:
+    actual_title, metadata, actual_content = parse_markdown_document(markdown)
+
+    if title is None:
+        assert actual_title.strip()
+    else:
+        assert actual_title == title
+
+    for field in required_metadata_fields:
+        assert field in metadata
+
+    assert metadata["source"] == source
+    assert metadata["adapter"] == adapter
+    assert metadata["canonical_id"] == canonical_id
+    assert metadata["source_url"] == source_url
+    assert metadata["source"].strip()
+    assert metadata["adapter"].strip()
+    assert metadata["canonical_id"].strip()
+    assert metadata["source_url"].strip()
+
+    if content is None:
+        assert actual_content.strip()
+    else:
+        assert actual_content == content.rstrip("\n")
+
+
+def assert_manifest_success_contract(
+    manifest: Path | Mapping[str, object],
+    *,
+    expected_files: Sequence[Mapping[str, object]] | None = None,
+    required_entry_fields: Sequence[str] = DEFAULT_MANIFEST_ENTRY_FIELDS,
+) -> None:
+    payload = _load_manifest(manifest) if isinstance(manifest, Path) else dict(manifest)
+
+    generated_at = payload.get("generated_at")
+    assert isinstance(generated_at, str)
+    assert generated_at.strip()
+
+    files = payload.get("files")
+    assert isinstance(files, list)
+    if expected_files is not None:
+        assert len(files) == len(expected_files)
+
+    for index, entry in enumerate(files):
+        assert isinstance(entry, dict)
+        _assert_manifest_entry_contract(entry, required_entry_fields=required_entry_fields)
+
+        if expected_files is None:
+            continue
+
+        for key, value in expected_files[index].items():
+            assert entry.get(key) == value
+
+
+def assert_no_partial_adapter_artifacts(
+    output_dir: Path,
+    *,
+    artifact_patterns: Sequence[str] = ("**/*.md",),
+    manifest_name: str = "manifest.json",
+) -> None:
+    assert not (output_dir / manifest_name).exists()
+    if not output_dir.exists():
+        return
+
+    partial_artifacts: list[Path] = []
+    for pattern in artifact_patterns:
+        partial_artifacts.extend(path for path in output_dir.glob(pattern) if path.is_file())
+
+    assert partial_artifacts == []
+
+
+def _assert_manifest_entry_contract(
+    entry: Mapping[str, object],
+    *,
+    required_entry_fields: Sequence[str],
+) -> None:
+    for field in required_entry_fields:
+        assert field in entry
+        value = entry[field]
+        assert isinstance(value, str)
+        assert value.strip()
+
+    output_path = entry["output_path"]
+    assert isinstance(output_path, str)
+    assert not Path(output_path).is_absolute()
+
+    title = entry.get("title")
+    if title is not None:
+        assert isinstance(title, str)
+        assert title.strip()
+
+
+def _load_manifest(manifest_path: Path) -> dict[str, Any]:
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload

--- a/tests/artifact_assertions.py
+++ b/tests/artifact_assertions.py
@@ -20,6 +20,10 @@ def assert_markdown_document(
     assert actual_content == content.rstrip("\n")
 
 
+def parse_markdown_document(markdown: str) -> tuple[str, dict[str, str], str]:
+    return _parse_markdown_document(markdown)
+
+
 def manifest_file(
     *,
     canonical_id: str,

--- a/tests/confluence/test_chaos.py
+++ b/tests/confluence/test_chaos.py
@@ -9,6 +9,7 @@ from pytest import CaptureFixture
 from knowledge_adapters.cli import main
 from knowledge_adapters.confluence.client import ConfluenceRequestError, fetch_real_page
 from knowledge_adapters.confluence.models import ResolvedTarget
+from tests.adapter_contracts import assert_no_partial_adapter_artifacts
 from tests.chaos import AdapterChaosScenario, ConfluenceHTTPChaos, select_chaos_scenario
 
 ConfluenceChaosInstaller = Callable[[AdapterChaosScenario], ConfluenceHTTPChaos]
@@ -148,9 +149,7 @@ def test_confluence_cli_real_mode_surfaces_chaos_without_artifacts(
     captured = capsys.readouterr()
     assert captured.out == ""
     assert captured.err == f"knowledge-adapters confluence: error: {expected_message}\n"
-    assert not (output_dir / "manifest.json").exists()
-    pages_dir = output_dir / "pages"
-    assert not pages_dir.exists() or list(pages_dir.glob("*.md")) == []
+    assert_no_partial_adapter_artifacts(output_dir)
 
 
 def test_chaos_random_selection_is_seeded() -> None:

--- a/tests/confluence/test_contracts.py
+++ b/tests/confluence/test_contracts.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from pytest import CaptureFixture
+
+from knowledge_adapters.cli import main
+from tests.adapter_contracts import (
+    assert_manifest_success_contract,
+    assert_normalized_markdown_contract,
+)
+
+
+def test_confluence_stub_write_satisfies_adapter_success_contract(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    output_dir = tmp_path / "out"
+
+    exit_code = main(
+        [
+            "confluence",
+            "--base-url",
+            "https://example.com/wiki",
+            "--target",
+            "12345",
+            "--output-dir",
+            str(output_dir),
+        ]
+    )
+
+    assert exit_code == 0
+    capsys.readouterr()
+
+    source_url = "https://example.com/wiki/pages/viewpage.action?pageId=12345"
+    artifact_path = output_dir / "pages" / "12345.md"
+    assert_normalized_markdown_contract(
+        artifact_path.read_text(encoding="utf-8"),
+        source="confluence",
+        adapter="confluence",
+        canonical_id="12345",
+        source_url=source_url,
+        title="stub-page-12345",
+        content="Stub content for page 12345.",
+    )
+    assert_manifest_success_contract(
+        output_dir / "manifest.json",
+        expected_files=[
+            {
+                "canonical_id": "12345",
+                "source_url": source_url,
+                "output_path": "pages/12345.md",
+                "title": "stub-page-12345",
+            }
+        ],
+    )

--- a/tests/test_cli_confluence.py
+++ b/tests/test_cli_confluence.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from tests.adapter_contracts import assert_no_partial_adapter_artifacts
 from tests.cli_helpers import run_cli
 from tests.cli_output_assertions import (
     assert_contains_normalized,
@@ -178,6 +179,7 @@ def test_confluence_cli_rejects_missing_tls_path_before_execution(
     tmp_path: Path,
 ) -> None:
     missing_ca_bundle = tmp_path / "missing-ca.pem"
+    output_dir = tmp_path / "artifacts"
 
     result = run_cli(
         tmp_path,
@@ -187,7 +189,7 @@ def test_confluence_cli_rejects_missing_tls_path_before_execution(
         "--target",
         "12345",
         "--output-dir",
-        "./artifacts",
+        str(output_dir),
         "--ca-bundle",
         str(missing_ca_bundle),
     )
@@ -196,6 +198,7 @@ def test_confluence_cli_rejects_missing_tls_path_before_execution(
     assert result.stdout == ""
     assert "does not exist" in result.stderr
     assert str(missing_ca_bundle.resolve()) in result.stderr
+    assert_no_partial_adapter_artifacts(output_dir)
 
 
 def test_confluence_help_lists_supported_auth_methods_and_examples(
@@ -241,6 +244,8 @@ def test_confluence_help_lists_supported_auth_methods_and_examples(
 
 
 def test_confluence_cli_rejects_invalid_base_url_before_planning(tmp_path: Path) -> None:
+    output_dir = tmp_path / "artifacts"
+
     result = run_cli(
         tmp_path,
         "confluence",
@@ -249,7 +254,7 @@ def test_confluence_cli_rejects_invalid_base_url_before_planning(tmp_path: Path)
         "--target",
         "12345",
         "--output-dir",
-        "./artifacts",
+        str(output_dir),
     )
 
     assert result.returncode == 2
@@ -261,3 +266,4 @@ def test_confluence_cli_rejects_invalid_base_url_before_planning(tmp_path: Path)
         "is invalid. Provide a full http:// or https:// Confluence base URL, for "
         "example 'https://example.com/wiki'.\n"
     ) == result.stderr
+    assert_no_partial_adapter_artifacts(output_dir)


### PR DESCRIPTION
## Summary

- Add test-only adapter contract helpers for normalized markdown invariants, manifest success invariants, and no-partial-artifact failure safety.
- Add focused Confluence coverage that exercises the scaffold against the deterministic stub write path.
- Reuse the no-partials helper in existing Confluence failure tests and document how future adapters should add scoped invariant/contract coverage.

## Scope check

- [x] This PR contains only one logical arc.

## Testing

- `make check`
- `make chaos-all`
- `make check-gh-env`

## Notes

- No production adapter behavior changes.
- Residual risk: the scaffold intentionally covers only adapters whose current output shape matches the existing normalized markdown and manifest layout.

## Issue closure

- N/A