### PR TITLE
[codex] Add chaos replay fingerprints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev test smoke lint fix format typecheck check check-env check-gh-env chaos-random chaos-all release-notes release-check release-publish clean
+.PHONY: dev test smoke lint fix format typecheck check check-env check-gh-env chaos-random chaos-replay chaos-all release-notes release-check release-publish clean
 
 VENV = .venv
 PYTHON = $(VENV)/bin/python
@@ -9,8 +9,9 @@ PYTEST = $(VENV)/bin/pytest
 CLI = $(VENV)/bin/knowledge-adapters
 RELEASE_VERSION = $(patsubst v%,%,$(VERSION))
 RELEASE_TAG = v$(RELEASE_VERSION)
-CHAOS_SEED ?= $(shell date +%s)
+CHAOS_SEED ?=
 CHAOS_SCENARIO ?=
+CHAOS_NODEID ?=
 
 $(VENV)/bin/activate:
 	python3 -m venv $(VENV)
@@ -35,6 +36,9 @@ smoke: $(VENV)/bin/activate
 chaos-random: $(VENV)/bin/activate
 	@set -e; \
 	seed="$(CHAOS_SEED)"; \
+	if [ -z "$$seed" ]; then \
+		seed="$$(date +%s)"; \
+	fi; \
 	scenario="$(CHAOS_SCENARIO)"; \
 	if [ -z "$$scenario" ]; then \
 		scenario="$$(CHAOS_SEED="$$seed" $(PYTHON) -c 'import os; from tests.chaos import select_chaos_scenario; print(select_chaos_scenario(os.environ["CHAOS_SEED"]).value)')"; \
@@ -43,11 +47,33 @@ chaos-random: $(VENV)/bin/activate
 	fi; \
 	echo "Chaos seed: $$seed"; \
 	echo "Chaos scenario: $$scenario"; \
-	echo "Rerun: make chaos-random CHAOS_SEED=$$seed CHAOS_SCENARIO=$$scenario"; \
-	$(PYTEST) -m chaos -k "$$scenario"
+	echo "Rerun: make chaos-replay CHAOS_SEED=$$seed CHAOS_SCENARIO=$$scenario"; \
+	CHAOS_TARGET=chaos-random CHAOS_SEED="$$seed" CHAOS_SCENARIO="$$scenario" $(PYTEST) -m chaos -k "$$scenario"
+
+chaos-replay: $(VENV)/bin/activate
+	@set -e; \
+	seed="$(CHAOS_SEED)"; \
+	scenario="$(CHAOS_SCENARIO)"; \
+	nodeid="$(CHAOS_NODEID)"; \
+	if [ -z "$$scenario" ]; then \
+		echo "Error: CHAOS_SCENARIO is required. Usage: make chaos-replay CHAOS_SCENARIO=<scenario> [CHAOS_SEED=<seed>] [CHAOS_NODEID=<pytest-node-id>]" >&2; \
+		exit 1; \
+	fi; \
+	CHAOS_SCENARIO="$$scenario" $(PYTHON) -c 'import os; from tests.chaos import AdapterChaosScenario; AdapterChaosScenario(os.environ["CHAOS_SCENARIO"])'; \
+	if [ -n "$$seed" ]; then \
+		echo "Chaos seed: $$seed"; \
+	fi; \
+	echo "Chaos scenario: $$scenario"; \
+	if [ -n "$$nodeid" ]; then \
+		echo "Chaos node id: $$nodeid"; \
+		CHAOS_TARGET=chaos-replay CHAOS_SEED="$$seed" CHAOS_SCENARIO="$$scenario" $(PYTEST) -m chaos "$$nodeid"; \
+	else \
+		echo "Chaos node id: <all matching scenario tests>"; \
+		CHAOS_TARGET=chaos-replay CHAOS_SEED="$$seed" CHAOS_SCENARIO="$$scenario" $(PYTEST) -m chaos -k "$$scenario"; \
+	fi
 
 chaos-all: $(VENV)/bin/activate
-	$(PYTEST) -m chaos
+	CHAOS_TARGET=chaos-all $(PYTEST) -m chaos
 
 lint: $(VENV)/bin/activate
 	$(RUFF) check .

--- a/docs/chaos-testing.md
+++ b/docs/chaos-testing.md
@@ -44,7 +44,7 @@ make chaos-random CHAOS_SEED=issue-247
 When `chaos-random` runs, it also prints a rerun command that pins both values:
 
 ```bash
-make chaos-random CHAOS_SEED=<printed-seed> CHAOS_SCENARIO=<printed-scenario>
+make chaos-replay CHAOS_SEED=<printed-seed> CHAOS_SCENARIO=<printed-scenario>
 ```
 
 Use that command to reproduce a random CI or local canary failure exactly.
@@ -52,6 +52,44 @@ Use that command to reproduce a random CI or local canary failure exactly.
 Use `make chaos-all` when you want the complete current chaos suite. That is the
 right target for local hardening before changing adapter failure behavior, and
 for scheduled automation that can spend more time on exhaustive chaos coverage.
+
+## Replaying Failures
+
+Use `make chaos-replay` to rerun a pinned chaos scenario without relying on
+local run history:
+
+```bash
+make chaos-replay CHAOS_SCENARIO=timeout
+```
+
+When a chaos test fails, pytest prints a node-specific replay command in the
+terminal summary:
+
+```bash
+make chaos-replay CHAOS_SEED=<seed> CHAOS_SCENARIO=<scenario> CHAOS_NODEID='<pytest-node-id>'
+```
+
+`CHAOS_SEED` is included when the failing run had one, such as a
+`make chaos-random` canary. `CHAOS_SCENARIO` is required so replay commands stay
+explicit. `CHAOS_NODEID` is optional; omit it to rerun every chaos test matching
+the pinned scenario.
+
+## Failure Fingerprints
+
+Chaos failures also print a `chaos-v1:<digest>` fingerprint with a compact JSON
+payload. The digest and payload are deterministic for the same failure context:
+
+- `scenario`
+- `nodeid`
+- `failure_type`
+- `failure_message`
+- `command_context`
+
+Use the fingerprint to recognize repeated failures across local runs and CI
+logs. Use the replay command next to the fingerprint to reproduce the specific
+scenario and pytest node. Fingerprints are intentionally lightweight log output;
+they are not persisted by the repository and do not imply any run history,
+database, dashboard, or production chaos behavior.
 
 The pull request CI workflow runs `make chaos-random` as a quick signal while
 leaving `make check` as the repository's canonical validation path.

--- a/tests/chaos.py
+++ b/tests/chaos.py
@@ -10,9 +10,12 @@ from __future__ import annotations
 
 import json
 import random
+import shlex
+from collections.abc import Mapping
 from dataclasses import dataclass
 from email.message import Message
 from enum import StrEnum
+from hashlib import sha256
 from types import TracebackType
 from typing import Literal, Self
 from urllib.error import HTTPError, URLError
@@ -31,9 +34,83 @@ class AdapterChaosScenario(StrEnum):
     PARTIAL_PAYLOAD = "partial_payload"
 
 
+CHAOS_FINGERPRINT_VERSION = "chaos-v1"
+
+
+@dataclass(frozen=True)
+class ChaosFailureFingerprint:
+    """Stable identifier and payload for a chaos validation failure."""
+
+    identifier: str
+    payload: Mapping[str, str]
+
+    def as_line(self) -> str:
+        """Return a compact, copyable fingerprint line."""
+        payload_json = json.dumps(self.payload, sort_keys=True, separators=(",", ":"))
+        return f"{self.identifier} {payload_json}"
+
+
 def select_chaos_scenario(seed: str) -> AdapterChaosScenario:
     """Select one named chaos scenario deterministically from a seed."""
     return random.Random(seed).choice(tuple(AdapterChaosScenario))
+
+
+def build_chaos_failure_fingerprint(
+    *,
+    scenario: str,
+    nodeid: str,
+    failure_type: str,
+    failure_message: str,
+    command_context: str,
+) -> ChaosFailureFingerprint:
+    """Build a deterministic fingerprint for comparing repeated chaos failures."""
+    payload = {
+        "command_context": _normalize_fingerprint_text(command_context),
+        "failure_message": _normalize_fingerprint_text(failure_message),
+        "failure_type": _normalize_fingerprint_text(failure_type),
+        "nodeid": _normalize_fingerprint_text(nodeid),
+        "scenario": _normalize_fingerprint_text(scenario),
+    }
+    payload_json = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    digest = sha256(payload_json.encode("utf-8")).hexdigest()[:16]
+    return ChaosFailureFingerprint(
+        identifier=f"{CHAOS_FINGERPRINT_VERSION}:{digest}",
+        payload=payload,
+    )
+
+
+def build_chaos_command_context(*, target: str, seed: str | None, scenario: str) -> str:
+    """Describe the Make command context that selected the failing chaos run."""
+    if target == "chaos-random":
+        parts = ["make", "chaos-random"]
+        if seed:
+            parts.append(f"CHAOS_SEED={shlex.quote(seed)}")
+        parts.append(f"CHAOS_SCENARIO={shlex.quote(scenario)}")
+        return " ".join(parts)
+    if target == "chaos-all":
+        return "make chaos-all"
+    if target == "chaos-replay":
+        parts = ["make", "chaos-replay"]
+        if seed:
+            parts.append(f"CHAOS_SEED={shlex.quote(seed)}")
+        parts.append(f"CHAOS_SCENARIO={shlex.quote(scenario)}")
+        return " ".join(parts)
+    return target or "pytest -m chaos"
+
+
+def build_chaos_replay_command(
+    *,
+    seed: str | None,
+    scenario: str,
+    nodeid: str,
+) -> str:
+    """Build a shell-safe Make command that replays one chaos failure."""
+    parts = ["make", "chaos-replay"]
+    if seed:
+        parts.append(f"CHAOS_SEED={shlex.quote(seed)}")
+    parts.append(f"CHAOS_SCENARIO={shlex.quote(scenario)}")
+    parts.append(f"CHAOS_NODEID={shlex.quote(nodeid)}")
+    return " ".join(parts)
 
 
 @dataclass(frozen=True)
@@ -126,6 +203,10 @@ def _request_url(request: object) -> str:
     if isinstance(request, str):
         return request
     return "https://example.com/unknown-chaos-request"
+
+
+def _normalize_fingerprint_text(value: str) -> str:
+    return " ".join(value.split())
 
 
 def _partial_page_payload(chaos: ConfluenceHTTPChaos) -> dict[str, object]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,16 +2,96 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+import os
+from collections.abc import Callable, Generator
+from dataclasses import dataclass
+from typing import cast
 
 import pytest
+from _pytest.reports import TestReport
+from _pytest.stash import StashKey
+from _pytest.terminal import TerminalReporter
+from pluggy import Result
 from pytest import MonkeyPatch
 
 from tests.chaos import (
     AdapterChaosScenario,
     ConfluenceHTTPChaos,
+    build_chaos_command_context,
+    build_chaos_failure_fingerprint,
+    build_chaos_replay_command,
     install_confluence_http_chaos,
 )
+
+
+@dataclass(frozen=True)
+class ChaosFailureReport:
+    """Terminal summary details for one failed chaos test."""
+
+    fingerprint_line: str
+    replay_command: str
+
+
+CHAOS_FAILURES_KEY = StashKey[list[ChaosFailureReport]]()
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.stash[CHAOS_FAILURES_KEY] = []
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(
+    item: pytest.Item,
+    call: pytest.CallInfo[object],
+) -> Generator[None]:
+    outcome = cast(Result[TestReport], (yield))
+    report = outcome.get_result()
+
+    if not report.failed or item.get_closest_marker("chaos") is None:
+        return
+
+    scenario = _chaos_scenario_for_item(item)
+    failure_type, failure_message = _chaos_failure_details(call, report)
+    seed = os.environ.get("CHAOS_SEED")
+    command_context = build_chaos_command_context(
+        target=os.environ.get("CHAOS_TARGET", ""),
+        seed=seed,
+        scenario=scenario,
+    )
+    fingerprint = build_chaos_failure_fingerprint(
+        scenario=scenario,
+        nodeid=report.nodeid,
+        failure_type=failure_type,
+        failure_message=failure_message,
+        command_context=command_context,
+    )
+
+    item.config.stash[CHAOS_FAILURES_KEY].append(
+        ChaosFailureReport(
+            fingerprint_line=fingerprint.as_line(),
+            replay_command=build_chaos_replay_command(
+                seed=seed,
+                scenario=scenario,
+                nodeid=report.nodeid,
+            ),
+        )
+    )
+
+
+def pytest_terminal_summary(
+    terminalreporter: TerminalReporter,
+    exitstatus: int,
+    config: pytest.Config,
+) -> None:
+    del exitstatus
+    failures = config.stash[CHAOS_FAILURES_KEY]
+    if not failures:
+        return
+
+    terminalreporter.section("chaos failure replay")
+    for failure in failures:
+        terminalreporter.write_line(f"fingerprint: {failure.fingerprint_line}")
+        terminalreporter.write_line(f"replay: {failure.replay_command}")
 
 
 @pytest.fixture
@@ -24,3 +104,31 @@ def confluence_chaos(
         return install_confluence_http_chaos(monkeypatch, scenario)
 
     return install
+
+
+def _chaos_scenario_for_item(item: pytest.Item) -> str:
+    callspec = getattr(item, "callspec", None)
+    params = getattr(callspec, "params", {})
+    if isinstance(params, dict) and "scenario" in params:
+        scenario = params["scenario"]
+        if isinstance(scenario, AdapterChaosScenario):
+            return scenario.value
+        return str(scenario)
+
+    scenario = os.environ.get("CHAOS_SCENARIO")
+    if scenario:
+        return scenario
+
+    return "unknown"
+
+
+def _chaos_failure_details(
+    call: pytest.CallInfo[object],
+    report: TestReport,
+) -> tuple[str, str]:
+    if call.excinfo is None:
+        return report.outcome, report.longreprtext
+
+    failure_type = type(call.excinfo.value).__name__
+    failure_message = str(call.excinfo.value).strip() or report.longreprtext
+    return failure_type, failure_message

--- a/tests/test_chaos_fingerprints.py
+++ b/tests/test_chaos_fingerprints.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from tests.chaos import (
+    build_chaos_command_context,
+    build_chaos_failure_fingerprint,
+    build_chaos_replay_command,
+)
+
+
+def test_chaos_failure_fingerprint_is_deterministic() -> None:
+    fingerprint = build_chaos_failure_fingerprint(
+        scenario="timeout",
+        nodeid="tests/confluence/test_chaos.py::test_failure[timeout]",
+        failure_type="AssertionError",
+        failure_message="expected timeout\n  got rate limit",
+        command_context="make chaos-random CHAOS_SEED=issue-247 CHAOS_SCENARIO=timeout",
+    )
+    repeated = build_chaos_failure_fingerprint(
+        scenario="timeout",
+        nodeid="tests/confluence/test_chaos.py::test_failure[timeout]",
+        failure_type="AssertionError",
+        failure_message="expected timeout   got rate limit",
+        command_context="make chaos-random CHAOS_SEED=issue-247 CHAOS_SCENARIO=timeout",
+    )
+
+    assert fingerprint == repeated
+    assert fingerprint.identifier == "chaos-v1:001a8e93f7b5fb08"
+    assert fingerprint.payload == {
+        "command_context": "make chaos-random CHAOS_SEED=issue-247 CHAOS_SCENARIO=timeout",
+        "failure_message": "expected timeout got rate limit",
+        "failure_type": "AssertionError",
+        "nodeid": "tests/confluence/test_chaos.py::test_failure[timeout]",
+        "scenario": "timeout",
+    }
+
+
+def test_chaos_failure_fingerprint_changes_for_distinct_failures() -> None:
+    timeout = build_chaos_failure_fingerprint(
+        scenario="timeout",
+        nodeid="tests/confluence/test_chaos.py::test_failure[timeout]",
+        failure_type="AssertionError",
+        failure_message="expected timeout",
+        command_context="make chaos-random CHAOS_SEED=issue-247 CHAOS_SCENARIO=timeout",
+    )
+    rate_limit = build_chaos_failure_fingerprint(
+        scenario="rate_limit",
+        nodeid="tests/confluence/test_chaos.py::test_failure[rate_limit]",
+        failure_type="AssertionError",
+        failure_message="expected rate limit",
+        command_context="make chaos-random CHAOS_SEED=issue-247 CHAOS_SCENARIO=rate_limit",
+    )
+
+    assert timeout.identifier != rate_limit.identifier
+
+
+def test_chaos_replay_command_quotes_node_ids() -> None:
+    command = build_chaos_replay_command(
+        seed="issue 247",
+        scenario="timeout",
+        nodeid="tests/confluence/test_chaos.py::test_failure[timeout]",
+    )
+
+    assert command == (
+        "make chaos-replay CHAOS_SEED='issue 247' CHAOS_SCENARIO=timeout "
+        "CHAOS_NODEID='tests/confluence/test_chaos.py::test_failure[timeout]'"
+    )
+
+
+def test_chaos_command_context_describes_make_target() -> None:
+    assert (
+        build_chaos_command_context(
+            target="chaos-random",
+            seed="issue 247",
+            scenario="timeout",
+        )
+        == "make chaos-random CHAOS_SEED='issue 247' CHAOS_SCENARIO=timeout"
+    )


### PR DESCRIPTION
## Summary

- add deterministic `chaos-v1` failure fingerprints for chaos validation failures
- print node-specific `make chaos-replay` commands from failed chaos runs without storing local run history
- add `make chaos-replay` for pinned scenario/node replay and document replay/fingerprint usage

## Scope check

- [x] This PR contains only one logical arc.

## Testing

- `make check`
- `make chaos-random`
- `make chaos-all`
- `make chaos-replay CHAOS_SEED=1777565691 CHAOS_SCENARIO=timeout`
- `make check-gh-env`

## Residual risks

- Fingerprints are intentionally log-only and compare the normalized failure message, so message text changes will produce a new fingerprint even for the same underlying defect.
