### PR TITLE
Add adapter readiness report

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev test smoke lint fix format typecheck check check-env check-gh-env chaos-random chaos-replay chaos-all release-notes release-check release-publish clean
+.PHONY: dev test smoke lint fix format typecheck check check-env check-gh-env adapter-readiness chaos-random chaos-replay chaos-all release-notes release-check release-publish clean
 
 VENV = .venv
 PYTHON = $(VENV)/bin/python
@@ -26,6 +26,9 @@ check-env:
 check-gh-env:
 	@command -v gh >/dev/null 2>&1 || { echo "Error: GitHub CLI (gh) is required but is not installed." >&2; exit 1; }
 	@gh auth status >/dev/null 2>&1 || { echo "Error: GitHub CLI authentication is required. Run 'gh auth login' and try again." >&2; exit 1; }
+
+adapter-readiness: $(VENV)/bin/activate
+	@$(PYTHON) -m knowledge_adapters.adapter_readiness
 
 test: $(VENV)/bin/activate
 	$(PYTEST)

--- a/docs/adapter-contract-tests.md
+++ b/docs/adapter-contract-tests.md
@@ -39,3 +39,7 @@ repository already has a deterministic seam for the failure. Use
 Keep these tests local and deterministic. They should not require live services,
 credentials, external network access, sleeps, or broad production validation
 changes.
+
+The adapter readiness report in [`adapter-readiness.md`](adapter-readiness.md)
+summarizes which current adapters have this coverage registered. Update that
+explicit model when an adapter gains contract or failure-safety coverage.

--- a/docs/adapter-readiness.md
+++ b/docs/adapter-readiness.md
@@ -1,0 +1,44 @@
+# Adapter Readiness Report
+
+The adapter readiness report is a lightweight coverage map for reliability
+work. It is not a quality score, release gate, dashboard, badge, or persistent
+tracking system.
+
+Run it locally with:
+
+```bash
+make adapter-readiness
+```
+
+The report is deterministic plain text. It starts from the explicit model in
+`src/knowledge_adapters/adapter_readiness.py` rather than scraping test names or
+inferring coverage from the filesystem.
+
+## Dimensions
+
+- Contract/invariant: the adapter has focused coverage registered against the
+  shared adapter contract or invariant helpers for successful normalized
+  artifacts and manifests.
+- Chaos: the adapter has deterministic local chaos tests registered for named
+  failure scenarios.
+- Replay: the adapter's chaos coverage can be rerun through the repository
+  replay target, such as `make chaos-replay`.
+- No partial artifacts: the adapter has failure-path coverage showing known
+  deterministic failures do not leave partial markdown artifacts or
+  `manifest.json` behind.
+
+## Updating Coverage
+
+When an adapter gains one of these reliability dimensions, update the explicit
+readiness model with the observed coverage and a short evidence note pointing
+to the test, helper, or Makefile target that proves it. Keep entries factual:
+describe coverage that exists in the repository today, not planned or desired
+coverage.
+
+Future adapters should be added to the model when they become real adapter CLI
+surfaces. They can start with `no` for dimensions they do not yet cover. Do not
+force a new adapter to add chaos or contract coverage just to appear in the
+report.
+
+If a future dimension would require fragile test-name parsing, keep it out of
+the report until it can be represented explicitly.

--- a/docs/adapter-readiness.md
+++ b/docs/adapter-readiness.md
@@ -33,7 +33,8 @@ When an adapter gains one of these reliability dimensions, update the explicit
 readiness model with the observed coverage and a short evidence note pointing
 to the test, helper, or Makefile target that proves it. Keep entries factual:
 describe coverage that exists in the repository today, not planned or desired
-coverage.
+coverage. When an evidence note includes a repo-relative file path, keep it
+pointing at a real file so the readiness tests can catch stale references.
 
 Future adapters should be added to the model when they become real adapter CLI
 surfaces. They can start with `no` for dimensions they do not yet cover. Do not

--- a/docs/chaos-testing.md
+++ b/docs/chaos-testing.md
@@ -93,3 +93,7 @@ database, dashboard, or production chaos behavior.
 
 The pull request CI workflow runs `make chaos-random` as a quick signal while
 leaving `make check` as the repository's canonical validation path.
+
+The adapter readiness report in [`adapter-readiness.md`](adapter-readiness.md)
+summarizes which current adapters have chaos and replay coverage registered.
+Update that explicit model when new adapter chaos scenarios are added.

--- a/src/knowledge_adapters/adapter_readiness.py
+++ b/src/knowledge_adapters/adapter_readiness.py
@@ -1,0 +1,187 @@
+"""Human-readable adapter reliability coverage reporting."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ReadinessDimension:
+    """One tracked reliability coverage dimension."""
+
+    key: str
+    title: str
+
+
+@dataclass(frozen=True)
+class AdapterReadiness:
+    """Observed reliability coverage for one adapter."""
+
+    adapter: str
+    coverage: dict[str, bool]
+    evidence: dict[str, str]
+
+
+READINESS_DIMENSIONS: tuple[ReadinessDimension, ...] = (
+    ReadinessDimension(
+        key="contract_invariant",
+        title="Contract/invariant",
+    ),
+    ReadinessDimension(
+        key="chaos",
+        title="Chaos",
+    ),
+    ReadinessDimension(
+        key="replay",
+        title="Replay",
+    ),
+    ReadinessDimension(
+        key="no_partial_artifacts",
+        title="No partial artifacts",
+    ),
+)
+
+ADAPTER_READINESS: tuple[AdapterReadiness, ...] = (
+    AdapterReadiness(
+        adapter="confluence",
+        coverage={
+            "contract_invariant": True,
+            "chaos": True,
+            "replay": True,
+            "no_partial_artifacts": True,
+        },
+        evidence={
+            "contract_invariant": (
+                "tests/confluence/test_contracts.py uses tests.adapter_contracts helpers."
+            ),
+            "chaos": (
+                "tests/confluence/test_chaos.py covers deterministic Confluence HTTP failures."
+            ),
+            "replay": "make chaos-replay reruns named Confluence chaos scenarios.",
+            "no_partial_artifacts": (
+                "Confluence failure tests assert no manifest or markdown artifacts are written."
+            ),
+        },
+    ),
+    AdapterReadiness(
+        adapter="git_repo",
+        coverage={
+            "contract_invariant": False,
+            "chaos": False,
+            "replay": False,
+            "no_partial_artifacts": False,
+        },
+        evidence={
+            "contract_invariant": "Not yet registered in the readiness model.",
+            "chaos": "No git_repo chaos scenarios are registered.",
+            "replay": "Replay applies to registered chaos scenarios; git_repo has none.",
+            "no_partial_artifacts": "No no-partial-artifact failure coverage is registered.",
+        },
+    ),
+    AdapterReadiness(
+        adapter="github_metadata",
+        coverage={
+            "contract_invariant": False,
+            "chaos": False,
+            "replay": False,
+            "no_partial_artifacts": False,
+        },
+        evidence={
+            "contract_invariant": "Not yet registered in the readiness model.",
+            "chaos": "No github_metadata chaos scenarios are registered.",
+            "replay": "Replay applies to registered chaos scenarios; github_metadata has none.",
+            "no_partial_artifacts": "No no-partial-artifact failure coverage is registered.",
+        },
+    ),
+    AdapterReadiness(
+        adapter="local_files",
+        coverage={
+            "contract_invariant": False,
+            "chaos": False,
+            "replay": False,
+            "no_partial_artifacts": False,
+        },
+        evidence={
+            "contract_invariant": "Not yet registered in the readiness model.",
+            "chaos": "No local_files chaos scenarios are registered.",
+            "replay": "Replay applies to registered chaos scenarios; local_files has none.",
+            "no_partial_artifacts": "No no-partial-artifact failure coverage is registered.",
+        },
+    ),
+)
+
+
+def adapter_readiness() -> tuple[AdapterReadiness, ...]:
+    """Return readiness rows in deterministic adapter-name order."""
+    return tuple(sorted(ADAPTER_READINESS, key=lambda row: row.adapter))
+
+
+def render_adapter_readiness_report(
+    rows: Sequence[AdapterReadiness] | None = None,
+) -> str:
+    """Render the readiness model as deterministic plain text."""
+    readiness_rows = tuple(rows) if rows is not None else adapter_readiness()
+    _validate_rows(readiness_rows)
+
+    headers = ("Adapter", *(dimension.title for dimension in READINESS_DIMENSIONS))
+    table_rows = [
+        (
+            row.adapter,
+            *(_format_coverage(row.coverage[dimension.key]) for dimension in READINESS_DIMENSIONS),
+        )
+        for row in readiness_rows
+    ]
+    widths = _column_widths((headers, *table_rows))
+
+    lines = [
+        "Adapter Readiness Coverage",
+        "",
+        "Lightweight coverage map; not a quality score.",
+        "",
+        _format_table_row(headers, widths),
+        _format_table_row(tuple("-" * width for width in widths), widths),
+    ]
+    lines.extend(_format_table_row(row, widths) for row in table_rows)
+    lines.extend(("", "Evidence:"))
+
+    for row in readiness_rows:
+        lines.append(f"{row.adapter}:")
+        for dimension in READINESS_DIMENSIONS:
+            status = _format_coverage(row.coverage[dimension.key])
+            lines.append(f"  {dimension.title}: {status} - {row.evidence[dimension.key]}")
+
+    return "\n".join(lines) + "\n"
+
+
+def main() -> None:
+    """Print the adapter readiness report."""
+    print(render_adapter_readiness_report(), end="")
+
+
+def _format_coverage(value: bool) -> str:
+    return "yes" if value else "no"
+
+
+def _column_widths(rows: Sequence[Sequence[str]]) -> tuple[int, ...]:
+    column_count = len(rows[0])
+    return tuple(max(len(row[index]) for row in rows) for index in range(column_count))
+
+
+def _format_table_row(row: Sequence[str], widths: Sequence[int]) -> str:
+    return "  ".join(cell.ljust(widths[index]) for index, cell in enumerate(row)).rstrip()
+
+
+def _validate_rows(rows: Sequence[AdapterReadiness]) -> None:
+    expected_keys = {dimension.key for dimension in READINESS_DIMENSIONS}
+    for row in rows:
+        coverage_keys = set(row.coverage)
+        evidence_keys = set(row.evidence)
+        if coverage_keys != expected_keys:
+            raise ValueError(f"{row.adapter} coverage keys do not match readiness dimensions.")
+        if evidence_keys != expected_keys:
+            raise ValueError(f"{row.adapter} evidence keys do not match readiness dimensions.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_adapter_readiness.py
+++ b/tests/test_adapter_readiness.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import pytest
+
+from knowledge_adapters.adapter_readiness import (
+    READINESS_DIMENSIONS,
+    AdapterReadiness,
+    adapter_readiness,
+    render_adapter_readiness_report,
+)
+
+
+def test_adapter_readiness_model_is_sorted_and_complete() -> None:
+    rows = adapter_readiness()
+    dimension_keys = {dimension.key for dimension in READINESS_DIMENSIONS}
+
+    assert tuple(row.adapter for row in rows) == (
+        "confluence",
+        "git_repo",
+        "github_metadata",
+        "local_files",
+    )
+    assert tuple(row.adapter for row in rows) == tuple(sorted(row.adapter for row in rows))
+    for row in rows:
+        assert set(row.coverage) == dimension_keys
+        assert set(row.evidence) == dimension_keys
+
+    confluence = rows[0]
+    assert confluence.coverage == {
+        "contract_invariant": True,
+        "chaos": True,
+        "replay": True,
+        "no_partial_artifacts": True,
+    }
+
+
+def test_adapter_readiness_report_is_deterministic() -> None:
+    report = render_adapter_readiness_report()
+
+    assert report == render_adapter_readiness_report()
+    assert report == (
+        "Adapter Readiness Coverage\n"
+        "\n"
+        "Lightweight coverage map; not a quality score.\n"
+        "\n"
+        "Adapter          Contract/invariant  Chaos  Replay  No partial artifacts\n"
+        "---------------  ------------------  -----  ------  --------------------\n"
+        "confluence       yes                 yes    yes     yes\n"
+        "git_repo         no                  no     no      no\n"
+        "github_metadata  no                  no     no      no\n"
+        "local_files      no                  no     no      no\n"
+        "\n"
+        "Evidence:\n"
+        "confluence:\n"
+        "  Contract/invariant: yes - tests/confluence/test_contracts.py uses "
+        "tests.adapter_contracts helpers.\n"
+        "  Chaos: yes - tests/confluence/test_chaos.py covers deterministic Confluence "
+        "HTTP failures.\n"
+        "  Replay: yes - make chaos-replay reruns named Confluence chaos scenarios.\n"
+        "  No partial artifacts: yes - Confluence failure tests assert no manifest or "
+        "markdown artifacts are written.\n"
+        "git_repo:\n"
+        "  Contract/invariant: no - Not yet registered in the readiness model.\n"
+        "  Chaos: no - No git_repo chaos scenarios are registered.\n"
+        "  Replay: no - Replay applies to registered chaos scenarios; git_repo has none.\n"
+        "  No partial artifacts: no - No no-partial-artifact failure coverage is registered.\n"
+        "github_metadata:\n"
+        "  Contract/invariant: no - Not yet registered in the readiness model.\n"
+        "  Chaos: no - No github_metadata chaos scenarios are registered.\n"
+        "  Replay: no - Replay applies to registered chaos scenarios; github_metadata has none.\n"
+        "  No partial artifacts: no - No no-partial-artifact failure coverage is registered.\n"
+        "local_files:\n"
+        "  Contract/invariant: no - Not yet registered in the readiness model.\n"
+        "  Chaos: no - No local_files chaos scenarios are registered.\n"
+        "  Replay: no - Replay applies to registered chaos scenarios; local_files has none.\n"
+        "  No partial artifacts: no - No no-partial-artifact failure coverage is registered.\n"
+    )
+
+
+def test_adapter_readiness_report_rejects_incomplete_rows() -> None:
+    row = AdapterReadiness(
+        adapter="example",
+        coverage={"chaos": True},
+        evidence={"chaos": "Example evidence."},
+    )
+
+    with pytest.raises(ValueError, match="coverage keys"):
+        render_adapter_readiness_report((row,))

--- a/tests/test_adapter_readiness.py
+++ b/tests/test_adapter_readiness.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import re
+from pathlib import Path
+
 import pytest
 
 from knowledge_adapters.adapter_readiness import (
@@ -7,6 +10,13 @@ from knowledge_adapters.adapter_readiness import (
     AdapterReadiness,
     adapter_readiness,
     render_adapter_readiness_report,
+)
+from knowledge_adapters.cli import build_parser
+
+NON_ADAPTER_CLI_COMMANDS = {"bundle", "run"}
+REPO_ROOT = Path(__file__).resolve().parents[1]
+EVIDENCE_PATH_RE = re.compile(
+    r"\b(?:[A-Za-z0-9_.-]+/)+[A-Za-z0-9_.-]+\.(?:md|py)\b|\bMakefile\b"
 )
 
 
@@ -32,6 +42,29 @@ def test_adapter_readiness_model_is_sorted_and_complete() -> None:
         "replay": True,
         "no_partial_artifacts": True,
     }
+
+
+def test_adapter_readiness_model_matches_adapter_cli_surfaces() -> None:
+    adapter_commands = _adapter_cli_commands()
+    readiness_adapters = {row.adapter for row in adapter_readiness()}
+
+    assert readiness_adapters == adapter_commands
+
+
+def test_adapter_readiness_evidence_paths_exist() -> None:
+    evidence_paths = {
+        path
+        for row in adapter_readiness()
+        for evidence in row.evidence.values()
+        for path in _evidence_path_references(evidence)
+    }
+
+    assert evidence_paths == {
+        "tests/confluence/test_chaos.py",
+        "tests/confluence/test_contracts.py",
+    }
+    for path in evidence_paths:
+        assert (REPO_ROOT / path).is_file(), path
 
 
 def test_adapter_readiness_report_is_deterministic() -> None:
@@ -86,3 +119,16 @@ def test_adapter_readiness_report_rejects_incomplete_rows() -> None:
 
     with pytest.raises(ValueError, match="coverage keys"):
         render_adapter_readiness_report((row,))
+
+
+def _adapter_cli_commands() -> set[str]:
+    parser = build_parser()
+    for action in parser._actions:
+        choices = getattr(action, "choices", None)
+        if isinstance(choices, dict):
+            return set(choices) - NON_ADAPTER_CLI_COMMANDS
+    raise AssertionError("CLI parser has no subcommands.")
+
+
+def _evidence_path_references(evidence: str) -> tuple[str, ...]:
+    return tuple(match.group(0) for match in EVIDENCE_PATH_RE.finditer(evidence))


### PR DESCRIPTION
## Summary

- add a deterministic adapter readiness report backed by an explicit coverage model
- wire `make adapter-readiness` for local dev/test reporting
- document the readiness dimensions and how to update the model as adapters mature
- add focused tests for deterministic rendering and model completeness

## Validation

- `make adapter-readiness`
- `make check`
- `make chaos-all`

## Residual risks

- Coverage is intentionally registered manually, so future adapter reliability work must update the model when it lands.
- The report reflects observed current coverage only; adapters with regular behavior tests but no registered reliability-harness coverage remain marked `no`.