### PR TITLE
docs: trim workflow doc drift

### DIFF
--- a/docs/codex-workflow.md
+++ b/docs/codex-workflow.md
@@ -4,9 +4,19 @@
 
 This document captures how to use Codex effectively in `knowledge-adapters`.
 
-For reusable prompt structures, thread habits, and broader AI workflow patterns,
-see `ai-workflow-playbook`. This file keeps only the local operating details
-that matter in this repository.
+For shared workflow rules, use:
+
+- `AGENTS.md` for repo-local execution requirements
+- `ai-workflow-playbook/docs/start-here.md` for the canonical workflow entry
+  point
+- `ai-workflow-playbook/docs/tool-adapters/codex.md` for Codex-specific
+  workflow behavior
+- `ai-workflow-playbook/docs/repo-readiness.md` and
+  `ai-workflow-playbook/docs/review-packet.md` for PR readiness and review
+  expectations
+
+This file keeps only the `knowledge-adapters` details that are worth knowing
+while using Codex in this repository.
 
 ## What Codex Is Best Used For Here
 
@@ -25,25 +35,8 @@ Use extra care before asking Codex to drive:
 - live private-system integration work without explicit task constraints
 - unrelated cleanup mixed into the same branch
 
-## Repo-Specific Working Agreement
-
-`AGENTS.md` is the canonical source for task completion requirements in this
-repo. If there is any overlap or inconsistency, `AGENTS.md` takes precedence.
-In practice, that means:
-
-1. start from `main` and work on a new branch
-2. keep the branch scoped to one PR-sized change
-3. run validation through the Makefile, not direct tool invocations
-4. do not consider the task complete until the change is committed, pushed, and
-   opened as a PR targeting `main`
-
-Branch names should follow the patterns in `AGENTS.md`, such as
-`feat/<short-name>` or `docs/<short-name>`.
-
-PRs should be ready for review by default and should include:
-
-- a short `Summary` section
-- a short `Testing` section
+For branch, PR, and validation workflow, follow `AGENTS.md` plus the playbook
+references above instead of treating this document as a second source of truth.
 
 ## Repository Guardrails
 
@@ -55,27 +48,5 @@ Keep changes aligned with the shape of this repository:
 - prefer contract and smoke coverage when changing adapter behavior
 - keep changes minimal and reversible when working on traversal, normalization,
   or incremental-sync behavior
-
-## Validation And CI
-
-The canonical local validation command is:
-
-```bash
-make check
-```
-
-Use the Makefile targets documented in this repo. Do not invoke `pytest`,
-`mypy`, or `ruff` directly when validating a task for completion.
-
-GitHub Actions mirrors that local path in `.github/workflows/ci.yml` through the
-`test` job, which runs `make check`.
-
-The enforced baseline on `main` is currently:
-
-- pull requests are required
-- admin enforcement is enabled
-- the required GitHub status check is `test`
-- required approving review count is `0`
-
-Do not rely on stronger GitHub enforcement than that baseline when writing or
-updating repo docs.
+- when working on CLI or adapter behavior, check nearby docs and examples so
+  command semantics, dry-run behavior, and artifact expectations stay accurate

--- a/docs/feature-delivery-workflow.md
+++ b/docs/feature-delivery-workflow.md
@@ -5,9 +5,16 @@
 This document explains what "feature delivery" should look like in
 `knowledge-adapters`.
 
-Reusable lifecycle models, review patterns, and prompt templates now belong in
-`ai-workflow-playbook`. This file keeps the repo-specific guidance needed to
-ship changes here without depending on that playbook.
+For the shared delivery model, use:
+
+- `AGENTS.md` for repo-local execution requirements
+- `ai-workflow-playbook/docs/feature-lifecycle.md` for the canonical delivery
+  lifecycle
+- `ai-workflow-playbook/docs/repo-readiness.md` for PR readiness defaults
+- `ai-workflow-playbook/docs/review-packet.md` for review packet expectations
+
+This file keeps only the `knowledge-adapters` guidance that is specific to how
+feature work should be shaped in this repository.
 
 ## What A Feature Usually Looks Like In This Repo
 
@@ -26,22 +33,8 @@ along repository seams such as:
 - adapter implementation next
 - CLI or documentation follow-up after behavior is stable
 
-## Repo-Specific Delivery Expectations
-
-When delivering a feature in this repo:
-
-1. work from a new branch based on `main`
-2. keep the change focused on the requested adapter, CLI path, or doc surface
-3. preserve public-safe defaults and avoid checking in secrets or private system
-   details
-4. validate through `make check`
-5. commit, push, and open a PR targeting `main`
-
-Open the PR as ready for review by default unless the task explicitly calls for
-a draft.
-
-`AGENTS.md` remains the canonical source for branch naming, validation, commit
-messages, and completion requirements.
+For branch, PR, and validation mechanics, follow `AGENTS.md` and the playbook
+references above.
 
 ## Feature-Specific Guardrails
 
@@ -51,19 +44,5 @@ Keep feature work grounded in the current design of this repo:
 - keep source-specific logic inside the relevant adapter package
 - update tests when behavior changes, especially around contract boundaries
 - avoid mixing live-integration work with unrelated cleanup
-- keep docs accurate to the current CLI, CI, and branch-protection baseline
-
-## CI And Merge Baseline
-
-The local and CI validation path for feature work is `make check`.
-
-The current enforced baseline on `main` is:
-
-- pull requests are required
-- admins are included in branch protection
-- the required status check is `test`
-- required approving review count is `0`
-
-That baseline is intentionally minimal. Repo docs may recommend a stricter
-working style, but they should not imply stronger enforced GitHub rules than
-those settings.
+- keep docs accurate to the current CLI, output layout, and adapter behavior
+- preserve public-safe defaults and avoid checking in private system details


### PR DESCRIPTION
## Summary
- trim `docs/codex-workflow.md` down to repo-specific Codex guidance that points readers to `AGENTS.md` (repo-local execution) and the canonical `ai-workflow-playbook` docs (shared workflow rules)
- trim `docs/feature-delivery-workflow.md` down to repo-specific feature delivery guidance, keeping repo-specific boundaries and delegating lifecycle and PR-default rules to the playbook
- replace duplicated branch, PR, validation, and lifecycle rules with pointers to canonical workflow docs

This reduces duplication and ensures future workflow changes are made in one place.

## Canonical Docs Referenced
- `ai-workflow-playbook/docs/start-here.md`
- `ai-workflow-playbook/docs/tool-adapters/codex.md`
- `ai-workflow-playbook/docs/feature-lifecycle.md`
- `ai-workflow-playbook/docs/repo-readiness.md`
- `ai-workflow-playbook/docs/review-packet.md`
- `AGENTS.md`

## Validation
- `make check`
- `make check-gh-env`

## Residual Risk
- Low. The change is docs-only and narrows these files so future workflow updates should happen in the playbook instead of drifting here.
