### PR TITLE
AGENTS: enforce thin-adapter rule for workflow docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,8 @@ This repository follows the shared workflow defined in the
 Use the playbook for general workflow rules. Follow this AGENTS.md for
 repo-specific execution details where they are more specific. Repo-local rules
 take precedence only for repo-specific behavior.
+Do not restate shared workflow rules in repo docs; link to ai-workflow-playbook
+and keep only repo-specific guidance.
 
 ## File Placement
 


### PR DESCRIPTION
Summary:
- Add a guardrail to AGENTS.md to prevent repo docs from restating shared workflow rules.

Details:
- Repo docs should link to ai-workflow-playbook for branch/PR/validation/lifecycle rules.
- Repo-local docs should only contain knowledge-adapters-specific guidance.

Why:
- Prevents repo-level shadow canonical workflow.
- Keeps ai-workflow-playbook as the single source of truth.

Validation:
- Docs-only change.
- No behavior changes.

Risk:
- Low; reinforces existing workflow model.