### PR TITLE
[codex] Trim release workflow doc

### DIFF
--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -2,28 +2,27 @@
 
 ## Purpose
 
-This document captures the lightweight release steps for
-`knowledge-adapters`.
+This document is the thin release adapter for `knowledge-adapters`.
 
 Keep the release arc focused on versioning and release metadata. Avoid mixing
 unrelated cleanup into the same PR.
 
+For branch, PR, and validation workflow, follow `AGENTS.md` and
+`ai-workflow-playbook/docs/start-here.md`.
+
 ## Release Steps
 
-1. ensure `main` is clean and up to date
-2. confirm the version bump is present
-3. confirm `CHANGELOG.md` is updated
-4. run `make check`
-5. create a release branch if needed
-6. merge the release PR
-7. sync `main` after the merge:
+1. confirm the version bump is present
+2. confirm `CHANGELOG.md` is updated
+3. validate the post-merge release prerequisites without creating a tag or
+   GitHub release:
 
    ```bash
-   git switch main
-   git pull --ff-only origin main
+   make release-check VERSION=0.8.1
    ```
 
-8. publish the post-merge tag and GitHub release:
+4. after the release PR lands and `main` is current per the shared workflow,
+   publish the post-merge tag and GitHub release:
 
    ```bash
    make release-publish VERSION=0.8.1
@@ -35,7 +34,5 @@ unrelated cleanup into the same PR.
 - `make release-publish` accepts `VERSION=X.Y.Z` or `VERSION=vX.Y.Z`, creates
   the annotated tag as `vX.Y.Z`, and uses the matching `## X.Y.Z` section from
   `CHANGELOG.md` as the GitHub release notes.
-- Use `make release-check VERSION=0.8.1` to validate the post-merge release
-  prerequisites without creating a tag or GitHub release.
 - Ensure the version, `CHANGELOG.md`, and tag all align before merging the
   release PR.


### PR DESCRIPTION
## Summary

- Trimmed `docs/release-workflow.md` into a thin release adapter over shared workflow guidance.
- Replaced generic branch, PR, and validation mechanics with pointers to `AGENTS.md` and `ai-workflow-playbook/docs/start-here.md`.
- Kept repo-specific release behavior for version, changelog, release check, tagging, and GitHub release publishing.

## Validation

- `make check`
- `make check-gh-env`
- Confirmed only `docs/release-workflow.md` is modified in the `knowledge-adapters` branch.

## Notes

- No release behavior changed.