### PR TITLE
[codex] Trim release workflow adapter

### DIFF
--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -7,8 +7,8 @@ This document is the thin release adapter for `knowledge-adapters`.
 Keep the release arc focused on versioning and release metadata. Avoid mixing
 unrelated cleanup into the same PR.
 
-For branch, PR, and validation workflow, follow `AGENTS.md` and
-`ai-workflow-playbook/docs/start-here.md`.
+For shared branch, PR, validation, and current-main workflow, follow
+`AGENTS.md` and `ai-workflow-playbook/docs/start-here.md`.
 
 ## Release Steps
 
@@ -21,8 +21,7 @@ For branch, PR, and validation workflow, follow `AGENTS.md` and
    make release-check VERSION=0.8.1
    ```
 
-4. after the release PR lands and `main` is current per the shared workflow,
-   publish the post-merge tag and GitHub release:
+4. after the release PR lands, publish the post-merge tag and GitHub release:
 
    ```bash
    make release-publish VERSION=0.8.1


### PR DESCRIPTION
## Summary

- Trimmed the release workflow doc so shared branch, PR, validation, and current-main workflow guidance points to `AGENTS.md` and `ai-workflow-playbook/docs/start-here.md`.
- Removed the remaining generic current-main wording from the release publish step while leaving release commands and semantics unchanged.

## Validation

- `make check-gh-env`
- `make check`