### PR TITLE
[codex] refactor auth strategy selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,9 @@ runs:
     dry_run: true
 ```
 
+- `auth_method` selects the adapter auth strategy for real Confluence runs.
+- The default remains `bearer-env`; existing CLI commands and `runs.yaml`
+  entries do not need migration.
 - `bearer-env` reads `CONFLUENCE_BEARER_TOKEN`.
 - Omit `ca_bundle` to fall back to `REQUESTS_CA_BUNDLE` or `SSL_CERT_FILE`.
 - Omit `client_cert_file` and `client_key_file` to fall back to

--- a/docs/github-metadata-v1.md
+++ b/docs/github-metadata-v1.md
@@ -67,6 +67,8 @@ issues, but must not create directories, write issue artifacts, or write
 v1 reads credentials from the environment only:
 
 - `token_env` names the environment variable.
+- `token_env` remains the only user-facing auth selector and maps to the
+  default `token-env` adapter auth strategy.
 - the token value is never supplied directly in CLI arguments or committed
   config
 - the adapter does not store credentials

--- a/src/knowledge_adapters/confluence/auth.py
+++ b/src/knowledge_adapters/confluence/auth.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import os
 import ssl
 from dataclasses import dataclass
+from typing import Protocol
 
-SUPPORTED_AUTH_METHODS = ("bearer-env", "client-cert-env")
 CONFLUENCE_CA_BUNDLE_ENV = "KNOWLEDGE_ADAPTERS_CONFLUENCE_CA_BUNDLE"
 
 
@@ -27,6 +27,94 @@ class ResolvedTLSInputs:
     client_key_file: str | None
 
 
+class ConfluenceAuthStrategy(Protocol):
+    """Small interface for Confluence real-client auth material construction."""
+
+    @property
+    def name(self) -> str:
+        """Stable configuration name for this strategy."""
+
+    def build_request_auth(
+        self,
+        *,
+        ca_bundle: str | None = None,
+        no_ca_bundle: bool = False,
+        client_cert_file: str | None = None,
+        client_key_file: str | None = None,
+    ) -> RequestAuth:
+        """Build request auth material for this strategy."""
+
+
+@dataclass(frozen=True)
+class BearerEnvAuthStrategy:
+    """Build bearer-token auth from the supported Confluence token env var."""
+
+    name: str = "bearer-env"
+
+    def build_request_auth(
+        self,
+        *,
+        ca_bundle: str | None = None,
+        no_ca_bundle: bool = False,
+        client_cert_file: str | None = None,
+        client_key_file: str | None = None,
+    ) -> RequestAuth:
+        return RequestAuth(
+            headers=_bearer_env_headers(),
+            ssl_context=_client_cert_ssl_context(
+                self.name,
+                ca_bundle=ca_bundle,
+                no_ca_bundle=no_ca_bundle,
+                client_cert_file=client_cert_file,
+                client_key_file=client_key_file,
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class ClientCertEnvAuthStrategy:
+    """Build client-certificate auth from the supported Confluence cert env vars."""
+
+    name: str = "client-cert-env"
+
+    def build_request_auth(
+        self,
+        *,
+        ca_bundle: str | None = None,
+        no_ca_bundle: bool = False,
+        client_cert_file: str | None = None,
+        client_key_file: str | None = None,
+    ) -> RequestAuth:
+        return RequestAuth(
+            headers={},
+            ssl_context=_client_cert_ssl_context(
+                self.name,
+                ca_bundle=ca_bundle,
+                no_ca_bundle=no_ca_bundle,
+                client_cert_file=client_cert_file,
+                client_key_file=client_key_file,
+            ),
+        )
+
+
+_AUTH_STRATEGIES: dict[str, ConfluenceAuthStrategy] = {
+    "bearer-env": BearerEnvAuthStrategy(),
+    "client-cert-env": ClientCertEnvAuthStrategy(),
+}
+SUPPORTED_AUTH_METHODS = tuple(_AUTH_STRATEGIES)
+
+
+def select_auth_strategy(auth_method: str) -> ConfluenceAuthStrategy:
+    """Select a supported Confluence auth strategy by its stable config name."""
+    try:
+        return _AUTH_STRATEGIES[auth_method]
+    except KeyError as exc:
+        supported_values = " or ".join(repr(method) for method in SUPPORTED_AUTH_METHODS)
+        raise ValueError(
+            f"Unsupported Confluence auth method {auth_method!r}. Use {supported_values}."
+        ) from exc
+
+
 def build_request_auth(
     auth_method: str,
     *,
@@ -36,25 +124,11 @@ def build_request_auth(
     client_key_file: str | None = None,
 ) -> RequestAuth:
     """Build auth material for a supported auth method."""
-    if auth_method == "bearer-env":
-        headers = _bearer_env_headers()
-    elif auth_method == "client-cert-env":
-        headers = {}
-    else:
-        supported_values = " or ".join(repr(method) for method in SUPPORTED_AUTH_METHODS)
-        raise ValueError(
-            f"Unsupported Confluence auth method {auth_method!r}. Use {supported_values}."
-        )
-
-    return RequestAuth(
-        headers=headers,
-        ssl_context=_client_cert_ssl_context(
-            auth_method,
-            ca_bundle=ca_bundle,
-            no_ca_bundle=no_ca_bundle,
-            client_cert_file=client_cert_file,
-            client_key_file=client_key_file,
-        ),
+    return select_auth_strategy(auth_method).build_request_auth(
+        ca_bundle=ca_bundle,
+        no_ca_bundle=no_ca_bundle,
+        client_cert_file=client_cert_file,
+        client_key_file=client_key_file,
     )
 
 

--- a/src/knowledge_adapters/github_metadata/auth.py
+++ b/src/knowledge_adapters/github_metadata/auth.py
@@ -1,0 +1,88 @@
+"""Authentication helpers for the github_metadata adapter."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Protocol
+
+GITHUB_API_VERSION = "2022-11-28"
+DEFAULT_AUTH_STRATEGY = "token-env"
+
+
+@dataclass(frozen=True)
+class RequestAuth:
+    """Request auth material for github_metadata API reads."""
+
+    headers: dict[str, str]
+    token_env: str
+
+
+class GitHubMetadataAuthStrategy(Protocol):
+    """Small interface for GitHub metadata request auth construction."""
+
+    @property
+    def name(self) -> str:
+        """Stable configuration name for this strategy."""
+
+    def build_request_auth(self, *, token_env: str) -> RequestAuth:
+        """Build request auth material for this strategy."""
+
+
+@dataclass(frozen=True)
+class TokenEnvAuthStrategy:
+    """Build bearer-token auth from the configured token environment variable."""
+
+    name: str = DEFAULT_AUTH_STRATEGY
+
+    def build_request_auth(self, *, token_env: str) -> RequestAuth:
+        token_env_name, token = resolve_token(token_env)
+        return RequestAuth(
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {token}",
+                "User-Agent": "knowledge-adapters-github-metadata",
+                "X-GitHub-Api-Version": GITHUB_API_VERSION,
+            },
+            token_env=token_env_name,
+        )
+
+
+_AUTH_STRATEGIES: dict[str, GitHubMetadataAuthStrategy] = {
+    DEFAULT_AUTH_STRATEGY: TokenEnvAuthStrategy(),
+}
+SUPPORTED_AUTH_STRATEGIES = tuple(_AUTH_STRATEGIES)
+
+
+def select_auth_strategy(auth_strategy: str) -> GitHubMetadataAuthStrategy:
+    """Select a supported GitHub metadata auth strategy by stable config name."""
+    try:
+        return _AUTH_STRATEGIES[auth_strategy]
+    except KeyError as exc:
+        supported_values = " or ".join(repr(strategy) for strategy in SUPPORTED_AUTH_STRATEGIES)
+        raise ValueError(
+            f"Unsupported GitHub metadata auth strategy {auth_strategy!r}. Use {supported_values}."
+        ) from exc
+
+
+def build_request_auth(
+    token_env: str,
+    *,
+    auth_strategy: str = DEFAULT_AUTH_STRATEGY,
+) -> RequestAuth:
+    """Build auth material for a supported GitHub metadata auth strategy."""
+    return select_auth_strategy(auth_strategy).build_request_auth(token_env=token_env)
+
+
+def resolve_token(token_env: str) -> tuple[str, str]:
+    """Resolve the GitHub token from an environment variable name."""
+    normalized_token_env = token_env.strip()
+    if not normalized_token_env:
+        raise ValueError("token_env must name a non-empty environment variable.")
+
+    token = os.getenv(normalized_token_env)
+    if token is None or not token.strip():
+        raise ValueError(
+            f"token_env {normalized_token_env!r} is not set or contains an empty value."
+        )
+    return normalized_token_env, token.strip()

--- a/src/knowledge_adapters/github_metadata/client.py
+++ b/src/knowledge_adapters/github_metadata/client.py
@@ -3,16 +3,22 @@
 from __future__ import annotations
 
 import json
-import os
 from dataclasses import dataclass, replace
 from datetime import datetime
 from urllib import parse, request
 from urllib.error import HTTPError, URLError
 
+from knowledge_adapters.github_metadata.auth import (
+    RequestAuth,
+    build_request_auth,
+)
+from knowledge_adapters.github_metadata.auth import (
+    resolve_token as resolve_token,
+)
+
 SUPPORTED_ISSUE_STATES = frozenset({"open", "closed", "all"})
 DEFAULT_GITHUB_WEB_ROOT = "https://github.com"
 DEFAULT_GITHUB_API_ROOT = "https://api.github.com"
-GITHUB_API_VERSION = "2022-11-28"
 _PAGE_SIZE = 100
 
 
@@ -189,20 +195,6 @@ def validate_max_items(max_items: int | None) -> int | None:
     return max_items
 
 
-def resolve_token(token_env: str) -> tuple[str, str]:
-    """Resolve the GitHub token from an environment variable name."""
-    normalized_token_env = token_env.strip()
-    if not normalized_token_env:
-        raise ValueError("token_env must name a non-empty environment variable.")
-
-    token = os.getenv(normalized_token_env)
-    if token is None or not token.strip():
-        raise ValueError(
-            f"token_env {normalized_token_env!r} is not set or contains an empty value."
-        )
-    return normalized_token_env, token.strip()
-
-
 def issue_list_api_url(
     *,
     api_root: str,
@@ -275,7 +267,7 @@ def list_repository_issues(
     normalized_since = validate_since(since)
     normalized_max_items = validate_max_items(max_items)
     base_urls = resolve_base_urls(base_url)
-    token_env_name, token = resolve_token(token_env)
+    request_auth = build_request_auth(token_env)
 
     next_url: str | None = issue_list_api_url(
         api_root=base_urls.api_root,
@@ -293,8 +285,7 @@ def list_repository_issues(
 
         payload, link_header = _request_json_list(
             next_url,
-            token=token,
-            token_env=token_env_name,
+            request_auth=request_auth,
             repo=normalized_repo,
             api_root=base_urls.api_root,
         )
@@ -328,8 +319,7 @@ def list_repository_issues(
                 repo_name=repo_name,
                 repo=normalized_repo,
                 api_root=base_urls.api_root,
-                token=token,
-                token_env=token_env_name,
+                request_auth=request_auth,
             ),
         )
         for issue in selected_issues
@@ -351,7 +341,7 @@ def list_repository_pull_requests(
     normalized_since = validate_since(since)
     normalized_max_items = validate_max_items(max_items)
     base_urls = resolve_base_urls(base_url)
-    token_env_name, token = resolve_token(token_env)
+    request_auth = build_request_auth(token_env)
 
     next_url: str | None = pull_request_list_api_url(
         api_root=base_urls.api_root,
@@ -368,8 +358,7 @@ def list_repository_pull_requests(
 
         payload, link_header = _request_json_list(
             next_url,
-            token=token,
-            token_env=token_env_name,
+            request_auth=request_auth,
             repo=normalized_repo,
             api_root=base_urls.api_root,
         )
@@ -413,7 +402,7 @@ def list_repository_releases(
     normalized_since = validate_since(since)
     normalized_max_items = validate_max_items(max_items)
     base_urls = resolve_base_urls(base_url)
-    token_env_name, token = resolve_token(token_env)
+    request_auth = build_request_auth(token_env)
 
     next_url: str | None = release_list_api_url(
         api_root=base_urls.api_root,
@@ -429,8 +418,7 @@ def list_repository_releases(
 
         payload, link_header = _request_json_list(
             next_url,
-            token=token,
-            token_env=token_env_name,
+            request_auth=request_auth,
             repo=normalized_repo,
             api_root=base_urls.api_root,
         )
@@ -642,8 +630,7 @@ def _list_issue_comments(
     repo_name: str,
     repo: str,
     api_root: str,
-    token: str,
-    token_env: str,
+    request_auth: RequestAuth,
 ) -> tuple[GitHubIssueComment, ...]:
     next_url: str | None = issue_comments_api_url(
         api_root=api_root,
@@ -660,8 +647,7 @@ def _list_issue_comments(
 
         payload, link_header = _request_json_list(
             next_url,
-            token=token,
-            token_env=token_env,
+            request_auth=request_auth,
             repo=repo,
             api_root=api_root,
         )
@@ -734,19 +720,13 @@ def _require_bool(payload: dict[str, object], key: str) -> bool:
 def _request_json_list(
     api_url: str,
     *,
-    token: str,
-    token_env: str,
+    request_auth: RequestAuth,
     repo: str,
     api_root: str,
 ) -> tuple[list[dict[str, object]], str | None]:
     api_request = request.Request(
         api_url,
-        headers={
-            "Accept": "application/vnd.github+json",
-            "Authorization": f"Bearer {token}",
-            "User-Agent": "knowledge-adapters-github-metadata",
-            "X-GitHub-Api-Version": GITHUB_API_VERSION,
-        },
+        headers=dict(request_auth.headers),
     )
     try:
         with request.urlopen(api_request, timeout=30) as response:
@@ -754,7 +734,12 @@ def _request_json_list(
             link_header = response.headers.get("Link")
     except HTTPError as exc:
         raise GitHubMetadataRequestError(
-            _request_failure_message(exc, repo=repo, api_root=api_root, token_env=token_env)
+            _request_failure_message(
+                exc,
+                repo=repo,
+                api_root=api_root,
+                token_env=request_auth.token_env,
+            )
         ) from exc
     except URLError as exc:
         raise GitHubMetadataRequestError(

--- a/tests/confluence/test_auth.py
+++ b/tests/confluence/test_auth.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import ssl
+from typing import cast
+
+import pytest
+from pytest import MonkeyPatch
+
+from knowledge_adapters.confluence.auth import (
+    SUPPORTED_AUTH_METHODS,
+    build_request_auth,
+    select_auth_strategy,
+)
+
+
+class _FakeSSLContext:
+    def __init__(self) -> None:
+        self.loaded_cert_chain: tuple[str, str | None] | None = None
+
+    def load_cert_chain(self, *, certfile: str, keyfile: str | None = None) -> None:
+        self.loaded_cert_chain = (certfile, keyfile)
+
+
+def test_confluence_auth_strategy_selection_keeps_stable_names() -> None:
+    assert SUPPORTED_AUTH_METHODS == ("bearer-env", "client-cert-env")
+    assert select_auth_strategy("bearer-env").name == "bearer-env"
+    assert select_auth_strategy("client-cert-env").name == "client-cert-env"
+
+
+def test_confluence_auth_strategy_selection_rejects_unknown_method() -> None:
+    with pytest.raises(
+        ValueError,
+        match="Unsupported Confluence auth method 'oauth'. Use 'bearer-env' or 'client-cert-env'.",
+    ):
+        select_auth_strategy("oauth")
+
+
+def test_confluence_bearer_strategy_preserves_header_and_tls_defaults(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", " test-token ")
+
+    request_auth = build_request_auth("bearer-env")
+
+    assert request_auth.headers == {"Authorization": "Bearer test-token"}
+    assert request_auth.ssl_context is None
+
+
+def test_confluence_client_cert_strategy_uses_tls_without_auth_header(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    ssl_context = _FakeSSLContext()
+    ssl_context_for_return = cast(ssl.SSLContext, ssl_context)
+
+    monkeypatch.setattr(
+        "knowledge_adapters.confluence.auth.ssl.create_default_context",
+        lambda *, cafile=None: ssl_context_for_return,
+    )
+
+    request_auth = build_request_auth(
+        "client-cert-env",
+        client_cert_file="/tmp/confluence-client.crt",
+        client_key_file="/tmp/confluence-client.key",
+    )
+
+    assert request_auth.headers == {}
+    assert request_auth.ssl_context is ssl_context_for_return
+    assert ssl_context.loaded_cert_chain == (
+        "/tmp/confluence-client.crt",
+        "/tmp/confluence-client.key",
+    )
+
+
+def test_confluence_client_cert_strategy_rejects_missing_certificate() -> None:
+    with pytest.raises(
+        ValueError,
+        match="Missing Confluence client certificate",
+    ):
+        build_request_auth("client-cert-env")
+
+
+def test_confluence_client_cert_strategy_wraps_invalid_tls_config(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    def fail_create_default_context(*, cafile: str | None = None) -> ssl.SSLContext:
+        del cafile
+        raise ssl.SSLError("bad tls")
+
+    monkeypatch.setattr(
+        "knowledge_adapters.confluence.auth.ssl.create_default_context",
+        fail_create_default_context,
+    )
+
+    with pytest.raises(ValueError, match="Invalid Confluence CA bundle"):
+        build_request_auth("client-cert-env", client_cert_file="/tmp/confluence-client.pem")

--- a/tests/test_github_metadata_auth.py
+++ b/tests/test_github_metadata_auth.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import pytest
+from pytest import MonkeyPatch
+
+from knowledge_adapters.github_metadata.auth import (
+    DEFAULT_AUTH_STRATEGY,
+    SUPPORTED_AUTH_STRATEGIES,
+    build_request_auth,
+    select_auth_strategy,
+)
+
+
+def test_github_metadata_auth_strategy_selection_keeps_stable_default() -> None:
+    assert DEFAULT_AUTH_STRATEGY == "token-env"
+    assert SUPPORTED_AUTH_STRATEGIES == ("token-env",)
+    assert select_auth_strategy("token-env").name == "token-env"
+
+
+def test_github_metadata_auth_strategy_selection_rejects_unknown_strategy() -> None:
+    with pytest.raises(
+        ValueError,
+        match="Unsupported GitHub metadata auth strategy 'oauth'. Use 'token-env'.",
+    ):
+        select_auth_strategy("oauth")
+
+
+def test_github_metadata_token_env_strategy_builds_existing_headers(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GH_TOKEN", " secret-token ")
+
+    request_auth = build_request_auth(" GH_TOKEN ")
+
+    assert request_auth.token_env == "GH_TOKEN"
+    assert request_auth.headers == {
+        "Accept": "application/vnd.github+json",
+        "Authorization": "Bearer secret-token",
+        "User-Agent": "knowledge-adapters-github-metadata",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+
+def test_github_metadata_token_env_strategy_rejects_empty_env_name() -> None:
+    with pytest.raises(ValueError, match="token_env must name a non-empty environment variable"):
+        build_request_auth("   ")
+
+
+def test_github_metadata_token_env_strategy_rejects_missing_token(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+
+    with pytest.raises(ValueError, match="token_env 'GH_TOKEN' is not set"):
+        build_request_auth("GH_TOKEN")


### PR DESCRIPTION
## Summary

- Added explicit, small auth strategy selection for Confluence real-client auth while preserving the existing `bearer-env` default and `client-cert-env` behavior.
- Moved GitHub metadata token/header construction into a dedicated auth helper and kept `token_env` as the only user-facing selector.
- Added focused tests for strategy selection, compatibility headers/TLS material, and missing/unsupported auth errors.
- Updated nearby docs to note that existing Confluence auth config and GitHub metadata `token_env` usage do not need migration.

## Validation

- `make check` passed: Ruff, mypy, and 391 pytest tests.
- `make check-gh-env` passed before opening this PR.

## Authoritative Auth Sources Checked

- GitHub REST getting-started docs describe the `Accept`, `X-GitHub-Api-Version`, and `Authorization` request headers, including `Authorization: Bearer YOUR-TOKEN`: https://docs.github.com/en/rest/using-the-rest-api/getting-started-with-the-rest-api
- Atlassian Confluence Cloud REST API docs state direct REST API authentication supports basic auth and authorization follows the authenticated user: https://developer.atlassian.com/cloud/confluence/rest/v1/intro/
- Atlassian Confluence Data Center REST API docs state Confluence REST access follows normal Confluence auth/permission checks and mention personal access tokens for Data Center 7.9+: https://developer.atlassian.com/server/confluence/confluence-server-rest-api/

## Residual Risks

- I did not find official Atlassian documentation confirming a universal Confluence `Authorization: Bearer` or client-certificate auth scheme for every Confluence deployment. This PR intentionally preserves the adapter's existing `bearer-env` and `client-cert-env` behavior instead of changing provider semantics.