### PR TITLE
Classify adapter failures

### DIFF
--- a/docs/confluence-real-client.md
+++ b/docs/confluence-real-client.md
@@ -226,6 +226,25 @@ The CLI should select the client mode and surface high-level errors, but it shou
 ## Error Behavior
 
 v1 should use fail-fast behavior with small, testable error categories surfaced by the real client.
+Confluence REST uses standard HTTP status codes and can return `429` with
+`Retry-After` for rate limits; see Atlassian's Confluence REST API reference and
+rate limiting guidance:
+
+- https://developer.atlassian.com/cloud/confluence/rest/v1/intro/
+- https://developer.atlassian.com/cloud/confluence/rate-limiting/
+
+The CLI keeps the existing concise error message and adds a stable
+`failure_class` detail line for classified real-client failures:
+
+- `auth`: authentication or authorization failure, including Confluence `401`
+  or `403`
+- `configuration`: missing or invalid local auth, TLS, or client certificate
+  inputs
+- `expected_retryable`: rate limiting, network timeouts, connection failures, or
+  other transport failures that operators may retry after the cause clears
+- `permanent`: not-found responses or malformed response payloads that should
+  not be retried without changing inputs or adapter behavior
+- `provider`: Confluence `5xx` provider-side failures
 
 ### Auth failure
 
@@ -240,9 +259,9 @@ Behavior:
 - do not write files
 - do not write or replace `manifest.json`
 
-Suggested error category:
+Failure class:
 
-- auth error
+- `auth`, except missing local credential material is `configuration`
 
 ### Page not found
 
@@ -256,9 +275,9 @@ Behavior:
 - do not write files
 - do not write or replace `manifest.json`
 
-Suggested error category:
+Failure class:
 
-- not found error
+- `permanent`
 
 ### Malformed or unexpected response shape
 
@@ -276,9 +295,9 @@ Behavior:
 - do not write files
 - do not write or replace `manifest.json`
 
-Suggested error category:
+Failure class:
 
-- response error
+- `permanent`
 
 ### Child-page discovery failure
 
@@ -298,7 +317,8 @@ v1 test coverage should rely on mocked or fixture-based tests for:
 - auth config validation for `bearer-env` and `client-cert-env`
 - request construction for the real client
 - response-to-payload mapping
-- error mapping for `401/403`, `404`, and malformed response bodies
+- error mapping and classification for `401/403`, `404`, `429`, `5xx`,
+  transport failures, and malformed response bodies
 - rejection of unsupported real-mode tree usage
 
 ### Preferred test style

--- a/docs/github-metadata-v1.md
+++ b/docs/github-metadata-v1.md
@@ -80,6 +80,12 @@ run must fail before making an API request. Authentication and authorization
 failures from GitHub should report the status code and repository being read,
 without printing the token.
 
+GitHub REST troubleshooting documents rate-limit responses, retry headers,
+authentication and permission troubleshooting, `404` behavior for inaccessible
+private resources, validation failures, and server timeouts:
+
+- https://docs.github.com/en/rest/using-the-rest-api/troubleshooting-the-rest-api
+
 ## API Behavior
 
 v1 uses the REST API only.
@@ -108,12 +114,22 @@ Basic error behavior:
 
 - invalid `repo`, `state`, `since`, or `max_items` values fail before requests
   where possible
-- 401 and 403 responses fail clearly with auth or authorization context
-- rate-limit responses fail clearly with the reset time or retry hint when
-  present
-- 404 responses fail clearly with the repository and base URL context
-- transient 5xx responses may be retried with a small fixed retry count, but v1
-  should not introduce a long-running scheduler or background retry system
+- classified failures add a stable `failure_class` detail line while preserving
+  the concise error message
+- `configuration`: invalid adapter inputs or missing local token environment
+  configuration
+- `auth`: `401` or non-rate-limit `403` responses
+- `expected_retryable`: GitHub rate-limit responses, including `403` or `429`
+  with rate-limit headers, and transport failures
+- `permanent`: `404`, invalid response payloads, and other non-retryable
+  request errors
+- `provider`: GitHub `5xx` provider-side failures
+
+GitHub may return `404` for an existing private resource when authentication or
+permissions are insufficient. The adapter keeps `404` classified as
+`permanent` because the response is not enough to reliably distinguish an
+unknown repository from a private inaccessible one; the message still says
+`not found or inaccessible`.
 
 ## Ordering
 

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -27,6 +27,7 @@ from knowledge_adapters.bundle import (
     describe_stale_mode,
 )
 from knowledge_adapters.confluence.auth import SUPPORTED_AUTH_METHODS, resolve_tls_inputs
+from knowledge_adapters.failures import adapter_failure_lines, response_or_config_failure
 
 TOP_LEVEL_HELP_EXAMPLES = """First steps:
   knowledge-adapters --help
@@ -1873,6 +1874,14 @@ def main(argv: Sequence[str] | None = None) -> int:
                 f"debug exception: {exc.underlying_error}",
             )
 
+        def _confluence_failure_lines(exc: RuntimeError | ValueError) -> tuple[str, ...] | None:
+            fallback = response_or_config_failure(exc) if isinstance(exc, ValueError) else None
+            lines = (
+                *adapter_failure_lines(exc, fallback=fallback),
+                *(_confluence_debug_lines(exc) or ()),
+            )
+            return lines or None
+
         def _build_manifest_entry_for_page(
             page: dict[str, object],
             output_path: Path,
@@ -2191,7 +2200,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 exit_with_cli_error(
                     str(exc),
                     command="confluence",
-                    debug_lines=_confluence_debug_lines(exc),
+                    debug_lines=_confluence_failure_lines(exc),
                 )
 
             _finish_progress_line()
@@ -2321,7 +2330,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 exit_with_cli_error(
                     str(exc),
                     command="confluence",
-                    debug_lines=_confluence_debug_lines(exc),
+                    debug_lines=_confluence_failure_lines(exc),
                 )
 
             try:
@@ -2397,7 +2406,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     exit_with_cli_error(
                         str(exc),
                         command="confluence",
-                        debug_lines=_confluence_debug_lines(exc),
+                        debug_lines=_confluence_failure_lines(exc),
                     )
             else:
                 root_page_id, pages = walk_pages(
@@ -2534,7 +2543,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 exit_with_cli_error(
                     str(exc),
                     command="confluence",
-                    debug_lines=_confluence_debug_lines(exc),
+                    debug_lines=_confluence_failure_lines(exc),
                 )
 
             try:
@@ -2605,7 +2614,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             exit_with_cli_error(
                 str(exc),
                 command="confluence",
-                debug_lines=_confluence_debug_lines(exc),
+                debug_lines=_confluence_failure_lines(exc),
             )
 
         _print_confluence_invocation()
@@ -2640,7 +2649,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     exit_with_cli_error(
                         str(exc),
                         command="confluence",
-                        debug_lines=_confluence_debug_lines(exc),
+                        debug_lines=_confluence_failure_lines(exc),
                     )
             planned_markdown = normalize_to_markdown(planned_page) if action == "write" else None
             _print_single_page_plan(
@@ -2704,7 +2713,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             exit_with_cli_error(
                 str(exc),
                 command="confluence",
-                debug_lines=_confluence_debug_lines(exc),
+                debug_lines=_confluence_failure_lines(exc),
             )
         except OSError as exc:
             exit_with_output_error(
@@ -3184,7 +3193,12 @@ def main(argv: Sequence[str] | None = None) -> int:
                     max_items=github_metadata_config.max_items,
                 )
         except (GitHubMetadataRequestError, ValueError) as exc:
-            exit_with_cli_error(str(exc), command="github_metadata")
+            fallback = response_or_config_failure(exc) if isinstance(exc, ValueError) else None
+            exit_with_cli_error(
+                str(exc),
+                command="github_metadata",
+                debug_lines=adapter_failure_lines(exc, fallback=fallback) or None,
+            )
 
         print("GitHub metadata adapter invoked")
         print(f"  repo: {github_metadata_config.repo}")

--- a/src/knowledge_adapters/confluence/client.py
+++ b/src/knowledge_adapters/confluence/client.py
@@ -13,6 +13,7 @@ from urllib.error import HTTPError, URLError
 from knowledge_adapters.confluence.auth import build_request_auth
 from knowledge_adapters.confluence.models import ResolvedTarget
 from knowledge_adapters.confluence.traversal import DISCOVERY_PROGRESS_INTERVAL
+from knowledge_adapters.failures import AdapterFailureClass, AdapterFailureClassification
 
 
 class ConfluenceRequestError(RuntimeError):
@@ -25,11 +26,13 @@ class ConfluenceRequestError(RuntimeError):
         request_url: str,
         auth_method: str,
         underlying_error: str,
+        classification: AdapterFailureClassification | None = None,
     ) -> None:
         super().__init__(message)
         self.request_url = request_url
         self.auth_method = auth_method
         self.underlying_error = underlying_error
+        self.classification = classification
 
 
 DiscoveryProgressCallback = Callable[[int], None]
@@ -347,6 +350,42 @@ def _looks_like_network_error(reason: object) -> bool:
     )
 
 
+def _request_failure_classification(exc: HTTPError | URLError) -> AdapterFailureClassification:
+    if isinstance(exc, HTTPError):
+        retry_after = exc.headers.get("Retry-After") if exc.headers is not None else None
+        if exc.code in {401, 403}:
+            return AdapterFailureClassification(
+                AdapterFailureClass.AUTH,
+                provider_status_code=exc.code,
+            )
+        if exc.code == 429:
+            return AdapterFailureClassification(
+                AdapterFailureClass.EXPECTED_RETRYABLE,
+                provider_status_code=exc.code,
+                retry_after=retry_after,
+            )
+        if exc.code == 404:
+            return AdapterFailureClassification(
+                AdapterFailureClass.PERMANENT,
+                provider_status_code=exc.code,
+            )
+        if 500 <= exc.code <= 599:
+            return AdapterFailureClassification(
+                AdapterFailureClass.PROVIDER,
+                provider_status_code=exc.code,
+                retry_after=retry_after,
+            )
+        return AdapterFailureClassification(
+            AdapterFailureClass.PERMANENT,
+            provider_status_code=exc.code,
+        )
+
+    reason = exc.reason
+    if _looks_like_tls_or_cert_error(reason):
+        return AdapterFailureClassification(AdapterFailureClass.CONFIGURATION)
+    return AdapterFailureClassification(AdapterFailureClass.EXPECTED_RETRYABLE)
+
+
 def _request_failure_message(exc: HTTPError | URLError, *, auth_method: str) -> str:
     if isinstance(exc, HTTPError):
         if exc.code in {401, 403}:
@@ -399,6 +438,7 @@ def _request_json(
             request_url=api_url,
             auth_method=auth_method,
             underlying_error=_underlying_request_error_message(exc),
+            classification=_request_failure_classification(exc),
         ) from exc
     except json.JSONDecodeError as exc:
         raise ValueError("Response error: invalid JSON payload.") from exc

--- a/src/knowledge_adapters/failures.py
+++ b/src/knowledge_adapters/failures.py
@@ -1,0 +1,65 @@
+"""Shared failure classification helpers for adapter errors."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Protocol
+
+
+class AdapterFailureClass(StrEnum):
+    """Stable adapter failure classes for operator handling and tests."""
+
+    EXPECTED_RETRYABLE = "expected_retryable"
+    PERMANENT = "permanent"
+    AUTH = "auth"
+    CONFIGURATION = "configuration"
+    PROVIDER = "provider"
+
+
+@dataclass(frozen=True)
+class AdapterFailureClassification:
+    """Structured classification for one adapter failure."""
+
+    failure_class: AdapterFailureClass
+    provider_status_code: int | None = None
+    retry_after: str | None = None
+
+
+class ClassifiedAdapterError(Protocol):
+    """Protocol for exceptions that carry adapter failure classification."""
+
+    classification: AdapterFailureClassification | None
+
+
+def response_or_config_failure(exc: Exception) -> AdapterFailureClassification:
+    """Classify untyped adapter exceptions without changing their public type."""
+    if isinstance(exc, ValueError) and str(exc).startswith("Response error:"):
+        return AdapterFailureClassification(AdapterFailureClass.PERMANENT)
+    return AdapterFailureClassification(AdapterFailureClass.CONFIGURATION)
+
+
+def adapter_failure_classification(exc: Exception) -> AdapterFailureClassification | None:
+    """Return structured classification attached to an adapter exception."""
+    classification = getattr(exc, "classification", None)
+    if isinstance(classification, AdapterFailureClassification):
+        return classification
+    return None
+
+
+def adapter_failure_lines(
+    exc: Exception,
+    *,
+    fallback: AdapterFailureClassification | None = None,
+) -> tuple[str, ...]:
+    """Render stable CLI detail lines for an adapter failure."""
+    classification = adapter_failure_classification(exc) or fallback
+    if classification is None:
+        return ()
+
+    lines = [f"failure_class: {classification.failure_class.value}"]
+    if classification.provider_status_code is not None:
+        lines.append(f"provider_status_code: {classification.provider_status_code}")
+    if classification.retry_after is not None:
+        lines.append(f"retry_after: {classification.retry_after}")
+    return tuple(lines)

--- a/src/knowledge_adapters/github_metadata/client.py
+++ b/src/knowledge_adapters/github_metadata/client.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from urllib import parse, request
 from urllib.error import HTTPError, URLError
 
+from knowledge_adapters.failures import AdapterFailureClass, AdapterFailureClassification
 from knowledge_adapters.github_metadata.auth import (
     RequestAuth,
     build_request_auth,
@@ -109,6 +110,15 @@ class GitHubRelease:
 
 class GitHubMetadataRequestError(RuntimeError):
     """Stable request failure for github_metadata API reads."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        classification: AdapterFailureClassification | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.classification = classification
 
 
 def resolve_base_urls(base_url: str | None = None) -> GitHubMetadataBaseUrls:
@@ -739,11 +749,13 @@ def _request_json_list(
                 repo=repo,
                 api_root=api_root,
                 token_env=request_auth.token_env,
-            )
+            ),
+            classification=_request_failure_classification(exc),
         ) from exc
     except URLError as exc:
         raise GitHubMetadataRequestError(
-            f"GitHub request failed while reading {repo} from {api_root}: {exc.reason}."
+            f"GitHub request failed while reading {repo} from {api_root}: {exc.reason}.",
+            classification=AdapterFailureClassification(AdapterFailureClass.EXPECTED_RETRYABLE),
         ) from exc
     except json.JSONDecodeError as exc:
         raise ValueError("Response error: invalid JSON payload.") from exc
@@ -778,6 +790,36 @@ def _request_failure_message(
     if 500 <= exc.code <= 599:
         return f"GitHub request failed (status {exc.code}) while reading {repo} from {api_root}."
     return f"GitHub request failed (status {exc.code}) while reading {repo} from {api_root}."
+
+
+def _request_failure_classification(exc: HTTPError) -> AdapterFailureClassification:
+    retry_after = exc.headers.get("Retry-After") if exc.headers is not None else None
+    if _rate_limit_hint(exc) is not None:
+        return AdapterFailureClassification(
+            AdapterFailureClass.EXPECTED_RETRYABLE,
+            provider_status_code=exc.code,
+            retry_after=retry_after,
+        )
+    if exc.code in {401, 403}:
+        return AdapterFailureClassification(
+            AdapterFailureClass.AUTH,
+            provider_status_code=exc.code,
+        )
+    if exc.code == 404:
+        return AdapterFailureClassification(
+            AdapterFailureClass.PERMANENT,
+            provider_status_code=exc.code,
+        )
+    if 500 <= exc.code <= 599:
+        return AdapterFailureClassification(
+            AdapterFailureClass.PROVIDER,
+            provider_status_code=exc.code,
+            retry_after=retry_after,
+        )
+    return AdapterFailureClassification(
+        AdapterFailureClass.PERMANENT,
+        provider_status_code=exc.code,
+    )
 
 
 def _rate_limit_hint(exc: HTTPError) -> str | None:

--- a/tests/confluence/test_chaos.py
+++ b/tests/confluence/test_chaos.py
@@ -108,27 +108,36 @@ def test_confluence_chaos_payload_failures_are_clear(
 
 
 @pytest.mark.parametrize(
-    ("scenario", "expected_message"),
+    ("scenario", "expected_message", "expected_detail_lines"),
     [
         (
             AdapterChaosScenario.TIMEOUT,
             "Confluence network request failed. Verify --base-url and network access.",
+            ("failure_class: expected_retryable",),
         ),
         (
             AdapterChaosScenario.RATE_LIMIT,
             "Confluence request failed (status 429). Verify --base-url and access.",
+            (
+                "failure_class: expected_retryable",
+                "provider_status_code: 429",
+                "retry_after: 60",
+            ),
         ),
         (
             AdapterChaosScenario.INVALID_JSON,
             "Response error: invalid JSON payload.",
+            ("failure_class: permanent",),
         ),
         (
             AdapterChaosScenario.EMPTY_RESPONSE,
             "Response error: invalid JSON payload.",
+            ("failure_class: permanent",),
         ),
         (
             AdapterChaosScenario.PARTIAL_PAYLOAD,
             "Response error: missing content.",
+            ("failure_class: permanent",),
         ),
     ],
 )
@@ -138,6 +147,7 @@ def test_confluence_cli_real_mode_surfaces_chaos_without_artifacts(
     confluence_chaos: ConfluenceChaosInstaller,
     scenario: AdapterChaosScenario,
     expected_message: str,
+    expected_detail_lines: tuple[str, ...],
 ) -> None:
     confluence_chaos(scenario)
     output_dir = tmp_path / "out"
@@ -148,7 +158,11 @@ def test_confluence_cli_real_mode_surfaces_chaos_without_artifacts(
     assert exc_info.value.code == 2
     captured = capsys.readouterr()
     assert captured.out == ""
-    assert captured.err == f"knowledge-adapters confluence: error: {expected_message}\n"
+    expected_detail_text = "".join(f"  {line}\n" for line in expected_detail_lines)
+    assert (
+        captured.err
+        == f"knowledge-adapters confluence: error: {expected_message}\n{expected_detail_text}"
+    )
     assert_no_partial_adapter_artifacts(output_dir)
 
 

--- a/tests/confluence/test_traversal_real.py
+++ b/tests/confluence/test_traversal_real.py
@@ -200,11 +200,13 @@ def _assert_concise_cli_error(
     capsys: CaptureFixture[str],
     *,
     expected_message: str,
+    expected_detail_lines: tuple[str, ...] = (),
 ) -> None:
     captured = capsys.readouterr()
+    expected_detail_text = "".join(f"  {line}\n" for line in expected_detail_lines)
     assert (
         captured.err
-        == f"knowledge-adapters confluence: error: {expected_message}\n"
+        == f"knowledge-adapters confluence: error: {expected_message}\n{expected_detail_text}"
     )
 
 
@@ -1733,6 +1735,7 @@ def test_real_tree_stops_immediately_on_malformed_child_list_response(
     _assert_concise_cli_error(
         capsys,
         expected_message="Response error: invalid child-list payload.",
+        expected_detail_lines=("failure_class: permanent",),
     )
     _assert_no_artifacts_written(output_dir)
 
@@ -1823,6 +1826,7 @@ def test_real_tree_stops_immediately_on_missing_or_invalid_child_ids(
     _assert_concise_cli_error(
         capsys,
         expected_message="Response error: invalid child page ID.",
+        expected_detail_lines=("failure_class: permanent",),
     )
     _assert_no_artifacts_written(output_dir)
 

--- a/tests/test_confluence_real_client_contract.py
+++ b/tests/test_confluence_real_client_contract.py
@@ -13,7 +13,9 @@ import pytest
 from pytest import CaptureFixture, MonkeyPatch
 
 from knowledge_adapters.cli import main
+from knowledge_adapters.confluence.client import ConfluenceRequestError
 from knowledge_adapters.confluence.models import ResolvedTarget
+from knowledge_adapters.failures import AdapterFailureClass
 from tests.cli_output_assertions import assert_dry_run_summary, assert_write_summary
 
 
@@ -212,13 +214,15 @@ def _valid_space_page_list_payload(
     return payload
 
 
-def _http_error(status_code: int) -> HTTPError:
-    headers = Message()
+def _http_error(status_code: int, *, headers: dict[str, str] | None = None) -> HTTPError:
+    header_message = Message()
+    for key, value in (headers or {}).items():
+        header_message[key] = value
     return HTTPError(
         url="https://example.com/wiki/api/content/12345",
         code=status_code,
         msg=f"synthetic http error {status_code}",
-        hdrs=headers,
+        hdrs=header_message,
         fp=io.BytesIO(b"{}"),
     )
 
@@ -1269,6 +1273,16 @@ def test_real_fetch_ignores_extra_irrelevant_fields_in_valid_response(
             "CONFLUENCE_CLIENT_KEY_FILE.",
         ),
         (404, "bearer-env", "Confluence page not found. Verify --target."),
+        (
+            429,
+            "bearer-env",
+            "Confluence request failed (status 429). Verify --base-url and access.",
+        ),
+        (
+            503,
+            "bearer-env",
+            "Confluence request failed (status 503). Verify --base-url and access.",
+        ),
     ],
 )
 def test_real_fetch_maps_http_status_failures(
@@ -1290,8 +1304,41 @@ def test_real_fetch_maps_http_status_failures(
         monkeypatch.setenv("CONFLUENCE_CLIENT_KEY_FILE", "/tmp/confluence-client.key")
     monkeypatch.setattr("urllib.request.urlopen", raise_http_error)
 
-    with pytest.raises(RuntimeError, match=f"^{re.escape(expected_message)}$"):
+    with pytest.raises(ConfluenceRequestError, match=f"^{re.escape(expected_message)}$"):
         _fetch_real_page(_real_target(), auth_method=auth_method)
+
+
+@pytest.mark.parametrize(
+    ("status_code", "headers", "expected_failure_class", "expected_retry_after"),
+    [
+        (401, {}, AdapterFailureClass.AUTH, None),
+        (403, {}, AdapterFailureClass.AUTH, None),
+        (404, {}, AdapterFailureClass.PERMANENT, None),
+        (429, {"Retry-After": "60"}, AdapterFailureClass.EXPECTED_RETRYABLE, "60"),
+        (503, {}, AdapterFailureClass.PROVIDER, None),
+    ],
+)
+def test_real_fetch_classifies_http_status_failures(
+    monkeypatch: MonkeyPatch,
+    status_code: int,
+    headers: dict[str, str],
+    expected_failure_class: AdapterFailureClass,
+    expected_retry_after: str | None,
+) -> None:
+    def raise_http_error(*args: object, **kwargs: object) -> object:
+        del args, kwargs
+        raise _http_error(status_code, headers=headers)
+
+    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
+    monkeypatch.setattr("urllib.request.urlopen", raise_http_error)
+
+    with pytest.raises(ConfluenceRequestError) as exc_info:
+        _fetch_real_page(_real_target())
+
+    assert exc_info.value.classification is not None
+    assert exc_info.value.classification.failure_class == expected_failure_class
+    assert exc_info.value.classification.provider_status_code == status_code
+    assert exc_info.value.classification.retry_after == expected_retry_after
 
 
 @pytest.mark.parametrize(
@@ -1334,8 +1381,55 @@ def test_real_fetch_maps_url_failures_to_clear_categories(
         monkeypatch.setenv("CONFLUENCE_CLIENT_KEY_FILE", "/tmp/confluence-client.key")
     monkeypatch.setattr("urllib.request.urlopen", raise_url_error)
 
-    with pytest.raises(RuntimeError, match=f"^{re.escape(expected_message)}$"):
+    with pytest.raises(ConfluenceRequestError, match=f"^{re.escape(expected_message)}$"):
         _fetch_real_page(_real_target(), auth_method=auth_method)
+
+
+@pytest.mark.parametrize(
+    ("raised_error", "auth_method", "expected_failure_class"),
+    [
+        (
+            _url_error(ssl.SSLError("tlsv13 alert certificate required")),
+            "client-cert-env",
+            AdapterFailureClass.CONFIGURATION,
+        ),
+        (
+            _url_error(TimeoutError("timed out")),
+            "bearer-env",
+            AdapterFailureClass.EXPECTED_RETRYABLE,
+        ),
+        (
+            _url_error(ValueError("synthetic transport failure")),
+            "bearer-env",
+            AdapterFailureClass.EXPECTED_RETRYABLE,
+        ),
+    ],
+)
+def test_real_fetch_classifies_url_failures(
+    monkeypatch: MonkeyPatch,
+    raised_error: URLError,
+    auth_method: str,
+    expected_failure_class: AdapterFailureClass,
+) -> None:
+    def raise_url_error(*args: object, **kwargs: object) -> object:
+        del args, kwargs
+        raise raised_error
+
+    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
+    if auth_method == "client-cert-env":
+        monkeypatch.setattr(
+            "knowledge_adapters.confluence.auth.ssl.create_default_context",
+            lambda *, cafile=None: _FakeSSLContext(),
+        )
+        monkeypatch.setenv("CONFLUENCE_CLIENT_CERT_FILE", "/tmp/confluence-client.crt")
+        monkeypatch.setenv("CONFLUENCE_CLIENT_KEY_FILE", "/tmp/confluence-client.key")
+    monkeypatch.setattr("urllib.request.urlopen", raise_url_error)
+
+    with pytest.raises(ConfluenceRequestError) as exc_info:
+        _fetch_real_page(_real_target(), auth_method=auth_method)
+
+    assert exc_info.value.classification is not None
+    assert exc_info.value.classification.failure_class == expected_failure_class
 
 
 def test_real_fetch_rejects_invalid_ca_bundle_before_request(
@@ -1662,11 +1756,12 @@ def test_real_child_list_fails_fast_on_invalid_response_shapes(
 
 
 @pytest.mark.parametrize(
-    ("raised_error", "expected_message"),
+    ("raised_error", "expected_message", "expected_detail_lines"),
     [
         (
             RuntimeError("Confluence auth failed. Check CONFLUENCE_BEARER_TOKEN."),
             "Confluence auth failed. Check CONFLUENCE_BEARER_TOKEN.",
+            (),
         ),
         (
             RuntimeError(
@@ -1675,12 +1770,18 @@ def test_real_child_list_fails_fast_on_invalid_response_shapes(
             ),
             "Confluence TLS/client certificate failed. Check "
             "CONFLUENCE_CLIENT_CERT_FILE / CONFLUENCE_CLIENT_KEY_FILE.",
+            (),
         ),
         (
             RuntimeError("Confluence page not found. Verify --target."),
             "Confluence page not found. Verify --target.",
+            (),
         ),
-        (ValueError("Response error: missing source_url."), "Response error: missing source_url."),
+        (
+            ValueError("Response error: missing source_url."),
+            "Response error: missing source_url.",
+            ("failure_class: permanent",),
+        ),
     ],
 )
 def test_real_client_cli_surfaces_fetch_failures_as_concise_cli_errors(
@@ -1689,6 +1790,7 @@ def test_real_client_cli_surfaces_fetch_failures_as_concise_cli_errors(
     capsys: CaptureFixture[str],
     raised_error: Exception,
     expected_message: str,
+    expected_detail_lines: tuple[str, ...],
 ) -> None:
     from knowledge_adapters.confluence import client as client_module
 
@@ -1703,7 +1805,11 @@ def test_real_client_cli_surfaces_fetch_failures_as_concise_cli_errors(
     assert exc_info.value.code == 2
 
     captured = capsys.readouterr()
-    assert captured.err == f"knowledge-adapters confluence: error: {expected_message}\n"
+    expected_detail_text = "".join(f"  {line}\n" for line in expected_detail_lines)
+    assert (
+        captured.err
+        == f"knowledge-adapters confluence: error: {expected_message}\n{expected_detail_text}"
+    )
     assert not (tmp_path / "out" / "manifest.json").exists()
     assert not (tmp_path / "out" / "pages" / "12345.md").exists()
 
@@ -1727,9 +1833,9 @@ def test_real_client_cli_debug_mode_surfaces_request_context_for_request_failure
 
     captured = capsys.readouterr()
     assert (
-        captured.err
-        == "knowledge-adapters confluence: error: Confluence request failed. "
+        captured.err == "knowledge-adapters confluence: error: Confluence request failed. "
         "Verify --base-url and try again.\n"
+        "  failure_class: expected_retryable\n"
         "  debug request_url: https://example.com/wiki/rest/api/content/12345"
         "?expand=body.storage,_links,version\n"
         "  debug client_mode: real\n"
@@ -1759,9 +1865,9 @@ def test_real_client_cli_default_mode_hides_debug_request_context(
 
     captured = capsys.readouterr()
     assert (
-        captured.err
-        == "knowledge-adapters confluence: error: Confluence request failed. "
+        captured.err == "knowledge-adapters confluence: error: Confluence request failed. "
         "Verify --base-url and try again.\n"
+        "  failure_class: expected_retryable\n"
     )
     assert "synthetic transport failure" not in captured.err
     assert "rest/api/content/12345" not in captured.err

--- a/tests/test_github_metadata.py
+++ b/tests/test_github_metadata.py
@@ -1,17 +1,22 @@
 from __future__ import annotations
 
 import hashlib
+import io
 import json
 from collections.abc import Mapping
+from email.message import Message
 from pathlib import Path
 from typing import Any, Literal
 from urllib import request
+from urllib.error import HTTPError
 
 import pytest
 from pytest import CaptureFixture, MonkeyPatch
 
 from knowledge_adapters.cli import main
+from knowledge_adapters.failures import AdapterFailureClass
 from knowledge_adapters.github_metadata.client import (
+    GitHubMetadataRequestError,
     issue_comments_api_url,
     issue_list_api_url,
     list_repository_issues,
@@ -165,6 +170,19 @@ def _install_fake_urlopen(
     return fake_urlopen
 
 
+def _github_http_error(status_code: int, *, headers: Mapping[str, str] | None = None) -> HTTPError:
+    header_message = Message()
+    for key, value in (headers or {}).items():
+        header_message[key] = value
+    return HTTPError(
+        url="https://api.github.com/repos/octo/project/issues",
+        code=status_code,
+        msg=f"synthetic http error {status_code}",
+        hdrs=header_message,
+        fp=io.BytesIO(b"{}"),
+    )
+
+
 def test_github_metadata_resolves_github_and_ghe_base_urls() -> None:
     github_urls = resolve_base_urls(None)
     assert github_urls.web_root == "https://github.com"
@@ -228,6 +246,70 @@ def test_github_metadata_missing_token_env_fails_before_request(
             repo="octo/project",
             token_env="GH_TOKEN",
         )
+
+
+@pytest.mark.parametrize(
+    ("status_code", "headers", "expected_failure_class", "expected_retry_after"),
+    [
+        (401, {}, AdapterFailureClass.AUTH, None),
+        (403, {}, AdapterFailureClass.AUTH, None),
+        (404, {}, AdapterFailureClass.PERMANENT, None),
+        (429, {"Retry-After": "60"}, AdapterFailureClass.EXPECTED_RETRYABLE, "60"),
+        (503, {}, AdapterFailureClass.PROVIDER, None),
+    ],
+)
+def test_github_metadata_classifies_request_failures(
+    monkeypatch: MonkeyPatch,
+    status_code: int,
+    headers: dict[str, str],
+    expected_failure_class: AdapterFailureClass,
+    expected_retry_after: str | None,
+) -> None:
+    def raise_http_error(api_request: request.Request, timeout: int) -> None:
+        del api_request, timeout
+        raise _github_http_error(status_code, headers=headers)
+
+    monkeypatch.setenv("GH_TOKEN", "secret-token")
+    monkeypatch.setattr(
+        "knowledge_adapters.github_metadata.client.request.urlopen",
+        raise_http_error,
+    )
+
+    with pytest.raises(GitHubMetadataRequestError) as exc_info:
+        list_repository_issues(repo="octo/project", token_env="GH_TOKEN")
+
+    assert exc_info.value.classification is not None
+    assert exc_info.value.classification.failure_class == expected_failure_class
+    assert exc_info.value.classification.provider_status_code == status_code
+    assert exc_info.value.classification.retry_after == expected_retry_after
+
+
+def test_github_metadata_cli_reports_configuration_failure_class(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(
+            [
+                "github_metadata",
+                "--repo",
+                "octo/project",
+                "--token-env",
+                "GH_TOKEN",
+                "--output-dir",
+                str(tmp_path / "out"),
+            ]
+        )
+
+    assert exc_info.value.code == 2
+    assert capsys.readouterr().err == (
+        "knowledge-adapters github_metadata: error: "
+        "token_env 'GH_TOKEN' is not set or contains an empty value.\n"
+        "  failure_class: configuration\n"
+    )
 
 
 def test_github_metadata_paginates_filters_prs_orders_and_limits_after_filtering(


### PR DESCRIPTION
## Summary
- add a shared adapter failure classification surface with `failure_class`, optional provider status, and retry hints
- classify Confluence real-client and GitHub metadata request/config/response failures without changing the primary error messages
- surface classification detail lines in CLI failures and cover them in focused tests
- document the user-facing classification values for Confluence and GitHub metadata

## Validation
- `make check` passed: ruff, mypy, and 396 pytest tests
- `make check-gh-env` passed

## Authoritative sources
- Atlassian Confluence REST API status-code reference: https://developer.atlassian.com/cloud/confluence/rest/v1/intro/
- Atlassian Confluence rate limiting and Retry-After guidance: https://developer.atlassian.com/cloud/confluence/rate-limiting/
- GitHub REST API troubleshooting, rate limits, auth, 404 behavior, and timeout guidance: https://docs.github.com/en/rest/using-the-rest-api/troubleshooting-the-rest-api

## Residual risks
- GitHub documents that 404 can hide inaccessible private resources; the adapter classifies 404 as `permanent` because the response alone cannot reliably distinguish missing from inaccessible. The message remains `not found or inaccessible`.