### PR TITLE
[codex] Make chaos CI replayable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,11 @@ chaos-random: $(VENV)/bin/activate
 	@set -e; \
 	seed="$(CHAOS_SEED)"; \
 	if [ -z "$$seed" ]; then \
-		seed="$$(date +%s)"; \
+		if [ -n "$$GITHUB_SHA" ]; then \
+			seed="ci-$$GITHUB_SHA"; \
+		else \
+			seed="$$(date +%s)"; \
+		fi; \
 	fi; \
 	scenario="$(CHAOS_SCENARIO)"; \
 	if [ -z "$$scenario" ]; then \
@@ -48,9 +52,10 @@ chaos-random: $(VENV)/bin/activate
 	else \
 		CHAOS_SCENARIO="$$scenario" $(PYTHON) -c 'import os; from tests.chaos import AdapterChaosScenario; AdapterChaosScenario(os.environ["CHAOS_SCENARIO"])'; \
 	fi; \
+	replay_command="$$(CHAOS_SEED="$$seed" CHAOS_SCENARIO="$$scenario" $(PYTHON) -c 'import os; from tests.chaos import build_chaos_replay_command; print(build_chaos_replay_command(seed=os.environ["CHAOS_SEED"], scenario=os.environ["CHAOS_SCENARIO"]))')"; \
 	echo "Chaos seed: $$seed"; \
 	echo "Chaos scenario: $$scenario"; \
-	echo "Rerun: make chaos-replay CHAOS_SEED=$$seed CHAOS_SCENARIO=$$scenario"; \
+	echo "CHAOS_REPLAY_COMMAND: $$replay_command"; \
 	CHAOS_TARGET=chaos-random CHAOS_SEED="$$seed" CHAOS_SCENARIO="$$scenario" $(PYTEST) -m chaos -k "$$scenario"
 
 chaos-replay: $(VENV)/bin/activate
@@ -63,15 +68,18 @@ chaos-replay: $(VENV)/bin/activate
 		exit 1; \
 	fi; \
 	CHAOS_SCENARIO="$$scenario" $(PYTHON) -c 'import os; from tests.chaos import AdapterChaosScenario; AdapterChaosScenario(os.environ["CHAOS_SCENARIO"])'; \
+	replay_command="$$(CHAOS_SEED="$$seed" CHAOS_SCENARIO="$$scenario" CHAOS_NODEID="$$nodeid" $(PYTHON) -c 'import os; from tests.chaos import build_chaos_replay_command; print(build_chaos_replay_command(seed=os.environ.get("CHAOS_SEED") or None, scenario=os.environ["CHAOS_SCENARIO"], nodeid=os.environ.get("CHAOS_NODEID") or None))')"; \
 	if [ -n "$$seed" ]; then \
 		echo "Chaos seed: $$seed"; \
 	fi; \
 	echo "Chaos scenario: $$scenario"; \
 	if [ -n "$$nodeid" ]; then \
 		echo "Chaos node id: $$nodeid"; \
+		echo "CHAOS_REPLAY_COMMAND: $$replay_command"; \
 		CHAOS_TARGET=chaos-replay CHAOS_SEED="$$seed" CHAOS_SCENARIO="$$scenario" $(PYTEST) -m chaos "$$nodeid"; \
 	else \
 		echo "Chaos node id: <all matching scenario tests>"; \
+		echo "CHAOS_REPLAY_COMMAND: $$replay_command"; \
 		CHAOS_TARGET=chaos-replay CHAOS_SEED="$$seed" CHAOS_SCENARIO="$$scenario" $(PYTEST) -m chaos -k "$$scenario"; \
 	fi
 

--- a/docs/chaos-testing.md
+++ b/docs/chaos-testing.md
@@ -44,10 +44,13 @@ make chaos-random CHAOS_SEED=issue-247
 When `chaos-random` runs, it also prints a rerun command that pins both values:
 
 ```bash
-make chaos-replay CHAOS_SEED=<printed-seed> CHAOS_SCENARIO=<printed-scenario>
+CHAOS_REPLAY_COMMAND: make chaos-replay CHAOS_SEED=<printed-seed> CHAOS_SCENARIO=<printed-scenario>
 ```
 
-Use that command to reproduce a random CI or local canary failure exactly.
+In GitHub Actions, `chaos-random` uses `ci-$GITHUB_SHA` when no explicit
+`CHAOS_SEED` is supplied. Local developer runs keep their existing timestamp
+fallback unless you pass `CHAOS_SEED` yourself. Use the printed command to
+reproduce a CI or local canary failure exactly.
 
 Use `make chaos-all` when you want the complete current chaos suite. That is the
 right target for local hardening before changing adapter failure behavior, and
@@ -66,7 +69,7 @@ When a chaos test fails, pytest prints a node-specific replay command in the
 terminal summary:
 
 ```bash
-make chaos-replay CHAOS_SEED=<seed> CHAOS_SCENARIO=<scenario> CHAOS_NODEID='<pytest-node-id>'
+CHAOS_FAILURE_REPLAY_COMMAND: make chaos-replay CHAOS_SEED=<seed> CHAOS_SCENARIO=<scenario> CHAOS_NODEID='<pytest-node-id>'
 ```
 
 `CHAOS_SEED` is included when the failing run had one, such as a
@@ -76,8 +79,9 @@ the pinned scenario.
 
 ## Failure Fingerprints
 
-Chaos failures also print a `chaos-v1:<digest>` fingerprint with a compact JSON
-payload. The digest and payload are deterministic for the same failure context:
+Chaos failures also print a `CHAOS_FAILURE_FINGERPRINT: chaos-v1:<digest>`
+line with a compact JSON payload. The digest and payload are deterministic for
+the same failure context:
 
 - `scenario`
 - `nodeid`

--- a/tests/chaos.py
+++ b/tests/chaos.py
@@ -102,14 +102,15 @@ def build_chaos_replay_command(
     *,
     seed: str | None,
     scenario: str,
-    nodeid: str,
+    nodeid: str | None = None,
 ) -> str:
     """Build a shell-safe Make command that replays one chaos failure."""
     parts = ["make", "chaos-replay"]
     if seed:
         parts.append(f"CHAOS_SEED={shlex.quote(seed)}")
     parts.append(f"CHAOS_SCENARIO={shlex.quote(scenario)}")
-    parts.append(f"CHAOS_NODEID={shlex.quote(nodeid)}")
+    if nodeid:
+        parts.append(f"CHAOS_NODEID={shlex.quote(nodeid)}")
     return " ".join(parts)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,8 +90,8 @@ def pytest_terminal_summary(
 
     terminalreporter.section("chaos failure replay")
     for failure in failures:
-        terminalreporter.write_line(f"fingerprint: {failure.fingerprint_line}")
-        terminalreporter.write_line(f"replay: {failure.replay_command}")
+        terminalreporter.write_line(f"CHAOS_FAILURE_FINGERPRINT: {failure.fingerprint_line}")
+        terminalreporter.write_line(f"CHAOS_FAILURE_REPLAY_COMMAND: {failure.replay_command}")
 
 
 @pytest.fixture

--- a/tests/test_chaos_ci_replay.py
+++ b/tests/test_chaos_ci_replay.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_make_chaos_random_uses_github_sha_seed_in_ci() -> None:
+    makefile = Path("Makefile").read_text()
+
+    assert 'if [ -n "$$GITHUB_SHA" ]; then' in makefile
+    assert 'seed="ci-$$GITHUB_SHA";' in makefile
+
+
+def test_make_chaos_targets_print_searchable_replay_command() -> None:
+    makefile = Path("Makefile").read_text()
+
+    assert "CHAOS_REPLAY_COMMAND: $$replay_command" in makefile
+    assert "build_chaos_replay_command" in makefile
+
+
+def test_chaos_failure_summary_uses_searchable_labels() -> None:
+    conftest = Path("tests/conftest.py").read_text()
+
+    assert "CHAOS_FAILURE_FINGERPRINT:" in conftest
+    assert "CHAOS_FAILURE_REPLAY_COMMAND:" in conftest

--- a/tests/test_chaos_fingerprints.py
+++ b/tests/test_chaos_fingerprints.py
@@ -66,6 +66,15 @@ def test_chaos_replay_command_quotes_node_ids() -> None:
     )
 
 
+def test_chaos_replay_command_can_target_scenario_only() -> None:
+    command = build_chaos_replay_command(
+        seed="ci abc123",
+        scenario="rate_limit",
+    )
+
+    assert command == "make chaos-replay CHAOS_SEED='ci abc123' CHAOS_SCENARIO=rate_limit"
+
+
 def test_chaos_command_context_describes_make_target() -> None:
     assert (
         build_chaos_command_context(


### PR DESCRIPTION
## Summary
- Make `make chaos-random` choose `ci-$GITHUB_SHA` when no `CHAOS_SEED` is supplied in GitHub Actions, while preserving the existing timestamp fallback for local developer runs.
- Print shell-safe `CHAOS_REPLAY_COMMAND:` output from `chaos-random` and `chaos-replay`, and make pytest chaos failure summaries searchable with `CHAOS_FAILURE_FINGERPRINT:` and `CHAOS_FAILURE_REPLAY_COMMAND:` labels.
- Add focused checks for CI seed fallback, replay command output, searchable failure labels, and scenario-only replay commands.

## Validation
- `make check` - 411 passed.
- `GITHUB_SHA=1234567890abcdef make chaos-random` - 2 chaos tests passed; output included `Chaos seed: ci-1234567890abcdef` and a copyable `CHAOS_REPLAY_COMMAND:` line.
- `make chaos-replay CHAOS_SEED=ci-1234567890abcdef CHAOS_SCENARIO=invalid_json` - 2 chaos tests passed; output included the same copyable replay command.

## Residual Risks
- I did not force an intentional chaos test failure locally; the failure-summary labels are covered by focused source checks and the existing pytest hook path remains structurally unchanged.

## Source Notes
- GitHub documents `GITHUB_SHA` as a default Actions environment variable containing the commit SHA that triggered the workflow: https://docs.github.com/en/actions/reference/workflows-and-actions/variables#default-environment-variables

Closes #259