### PR TITLE
[codex] Document make check validation contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,8 +43,15 @@ Before committing or opening a PR:
 make check
 ```
 
-Run validation through the Makefile targets for this repository.
-Do not invoke `pytest`, `mypy`, or `ruff` directly; use `make check` and other documented `make` targets instead.
+`make check` is the canonical local blocking validation entrypoint. It runs:
+
+- `make lint`
+- `make typecheck`
+- `make test`
+
+Run validation through the Makefile targets for this repository. Do not invoke
+`pytest`, `mypy`, or `ruff` directly; use `make check` and other documented
+`make` targets instead.
 
 If lint issues are auto-fixable:
 
@@ -54,8 +61,24 @@ make format
 make check
 ```
 
+The pull request CI workflow also runs `make smoke` and `make chaos-random`
+before `make check`. These are CI canaries outside the required local
+completion path; run them locally when the task touches CLI smoke coverage,
+chaos behavior, or when investigating a related failure.
+
+`make chaos-all`, `make chaos-replay`, and `make adapter-readiness` are
+advisory or diagnostic targets. They do not replace `make check` and are not
+hidden release gates.
+
+`make check` must stay deterministic and must not require live provider access,
+network credentials, GitHub authentication, or release permissions. Optional
+live-provider validation remains outside normal repository validation and must
+be reported separately when used.
+
 Run `make check-gh-env` before pull request or release workflows that require
-an authenticated `gh` session.
+an authenticated `gh` session. Release-only targets such as `make release-check`
+and `make release-publish` are scoped to the documented release workflow and are
+not part of normal local PR validation.
 
 ---
 


### PR DESCRIPTION
## Summary

- Document `make check` as the canonical local blocking validation entrypoint and list its included targets: `lint`, `typecheck`, and `test`.
- Clarify that CI also runs `smoke` and `chaos-random` as canaries outside the required local completion path.
- Distinguish advisory, diagnostic, credentialed, and release-only targets from normal local PR validation.

## Validation

- `make check` passed locally: ruff, mypy, and 407 pytest tests.
- `make check-gh-env` passed before opening this PR.

## Residual Risks

- No validation behavior changed; this PR documents the existing Makefile and CI contract only.
- CI canaries (`make smoke`, `make chaos-random`) were inspected in workflow configuration but not run separately as local blockers.

Closes #260