### PR TITLE
Add lightweight adapter run reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,17 @@ adapter-specific inputs such as `base_url`/`target` or `file_path`, and its own
 `output_dir`. `runs.example.yaml` is committed for reference, while `runs.yaml`
 is gitignored for local use.
 
+To keep a lightweight human-readable record of a config-driven execution, pass
+`--report-output`:
+
+```bash
+knowledge-adapters run runs.yaml --report-output ./artifacts/run-report.md
+```
+
+The report is Markdown and includes the selected runs, per-run success or
+failure status, write/skip counts, and failure classification details when an
+adapter exposes them.
+
 ### Bundle Usage
 
 Bundle one or more existing adapter outputs directly:

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -28,6 +28,11 @@ from knowledge_adapters.bundle import (
 )
 from knowledge_adapters.confluence.auth import SUPPORTED_AUTH_METHODS, resolve_tls_inputs
 from knowledge_adapters.failures import adapter_failure_lines, response_or_config_failure
+from knowledge_adapters.run_report import (
+    RunReportRecord,
+    SkippedRunRecord,
+    render_run_report_markdown,
+)
 
 TOP_LEVEL_HELP_EXAMPLES = """First steps:
   knowledge-adapters --help
@@ -139,6 +144,7 @@ RUN_HELP_EXAMPLES = """Examples:
   knowledge-adapters run ./configs/runs.yaml
   knowledge-adapters run runs.yaml --only team-notes,docs-home
   knowledge-adapters run runs.yaml --continue-on-error
+  knowledge-adapters run runs.yaml --report-output ./artifacts/run-report.md
 """
 
 BUNDLE_HELP_EXAMPLES = """Examples:
@@ -1034,6 +1040,14 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     run_parser.add_argument(
+        "--report-output",
+        metavar="PATH",
+        help=(
+            "Write a lightweight Markdown report for this config-driven run, including "
+            "per-run status and failure classification details when available."
+        ),
+    )
+    run_parser.add_argument(
         "--debug",
         action="store_true",
         help=(
@@ -1216,6 +1230,39 @@ def _execute_configured_run(
         return main(argv)
 
 
+def _resolve_run_report_output(report_output: str) -> Path:
+    """Resolve a user-provided run report output path."""
+    return Path(report_output).expanduser().resolve()
+
+
+def _write_run_report(
+    *,
+    report_output_path: Path,
+    config_path: Path,
+    selected_run_count: int,
+    skipped_disabled_runs: tuple[SkippedRunRecord, ...],
+    records: tuple[RunReportRecord, ...],
+) -> None:
+    """Write the optional config-driven run report."""
+    try:
+        report_output_path.parent.mkdir(parents=True, exist_ok=True)
+        report_output_path.write_text(
+            render_run_report_markdown(
+                config_path=config_path,
+                selected_run_count=selected_run_count,
+                skipped_disabled_runs=skipped_disabled_runs,
+                records=records,
+            ),
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        exit_with_cli_error(
+            f"Could not write run report {report_output_path}: {exc}.",
+            command="run",
+        )
+    print(f"Run report: {render_user_path(report_output_path)}")
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     """Run the CLI."""
     raw_argv = tuple(sys.argv[1:] if argv is None else argv)
@@ -1242,6 +1289,16 @@ def main(argv: Sequence[str] | None = None) -> int:
                 configured_run for configured_run in run_config.runs if not configured_run.enabled
             )
         )
+        skipped_disabled_report_runs = tuple(
+            SkippedRunRecord(name=configured_run.name, run_type=configured_run.run_type)
+            for configured_run in skipped_disabled_runs
+        )
+        report_output_path = (
+            _resolve_run_report_output(args.report_output)
+            if args.report_output is not None
+            else None
+        )
+        run_report_records: list[RunReportRecord] = []
 
         print("Config-driven run invoked")
         print(f"  config_path: {render_user_path(run_config.config_path)}")
@@ -1299,6 +1356,16 @@ def main(argv: Sequence[str] | None = None) -> int:
                 )
                 print("Run interrupted: skipping remaining work for this run")
                 print("Run summary: interrupted, skipped remaining work for this run")
+                run_report_records.append(
+                    RunReportRecord(
+                        index=index,
+                        total=len(selected_runs),
+                        name=configured_run.name,
+                        run_type=configured_run.run_type,
+                        command=display_command,
+                        status="interrupted",
+                    )
+                )
                 continue
             except SystemExit:
                 print(
@@ -1311,7 +1378,27 @@ def main(argv: Sequence[str] | None = None) -> int:
                     display_command=display_command,
                     stderr_output=captured_stderr.getvalue(),
                 )
+                run_report_records.append(
+                    RunReportRecord(
+                        index=index,
+                        total=len(selected_runs),
+                        name=configured_run.name,
+                        run_type=configured_run.run_type,
+                        command=display_command,
+                        status="failed",
+                        failure_message=message,
+                        failure_details=nested_details,
+                    )
+                )
                 if not args.continue_on_error:
+                    if report_output_path is not None:
+                        _write_run_report(
+                            report_output_path=report_output_path,
+                            config_path=run_config.config_path,
+                            selected_run_count=len(selected_runs),
+                            skipped_disabled_runs=skipped_disabled_report_runs,
+                            records=tuple(run_report_records),
+                        )
                     exit_with_cli_error(
                         message,
                         command="run",
@@ -1333,7 +1420,27 @@ def main(argv: Sequence[str] | None = None) -> int:
                     stderr_output=captured_stderr.getvalue(),
                     exit_code=exit_code,
                 )
+                run_report_records.append(
+                    RunReportRecord(
+                        index=index,
+                        total=len(selected_runs),
+                        name=configured_run.name,
+                        run_type=configured_run.run_type,
+                        command=display_command,
+                        status="failed",
+                        failure_message=message,
+                        failure_details=nested_details,
+                    )
+                )
                 if not args.continue_on_error:
+                    if report_output_path is not None:
+                        _write_run_report(
+                            report_output_path=report_output_path,
+                            config_path=run_config.config_path,
+                            selected_run_count=len(selected_runs),
+                            skipped_disabled_runs=skipped_disabled_report_runs,
+                            records=tuple(run_report_records),
+                        )
                     exit_with_cli_error(
                         message,
                         command="run",
@@ -1353,6 +1460,19 @@ def main(argv: Sequence[str] | None = None) -> int:
             print(
                 f"Run {index}/{len(selected_runs)} completed: "
                 f"{configured_run.name} ({configured_run.run_type})"
+            )
+            run_report_records.append(
+                RunReportRecord(
+                    index=index,
+                    total=len(selected_runs),
+                    name=configured_run.name,
+                    run_type=configured_run.run_type,
+                    command=display_command,
+                    status="completed",
+                    dry_run=summary.dry_run,
+                    wrote=summary.wrote,
+                    skipped=summary.skipped,
+                )
             )
             completed_runs += 1
             if summary.dry_run:
@@ -1378,6 +1498,14 @@ def main(argv: Sequence[str] | None = None) -> int:
         if dry_run_runs > 0:
             print(f"  would_write: {total_would_write}")
             print(f"  would_skip: {total_would_skip}")
+        if report_output_path is not None:
+            _write_run_report(
+                report_output_path=report_output_path,
+                config_path=run_config.config_path,
+                selected_run_count=len(selected_runs),
+                skipped_disabled_runs=skipped_disabled_report_runs,
+                records=tuple(run_report_records),
+            )
         if failed_runs > 0:
             if interrupted_runs > 0:
                 print(

--- a/src/knowledge_adapters/run_report.py
+++ b/src/knowledge_adapters/run_report.py
@@ -1,0 +1,167 @@
+"""Lightweight report rendering for config-driven adapter runs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+RunReportStatus = Literal["completed", "failed", "interrupted"]
+
+
+@dataclass(frozen=True)
+class RunReportRecord:
+    """One configured adapter execution recorded for the run report."""
+
+    index: int
+    total: int
+    name: str
+    run_type: str
+    command: str
+    status: RunReportStatus
+    dry_run: bool | None = None
+    wrote: int | None = None
+    skipped: int | None = None
+    failure_message: str | None = None
+    failure_details: tuple[str, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class SkippedRunRecord:
+    """One configured run skipped because enabled: false was honored."""
+
+    name: str
+    run_type: str
+
+
+def render_run_report_markdown(
+    *,
+    config_path: Path,
+    selected_run_count: int,
+    skipped_disabled_runs: tuple[SkippedRunRecord, ...],
+    records: tuple[RunReportRecord, ...],
+) -> str:
+    """Render a concise, human-readable Markdown report."""
+    completed_runs = sum(1 for record in records if record.status == "completed")
+    failed_runs = sum(1 for record in records if record.status == "failed")
+    interrupted_runs = sum(1 for record in records if record.status == "interrupted")
+    write_runs = sum(
+        1 for record in records if record.status == "completed" and record.dry_run is False
+    )
+    dry_run_runs = sum(
+        1 for record in records if record.status == "completed" and record.dry_run is True
+    )
+    wrote = sum(record.wrote or 0 for record in records if record.dry_run is False)
+    skipped = sum(record.skipped or 0 for record in records if record.dry_run is False)
+    would_write = sum(record.wrote or 0 for record in records if record.dry_run is True)
+    would_skip = sum(record.skipped or 0 for record in records if record.dry_run is True)
+
+    lines = [
+        "# Knowledge Adapter Run Report",
+        "",
+        f"- Config: `{config_path}`",
+        f"- Runs selected: {selected_run_count}",
+        f"- Runs completed: {completed_runs}",
+        f"- Runs failed: {failed_runs}",
+        f"- Runs interrupted: {interrupted_runs}",
+        f"- Runs skipped disabled: {len(skipped_disabled_runs)}",
+        f"- Write runs: {write_runs}",
+        f"- Dry-run runs: {dry_run_runs}",
+        f"- Wrote: {wrote}",
+        f"- Skipped: {skipped}",
+    ]
+    if dry_run_runs > 0:
+        lines.extend(
+            [
+                f"- Would write: {would_write}",
+                f"- Would skip: {would_skip}",
+            ]
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Runs",
+            "",
+            "| # | Name | Type | Status | Result | Failure class |",
+            "| --- | --- | --- | --- | --- | --- |",
+        ]
+    )
+    if records:
+        lines.extend(_render_record_row(record) for record in records)
+    else:
+        lines.append("| - | - | - | none | No runs executed. | - |")
+
+    if skipped_disabled_runs:
+        lines.extend(
+            [
+                "",
+                "## Skipped Disabled Runs",
+                "",
+                "| Name | Type |",
+                "| --- | --- |",
+            ]
+        )
+        lines.extend(
+            f"| {_markdown_cell(record.name)} | {_markdown_cell(record.run_type)} |"
+            for record in skipped_disabled_runs
+        )
+
+    failed_records = tuple(record for record in records if record.status == "failed")
+    if failed_records:
+        lines.extend(["", "## Failure Details"])
+        for record in failed_records:
+            lines.extend(
+                [
+                    "",
+                    f"### {record.index}. {record.name} ({record.run_type})",
+                    "",
+                    f"- Message: {_markdown_inline(record.failure_message or 'Run failed.')}",
+                    f"- Command: `{_markdown_inline(record.command)}`",
+                ]
+            )
+            if record.failure_details:
+                lines.append("- Details:")
+                lines.extend(
+                    f"  - `{_markdown_inline(detail.strip())}`"
+                    for detail in record.failure_details
+                )
+
+    return "\n".join(lines) + "\n"
+
+
+def _render_record_row(record: RunReportRecord) -> str:
+    return (
+        f"| {record.index}/{record.total} "
+        f"| {_markdown_cell(record.name)} "
+        f"| {_markdown_cell(record.run_type)} "
+        f"| {record.status} "
+        f"| {_markdown_cell(_record_result(record))} "
+        f"| {_markdown_cell(_failure_class(record) or '-')} |"
+    )
+
+
+def _record_result(record: RunReportRecord) -> str:
+    if record.status == "completed":
+        if record.dry_run:
+            return f"would write {record.wrote or 0}, would skip {record.skipped or 0}"
+        return f"wrote {record.wrote or 0}, skipped {record.skipped or 0}"
+    if record.status == "interrupted":
+        return "interrupted before completion"
+    return record.failure_message or "failed"
+
+
+def _failure_class(record: RunReportRecord) -> str | None:
+    for detail in record.failure_details:
+        stripped_detail = detail.strip()
+        if stripped_detail.startswith("failure_class:"):
+            return stripped_detail.partition(":")[2].strip() or None
+    return None
+
+
+def _markdown_cell(value: str) -> str:
+    return value.replace("\\", "\\\\").replace("|", "\\|").replace("\n", "<br>")
+
+
+def _markdown_inline(value: str) -> str:
+    return value.replace("`", "\\`")

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -53,6 +53,87 @@ runs:
     assert "Hello from config run." in local_output_path.read_text(encoding="utf-8")
 
 
+def test_run_cli_writes_markdown_report(tmp_path: Path) -> None:
+    inputs_dir = tmp_path / "inputs"
+    inputs_dir.mkdir()
+    source_file = inputs_dir / "today.txt"
+    source_file.write_text("Hello from config run.\n", encoding="utf-8")
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: team-notes
+    type: local_files
+    file_path: ./inputs/today.txt
+    output_dir: ./artifacts/local/team-notes
+  - name: docs-home
+    type: confluence
+    base_url: https://example.com/wiki
+    target: "12345"
+    output_dir: ./artifacts/confluence/docs-home
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = run_cli(tmp_path, "run", "./runs.yaml", "--report-output", "./reports/run.md")
+
+    report_path = tmp_path / "reports" / "run.md"
+    assert result.returncode == 0, result.stderr
+    assert f"Run report: {report_path.resolve()}" in result.stdout
+    report = report_path.read_text(encoding="utf-8")
+    assert "# Knowledge Adapter Run Report" in report
+    assert f"- Config: `{config_path.resolve()}`" in report
+    assert "- Runs selected: 2" in report
+    assert "- Runs completed: 2" in report
+    assert "- Runs failed: 0" in report
+    assert "| 1/2 | team-notes | local_files | completed | wrote 1, skipped 0 | - |" in report
+    assert "| 2/2 | docs-home | confluence | completed | wrote 1, skipped 0 | - |" in report
+
+
+def test_run_cli_report_includes_failure_classification(tmp_path: Path) -> None:
+    inputs_dir = tmp_path / "inputs"
+    inputs_dir.mkdir()
+    source_file = inputs_dir / "today.txt"
+    source_file.write_text("Hello from config run.\n", encoding="utf-8")
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: docs-home
+    type: confluence
+    base_url: https://example.com/wiki
+    target: "12345"
+    output_dir: ./artifacts/confluence/docs-home
+    client_mode: real
+  - name: team-notes
+    type: local_files
+    file_path: ./inputs/today.txt
+    output_dir: ./artifacts/local/team-notes
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = run_cli(
+        tmp_path,
+        "run",
+        "./runs.yaml",
+        "--continue-on-error",
+        "--report-output",
+        "./reports/run.md",
+    )
+
+    report = (tmp_path / "reports" / "run.md").read_text(encoding="utf-8")
+    assert result.returncode == 1
+    assert "- Runs completed: 1" in report
+    assert "- Runs failed: 1" in report
+    assert "| 1/2 | docs-home | confluence | failed | " in report
+    assert "| configuration |" in report
+    assert "failure_class: configuration" in report
+    assert "| 2/2 | team-notes | local_files | completed | wrote 1, skipped 0 | - |" in report
+
+
 def test_run_cli_supports_only_and_disabled_runs(tmp_path: Path) -> None:
     inputs_dir = tmp_path / "inputs"
     inputs_dir.mkdir()


### PR DESCRIPTION
## Summary
- Add optional `knowledge-adapters run --report-output PATH` Markdown run reports.
- Record per-run completed, failed, and interrupted statuses with write/skip counts.
- Include nested adapter failure classification details when available.
- Document the report flag in the multi-run README flow.

## Validation
- `make check`

## Residual risks
- Reports are opt-in to preserve existing run behavior; operators must pass `--report-output` when they want the artifact.
- Report contents are intentionally lightweight and derived from existing CLI summaries, not a metrics or retention system.

Closes #245