### PR TITLE
[codex] Require canonical validation for release checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,11 @@ release-check: check-gh-env
 				exit 1; \
 			} \
 		}' CHANGELOG.md >/dev/null
+	@echo "Running canonical validation: make check"
+	@$(MAKE) check || { \
+		echo "Error: canonical validation failed; release-check requires 'make check' to pass." >&2; \
+		exit 1; \
+	}
 	@if [ "$$(git branch --show-current)" != "main" ]; then \
 		echo "Error: release must run from main after the release PR is merged." >&2; \
 		exit 1; \

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -15,7 +15,8 @@ For shared branch, PR, validation, and current-main workflow, follow
 1. confirm the version bump is present
 2. confirm `CHANGELOG.md` is updated
 3. validate the post-merge release prerequisites without creating a tag or
-   GitHub release:
+   GitHub release; this also runs the repository's canonical `make check`
+   validation:
 
    ```bash
    make release-check VERSION=0.8.1


### PR DESCRIPTION
## Summary

- Make `make release-check VERSION=...` run the repository's canonical `make check` validation before release readiness can continue.
- Add a release-specific failure message when canonical validation fails.
- Update the nearby release workflow doc so the `release-check` contract mentions `make check`.

## Validation

- `make check` passed: Ruff, mypy, and 407 pytest tests.
- `make release-check VERSION=0.8.0` exercised the new `make check` step: Ruff, mypy, and 407 pytest tests passed, then the command stopped at the existing branch guard because release checks must run from `main` after the release PR is merged.
- `make release-check VERSION=0.8.0 PYTEST=false` confirmed a failing canonical validation blocks `release-check` with: `Error: canonical validation failed; release-check requires 'make check' to pass.`

## Residual Risks

- Full release readiness was not run to completion locally because this work is intentionally on a feature branch and the existing release workflow requires `main` before tag and GitHub release checks continue.

Closes #257