### PR TITLE
chore: document repo-local execution guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,14 @@ and keep only repo-specific guidance.
 
 ---
 
+## Local Execution
+
+- Run commands from this repository working directory by default.
+- Keep temporary workflow state repo-local, including `.worktrees/`.
+- Prefer direct `gh ...` commands unless shell behavior is required.
+
+---
+
 ## Branches
 
 - Use repo-appropriate branch prefixes such as `feat/`, `fix/`, `docs/`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ and keep only repo-specific guidance.
 ## Local Execution
 
 - Run commands from this repository working directory by default.
-- Keep temporary workflow state repo-local, including `.worktrees/`.
+- Keep temporary workflow state repo-local, for example `.worktrees/`.
 - Prefer direct `gh ...` commands unless shell behavior is required.
 
 ---


### PR DESCRIPTION
Summary
- Add a thin repo-local execution section to AGENTS.md.
- Point normal command execution at the repository working directory.
- Keep temporary workflow state repo-local by default and prefer direct gh commands.

Files changed
- AGENTS.md

Validation
- make check

Residual risks or open questions
- None.
