### PR TITLE
[codex] Document direct git and gh usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ and keep only repo-specific guidance.
 
 - Run commands from this repository working directory by default.
 - Keep temporary workflow state repo-local, for example `.worktrees/`.
-- Prefer direct `gh ...` commands unless shell behavior is required.
+- Prefer direct `git ...` and `gh ...` commands unless shell behavior is required.
 
 ---
 


### PR DESCRIPTION
Summary
- Update repo-local execution guidance to prefer direct git and gh commands for normal repository operations.

Validation
- make check