### PR TITLE
AGENTS-workflow-policy-alignment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,19 @@ take precedence only for repo-specific behavior.
 Do not restate shared workflow rules in repo docs; link to ai-workflow-playbook
 and keep only repo-specific guidance.
 
+## Startup And Interaction Mode
+
+- Start with `ai-workflow-playbook/docs/start-here.md` before repository or
+  software work.
+- Before acting, select the interaction mode from
+  `ai-workflow-playbook/docs/repo-readiness.md`: implementation, review/audit,
+  or orchestration/prompt-authoring.
+- Implementation agents make explicit repo changes and carry them through
+  validation, commit, push, and PR delivery.
+- Review/audit agents inspect and report findings without mutating the repo.
+- Orchestration/prompt-authoring agents produce complete, self-contained
+  handoffs or prompts unless explicitly asked to implement.
+
 ## File Placement
 
 - Put adapter implementation under `src/knowledge_adapters/<source>/`.
@@ -30,7 +43,14 @@ and keep only repo-specific guidance.
 
 - Run commands from this repository working directory by default.
 - Keep temporary workflow state repo-local, for example `.worktrees/`.
-- Prefer direct `git ...` and `gh ...` commands unless shell behavior is required.
+- Use direct command execution for ordinary repo commands such as `git ...`,
+  `gh ...`, `make ...`, `python ...`, and repo-local scripts or tools.
+- Before using `zsh`, `bash`, `sh`, `zsh -lc`, `bash -lc`, `sh -c`, aliases, or
+  equivalent wrapper shells, check whether the command has a direct form and
+  use that direct form when it does.
+- Use shell wrappers only when shell syntax is genuinely required, such as
+  pipelines, redirection, glob expansion, command chaining, scoped environment
+  assignment, compound commands, or shell builtins.
 
 ---
 


### PR DESCRIPTION
## Summary

- Add a thin startup and interaction-mode pointer to repo-local `AGENTS.md`.
- Strengthen local command-form guidance to include direct `git`, `gh`, `make`, `python`, repo-local scripts, and wrapper-shell preflight.
- Preserve existing adapter validation, CI-canary, advisory, and release-only guidance.

## Validation

- `make check` passed.

## Source evidence

- `ai-workflow-playbook/docs/start-here.md`
- `ai-workflow-playbook/docs/repo-readiness.md`
- `ai-workflow-playbook/docs/prompts.md`
- `ai-workflow-playbook/docs/review-packet.md`
- `ai-workflow-playbook/docs/tool-adapters/codex.md`
- `ai-workflow-incubator/workflow-patterns/operational-evidence/2026-05-08-workflow-policy-transmission-drift.md`
- `ai-workflow-playbook` PR #149, "Promote canonical workflow output rules"

## Residual risks / follow-ups

- No PR/review template or enforcement automation updates are included.
