### PR TITLE
[codex] Add public source ingestion adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Formal changelog coverage begins at `0.2.0`, when this repository started using
 `CHANGELOG.md` as part of the release flow. Earlier tagged releases `v0.1.0` and
 `v0.1.1` predate that practice and are not backfilled here.
 
+## Unreleased
+
+- Added `public_webpage` and `public_pdf` adapters for producing unreviewed
+  markdown-first candidate artifacts from public webpage/article and PDF/report
+  URLs without retaining raw fetched bytes.
+- Added `pypdf` as the PDF text extraction dependency and documented the
+  extraction limitations surfaced in generated candidate output.
+
 ## 0.8.0
 
 This minor release moves the project from capability to control: more adapters,

--- a/README.md
+++ b/README.md
@@ -93,8 +93,10 @@ knowledge-adapters public_webpage \
 
 This fetches the public HTTP(S) URL, extracts visible text with the Python
 standard-library HTML parser, previews the generated candidate markdown, and
-does not write files in dry-run mode. Raw fetched HTML is held only in memory.
-The output is explicitly unreviewed candidate material; links, images, tables,
+does not write files in dry-run mode. Localhost, `.local`, private, link-local,
+multicast, unspecified, reserved, and credential-bearing targets are rejected
+before fetch and after redirects. Raw fetched HTML is held only in memory. The
+output is explicitly unreviewed candidate material; links, images, tables,
 comments, and publication metadata may be incomplete.
 
 Public PDF/report first run:
@@ -108,10 +110,11 @@ knowledge-adapters public_pdf \
 
 This fetches the public PDF URL, extracts text with `pypdf`, previews candidate
 markdown with extraction limitations, and does not write files in dry-run mode.
-Raw fetched PDF bytes are held only in memory. PDF layout, tables, figures,
-footnotes, headers, reading order, and scanned image-only pages may be
-incomplete or missing, so review against the source PDF before retaining any
-knowledge.
+Localhost, `.local`, private, link-local, multicast, unspecified, reserved, and
+credential-bearing targets are rejected before fetch and after redirects. Raw
+fetched PDF bytes are held only in memory. PDF layout, tables, figures,
+footnotes, headers, reading order, and scanned image-only pages may be incomplete
+or missing, so review against the source PDF before retaining any knowledge.
 
 Recommended Confluence first run:
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ adapter:
 ```bash
 knowledge-adapters --help
 knowledge-adapters local_files --help
+knowledge-adapters public_webpage --help
+knowledge-adapters public_pdf --help
 knowledge-adapters confluence --help
 ```
 
@@ -79,6 +81,37 @@ files.
 
 Files that are not valid UTF-8 text, including binary files or files saved with
 another encoding, fail fast with guidance to re-save the input as UTF-8.
+
+Public webpage/article first run:
+
+```bash
+knowledge-adapters public_webpage \
+  --url https://meaningfultech.com/p/the-vibe-coding-illusion-why-faster \
+  --output-dir ./artifacts/public-web/meaningfultech-vibe-coding \
+  --dry-run
+```
+
+This fetches the public HTTP(S) URL, extracts visible text with the Python
+standard-library HTML parser, previews the generated candidate markdown, and
+does not write files in dry-run mode. Raw fetched HTML is held only in memory.
+The output is explicitly unreviewed candidate material; links, images, tables,
+comments, and publication metadata may be incomplete.
+
+Public PDF/report first run:
+
+```bash
+knowledge-adapters public_pdf \
+  --url https://dora.dev/research/2023/dora-report/2023-dora-accelerate-state-of-devops-report.pdf \
+  --output-dir ./artifacts/public-pdf/dora-2023 \
+  --dry-run
+```
+
+This fetches the public PDF URL, extracts text with `pypdf`, previews candidate
+markdown with extraction limitations, and does not write files in dry-run mode.
+Raw fetched PDF bytes are held only in memory. PDF layout, tables, figures,
+footnotes, headers, reading order, and scanned image-only pages may be
+incomplete or missing, so review against the source PDF before retaining any
+knowledge.
 
 Recommended Confluence first run:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ authors = [
   { name = "Keith Minnig" }
 ]
 dependencies = [
+  "pypdf>=5.0",
   "PyYAML>=6.0",
 ]
 

--- a/runs.example.yaml
+++ b/runs.example.yaml
@@ -8,6 +8,22 @@ runs:
     file_path: ./example-inputs/team-notes.txt
     output_dir: ./artifacts/local/team-notes
 
+  # Public webpage/article example. Output is unreviewed candidate material,
+  # not retained knowledge.
+  - name: meaningfultech-vibe-coding
+    type: public_webpage
+    url: https://meaningfultech.com/p/the-vibe-coding-illusion-why-faster
+    output_dir: ./artifacts/public-web/meaningfultech-vibe-coding
+    dry_run: true
+
+  # Public PDF/report example. PDF text extraction uses pypdf and has visible
+  # limitations in the generated candidate markdown.
+  - name: dora-2023-report
+    type: public_pdf
+    url: https://dora.dev/research/2023/dora-report/2023-dora-accelerate-state-of-devops-report.pdf
+    output_dir: ./artifacts/public-pdf/dora-2023
+    dry_run: true
+
   # Minimal git_repo example. Use include filters by default; ingesting an
   # entire repository is usually not the safest starting point.
   - name: example-repo

--- a/src/knowledge_adapters/adapter_readiness.py
+++ b/src/knowledge_adapters/adapter_readiness.py
@@ -109,6 +109,36 @@ ADAPTER_READINESS: tuple[AdapterReadiness, ...] = (
             "no_partial_artifacts": "No no-partial-artifact failure coverage is registered.",
         },
     ),
+    AdapterReadiness(
+        adapter="public_pdf",
+        coverage={
+            "contract_invariant": False,
+            "chaos": False,
+            "replay": False,
+            "no_partial_artifacts": False,
+        },
+        evidence={
+            "contract_invariant": "Not yet registered in the readiness model.",
+            "chaos": "No public_pdf chaos scenarios are registered.",
+            "replay": "Replay applies to registered chaos scenarios; public_pdf has none.",
+            "no_partial_artifacts": "No no-partial-artifact failure coverage is registered.",
+        },
+    ),
+    AdapterReadiness(
+        adapter="public_webpage",
+        coverage={
+            "contract_invariant": False,
+            "chaos": False,
+            "replay": False,
+            "no_partial_artifacts": False,
+        },
+        evidence={
+            "contract_invariant": "Not yet registered in the readiness model.",
+            "chaos": "No public_webpage chaos scenarios are registered.",
+            "replay": "Replay applies to registered chaos scenarios; public_webpage has none.",
+            "no_partial_artifacts": "No no-partial-artifact failure coverage is registered.",
+        },
+    ),
 )
 
 

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -742,9 +742,11 @@ def build_parser() -> argparse.ArgumentParser:
             "standard-library HTML parser, and write one markdown-first candidate "
             "artifact plus manifest.json. Output is explicitly unreviewed candidate "
             "material; scripts, styles, links, images, tables, comments, and "
-            "publication metadata may be incomplete. Raw fetched HTML is held only "
-            "in memory and is not retained unless the caller chooses to keep the "
-            "generated candidate output."
+            "publication metadata may be incomplete. Localhost, .local, private, "
+            "link-local, multicast, unspecified, reserved, and credential-bearing "
+            "targets are rejected before fetch and after redirects. Raw fetched HTML "
+            "is held only in memory and is not retained unless the caller chooses to "
+            "keep the generated candidate output."
         ),
         epilog=PUBLIC_WEBPAGE_HELP_EXAMPLES,
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -778,8 +780,10 @@ def build_parser() -> argparse.ArgumentParser:
             "write one markdown-first candidate artifact plus manifest.json. Output "
             "is explicitly unreviewed candidate material; PDF layout, tables, figures, "
             "footnotes, headers, reading order, and scanned image-only pages may be "
-            "incomplete or missing. Raw fetched PDF bytes are held only in memory and "
-            "are not retained unless the caller chooses to keep the generated "
+            "incomplete or missing. Localhost, .local, private, link-local, multicast, "
+            "unspecified, reserved, and credential-bearing targets are rejected before "
+            "fetch and after redirects. Raw fetched PDF bytes are held only in memory "
+            "and are not retained unless the caller chooses to keep the generated "
             "candidate output."
         ),
         epilog=PUBLIC_PDF_HELP_EXAMPLES,

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -38,6 +38,8 @@ TOP_LEVEL_HELP_EXAMPLES = """First steps:
   knowledge-adapters --help
   knowledge-adapters run runs.yaml
   knowledge-adapters local_files --help
+  knowledge-adapters public_webpage --help
+  knowledge-adapters public_pdf --help
   knowledge-adapters git_repo --help
   knowledge-adapters github_metadata --help
   knowledge-adapters confluence --help
@@ -89,6 +91,29 @@ LOCAL_FILES_HELP_EXAMPLES = """Examples:
     --file-path ./notes/today.txt \\
     --output-dir ./artifacts
 """
+
+PUBLIC_WEBPAGE_HELP_EXAMPLES = """Examples:
+  knowledge-adapters public_webpage \\
+    --url https://meaningfultech.com/p/the-vibe-coding-illusion-why-faster \\
+    --output-dir ./artifacts/public-web/meaningfultech-vibe-coding \\
+    --dry-run
+  knowledge-adapters public_webpage \\
+    --url https://meaningfultech.com/p/the-vibe-coding-illusion-why-faster \\
+    --output-dir ./artifacts/public-web/meaningfultech-vibe-coding
+"""
+
+PUBLIC_PDF_HELP_EXAMPLES = (
+    "Examples:\n"
+    "  knowledge-adapters public_pdf \\\n"
+    "    --url https://dora.dev/research/2023/dora-report/"
+    "2023-dora-accelerate-state-of-devops-report.pdf \\\n"
+    "    --output-dir ./artifacts/public-pdf/dora-2023 \\\n"
+    "    --dry-run\n"
+    "  knowledge-adapters public_pdf \\\n"
+    "    --url https://dora.dev/research/2023/dora-report/"
+    "2023-dora-accelerate-state-of-devops-report.pdf \\\n"
+    "    --output-dir ./artifacts/public-pdf/dora-2023\n"
+)
 
 GIT_REPO_HELP_EXAMPLES = """Examples:
   knowledge-adapters git_repo \\
@@ -706,6 +731,78 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "Preview the resolved file path, artifact path, manifest path, and "
             "normalized markdown without writing files."
+        ),
+    )
+
+    public_webpage_parser = subparsers.add_parser(
+        "public_webpage",
+        help="Fetch one public webpage URL into unreviewed candidate markdown.",
+        description=(
+            "Fetch one public HTTP(S) webpage URL, extract visible text with a "
+            "standard-library HTML parser, and write one markdown-first candidate "
+            "artifact plus manifest.json. Output is explicitly unreviewed candidate "
+            "material; scripts, styles, links, images, tables, comments, and "
+            "publication metadata may be incomplete. Raw fetched HTML is held only "
+            "in memory and is not retained unless the caller chooses to keep the "
+            "generated candidate output."
+        ),
+        epilog=PUBLIC_WEBPAGE_HELP_EXAMPLES,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    add_verbose_argument(public_webpage_parser)
+    public_webpage_parser.add_argument(
+        "--url",
+        required=True,
+        help="Public http or https webpage/article URL to fetch.",
+    )
+    public_webpage_parser.add_argument(
+        "--output-dir",
+        required=True,
+        metavar="DIR",
+        help="Directory where pages/ and manifest.json are written.",
+    )
+    public_webpage_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Fetch and extract the source, then preview artifact path, manifest path, "
+            "and normalized candidate markdown without writing files."
+        ),
+    )
+
+    public_pdf_parser = subparsers.add_parser(
+        "public_pdf",
+        help="Fetch one public PDF/report URL into unreviewed candidate markdown.",
+        description=(
+            "Fetch one public HTTP(S) PDF/report URL, extract text with pypdf, and "
+            "write one markdown-first candidate artifact plus manifest.json. Output "
+            "is explicitly unreviewed candidate material; PDF layout, tables, figures, "
+            "footnotes, headers, reading order, and scanned image-only pages may be "
+            "incomplete or missing. Raw fetched PDF bytes are held only in memory and "
+            "are not retained unless the caller chooses to keep the generated "
+            "candidate output."
+        ),
+        epilog=PUBLIC_PDF_HELP_EXAMPLES,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    add_verbose_argument(public_pdf_parser)
+    public_pdf_parser.add_argument(
+        "--url",
+        required=True,
+        help="Public http or https PDF/report URL to fetch.",
+    )
+    public_pdf_parser.add_argument(
+        "--output-dir",
+        required=True,
+        metavar="DIR",
+        help="Directory where pages/ and manifest.json are written.",
+    )
+    public_pdf_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Fetch and extract the source, then preview artifact path, manifest path, "
+            "extraction limitations, and normalized candidate markdown without writing files."
         ),
     )
 
@@ -3230,6 +3327,187 @@ def main(argv: Sequence[str] | None = None) -> int:
         print("\nSummary: wrote 1, skipped 0")
         print(f"  stale_artifacts: {len(stale_artifacts)}")
         print_stale_artifacts(local_files_config.output_dir, stale_artifacts)
+        print(f"Artifact path: {render_user_path(output_path)}")
+        print(f"Manifest path: {render_user_path(manifest)}")
+        print_write_complete(output_dir)
+        return 0
+
+    if args.command in {"public_webpage", "public_pdf"}:
+        import hashlib
+
+        from knowledge_adapters.manifest import (
+            build_manifest_entry,
+            write_manifest,
+        )
+        from knowledge_adapters.manifest_stale import (
+            find_stale_artifacts,
+            load_previous_manifest_index,
+        )
+
+        command = str(args.command)
+        url = str(args.url)
+        output_dir_arg = str(args.output_dir)
+        dry_run = bool(args.dry_run)
+        output_dir_input = Path(output_dir_arg).expanduser()
+        output_dir = output_dir_input.resolve()
+        if output_dir_input.exists() and not output_dir_input.is_dir():
+            exit_with_cli_error(
+                (
+                    f"Output path is not a directory: {output_dir}. "
+                    "Verify --output-dir and use a directory path."
+                ),
+                command=command,
+            )
+
+        try:
+            if command == "public_webpage":
+                from knowledge_adapters.public_webpage.client import fetch_webpage
+                from knowledge_adapters.public_webpage.config import PublicWebpageConfig
+                from knowledge_adapters.public_webpage.normalize import normalize_to_markdown
+                from knowledge_adapters.public_webpage.writer import (
+                    markdown_path as public_markdown_path,
+                )
+                from knowledge_adapters.public_webpage.writer import (
+                    write_markdown as public_write_markdown,
+                )
+
+                public_webpage_config = PublicWebpageConfig(
+                    url=url,
+                    output_dir=output_dir_arg,
+                    dry_run=dry_run,
+                )
+                webpage_document = fetch_webpage(public_webpage_config.url)
+                title = webpage_document.title
+                canonical_id = webpage_document.canonical_id
+                source_url = webpage_document.source_url
+                fetched_at = webpage_document.fetched_at
+                content = webpage_document.content
+                extraction_notes = webpage_document.extraction_notes
+                page_count: int | None = None
+                source = webpage_document.source
+                adapter = webpage_document.adapter
+                adapter_title = "Public webpage"
+                plan_title = "Public webpage run"
+            else:
+                from knowledge_adapters.public_pdf.client import fetch_pdf
+                from knowledge_adapters.public_pdf.config import PublicPdfConfig
+                from knowledge_adapters.public_pdf.normalize import normalize_to_markdown
+                from knowledge_adapters.public_pdf.writer import (
+                    markdown_path as public_markdown_path,
+                )
+                from knowledge_adapters.public_pdf.writer import (
+                    write_markdown as public_write_markdown,
+                )
+
+                public_pdf_config = PublicPdfConfig(
+                    url=url,
+                    output_dir=output_dir_arg,
+                    dry_run=dry_run,
+                )
+                pdf_document = fetch_pdf(public_pdf_config.url)
+                title = pdf_document.title
+                canonical_id = pdf_document.canonical_id
+                source_url = pdf_document.source_url
+                fetched_at = pdf_document.fetched_at
+                content = pdf_document.content
+                extraction_notes = pdf_document.extraction_notes
+                page_count = pdf_document.page_count
+                source = pdf_document.source
+                adapter = pdf_document.adapter
+                adapter_title = "Public PDF/report"
+                plan_title = "Public PDF/report run"
+        except ValueError as exc:
+            exit_with_cli_error(str(exc), command=command)
+
+        candidate: dict[str, object] = {
+            "title": title,
+            "canonical_id": canonical_id,
+            "source_url": source_url,
+            "fetched_at": fetched_at,
+            "content": content,
+            "extraction_notes": extraction_notes,
+            "source": source,
+            "adapter": adapter,
+        }
+        if page_count is not None:
+            candidate["page_count"] = page_count
+        markdown = normalize_to_markdown(candidate)
+
+        print(f"{adapter_title} adapter invoked")
+        print(f"  url: {url}")
+        print(f"  output_dir: {render_user_path(output_dir_arg)}")
+        print(f"  run_mode: {'dry-run' if dry_run else 'write'}")
+
+        try:
+            previous_manifest_index = load_previous_manifest_index(output_dir_arg)
+        except RuntimeError as exc:
+            exit_with_cli_error(str(exc), command=command)
+
+        output_path = public_markdown_path(output_dir_arg, source_url)
+        manifest_output_path = output_dir / "manifest.json"
+        manifest_entry = build_manifest_entry(
+            canonical_id=canonical_id,
+            source_url=source_url,
+            output_path=output_path,
+            output_dir=output_dir_arg,
+            title=title,
+            content_hash=hashlib.sha256(markdown.encode("utf-8")).hexdigest(),
+        )
+        stale_artifacts = [
+            (artifact.canonical_id, artifact.output_path)
+            for artifact in find_stale_artifacts(
+                output_dir_arg,
+                previous_manifest_index,
+                current_output_paths=[str(manifest_entry["output_path"])],
+            )
+        ]
+
+        print(f"\nPlan: {plan_title}")
+        print(f"  source_url: {source_url}")
+        print(f"  title: {title}")
+        print(f"  fetched_at: {fetched_at}")
+        if page_count is not None:
+            print(f"  page_count: {page_count}")
+        print(f"  Artifact path: {render_user_path(output_path)}")
+        print(f"  Manifest path: {render_user_path(manifest_output_path)}")
+        print("  candidate_status: unreviewed")
+        print(f"  extraction_notes: {extraction_notes}")
+        if content:
+            print("  content_status: extracted text with content")
+        else:
+            print(
+                "  content_status: no text extracted; output will contain metadata, "
+                "candidate warning, and an empty content section"
+            )
+        print(f"  action: {'would write' if dry_run else 'write'}")
+
+        if dry_run:
+            print("  Summary: would write 1, would skip 0")
+            print(f"  stale_artifacts: {len(stale_artifacts)}")
+            print_stale_artifacts(output_dir_arg, stale_artifacts)
+            print()
+            print(markdown)
+            print_dry_run_complete()
+            return 0
+
+        try:
+            public_write_markdown(
+                output_dir_arg,
+                source_url,
+                markdown,
+            )
+            manifest = write_manifest(output_dir_arg, [manifest_entry])
+        except OSError as exc:
+            exit_with_output_error(
+                output_dir_arg,
+                command=command,
+                exc=exc,
+            )
+
+        print(f"\nWrote: {render_user_path(output_path)}")
+        print("\nSummary: wrote 1, skipped 0")
+        print(f"  stale_artifacts: {len(stale_artifacts)}")
+        print_stale_artifacts(output_dir_arg, stale_artifacts)
         print(f"Artifact path: {render_user_path(output_path)}")
         print(f"Manifest path: {render_user_path(manifest)}")
         print_write_complete(output_dir)

--- a/src/knowledge_adapters/public_pdf/__init__.py
+++ b/src/knowledge_adapters/public_pdf/__init__.py
@@ -1,0 +1,2 @@
+"""Public PDF/report adapter."""
+

--- a/src/knowledge_adapters/public_pdf/client.py
+++ b/src/knowledge_adapters/public_pdf/client.py
@@ -1,0 +1,72 @@
+"""Public PDF/report fetching and extraction."""
+
+from __future__ import annotations
+
+import io
+from dataclasses import dataclass
+
+from pypdf import PdfReader
+
+from knowledge_adapters.public_sources import fetch_public_url
+
+MAX_PDF_BYTES = 50_000_000
+PDF_EXTRACTION_NOTES = (
+    "Unreviewed candidate material. Fetched a public PDF/report and extracted text with "
+    "pypdf. PDF layout, tables, figures, footnotes, headers, reading order, and scanned "
+    "image-only pages may be incomplete or missing; review against the source PDF before "
+    "retaining any knowledge."
+)
+
+
+@dataclass(frozen=True)
+class PublicPdfDocument:
+    """One extracted public PDF/report candidate."""
+
+    title: str
+    canonical_id: str
+    source_url: str
+    fetched_at: str
+    content: str
+    page_count: int
+    extraction_notes: str = PDF_EXTRACTION_NOTES
+    source: str = "public_pdf"
+    adapter: str = "public_pdf"
+
+
+def fetch_pdf(url: str) -> PublicPdfDocument:
+    """Fetch and extract text from one public PDF URL."""
+    fetched = fetch_public_url(
+        url,
+        accepted_content_types=("application/pdf",),
+        max_bytes=MAX_PDF_BYTES,
+    )
+    try:
+        reader = PdfReader(io.BytesIO(fetched.content))
+    except Exception as exc:
+        raise ValueError(
+            "Could not parse PDF bytes. Verify the URL returns a valid, unencrypted PDF."
+        ) from exc
+
+    metadata = reader.metadata
+    title = ""
+    if metadata is not None and metadata.title:
+        title = str(metadata.title).strip()
+    if not title:
+        title = fetched.final_url.rsplit("/", maxsplit=1)[-1] or fetched.final_url
+
+    pages: list[str] = []
+    for index, page in enumerate(reader.pages, start=1):
+        try:
+            text = page.extract_text() or ""
+        except Exception as exc:
+            raise ValueError(f"Could not extract text from PDF page {index}.") from exc
+        pages.append(f"## Page {index}\n\n{text.strip()}")
+
+    return PublicPdfDocument(
+        title=title,
+        canonical_id=fetched.final_url,
+        source_url=fetched.final_url,
+        fetched_at=fetched.retrieved_at,
+        content="\n\n".join(pages).strip(),
+        page_count=len(reader.pages),
+    )

--- a/src/knowledge_adapters/public_pdf/config.py
+++ b/src/knowledge_adapters/public_pdf/config.py
@@ -1,0 +1,14 @@
+"""Configuration models for the public PDF/report adapter."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PublicPdfConfig:
+    """Runtime configuration for the public PDF/report adapter."""
+
+    url: str
+    output_dir: str
+    dry_run: bool = False

--- a/src/knowledge_adapters/public_pdf/normalize.py
+++ b/src/knowledge_adapters/public_pdf/normalize.py
@@ -1,0 +1,39 @@
+"""Normalization logic for the public PDF/report adapter."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+
+def normalize_to_markdown(page: Mapping[str, object]) -> str:
+    """Normalize a fetched public PDF/report into reviewable candidate markdown."""
+    title = str(page.get("title", "untitled"))
+    canonical_id = str(page.get("canonical_id", ""))
+    source_url = str(page.get("source_url", ""))
+    fetched_at = str(page.get("fetched_at", ""))
+    source = str(page.get("source", "public_pdf"))
+    adapter = str(page.get("adapter", "public_pdf"))
+    page_count = str(page.get("page_count", ""))
+    extraction_notes = str(page.get("extraction_notes", "Unreviewed candidate material."))
+    content = str(page.get("content", "")).rstrip("\n")
+
+    return f"""# {title}
+
+## Metadata
+- source: {source}
+- canonical_id: {canonical_id}
+- parent_id:
+- source_url: {source_url}
+- fetched_at: {fetched_at}
+- updated_at:
+- adapter: {adapter}
+- candidate_status: unreviewed
+- page_count: {page_count}
+- extraction_notes: {extraction_notes}
+
+## Content
+
+> This is unreviewed candidate material generated from an external public PDF/report.
+
+{content}
+"""

--- a/src/knowledge_adapters/public_pdf/writer.py
+++ b/src/knowledge_adapters/public_pdf/writer.py
@@ -1,0 +1,28 @@
+"""File writing utilities for the public PDF/report adapter."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from knowledge_adapters.public_sources import output_name_for_url
+
+
+def markdown_path(output_dir: str, url: str) -> Path:
+    """Return the deterministic markdown path for one public PDF/report."""
+    return Path(output_dir) / "pages" / f"{output_name_for_url(url)}.md"
+
+
+def write_markdown(
+    output_dir: str,
+    url: str,
+    markdown: str,
+    *,
+    dry_run: bool = False,
+) -> Path:
+    """Write normalized markdown to a deterministic local path."""
+    output_path = markdown_path(output_dir, url)
+    if dry_run:
+        return output_path
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(markdown, encoding="utf-8")
+    return output_path

--- a/src/knowledge_adapters/public_sources.py
+++ b/src/knowledge_adapters/public_sources.py
@@ -1,0 +1,124 @@
+"""Shared helpers for public URL source adapters."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
+
+DEFAULT_USER_AGENT = "knowledge-adapters/0.8 public-source-ingestion"
+DEFAULT_FETCH_TIMEOUT_SECONDS = 30
+
+
+@dataclass(frozen=True)
+class FetchedPublicResource:
+    """One fetched public URL response held in memory."""
+
+    url: str
+    final_url: str
+    content: bytes
+    content_type: str
+    content_charset: str | None
+    retrieved_at: str
+
+
+def fetch_public_url(
+    url: str,
+    *,
+    accepted_content_types: tuple[str, ...],
+    timeout_seconds: int = DEFAULT_FETCH_TIMEOUT_SECONDS,
+    max_bytes: int,
+) -> FetchedPublicResource:
+    """Fetch one public HTTP(S) URL into memory."""
+    validate_public_http_url(url)
+    request = Request(
+        url,
+        headers={
+            "Accept": ", ".join(accepted_content_types) if accepted_content_types else "*/*",
+            "User-Agent": DEFAULT_USER_AGENT,
+        },
+    )
+    try:
+        with urlopen(request, timeout=timeout_seconds) as response:
+            final_url = response.geturl()
+            validate_public_http_url(final_url)
+            headers = response.headers
+            content_type = headers.get_content_type()
+            content_charset = headers.get_content_charset()
+            _validate_content_type(content_type, accepted_content_types)
+            content_length = headers.get("Content-Length")
+            if content_length is not None and int(content_length) > max_bytes:
+                raise ValueError(
+                    f"Response is too large: {content_length} bytes exceeds "
+                    f"{max_bytes} byte limit."
+                )
+            content = response.read(max_bytes + 1)
+    except HTTPError as exc:
+        raise ValueError(f"HTTP request failed for {url}: {exc.code} {exc.reason}.") from exc
+    except URLError as exc:
+        raise ValueError(f"Could not fetch {url}: {exc.reason}.") from exc
+    except TimeoutError as exc:
+        raise ValueError(f"Timed out fetching {url}.") from exc
+    except OSError as exc:
+        raise ValueError(f"Could not fetch {url}: {exc}.") from exc
+
+    if len(content) > max_bytes:
+        raise ValueError(f"Response is too large: exceeds {max_bytes} byte limit.")
+
+    return FetchedPublicResource(
+        url=url,
+        final_url=final_url,
+        content=content,
+        content_type=content_type,
+        content_charset=content_charset,
+        retrieved_at=datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+    )
+
+
+def validate_public_http_url(url: str) -> None:
+    """Validate the adapter URL surface without accepting local file paths."""
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError("URL must use http or https.")
+    if not parsed.netloc:
+        raise ValueError("URL must include a host.")
+    if parsed.username or parsed.password:
+        raise ValueError("URL must not include embedded credentials.")
+
+
+def output_name_for_url(url: str) -> str:
+    """Build a deterministic, collision-resistant markdown filename stem."""
+    parsed = urlparse(url)
+    path_name = Path(parsed.path).name
+    if path_name:
+        stem = Path(path_name).stem or path_name
+    else:
+        stem = parsed.netloc
+    slug = re.sub(r"[^A-Za-z0-9._-]+", "-", stem).strip("-._").lower()
+    if not slug:
+        slug = "public-source"
+    digest = hashlib.sha256(url.encode("utf-8")).hexdigest()[:12]
+    return f"{slug}-{digest}"
+
+
+def decode_text_response(content: bytes, charset: str | None) -> str:
+    """Decode an HTTP text response using declared charset with UTF-8 fallback."""
+    charset = charset or "utf-8"
+    try:
+        return content.decode(charset)
+    except (LookupError, UnicodeDecodeError):
+        return content.decode("utf-8", errors="replace")
+
+
+def _validate_content_type(content_type: str, accepted_content_types: tuple[str, ...]) -> None:
+    if not accepted_content_types:
+        return
+    if content_type in accepted_content_types:
+        return
+    accepted = ", ".join(accepted_content_types)
+    raise ValueError(f"Unsupported content type {content_type!r}; expected one of: {accepted}.")

--- a/src/knowledge_adapters/public_sources.py
+++ b/src/knowledge_adapters/public_sources.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import ipaddress
 import re
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -81,7 +82,7 @@ def fetch_public_url(
 
 
 def validate_public_http_url(url: str) -> None:
-    """Validate the adapter URL surface without accepting local file paths."""
+    """Validate that a source URL stays on the public HTTP(S) surface."""
     parsed = urlparse(url)
     if parsed.scheme not in {"http", "https"}:
         raise ValueError("URL must use http or https.")
@@ -89,6 +90,40 @@ def validate_public_http_url(url: str) -> None:
         raise ValueError("URL must include a host.")
     if parsed.username or parsed.password:
         raise ValueError("URL must not include embedded credentials.")
+    try:
+        hostname = parsed.hostname
+    except ValueError as exc:
+        raise ValueError("URL host is invalid.") from exc
+    if hostname is None or not hostname.strip():
+        raise ValueError("URL must include a host.")
+
+    _validate_public_hostname(hostname)
+
+
+def _validate_public_hostname(hostname: str) -> None:
+    normalized_hostname = hostname.rstrip(".").lower()
+    if normalized_hostname == "localhost":
+        raise ValueError("URL host must not be localhost.")
+    if normalized_hostname.endswith(".local"):
+        raise ValueError("URL host must not be a .local hostname.")
+
+    try:
+        address = ipaddress.ip_address(normalized_hostname)
+    except ValueError:
+        return
+
+    if address.is_loopback:
+        raise ValueError("URL host must not be a loopback IP address.")
+    if address.is_link_local:
+        raise ValueError("URL host must not be a link-local IP address.")
+    if address.is_multicast:
+        raise ValueError("URL host must not be a multicast IP address.")
+    if address.is_unspecified:
+        raise ValueError("URL host must not be an unspecified IP address.")
+    if address.is_reserved:
+        raise ValueError("URL host must not be a reserved IP address.")
+    if address.is_private:
+        raise ValueError("URL host must not be a private IP address.")
 
 
 def output_name_for_url(url: str) -> str:

--- a/src/knowledge_adapters/public_webpage/__init__.py
+++ b/src/knowledge_adapters/public_webpage/__init__.py
@@ -1,0 +1,2 @@
+"""Public webpage adapter."""
+

--- a/src/knowledge_adapters/public_webpage/client.py
+++ b/src/knowledge_adapters/public_webpage/client.py
@@ -1,0 +1,149 @@
+"""Public webpage fetching and extraction."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from html.parser import HTMLParser
+
+from knowledge_adapters.public_sources import decode_text_response, fetch_public_url
+
+MAX_WEBPAGE_BYTES = 5_000_000
+WEBPAGE_EXTRACTION_NOTES = (
+    "Unreviewed candidate material. Fetched a public webpage and extracted visible text "
+    "with the Python standard-library HTML parser. Scripts and styles are omitted; "
+    "links, images, tables, comments, and publication metadata may be incomplete."
+)
+
+
+@dataclass(frozen=True)
+class PublicWebpageDocument:
+    """One extracted public webpage candidate."""
+
+    title: str
+    canonical_id: str
+    source_url: str
+    fetched_at: str
+    content: str
+    extraction_notes: str = WEBPAGE_EXTRACTION_NOTES
+    source: str = "public_webpage"
+    adapter: str = "public_webpage"
+
+
+def fetch_webpage(url: str) -> PublicWebpageDocument:
+    """Fetch and extract one public webpage URL."""
+    fetched = fetch_public_url(
+        url,
+        accepted_content_types=("text/html", "application/xhtml+xml"),
+        max_bytes=MAX_WEBPAGE_BYTES,
+    )
+    html = decode_text_response(fetched.content, fetched.content_charset)
+    extractor = _ReadableHTMLExtractor()
+    extractor.feed(html)
+    extractor.close()
+    title = extractor.title.strip() or fetched.final_url
+    content = extractor.markdown_text()
+    return PublicWebpageDocument(
+        title=title,
+        canonical_id=fetched.final_url,
+        source_url=fetched.final_url,
+        fetched_at=fetched.retrieved_at,
+        content=content,
+    )
+
+
+class _ReadableHTMLExtractor(HTMLParser):
+    """Small readable-text extractor for untrusted public HTML."""
+
+    _BLOCK_TAGS = {
+        "address",
+        "article",
+        "aside",
+        "blockquote",
+        "br",
+        "dd",
+        "div",
+        "dl",
+        "dt",
+        "figcaption",
+        "figure",
+        "footer",
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+        "header",
+        "hr",
+        "li",
+        "main",
+        "nav",
+        "ol",
+        "p",
+        "pre",
+        "section",
+        "table",
+        "td",
+        "th",
+        "tr",
+        "ul",
+    }
+    _IGNORED_TAGS = {"script", "style", "noscript", "template", "svg"}
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.title = ""
+        self._in_title = False
+        self._ignored_depth = 0
+        self._parts: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        del attrs
+        normalized_tag = tag.lower()
+        if normalized_tag == "title":
+            self._in_title = True
+        if normalized_tag in self._IGNORED_TAGS:
+            self._ignored_depth += 1
+            return
+        if normalized_tag in self._BLOCK_TAGS:
+            self._append_break()
+
+    def handle_endtag(self, tag: str) -> None:
+        normalized_tag = tag.lower()
+        if normalized_tag == "title":
+            self._in_title = False
+        if normalized_tag in self._IGNORED_TAGS and self._ignored_depth > 0:
+            self._ignored_depth -= 1
+            return
+        if normalized_tag in self._BLOCK_TAGS:
+            self._append_break()
+
+    def handle_data(self, data: str) -> None:
+        if self._ignored_depth > 0:
+            return
+        text = " ".join(data.split())
+        if not text:
+            return
+        if self._in_title:
+            self.title = f"{self.title} {text}".strip()
+            return
+        self._parts.append(text)
+
+    def markdown_text(self) -> str:
+        """Return paragraph-oriented markdown text."""
+        paragraphs: list[str] = []
+        current: list[str] = []
+        for part in self._parts:
+            if part == "\n":
+                if current:
+                    paragraphs.append(" ".join(current))
+                    current = []
+                continue
+            current.append(part)
+        if current:
+            paragraphs.append(" ".join(current))
+        return "\n\n".join(paragraphs)
+
+    def _append_break(self) -> None:
+        if self._parts and self._parts[-1] != "\n":
+            self._parts.append("\n")

--- a/src/knowledge_adapters/public_webpage/config.py
+++ b/src/knowledge_adapters/public_webpage/config.py
@@ -1,0 +1,14 @@
+"""Configuration models for the public webpage adapter."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PublicWebpageConfig:
+    """Runtime configuration for the public webpage adapter."""
+
+    url: str
+    output_dir: str
+    dry_run: bool = False

--- a/src/knowledge_adapters/public_webpage/normalize.py
+++ b/src/knowledge_adapters/public_webpage/normalize.py
@@ -1,0 +1,37 @@
+"""Normalization logic for the public webpage adapter."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+
+def normalize_to_markdown(page: Mapping[str, object]) -> str:
+    """Normalize a fetched public webpage into reviewable candidate markdown."""
+    title = str(page.get("title", "untitled"))
+    canonical_id = str(page.get("canonical_id", ""))
+    source_url = str(page.get("source_url", ""))
+    fetched_at = str(page.get("fetched_at", ""))
+    source = str(page.get("source", "public_webpage"))
+    adapter = str(page.get("adapter", "public_webpage"))
+    extraction_notes = str(page.get("extraction_notes", "Unreviewed candidate material."))
+    content = str(page.get("content", "")).rstrip("\n")
+
+    return f"""# {title}
+
+## Metadata
+- source: {source}
+- canonical_id: {canonical_id}
+- parent_id:
+- source_url: {source_url}
+- fetched_at: {fetched_at}
+- updated_at:
+- adapter: {adapter}
+- candidate_status: unreviewed
+- extraction_notes: {extraction_notes}
+
+## Content
+
+> This is unreviewed candidate material generated from an external public source.
+
+{content}
+"""

--- a/src/knowledge_adapters/public_webpage/writer.py
+++ b/src/knowledge_adapters/public_webpage/writer.py
@@ -1,0 +1,28 @@
+"""File writing utilities for the public webpage adapter."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from knowledge_adapters.public_sources import output_name_for_url
+
+
+def markdown_path(output_dir: str, url: str) -> Path:
+    """Return the deterministic markdown path for one public webpage."""
+    return Path(output_dir) / "pages" / f"{output_name_for_url(url)}.md"
+
+
+def write_markdown(
+    output_dir: str,
+    url: str,
+    markdown: str,
+    *,
+    dry_run: bool = False,
+) -> Path:
+    """Write normalized markdown to a deterministic local path."""
+    output_path = markdown_path(output_dir, url)
+    if dry_run:
+        return output_path
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(markdown, encoding="utf-8")
+    return output_path

--- a/src/knowledge_adapters/run_config.py
+++ b/src/knowledge_adapters/run_config.py
@@ -32,7 +32,15 @@ from knowledge_adapters.confluence.resolve import (
 from knowledge_adapters.github_metadata.config import SUPPORTED_RESOURCE_TYPES
 
 SUPPORTED_RUN_TYPES = frozenset(
-    {"bundle", "confluence", "git_repo", "github_metadata", "local_files"}
+    {
+        "bundle",
+        "confluence",
+        "git_repo",
+        "github_metadata",
+        "local_files",
+        "public_pdf",
+        "public_webpage",
+    }
 )
 _SUPPORTED_CONFLUENCE_CLIENT_MODES = frozenset({"real", "stub"})
 _SUPPORTED_GITHUB_METADATA_STATES = frozenset({"open", "closed", "all"})
@@ -83,6 +91,9 @@ _BUNDLE_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | _BUNDLE_OPTION_KEYS | frozenset(
 _NAMED_BUNDLE_ALLOWED_KEYS = _BUNDLE_OPTION_KEYS | frozenset({"name", "runs"})
 _LOCAL_FILES_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
     {"dry_run", "enabled", "file_path", "output_dir"}
+)
+_PUBLIC_URL_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
+    {"dry_run", "enabled", "output_dir", "url"}
 )
 _GIT_REPO_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
     {"dry_run", "enabled", "exclude", "include", "output_dir", "ref", "repo_url", "subdir"}
@@ -330,6 +341,20 @@ def _parse_run(
         argv = _build_git_repo_argv(run_config, name=name, config_path=config_path)
     elif run_type == "github_metadata":
         argv = _build_github_metadata_argv(run_config, name=name, config_path=config_path)
+    elif run_type == "public_webpage":
+        argv = _build_public_url_argv(
+            run_config,
+            command="public_webpage",
+            name=name,
+            config_path=config_path,
+        )
+    elif run_type == "public_pdf":
+        argv = _build_public_url_argv(
+            run_config,
+            command="public_pdf",
+            name=name,
+            config_path=config_path,
+        )
     else:
         argv = _build_local_files_argv(run_config, name=name, config_path=config_path)
     dry_run = _optional_bool(
@@ -1035,6 +1060,37 @@ def _build_git_repo_argv(
     ):
         argv.extend(["--exclude", exclude_pattern])
 
+    if _optional_bool(run_config, "dry_run", index=index, config_path=config_path, default=False):
+        argv.append("--dry-run")
+    return tuple(argv)
+
+
+def _build_public_url_argv(
+    run_config: dict[str, object],
+    *,
+    command: str,
+    name: str,
+    config_path: Path,
+) -> tuple[str, ...]:
+    _reject_unknown_keys(
+        run_config,
+        allowed_keys=_PUBLIC_URL_ALLOWED_KEYS,
+        name=name,
+        config_path=config_path,
+    )
+    index = _run_index(name=name, config_path=config_path)
+    url = _require_string(run_config, "url", index=index, config_path=config_path)
+    output_dir = _resolve_path_string(
+        _require_string(run_config, "output_dir", index=index, config_path=config_path),
+        config_path=config_path,
+    )
+    argv: list[str] = [
+        command,
+        "--url",
+        url,
+        "--output-dir",
+        output_dir,
+    ]
     if _optional_bool(run_config, "dry_run", index=index, config_path=config_path, default=False):
         argv.append("--dry-run")
     return tuple(argv)

--- a/tests/test_adapter_readiness.py
+++ b/tests/test_adapter_readiness.py
@@ -29,6 +29,8 @@ def test_adapter_readiness_model_is_sorted_and_complete() -> None:
         "git_repo",
         "github_metadata",
         "local_files",
+        "public_pdf",
+        "public_webpage",
     )
     assert tuple(row.adapter for row in rows) == tuple(sorted(row.adapter for row in rows))
     for row in rows:
@@ -82,6 +84,8 @@ def test_adapter_readiness_report_is_deterministic() -> None:
         "git_repo         no                  no     no      no\n"
         "github_metadata  no                  no     no      no\n"
         "local_files      no                  no     no      no\n"
+        "public_pdf       no                  no     no      no\n"
+        "public_webpage   no                  no     no      no\n"
         "\n"
         "Evidence:\n"
         "confluence:\n"
@@ -106,6 +110,16 @@ def test_adapter_readiness_report_is_deterministic() -> None:
         "  Contract/invariant: no - Not yet registered in the readiness model.\n"
         "  Chaos: no - No local_files chaos scenarios are registered.\n"
         "  Replay: no - Replay applies to registered chaos scenarios; local_files has none.\n"
+        "  No partial artifacts: no - No no-partial-artifact failure coverage is registered.\n"
+        "public_pdf:\n"
+        "  Contract/invariant: no - Not yet registered in the readiness model.\n"
+        "  Chaos: no - No public_pdf chaos scenarios are registered.\n"
+        "  Replay: no - Replay applies to registered chaos scenarios; public_pdf has none.\n"
+        "  No partial artifacts: no - No no-partial-artifact failure coverage is registered.\n"
+        "public_webpage:\n"
+        "  Contract/invariant: no - Not yet registered in the readiness model.\n"
+        "  Chaos: no - No public_webpage chaos scenarios are registered.\n"
+        "  Replay: no - Replay applies to registered chaos scenarios; public_webpage has none.\n"
         "  No partial artifacts: no - No no-partial-artifact failure coverage is registered.\n"
     )
 

--- a/tests/test_cli_help.py
+++ b/tests/test_cli_help.py
@@ -31,6 +31,37 @@ def test_local_files_cli_help_includes_first_run_guidance(tmp_path: Path) -> Non
     assert "--dry-run" in stdout
 
 
+def test_public_webpage_cli_help_includes_candidate_guidance(tmp_path: Path) -> None:
+    result = run_cli(tmp_path, "public_webpage", "--help")
+    stdout = normalize_whitespace(result.stdout)
+
+    assert result.returncode == 0, result.stderr
+    assert "Fetch one public HTTP(S) webpage URL" in stdout
+    assert "standard-library HTML parser" in stdout
+    assert "Output is explicitly unreviewed candidate material" in stdout
+    assert "Raw fetched HTML is held only in memory" in stdout
+    assert "--url URL" in stdout
+    assert "--output-dir DIR" in stdout
+    assert "--dry-run" in stdout
+    assert "meaningfultech.com/p/the-vibe-coding-illusion-why-faster" in stdout
+
+
+def test_public_pdf_cli_help_includes_extraction_limitations(tmp_path: Path) -> None:
+    result = run_cli(tmp_path, "public_pdf", "--help")
+    stdout = normalize_whitespace(result.stdout)
+
+    assert result.returncode == 0, result.stderr
+    assert "Fetch one public HTTP(S) PDF/report URL" in stdout
+    assert "extract text with pypdf" in stdout
+    assert "PDF layout, tables, figures" in stdout
+    assert "scanned image-only pages may be incomplete or missing" in stdout
+    assert "Raw fetched PDF bytes are held only in memory" in stdout
+    assert "--url URL" in stdout
+    assert "--output-dir DIR" in stdout
+    assert "--dry-run" in stdout
+    assert "2023-dora-accelerate-state-of-devops-report.pdf" in stdout
+
+
 def test_git_repo_cli_help_includes_filter_and_binary_guidance(tmp_path: Path) -> None:
     result = run_cli(tmp_path, "git_repo", "--help")
     stdout = normalize_whitespace(result.stdout)

--- a/tests/test_cli_help.py
+++ b/tests/test_cli_help.py
@@ -39,6 +39,8 @@ def test_public_webpage_cli_help_includes_candidate_guidance(tmp_path: Path) -> 
     assert "Fetch one public HTTP(S) webpage URL" in stdout
     assert "standard-library HTML parser" in stdout
     assert "Output is explicitly unreviewed candidate material" in stdout
+    assert "Localhost, .local, private, link-local, multicast" in stdout
+    assert "rejected before fetch and after redirects" in stdout
     assert "Raw fetched HTML is held only in memory" in stdout
     assert "--url URL" in stdout
     assert "--output-dir DIR" in stdout
@@ -55,6 +57,8 @@ def test_public_pdf_cli_help_includes_extraction_limitations(tmp_path: Path) -> 
     assert "extract text with pypdf" in stdout
     assert "PDF layout, tables, figures" in stdout
     assert "scanned image-only pages may be incomplete or missing" in stdout
+    assert "Localhost, .local, private, link-local, multicast" in stdout
+    assert "rejected before fetch and after redirects" in stdout
     assert "Raw fetched PDF bytes are held only in memory" in stdout
     assert "--url URL" in stdout
     assert "--output-dir DIR" in stdout

--- a/tests/test_public_sources.py
+++ b/tests/test_public_sources.py
@@ -4,13 +4,18 @@ from email.message import Message
 from pathlib import Path
 from typing import Any, Literal
 
+import pytest
 from pytest import CaptureFixture, MonkeyPatch
 
 from knowledge_adapters.cli import main
 from knowledge_adapters.public_pdf.client import PublicPdfDocument
 from knowledge_adapters.public_pdf.normalize import normalize_to_markdown as normalize_pdf
 from knowledge_adapters.public_pdf.writer import markdown_path as pdf_markdown_path
-from knowledge_adapters.public_sources import fetch_public_url, output_name_for_url
+from knowledge_adapters.public_sources import (
+    fetch_public_url,
+    output_name_for_url,
+    validate_public_http_url,
+)
 from knowledge_adapters.public_webpage.client import PublicWebpageDocument, fetch_webpage
 from knowledge_adapters.public_webpage.normalize import normalize_to_markdown as normalize_webpage
 from knowledge_adapters.public_webpage.writer import markdown_path as webpage_markdown_path
@@ -82,6 +87,89 @@ def test_fetch_public_url_uses_in_memory_response_and_metadata(
     assert fetched.content_type == "text/html"
     assert fetched.content_charset == "utf-8"
     assert fetched.retrieved_at.endswith("Z")
+
+
+@pytest.mark.parametrize(
+    "url",
+    (
+        "https://example.com/article",
+        "http://subdomain.example.org/report",
+        "https://8.8.8.8/dns-over-https",
+        "https://[2606:4700:4700::1111]/",
+    ),
+)
+def test_validate_public_http_url_accepts_public_http_targets(url: str) -> None:
+    validate_public_http_url(url)
+
+
+@pytest.mark.parametrize(
+    "url",
+    (
+        "ftp://example.com/report",
+        "file:///etc/passwd",
+        "https://user:pass@example.com/report",
+        "https://localhost/report",
+        "https://localhost./report",
+        "https://printer.local/report",
+        "https://printer.local./report",
+        "https://127.0.0.1/report",
+        "https://[::1]/report",
+        "https://10.0.0.1/report",
+        "https://172.16.0.1/report",
+        "https://192.168.0.1/report",
+        "https://169.254.1.1/report",
+        "https://169.254.169.254/latest/meta-data/",
+        "https://[fe80::1]/report",
+        "https://224.0.0.1/report",
+        "https://[ff02::1]/report",
+        "https://0.0.0.0/report",
+        "https://[::]/report",
+        "https://240.0.0.1/report",
+        "https://[2001:db8::1]/report",
+    ),
+)
+def test_validate_public_http_url_rejects_local_private_internal_targets(url: str) -> None:
+    with pytest.raises(ValueError):
+        validate_public_http_url(url)
+
+
+def test_fetch_public_url_does_not_request_rejected_original_url(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    def fake_urlopen(request: object, timeout: int) -> _FakeResponse:
+        del request, timeout
+        raise AssertionError("blocked original URL should not be requested")
+
+    monkeypatch.setattr("knowledge_adapters.public_sources.urlopen", fake_urlopen)
+
+    with pytest.raises(ValueError, match="private IP"):
+        fetch_public_url(
+            "https://10.0.0.1/report",
+            accepted_content_types=("text/html",),
+            max_bytes=1000,
+        )
+
+
+def test_fetch_public_url_revalidates_and_rejects_redirect_final_url(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    def fake_urlopen(request: object, timeout: int) -> _FakeResponse:
+        del request, timeout
+        return _FakeResponse(
+            url="https://169.254.169.254/latest/meta-data/",
+            content=b"metadata",
+            content_type="text/html",
+            charset="utf-8",
+        )
+
+    monkeypatch.setattr("knowledge_adapters.public_sources.urlopen", fake_urlopen)
+
+    with pytest.raises(ValueError, match="link-local"):
+        fetch_public_url(
+            "https://example.com/redirect",
+            accepted_content_types=("text/html",),
+            max_bytes=1000,
+        )
 
 
 def test_fetch_webpage_extracts_title_and_visible_text(monkeypatch: MonkeyPatch) -> None:

--- a/tests/test_public_sources.py
+++ b/tests/test_public_sources.py
@@ -1,0 +1,304 @@
+from __future__ import annotations
+
+from email.message import Message
+from pathlib import Path
+from typing import Any, Literal
+
+from pytest import CaptureFixture, MonkeyPatch
+
+from knowledge_adapters.cli import main
+from knowledge_adapters.public_pdf.client import PublicPdfDocument
+from knowledge_adapters.public_pdf.normalize import normalize_to_markdown as normalize_pdf
+from knowledge_adapters.public_pdf.writer import markdown_path as pdf_markdown_path
+from knowledge_adapters.public_sources import fetch_public_url, output_name_for_url
+from knowledge_adapters.public_webpage.client import PublicWebpageDocument, fetch_webpage
+from knowledge_adapters.public_webpage.normalize import normalize_to_markdown as normalize_webpage
+from knowledge_adapters.public_webpage.writer import markdown_path as webpage_markdown_path
+from tests.artifact_assertions import assert_manifest_entries, assert_markdown_document
+
+MEANINGFULTECH_URL = "https://meaningfultech.com/p/the-vibe-coding-illusion-why-faster"
+DORA_2023_PDF_URL = (
+    "https://dora.dev/research/2023/dora-report/"
+    "2023-dora-accelerate-state-of-devops-report.pdf"
+)
+
+
+class _FakeResponse:
+    def __init__(
+        self,
+        *,
+        url: str,
+        content: bytes,
+        content_type: str,
+        charset: str | None = None,
+    ) -> None:
+        self._url = url
+        self._content = content
+        self.headers = Message()
+        self.headers["Content-Type"] = (
+            f"{content_type}; charset={charset}" if charset is not None else content_type
+        )
+        self.headers["Content-Length"] = str(len(content))
+
+    def __enter__(self) -> _FakeResponse:
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> Literal[False]:
+        return False
+
+    def geturl(self) -> str:
+        return self._url
+
+    def read(self, amount: int = -1) -> bytes:
+        if amount < 0:
+            return self._content
+        return self._content[:amount]
+
+
+def test_fetch_public_url_uses_in_memory_response_and_metadata(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    def fake_urlopen(request: Any, timeout: int) -> _FakeResponse:
+        del timeout
+        assert request.full_url == MEANINGFULTECH_URL
+        return _FakeResponse(
+            url=MEANINGFULTECH_URL,
+            content=b"<html>Hello</html>",
+            content_type="text/html",
+            charset="utf-8",
+        )
+
+    monkeypatch.setattr("knowledge_adapters.public_sources.urlopen", fake_urlopen)
+
+    fetched = fetch_public_url(
+        MEANINGFULTECH_URL,
+        accepted_content_types=("text/html",),
+        max_bytes=1000,
+    )
+
+    assert fetched.url == MEANINGFULTECH_URL
+    assert fetched.final_url == MEANINGFULTECH_URL
+    assert fetched.content == b"<html>Hello</html>"
+    assert fetched.content_type == "text/html"
+    assert fetched.content_charset == "utf-8"
+    assert fetched.retrieved_at.endswith("Z")
+
+
+def test_fetch_webpage_extracts_title_and_visible_text(monkeypatch: MonkeyPatch) -> None:
+    html = b"""
+<html>
+  <head><title>The Vibe Coding Illusion</title><style>hidden</style></head>
+  <body>
+    <article>
+      <h1>The Vibe Coding Illusion</h1>
+      <p>Faster typing is not the same as faster delivery.</p>
+      <script>doNotKeep()</script>
+      <p>Review still matters.</p>
+    </article>
+  </body>
+</html>
+"""
+
+    def fake_urlopen(request: object, timeout: int) -> _FakeResponse:
+        del request, timeout
+        return _FakeResponse(
+            url=MEANINGFULTECH_URL,
+            content=html,
+            content_type="text/html",
+            charset="utf-8",
+        )
+
+    monkeypatch.setattr("knowledge_adapters.public_sources.urlopen", fake_urlopen)
+
+    document = fetch_webpage(MEANINGFULTECH_URL)
+
+    assert document.title == "The Vibe Coding Illusion"
+    assert document.source_url == MEANINGFULTECH_URL
+    assert "Faster typing is not the same as faster delivery." in document.content
+    assert "Review still matters." in document.content
+    assert "doNotKeep" not in document.content
+    assert "Unreviewed candidate material" in document.extraction_notes
+
+
+def test_public_webpage_normalizer_marks_candidate_status() -> None:
+    markdown = normalize_webpage(
+        {
+            "title": "The Vibe Coding Illusion",
+            "canonical_id": MEANINGFULTECH_URL,
+            "source_url": MEANINGFULTECH_URL,
+            "fetched_at": "2026-05-11T12:00:00Z",
+            "content": "Article text.",
+            "extraction_notes": "Unreviewed candidate material. HTML extraction note.",
+        }
+    )
+
+    assert_markdown_document(
+        markdown,
+        title="The Vibe Coding Illusion",
+        metadata={
+            "source": "public_webpage",
+            "canonical_id": MEANINGFULTECH_URL,
+            "parent_id": "",
+            "source_url": MEANINGFULTECH_URL,
+            "fetched_at": "2026-05-11T12:00:00Z",
+            "updated_at": "",
+            "adapter": "public_webpage",
+            "candidate_status": "unreviewed",
+            "extraction_notes": "Unreviewed candidate material. HTML extraction note.",
+        },
+        content=(
+            "> This is unreviewed candidate material generated from an external public source.\n\n"
+            "Article text."
+        ),
+    )
+
+
+def test_public_pdf_normalizer_marks_limitations() -> None:
+    markdown = normalize_pdf(
+        {
+            "title": "DORA 2023 Accelerate State of DevOps Report",
+            "canonical_id": DORA_2023_PDF_URL,
+            "source_url": DORA_2023_PDF_URL,
+            "fetched_at": "2026-05-11T12:00:00Z",
+            "page_count": 2,
+            "content": "## Page 1\n\nReport text.",
+            "extraction_notes": "Unreviewed candidate material. PDF extraction limitations.",
+        }
+    )
+
+    assert_markdown_document(
+        markdown,
+        title="DORA 2023 Accelerate State of DevOps Report",
+        metadata={
+            "source": "public_pdf",
+            "canonical_id": DORA_2023_PDF_URL,
+            "parent_id": "",
+            "source_url": DORA_2023_PDF_URL,
+            "fetched_at": "2026-05-11T12:00:00Z",
+            "updated_at": "",
+            "adapter": "public_pdf",
+            "candidate_status": "unreviewed",
+            "page_count": "2",
+            "extraction_notes": "Unreviewed candidate material. PDF extraction limitations.",
+        },
+        content=(
+            "> This is unreviewed candidate material generated from an external public "
+            "PDF/report.\n\n## Page 1\n\nReport text."
+        ),
+    )
+
+
+def test_public_webpage_cli_writes_candidate_markdown(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+    monkeypatch: MonkeyPatch,
+) -> None:
+    output_dir = tmp_path / "out"
+
+    def fake_fetch(url: str) -> PublicWebpageDocument:
+        assert url == MEANINGFULTECH_URL
+        return PublicWebpageDocument(
+            title="The Vibe Coding Illusion",
+            canonical_id=MEANINGFULTECH_URL,
+            source_url=MEANINGFULTECH_URL,
+            fetched_at="2026-05-11T12:00:00Z",
+            content="Article candidate text.",
+        )
+
+    monkeypatch.setattr("knowledge_adapters.public_webpage.client.fetch_webpage", fake_fetch)
+
+    exit_code = main(
+        [
+            "public_webpage",
+            "--url",
+            MEANINGFULTECH_URL,
+            "--output-dir",
+            str(output_dir),
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "Public webpage adapter invoked" in captured.out
+    assert "candidate_status: unreviewed" in captured.out
+    assert "Summary: wrote 1, skipped 0" in captured.out
+
+    output_path = webpage_markdown_path(str(output_dir), MEANINGFULTECH_URL)
+    assert output_path.exists()
+    assert "Article candidate text." in output_path.read_text(encoding="utf-8")
+    assert_manifest_entries(
+        output_dir / "manifest.json",
+        files=[
+            {
+                "canonical_id": MEANINGFULTECH_URL,
+                "source_url": MEANINGFULTECH_URL,
+                "output_path": output_path.relative_to(output_dir).as_posix(),
+                "title": "The Vibe Coding Illusion",
+                "content_hash": _content_hash_from_manifest(output_dir / "manifest.json"),
+            }
+        ],
+    )
+
+
+def test_public_pdf_cli_dry_run_reports_limitations_without_writing(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+    monkeypatch: MonkeyPatch,
+) -> None:
+    output_dir = tmp_path / "out"
+
+    def fake_fetch(url: str) -> PublicPdfDocument:
+        assert url == DORA_2023_PDF_URL
+        return PublicPdfDocument(
+            title="DORA 2023 Accelerate State of DevOps Report",
+            canonical_id=DORA_2023_PDF_URL,
+            source_url=DORA_2023_PDF_URL,
+            fetched_at="2026-05-11T12:00:00Z",
+            content="## Page 1\n\nReport candidate text.",
+            page_count=1,
+        )
+
+    monkeypatch.setattr("knowledge_adapters.public_pdf.client.fetch_pdf", fake_fetch)
+
+    exit_code = main(
+        [
+            "public_pdf",
+            "--url",
+            DORA_2023_PDF_URL,
+            "--output-dir",
+            str(output_dir),
+            "--dry-run",
+        ]
+    )
+
+    assert exit_code == 0
+    output_path = pdf_markdown_path(str(output_dir), DORA_2023_PDF_URL)
+    assert not output_path.exists()
+    assert not (output_dir / "manifest.json").exists()
+
+    captured = capsys.readouterr()
+    assert "Public PDF/report adapter invoked" in captured.out
+    assert "run_mode: dry-run" in captured.out
+    assert "page_count: 1" in captured.out
+    assert "candidate_status: unreviewed" in captured.out
+    assert "PDF layout, tables, figures" in captured.out
+    assert "Summary: would write 1, would skip 0" in captured.out
+    assert "Report candidate text." in captured.out
+
+
+def test_output_name_for_url_includes_slug_and_hash() -> None:
+    output_name = output_name_for_url(DORA_2023_PDF_URL)
+
+    assert output_name.startswith("2023-dora-accelerate-state-of-devops-report-")
+    assert len(output_name.rsplit("-", maxsplit=1)[-1]) == 12
+
+
+def _content_hash_from_manifest(manifest_path: Path) -> str:
+    import json
+
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    files = payload["files"]
+    assert isinstance(files, list)
+    content_hash = files[0]["content_hash"]
+    assert isinstance(content_hash, str)
+    return content_hash

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -205,6 +205,68 @@ runs:
     )
 
 
+def test_load_run_config_supports_public_webpage_and_pdf_urls(tmp_path: Path) -> None:
+    meaningfultech_url = "https://meaningfultech.com/p/the-vibe-coding-illusion-why-faster"
+    dora_pdf_url = (
+        "https://dora.dev/research/2023/dora-report/"
+        "2023-dora-accelerate-state-of-devops-report.pdf"
+    )
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        f"""
+runs:
+  - name: meaningfultech-vibe-coding
+    type: public_webpage
+    url: {meaningfultech_url}
+    output_dir: ./artifacts/public-web/meaningfultech-vibe-coding
+    dry_run: true
+  - name: dora-2023-report
+    type: public_pdf
+    url: {dora_pdf_url}
+    output_dir: ./artifacts/public-pdf/dora-2023
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    run_config = load_run_config(config_path)
+
+    assert run_config.runs == (
+        ConfiguredRun(
+            name="meaningfultech-vibe-coding",
+            run_type="public_webpage",
+            argv=(
+                "public_webpage",
+                "--url",
+                meaningfultech_url,
+                "--output-dir",
+                str(
+                    (
+                        tmp_path
+                        / "artifacts"
+                        / "public-web"
+                        / "meaningfultech-vibe-coding"
+                    ).resolve()
+                ),
+                "--dry-run",
+            ),
+            dry_run=True,
+        ),
+        ConfiguredRun(
+            name="dora-2023-report",
+            run_type="public_pdf",
+            argv=(
+                "public_pdf",
+                "--url",
+                dora_pdf_url,
+                "--output-dir",
+                str((tmp_path / "artifacts" / "public-pdf" / "dora-2023").resolve()),
+            ),
+            dry_run=False,
+        ),
+    )
+
+
 def test_load_run_config_supports_bundle_stale_mode(tmp_path: Path) -> None:
     config_path = tmp_path / "runs.yaml"
     config_path.write_text(


### PR DESCRIPTION
## Summary

- Add `public_webpage` ingestion for public webpage/article URLs into unreviewed markdown-first candidate artifacts.
- Add `public_pdf` ingestion for public PDF/report URLs into unreviewed markdown-first candidate artifacts.
- Wire both adapters into CLI help, `runs.yaml` config loading, run examples, readiness reporting, docs, and deterministic unit tests.

## Behavior

- Generated output includes source URL, title when available, retrieval timestamp, candidate status, extraction notes, and adapter metadata.
- Raw fetched HTML/PDF bytes are held in memory only; the adapter writes only caller-selected candidate markdown and manifest output paths.
- Dry-run fetches and extracts, then previews the candidate markdown and planned paths without writing files.

## Validation

- `make check` passed: Ruff, mypy, and 423 pytest tests.
- `make check-gh-env` passed.

## Dependency

- Adds `pypdf>=5.0` for PDF text extraction.

## Manual Live Validation

Not run locally to keep canonical validation deterministic and avoid flaky network-dependent checks. Optional commands:

```bash
knowledge-adapters public_webpage \
  --url https://meaningfultech.com/p/the-vibe-coding-illusion-why-faster \
  --output-dir ./artifacts/public-web/meaningfultech-vibe-coding \
  --dry-run

knowledge-adapters public_pdf \
  --url https://dora.dev/research/2023/dora-report/2023-dora-accelerate-state-of-devops-report.pdf \
  --output-dir ./artifacts/public-pdf/dora-2023 \
  --dry-run
```
