### PR TITLE
[codex] Normalize public PDF replay noise

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,12 @@ Localhost, `.local`, private, link-local, multicast, unspecified, reserved, and
 credential-bearing targets are rejected before fetch and after redirects. Raw
 fetched PDF bytes are held only in memory. PDF layout, tables, figures,
 footnotes, headers, reading order, and scanned image-only pages may be incomplete
-or missing, so review against the source PDF before retaining any knowledge.
+or missing, so review against the source PDF before retaining any knowledge. The
+PDF adapter applies only mechanical replay-noise normalization: it repairs
+broken `http://` and `https://` scheme spacing from extraction and suppresses
+short repeated trailing footer lines when they recur by page position across a
+majority of pages. It does not infer sections, rewrite prose, retain source
+PDFs, or auto-promote extracted material.
 
 Recommended Confluence first run:
 

--- a/src/knowledge_adapters/public_pdf/client.py
+++ b/src/knowledge_adapters/public_pdf/client.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 
 from pypdf import PdfReader
 
+from knowledge_adapters.public_pdf.normalize import normalize_extracted_pages
 from knowledge_adapters.public_sources import fetch_public_url
 
 MAX_PDF_BYTES = 50_000_000
@@ -14,7 +15,9 @@ PDF_EXTRACTION_NOTES = (
     "Unreviewed candidate material. Fetched a public PDF/report and extracted text with "
     "pypdf. PDF layout, tables, figures, footnotes, headers, reading order, and scanned "
     "image-only pages may be incomplete or missing; review against the source PDF before "
-    "retaining any knowledge."
+    "retaining any knowledge. Clearly mechanical extraction artifacts may be normalized: "
+    "broken HTTP(S) URL scheme spacing is repaired, and short repeated trailing footer "
+    "lines may be suppressed when they recur by page position."
 )
 
 
@@ -54,13 +57,18 @@ def fetch_pdf(url: str) -> PublicPdfDocument:
     if not title:
         title = fetched.final_url.rsplit("/", maxsplit=1)[-1] or fetched.final_url
 
-    pages: list[str] = []
+    raw_pages: list[str] = []
     for index, page in enumerate(reader.pages, start=1):
         try:
             text = page.extract_text() or ""
         except Exception as exc:
             raise ValueError(f"Could not extract text from PDF page {index}.") from exc
-        pages.append(f"## Page {index}\n\n{text.strip()}")
+        raw_pages.append(text)
+
+    pages = [
+        f"## Page {index}\n\n{text.strip()}"
+        for index, text in enumerate(normalize_extracted_pages(raw_pages), start=1)
+    ]
 
     return PublicPdfDocument(
         title=title,

--- a/src/knowledge_adapters/public_pdf/normalize.py
+++ b/src/knowledge_adapters/public_pdf/normalize.py
@@ -2,7 +2,23 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+import re
+from collections.abc import Mapping, Sequence
+
+_BROKEN_URL_SCHEME_RE = re.compile(
+    r"\b(?P<scheme>https?)\s*:\s*/\s*/\s*"
+    r"(?P<host>[A-Za-z0-9][A-Za-z0-9.-]*(?::\d+)?)"
+    r"(?P<path>[/#?][^\s<>()\[\]{}\"']*)?",
+    re.IGNORECASE,
+)
+_MAX_FOOTER_CANDIDATE_LINES = 3
+_MAX_FOOTER_LINE_LENGTH = 140
+
+
+def normalize_extracted_pages(page_texts: Sequence[str]) -> list[str]:
+    """Normalize clearly mechanical artifacts from extracted PDF page text."""
+    pages = [_normalize_broken_url_spacing(page_text) for page_text in page_texts]
+    return _suppress_repeated_footer_lines(pages)
 
 
 def normalize_to_markdown(page: Mapping[str, object]) -> str:
@@ -37,3 +53,61 @@ def normalize_to_markdown(page: Mapping[str, object]) -> str:
 
 {content}
 """
+
+
+def _normalize_broken_url_spacing(text: str) -> str:
+    return _BROKEN_URL_SCHEME_RE.sub(_join_broken_url_scheme, text)
+
+
+def _join_broken_url_scheme(match: re.Match[str]) -> str:
+    path = match.group("path") or ""
+    return f"{match.group('scheme')}://{match.group('host')}{path}"
+
+
+def _suppress_repeated_footer_lines(page_texts: list[str]) -> list[str]:
+    if len(page_texts) < 2:
+        return [page_text.strip() for page_text in page_texts]
+
+    page_lines = [page_text.splitlines() for page_text in page_texts]
+    candidates: dict[tuple[int, str], set[int]] = {}
+    candidate_indexes: dict[tuple[int, str], list[tuple[int, int]]] = {}
+
+    for page_index, lines in enumerate(page_lines):
+        nonempty_indexes = [index for index, line in enumerate(lines) if line.strip()]
+        trailing_indexes = nonempty_indexes[-_MAX_FOOTER_CANDIDATE_LINES:]
+        for depth, line_index in enumerate(reversed(trailing_indexes), start=1):
+            signature = _footer_signature(lines[line_index])
+            if signature is None:
+                continue
+            key = (depth, signature)
+            candidates.setdefault(key, set()).add(page_index)
+            candidate_indexes.setdefault(key, []).append((page_index, line_index))
+
+    min_repeated_pages = 2 if len(page_texts) == 2 else (len(page_texts) // 2) + 1
+    indexes_to_remove: set[tuple[int, int]] = set()
+    for key, page_indexes in candidates.items():
+        if len(page_indexes) >= min_repeated_pages:
+            indexes_to_remove.update(candidate_indexes[key])
+
+    normalized_pages: list[str] = []
+    for page_index, lines in enumerate(page_lines):
+        kept_lines = [
+            line.rstrip()
+            for line_index, line in enumerate(lines)
+            if (page_index, line_index) not in indexes_to_remove
+        ]
+        normalized_pages.append("\n".join(kept_lines).strip())
+    return normalized_pages
+
+
+def _footer_signature(line: str) -> str | None:
+    cleaned = " ".join(line.strip().split())
+    if not cleaned or len(cleaned) > _MAX_FOOTER_LINE_LENGTH:
+        return None
+
+    signature = cleaned.casefold()
+    signature = re.sub(r"\bpage\s+\d+(\s+(of|/)\s+\d+)?\b", "page #", signature)
+    signature = re.sub(r"\bp\.\s*\d+(\s*/\s*\d+)?\b", "p. #", signature)
+    signature = re.sub(r"([|:/-]\s*)\d+(\s*(of|/)\s*\d+)?$", r"\1#", signature)
+    signature = re.sub(r"^\d+(\s*/\s*\d+)?$", "#", signature)
+    return signature

--- a/tests/test_public_sources.py
+++ b/tests/test_public_sources.py
@@ -9,7 +9,12 @@ from pytest import CaptureFixture, MonkeyPatch
 
 from knowledge_adapters.cli import main
 from knowledge_adapters.public_pdf.client import PublicPdfDocument
-from knowledge_adapters.public_pdf.normalize import normalize_to_markdown as normalize_pdf
+from knowledge_adapters.public_pdf.normalize import (
+    normalize_extracted_pages as normalize_pdf_pages,
+)
+from knowledge_adapters.public_pdf.normalize import (
+    normalize_to_markdown as normalize_pdf,
+)
 from knowledge_adapters.public_pdf.writer import markdown_path as pdf_markdown_path
 from knowledge_adapters.public_sources import (
     fetch_public_url,
@@ -274,6 +279,56 @@ def test_public_pdf_normalizer_marks_limitations() -> None:
             "PDF/report.\n\n## Page 1\n\nReport text."
         ),
     )
+
+
+def test_public_pdf_page_normalization_repairs_broken_url_spacing() -> None:
+    normalized_pages = normalize_pdf_pages(
+        [
+            (
+                "Read the report at https:/ /dora.dev/research/2023/dora-report/ "
+                "or mirror https: //example.com/report.pdf."
+            )
+        ]
+    )
+
+    assert normalized_pages == [
+        (
+            "Read the report at https://dora.dev/research/2023/dora-report/ "
+            "or mirror https://example.com/report.pdf."
+        )
+    ]
+
+
+def test_public_pdf_page_normalization_suppresses_repeated_footer_lines() -> None:
+    normalized_pages = normalize_pdf_pages(
+        [
+            "Executive summary\n2023 Accelerate State of DevOps Report | 1",
+            "Key findings\n2023 Accelerate State of DevOps Report | 2",
+            "Closing notes\n2023 Accelerate State of DevOps Report | 3",
+        ]
+    )
+
+    assert normalized_pages == [
+        "Executive summary",
+        "Key findings",
+        "Closing notes",
+    ]
+
+
+def test_public_pdf_page_normalization_keeps_non_repeated_trailing_text() -> None:
+    normalized_pages = normalize_pdf_pages(
+        [
+            "Executive summary\nImportant benchmark: 12",
+            "Key findings\nDifferent closing detail: 13",
+            "Closing notes\n2023 Accelerate State of DevOps Report | 3",
+        ]
+    )
+
+    assert normalized_pages == [
+        "Executive summary\nImportant benchmark: 12",
+        "Key findings\nDifferent closing detail: 13",
+        "Closing notes\n2023 Accelerate State of DevOps Report | 3",
+    ]
 
 
 def test_public_webpage_cli_writes_candidate_markdown(


### PR DESCRIPTION
Refs CAK-15

## Summary
- Normalize clearly mechanical public_pdf extraction artifacts before replay candidate markdown is assembled.
- Repair broken HTTP(S) URL scheme spacing such as `https:/ /dora.dev` -> `https://dora.dev` and `https: //example.com` -> `https://example.com`.
- Suppress short trailing footer lines only when they recur by the same page-bottom position across a majority of pages.
- Document the behavior and keep extraction notes explicit that candidates remain unreviewed.

## Before / After Examples

Broken URL spacing:

```text
Before: Read the report at https:/ /dora.dev/research/2023/dora-report/
After:  Read the report at https://dora.dev/research/2023/dora-report/
```

Repeated footer noise:

```text
Before page 1: Executive summary
               2023 Accelerate State of DevOps Report | 1
Before page 2: Key findings
               2023 Accelerate State of DevOps Report | 2
After page 1:  Executive summary
After page 2:  Key findings
```

## Normalization Rules Implemented
- URL repair is limited to `http://` and `https://` scheme separator spacing around the colon and two slashes.
- Footer suppression considers only the last three non-empty lines on each extracted page.
- Footer candidates must be short and must repeat by trailing-line depth across a majority of pages, with simple page-number variation tolerated.
- Output remains deterministic because the rules operate only on the extracted page text sequence.

## Limitations / Non-goals
- Does not infer sections, headings, table structure, reading order, or semantic document layout.
- Does not rewrite prose, clean arbitrary whitespace, or repair URL path spacing beyond the scheme separator artifact.
- Does not change retention semantics, retain source PDFs, or auto-promote extracted material.

## Validation
- `make check` passed: lint, mypy, and 453 tests.
- `git diff --check` passed.