### PR TITLE
Improve public PDF candidate diffability

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,11 @@ PDF adapter applies only mechanical replay-noise normalization: it repairs
 broken `http://` and `https://` scheme spacing from extraction and suppresses
 short repeated trailing footer lines when they recur by page position across a
 majority of pages. It does not infer sections, rewrite prose, retain source
-PDFs, or auto-promote extracted material.
+PDFs, or auto-promote extracted material. Public PDF candidate markdown omits
+the volatile per-run fetch timestamp and stores it in `manifest.json` instead,
+so rerunning unchanged extracted content keeps the reviewable candidate file and
+its `content_hash` stable; the manifest still includes run metadata such as
+`generated_at`.
 
 Recommended Confluence first run:
 

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -3457,6 +3457,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             title=title,
             content_hash=hashlib.sha256(markdown.encode("utf-8")).hexdigest(),
         )
+        if command == "public_pdf":
+            manifest_entry["fetched_at"] = fetched_at
         stale_artifacts = [
             (artifact.canonical_id, artifact.output_path)
             for artifact in find_stale_artifacts(

--- a/src/knowledge_adapters/public_pdf/normalize.py
+++ b/src/knowledge_adapters/public_pdf/normalize.py
@@ -13,6 +13,7 @@ _BROKEN_URL_SCHEME_RE = re.compile(
 )
 _MAX_FOOTER_CANDIDATE_LINES = 3
 _MAX_FOOTER_LINE_LENGTH = 140
+STABLE_FETCHED_AT_NOTE = "see manifest fetched_at; omitted from candidate markdown for stable diffs"
 
 
 def normalize_extracted_pages(page_texts: Sequence[str]) -> list[str]:
@@ -26,7 +27,6 @@ def normalize_to_markdown(page: Mapping[str, object]) -> str:
     title = str(page.get("title", "untitled"))
     canonical_id = str(page.get("canonical_id", ""))
     source_url = str(page.get("source_url", ""))
-    fetched_at = str(page.get("fetched_at", ""))
     source = str(page.get("source", "public_pdf"))
     adapter = str(page.get("adapter", "public_pdf"))
     page_count = str(page.get("page_count", ""))
@@ -40,7 +40,7 @@ def normalize_to_markdown(page: Mapping[str, object]) -> str:
 - canonical_id: {canonical_id}
 - parent_id:
 - source_url: {source_url}
-- fetched_at: {fetched_at}
+- fetched_at: {STABLE_FETCHED_AT_NOTE}
 - updated_at:
 - adapter: {adapter}
 - candidate_status: unreviewed

--- a/tests/test_public_sources.py
+++ b/tests/test_public_sources.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from email.message import Message
 from pathlib import Path
 from typing import Any, Literal
@@ -9,6 +10,9 @@ from pytest import CaptureFixture, MonkeyPatch
 
 from knowledge_adapters.cli import main
 from knowledge_adapters.public_pdf.client import PublicPdfDocument
+from knowledge_adapters.public_pdf.normalize import (
+    STABLE_FETCHED_AT_NOTE,
+)
 from knowledge_adapters.public_pdf.normalize import (
     normalize_extracted_pages as normalize_pdf_pages,
 )
@@ -267,7 +271,7 @@ def test_public_pdf_normalizer_marks_limitations() -> None:
             "canonical_id": DORA_2023_PDF_URL,
             "parent_id": "",
             "source_url": DORA_2023_PDF_URL,
-            "fetched_at": "2026-05-11T12:00:00Z",
+            "fetched_at": STABLE_FETCHED_AT_NOTE,
             "updated_at": "",
             "adapter": "public_pdf",
             "candidate_status": "unreviewed",
@@ -329,6 +333,153 @@ def test_public_pdf_page_normalization_keeps_non_repeated_trailing_text() -> Non
         "Key findings\nDifferent closing detail: 13",
         "Closing notes\n2023 Accelerate State of DevOps Report | 3",
     ]
+
+
+def test_public_pdf_cli_keeps_candidate_content_stable_across_fetch_times(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+    monkeypatch: MonkeyPatch,
+) -> None:
+    output_dir = tmp_path / "out"
+    documents = iter(
+        (
+            PublicPdfDocument(
+                title="DORA 2023 Accelerate State of DevOps Report",
+                canonical_id=DORA_2023_PDF_URL,
+                source_url=DORA_2023_PDF_URL,
+                fetched_at="2026-05-11T12:00:00Z",
+                content="## Page 1\n\nStable report candidate text.",
+                page_count=1,
+            ),
+            PublicPdfDocument(
+                title="DORA 2023 Accelerate State of DevOps Report",
+                canonical_id=DORA_2023_PDF_URL,
+                source_url=DORA_2023_PDF_URL,
+                fetched_at="2026-05-11T12:30:00Z",
+                content="## Page 1\n\nStable report candidate text.",
+                page_count=1,
+            ),
+        )
+    )
+
+    def fake_fetch(url: str) -> PublicPdfDocument:
+        assert url == DORA_2023_PDF_URL
+        return next(documents)
+
+    monkeypatch.setattr("knowledge_adapters.public_pdf.client.fetch_pdf", fake_fetch)
+
+    assert (
+        main(
+            [
+                "public_pdf",
+                "--url",
+                DORA_2023_PDF_URL,
+                "--output-dir",
+                str(output_dir),
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+    output_path = pdf_markdown_path(str(output_dir), DORA_2023_PDF_URL)
+    first_markdown = output_path.read_text(encoding="utf-8")
+    first_manifest = _manifest_payload(output_dir / "manifest.json")
+
+    assert (
+        main(
+            [
+                "public_pdf",
+                "--url",
+                DORA_2023_PDF_URL,
+                "--output-dir",
+                str(output_dir),
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+    second_markdown = output_path.read_text(encoding="utf-8")
+    second_manifest = _manifest_payload(output_dir / "manifest.json")
+
+    assert first_markdown == second_markdown
+    assert STABLE_FETCHED_AT_NOTE in first_markdown
+    assert "2026-05-11T12:00:00Z" not in first_markdown
+    assert "2026-05-11T12:30:00Z" not in second_markdown
+    assert first_manifest["files"][0]["content_hash"] == second_manifest["files"][0]["content_hash"]
+    assert first_manifest["files"][0]["fetched_at"] == "2026-05-11T12:00:00Z"
+    assert second_manifest["files"][0]["fetched_at"] == "2026-05-11T12:30:00Z"
+
+
+def test_public_pdf_cli_changes_candidate_hash_when_extracted_content_changes(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+    monkeypatch: MonkeyPatch,
+) -> None:
+    output_dir = tmp_path / "out"
+    documents = iter(
+        (
+            PublicPdfDocument(
+                title="DORA 2023 Accelerate State of DevOps Report",
+                canonical_id=DORA_2023_PDF_URL,
+                source_url=DORA_2023_PDF_URL,
+                fetched_at="2026-05-11T12:00:00Z",
+                content="## Page 1\n\nOriginal report candidate text.",
+                page_count=1,
+            ),
+            PublicPdfDocument(
+                title="DORA 2023 Accelerate State of DevOps Report",
+                canonical_id=DORA_2023_PDF_URL,
+                source_url=DORA_2023_PDF_URL,
+                fetched_at="2026-05-11T12:30:00Z",
+                content="## Page 1\n\nUpdated report candidate text.",
+                page_count=1,
+            ),
+        )
+    )
+
+    def fake_fetch(url: str) -> PublicPdfDocument:
+        assert url == DORA_2023_PDF_URL
+        return next(documents)
+
+    monkeypatch.setattr("knowledge_adapters.public_pdf.client.fetch_pdf", fake_fetch)
+
+    assert (
+        main(
+            [
+                "public_pdf",
+                "--url",
+                DORA_2023_PDF_URL,
+                "--output-dir",
+                str(output_dir),
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+    output_path = pdf_markdown_path(str(output_dir), DORA_2023_PDF_URL)
+    first_markdown = output_path.read_text(encoding="utf-8")
+    first_manifest = _manifest_payload(output_dir / "manifest.json")
+
+    assert (
+        main(
+            [
+                "public_pdf",
+                "--url",
+                DORA_2023_PDF_URL,
+                "--output-dir",
+                str(output_dir),
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+    second_markdown = output_path.read_text(encoding="utf-8")
+    second_manifest = _manifest_payload(output_dir / "manifest.json")
+
+    assert first_markdown != second_markdown
+    assert "Original report candidate text." in first_markdown
+    assert "Updated report candidate text." in second_markdown
+    assert first_manifest["files"][0]["content_hash"] != second_manifest["files"][0]["content_hash"]
 
 
 def test_public_webpage_cli_writes_candidate_markdown(
@@ -437,11 +588,15 @@ def test_output_name_for_url_includes_slug_and_hash() -> None:
 
 
 def _content_hash_from_manifest(manifest_path: Path) -> str:
-    import json
-
-    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    payload = _manifest_payload(manifest_path)
     files = payload["files"]
     assert isinstance(files, list)
     content_hash = files[0]["content_hash"]
     assert isinstance(content_hash, str)
     return content_hash
+
+
+def _manifest_payload(manifest_path: Path) -> dict[str, Any]:
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload


### PR DESCRIPTION
## Summary
- Reduces public_pdf candidate markdown churn by replacing the volatile per-run fetched_at value with a stable note in the reviewable candidate file.
- Preserves the actual public_pdf fetched_at timestamp in manifest.json entry metadata for provenance/review.
- Keeps public_pdf content_hash tied to stable candidate markdown so unchanged extracted content keeps the same hash across reruns.

## Before/after diffability
Before: rerunning the same extracted PDF content at a later time changed the candidate markdown fetched_at field, which changed the candidate file and its manifest content_hash even when the extracted content was identical.

After: rerunning unchanged extracted PDF content keeps the candidate markdown and content_hash stable. The manifest can still show runtime metadata churn, including generated_at and public_pdf fetched_at, but that volatility no longer dominates the reviewable candidate content diff.

## Tests added
- Added a public_pdf CLI rerun test proving identical extracted content with different fetch timestamps produces identical candidate markdown and content_hash.
- Added a public_pdf CLI changed-content test proving meaningful extracted content changes still change candidate markdown and content_hash.
- Updated the public_pdf normalizer metadata expectation for the stable fetched_at note.

## Limitations and non-goals
- Does not change retention semantics.
- Does not add auto-promotion logic.
- Does not broaden public_pdf ingestion behavior.
- Does not remove manifest-level runtime metadata such as generated_at; manifest diffs may still show run metadata churn.

## Validation
- make check
- git diff --check

Reference: CAK-15