### PR TITLE
Add public PDF replay-quality metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,13 @@ PDFs, or auto-promote extracted material. Public PDF candidate markdown omits
 the volatile per-run fetch timestamp and stores it in `manifest.json` instead,
 so rerunning unchanged extracted content keeps the reviewable candidate file and
 its `content_hash` stable; the manifest still includes run metadata such as
-`generated_at`.
+`generated_at`. Public PDF outputs also include descriptive replay-quality
+metadata in the candidate metadata block and manifest entry. These fields report
+mechanical extraction conditions such as footer suppression counts, URL spacing
+normalization counts, page-count context, possible layout-artifact line density,
+and adapter-known extraction warnings. They are informational review aids only:
+they do not approve the candidate, authorize retention, promote content, rank
+documents, or assert semantic correctness.
 
 Recommended Confluence first run:
 

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -8,7 +8,7 @@ import math
 import re
 import shlex
 import sys
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from contextlib import redirect_stderr, redirect_stdout
 from dataclasses import dataclass
 from pathlib import Path
@@ -1217,6 +1217,43 @@ def print_stale_artifacts(
     remaining_count = len(stale_artifacts) - stale_preview_limit
     if remaining_count > 0:
         print(f"    ... and {remaining_count} more")
+
+
+def _print_public_pdf_replay_quality_metadata(metadata: Mapping[str, object]) -> None:
+    page_context = _metadata_mapping(metadata, "page_count_context")
+    url_spacing = _metadata_mapping(metadata, "url_spacing_normalization")
+    footer = _metadata_mapping(metadata, "repeated_footer_suppression")
+    layout_density = _metadata_mapping(metadata, "possible_layout_artifact_density")
+    warnings = metadata.get("extraction_warnings", ())
+    if isinstance(warnings, Sequence) and not isinstance(warnings, str):
+        warning_text = ", ".join(str(warning) for warning in warnings)
+    else:
+        warning_text = str(warnings)
+
+    print("  replay_quality_metadata:")
+    print("    metadata_note: informational only; does not authorize retention or promotion")
+    print(f"    page_count: {page_context.get('page_count', '')}")
+    print(f"    empty_page_count: {page_context.get('empty_page_count', '')}")
+    print(
+        "    url_spacing_normalization_count: "
+        f"{url_spacing.get('replacement_count', '')}"
+    )
+    print(
+        "    repeated_footer_suppressed_line_count: "
+        f"{footer.get('suppressed_line_count', '')}"
+    )
+    print(
+        "    possible_layout_artifact_lines: "
+        f"{layout_density.get('possible_artifact_line_count', '')}/"
+        f"{layout_density.get('line_count', '')} "
+        f"({layout_density.get('possible_artifact_line_ratio', '')})"
+    )
+    print(f"    extraction_warnings: {warning_text}")
+
+
+def _metadata_mapping(metadata: Mapping[str, object], key: str) -> Mapping[str, object]:
+    value = metadata.get(key, {})
+    return value if isinstance(value, Mapping) else {}
 
 
 def print_dry_run_complete() -> None:
@@ -3388,6 +3425,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 content = webpage_document.content
                 extraction_notes = webpage_document.extraction_notes
                 page_count: int | None = None
+                replay_quality_metadata: Mapping[str, object] | None = None
                 source = webpage_document.source
                 adapter = webpage_document.adapter
                 adapter_title = "Public webpage"
@@ -3416,6 +3454,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 content = pdf_document.content
                 extraction_notes = pdf_document.extraction_notes
                 page_count = pdf_document.page_count
+                replay_quality_metadata = pdf_document.replay_quality_metadata
                 source = pdf_document.source
                 adapter = pdf_document.adapter
                 adapter_title = "Public PDF/report"
@@ -3435,6 +3474,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         }
         if page_count is not None:
             candidate["page_count"] = page_count
+        if replay_quality_metadata:
+            candidate["replay_quality_metadata"] = dict(replay_quality_metadata)
         markdown = normalize_to_markdown(candidate)
 
         print(f"{adapter_title} adapter invoked")
@@ -3459,6 +3500,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         if command == "public_pdf":
             manifest_entry["fetched_at"] = fetched_at
+            if replay_quality_metadata:
+                manifest_entry["replay_quality_metadata"] = dict(replay_quality_metadata)
         stale_artifacts = [
             (artifact.canonical_id, artifact.output_path)
             for artifact in find_stale_artifacts(
@@ -3478,6 +3521,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"  Manifest path: {render_user_path(manifest_output_path)}")
         print("  candidate_status: unreviewed")
         print(f"  extraction_notes: {extraction_notes}")
+        if replay_quality_metadata:
+            _print_public_pdf_replay_quality_metadata(replay_quality_metadata)
         if content:
             print("  content_status: extracted text with content")
         else:

--- a/src/knowledge_adapters/public_pdf/client.py
+++ b/src/knowledge_adapters/public_pdf/client.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import io
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from pypdf import PdfReader
 
-from knowledge_adapters.public_pdf.normalize import normalize_extracted_pages
+from knowledge_adapters.public_pdf.normalize import (
+    normalize_extracted_pages_with_replay_metadata,
+)
 from knowledge_adapters.public_sources import fetch_public_url
 
 MAX_PDF_BYTES = 50_000_000
@@ -31,6 +33,7 @@ class PublicPdfDocument:
     fetched_at: str
     content: str
     page_count: int
+    replay_quality_metadata: dict[str, object] = field(default_factory=dict)
     extraction_notes: str = PDF_EXTRACTION_NOTES
     source: str = "public_pdf"
     adapter: str = "public_pdf"
@@ -65,9 +68,12 @@ def fetch_pdf(url: str) -> PublicPdfDocument:
             raise ValueError(f"Could not extract text from PDF page {index}.") from exc
         raw_pages.append(text)
 
+    normalized_page_texts, replay_quality_metadata = (
+        normalize_extracted_pages_with_replay_metadata(raw_pages)
+    )
     pages = [
         f"## Page {index}\n\n{text.strip()}"
-        for index, text in enumerate(normalize_extracted_pages(raw_pages), start=1)
+        for index, text in enumerate(normalized_page_texts, start=1)
     ]
 
     return PublicPdfDocument(
@@ -77,4 +83,5 @@ def fetch_pdf(url: str) -> PublicPdfDocument:
         fetched_at=fetched.retrieved_at,
         content="\n\n".join(pages).strip(),
         page_count=len(reader.pages),
+        replay_quality_metadata=replay_quality_metadata,
     )

--- a/src/knowledge_adapters/public_pdf/normalize.py
+++ b/src/knowledge_adapters/public_pdf/normalize.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import re
 from collections.abc import Mapping, Sequence
 
@@ -11,15 +12,65 @@ _BROKEN_URL_SCHEME_RE = re.compile(
     r"(?P<path>[/#?][^\s<>()\[\]{}\"']*)?",
     re.IGNORECASE,
 )
+_WIDE_SPACING_RE = re.compile(r"\S\s{3,}\S")
+_HYPHENATED_LINE_BREAK_RE = re.compile(r"[A-Za-z]{2,}-$")
 _MAX_FOOTER_CANDIDATE_LINES = 3
 _MAX_FOOTER_LINE_LENGTH = 140
+_BASE_EXTRACTION_WARNINGS = (
+    "pdf_layout_tables_figures_footnotes_headers_reading_order_may_be_incomplete",
+    "scanned_image_only_pages_may_be_missing",
+)
 STABLE_FETCHED_AT_NOTE = "see manifest fetched_at; omitted from candidate markdown for stable diffs"
+REPLAY_QUALITY_METADATA_NOTE = (
+    "informational only; does not authorize retention or promotion"
+)
 
 
 def normalize_extracted_pages(page_texts: Sequence[str]) -> list[str]:
     """Normalize clearly mechanical artifacts from extracted PDF page text."""
-    pages = [_normalize_broken_url_spacing(page_text) for page_text in page_texts]
-    return _suppress_repeated_footer_lines(pages)
+    pages, _metadata = normalize_extracted_pages_with_replay_metadata(page_texts)
+    return pages
+
+
+def normalize_extracted_pages_with_replay_metadata(
+    page_texts: Sequence[str],
+) -> tuple[list[str], dict[str, object]]:
+    """Normalize extracted pages and describe deterministic replay-quality signals."""
+    normalized_pages: list[str] = []
+    url_replacement_count = 0
+    url_affected_page_count = 0
+    for page_text in page_texts:
+        normalized_page, replacement_count = _normalize_broken_url_spacing_with_count(page_text)
+        normalized_pages.append(normalized_page)
+        url_replacement_count += replacement_count
+        if replacement_count:
+            url_affected_page_count += 1
+
+    normalized_pages, footer_metadata = _suppress_repeated_footer_lines_with_metadata(
+        normalized_pages
+    )
+    empty_page_count = sum(1 for page_text in normalized_pages if not page_text.strip())
+    page_count = len(page_texts)
+    metadata: dict[str, object] = {
+        "metadata_scope": "public_pdf_replay_quality",
+        "metadata_note": REPLAY_QUALITY_METADATA_NOTE,
+        "page_count_context": {
+            "page_count": page_count,
+            "pages_with_extracted_text_count": page_count - empty_page_count,
+            "empty_page_count": empty_page_count,
+        },
+        "url_spacing_normalization": {
+            "activity": "normalized" if url_replacement_count else "none",
+            "replacement_count": url_replacement_count,
+            "affected_page_count": url_affected_page_count,
+        },
+        "repeated_footer_suppression": footer_metadata,
+        "possible_layout_artifact_density": _possible_layout_artifact_density(
+            normalized_pages
+        ),
+        "extraction_warnings": _extraction_warning_codes(empty_page_count),
+    }
+    return normalized_pages, metadata
 
 
 def normalize_to_markdown(page: Mapping[str, object]) -> str:
@@ -31,6 +82,12 @@ def normalize_to_markdown(page: Mapping[str, object]) -> str:
     adapter = str(page.get("adapter", "public_pdf"))
     page_count = str(page.get("page_count", ""))
     extraction_notes = str(page.get("extraction_notes", "Unreviewed candidate material."))
+    replay_quality_metadata = page.get("replay_quality_metadata")
+    replay_quality_lines = (
+        _render_replay_quality_metadata(replay_quality_metadata)
+        if isinstance(replay_quality_metadata, Mapping) and replay_quality_metadata
+        else ""
+    )
     content = str(page.get("content", "")).rstrip("\n")
 
     return f"""# {title}
@@ -46,6 +103,7 @@ def normalize_to_markdown(page: Mapping[str, object]) -> str:
 - candidate_status: unreviewed
 - page_count: {page_count}
 - extraction_notes: {extraction_notes}
+{replay_quality_lines}
 
 ## Content
 
@@ -56,7 +114,11 @@ def normalize_to_markdown(page: Mapping[str, object]) -> str:
 
 
 def _normalize_broken_url_spacing(text: str) -> str:
-    return _BROKEN_URL_SCHEME_RE.sub(_join_broken_url_scheme, text)
+    return _normalize_broken_url_spacing_with_count(text)[0]
+
+
+def _normalize_broken_url_spacing_with_count(text: str) -> tuple[str, int]:
+    return _BROKEN_URL_SCHEME_RE.subn(_join_broken_url_scheme, text)
 
 
 def _join_broken_url_scheme(match: re.Match[str]) -> str:
@@ -65,8 +127,19 @@ def _join_broken_url_scheme(match: re.Match[str]) -> str:
 
 
 def _suppress_repeated_footer_lines(page_texts: list[str]) -> list[str]:
+    return _suppress_repeated_footer_lines_with_metadata(page_texts)[0]
+
+
+def _suppress_repeated_footer_lines_with_metadata(
+    page_texts: list[str],
+) -> tuple[list[str], dict[str, object]]:
     if len(page_texts) < 2:
-        return [page_text.strip() for page_text in page_texts]
+        return [page_text.strip() for page_text in page_texts], {
+            "activity": "none",
+            "suppressed_line_count": 0,
+            "affected_page_count": 0,
+            "detected_footer_pattern_count": 0,
+        }
 
     page_lines = [page_text.splitlines() for page_text in page_texts]
     candidates: dict[tuple[int, str], set[int]] = {}
@@ -85,8 +158,10 @@ def _suppress_repeated_footer_lines(page_texts: list[str]) -> list[str]:
 
     min_repeated_pages = 2 if len(page_texts) == 2 else (len(page_texts) // 2) + 1
     indexes_to_remove: set[tuple[int, int]] = set()
+    detected_footer_pattern_count = 0
     for key, page_indexes in candidates.items():
         if len(page_indexes) >= min_repeated_pages:
+            detected_footer_pattern_count += 1
             indexes_to_remove.update(candidate_indexes[key])
 
     normalized_pages: list[str] = []
@@ -97,7 +172,12 @@ def _suppress_repeated_footer_lines(page_texts: list[str]) -> list[str]:
             if (page_index, line_index) not in indexes_to_remove
         ]
         normalized_pages.append("\n".join(kept_lines).strip())
-    return normalized_pages
+    return normalized_pages, {
+        "activity": "suppressed" if indexes_to_remove else "none",
+        "suppressed_line_count": len(indexes_to_remove),
+        "affected_page_count": len({page_index for page_index, _line_index in indexes_to_remove}),
+        "detected_footer_pattern_count": detected_footer_pattern_count,
+    }
 
 
 def _footer_signature(line: str) -> str | None:
@@ -111,3 +191,93 @@ def _footer_signature(line: str) -> str | None:
     signature = re.sub(r"([|:/-]\s*)\d+(\s*(of|/)\s*\d+)?$", r"\1#", signature)
     signature = re.sub(r"^\d+(\s*/\s*\d+)?$", "#", signature)
     return signature
+
+
+def _possible_layout_artifact_density(page_texts: Sequence[str]) -> dict[str, object]:
+    line_count = 0
+    possible_artifact_line_count = 0
+    for page_text in page_texts:
+        lines = [line.strip() for line in page_text.splitlines() if line.strip()]
+        for index, line in enumerate(lines):
+            line_count += 1
+            next_line = lines[index + 1] if index + 1 < len(lines) else ""
+            if _is_possible_layout_artifact_line(line, next_line):
+                possible_artifact_line_count += 1
+
+    return {
+        "basis": "normalized_extracted_text_lines",
+        "line_count": line_count,
+        "possible_artifact_line_count": possible_artifact_line_count,
+        "possible_artifact_line_ratio": (
+            f"{possible_artifact_line_count / line_count:.3f}" if line_count else "0.000"
+        ),
+    }
+
+
+def _is_possible_layout_artifact_line(line: str, next_line: str) -> bool:
+    return bool(
+        _WIDE_SPACING_RE.search(line)
+        or (
+            _HYPHENATED_LINE_BREAK_RE.search(line)
+            and bool(next_line)
+            and next_line[0].islower()
+        )
+    )
+
+
+def _extraction_warning_codes(empty_page_count: int) -> list[str]:
+    warnings = list(_BASE_EXTRACTION_WARNINGS)
+    if empty_page_count:
+        warnings.append("empty_pages_without_extracted_text")
+    return warnings
+
+
+def _render_replay_quality_metadata(metadata: Mapping[str, object]) -> str:
+    page_context = _mapping_value(metadata, "page_count_context")
+    url_spacing = _mapping_value(metadata, "url_spacing_normalization")
+    footer = _mapping_value(metadata, "repeated_footer_suppression")
+    layout_density = _mapping_value(metadata, "possible_layout_artifact_density")
+    warnings = metadata.get("extraction_warnings", ())
+    warning_text = (
+        "; ".join(str(warning) for warning in warnings)
+        if isinstance(warnings, Sequence) and not isinstance(warnings, str)
+        else str(warnings)
+    )
+    return "\n".join(
+        (
+            f"- replay_quality_metadata_note: {REPLAY_QUALITY_METADATA_NOTE}",
+            f"- replay_quality_page_count: {_metadata_value(page_context, 'page_count')}",
+            (
+                "- replay_quality_empty_page_count: "
+                f"{_metadata_value(page_context, 'empty_page_count')}"
+            ),
+            (
+                "- replay_quality_url_spacing_normalization_count: "
+                f"{_metadata_value(url_spacing, 'replacement_count')}"
+            ),
+            (
+                "- replay_quality_repeated_footer_suppressed_line_count: "
+                f"{_metadata_value(footer, 'suppressed_line_count')}"
+            ),
+            (
+                "- replay_quality_possible_layout_artifact_lines: "
+                f"{_metadata_value(layout_density, 'possible_artifact_line_count')}/"
+                f"{_metadata_value(layout_density, 'line_count')} "
+                f"({_metadata_value(layout_density, 'possible_artifact_line_ratio')})"
+            ),
+            f"- replay_quality_extraction_warnings: {warning_text}",
+            (
+                "- replay_quality_metadata_json: "
+                f"{json.dumps(dict(metadata), sort_keys=True, separators=(',', ':'))}"
+            ),
+        )
+    )
+
+
+def _mapping_value(metadata: Mapping[str, object], key: str) -> Mapping[str, object]:
+    value = metadata.get(key, {})
+    return value if isinstance(value, Mapping) else {}
+
+
+def _metadata_value(metadata: Mapping[str, object], key: str) -> object:
+    return metadata.get(key, "")

--- a/tests/test_public_sources.py
+++ b/tests/test_public_sources.py
@@ -17,6 +17,9 @@ from knowledge_adapters.public_pdf.normalize import (
     normalize_extracted_pages as normalize_pdf_pages,
 )
 from knowledge_adapters.public_pdf.normalize import (
+    normalize_extracted_pages_with_replay_metadata as normalize_pdf_pages_with_metadata,
+)
+from knowledge_adapters.public_pdf.normalize import (
     normalize_to_markdown as normalize_pdf,
 )
 from knowledge_adapters.public_pdf.writer import markdown_path as pdf_markdown_path
@@ -319,6 +322,65 @@ def test_public_pdf_page_normalization_suppresses_repeated_footer_lines() -> Non
     ]
 
 
+def test_public_pdf_page_normalization_reports_replay_quality_metadata() -> None:
+    raw_pages = [
+        "Metric   Value\nRead https:/ /example.com/report\nDORA Report | 1",
+        "Findings\nDORA Report | 2",
+    ]
+
+    first_pages, first_metadata = normalize_pdf_pages_with_metadata(raw_pages)
+    second_pages, second_metadata = normalize_pdf_pages_with_metadata(raw_pages)
+
+    assert first_pages == [
+        "Metric   Value\nRead https://example.com/report",
+        "Findings",
+    ]
+    assert first_pages == second_pages
+    assert first_metadata == second_metadata
+    assert first_metadata["url_spacing_normalization"] == {
+        "activity": "normalized",
+        "replacement_count": 1,
+        "affected_page_count": 1,
+    }
+    assert first_metadata["repeated_footer_suppression"] == {
+        "activity": "suppressed",
+        "suppressed_line_count": 2,
+        "affected_page_count": 2,
+        "detected_footer_pattern_count": 1,
+    }
+    assert first_metadata["page_count_context"] == {
+        "page_count": 2,
+        "pages_with_extracted_text_count": 2,
+        "empty_page_count": 0,
+    }
+    assert first_metadata["possible_layout_artifact_density"] == {
+        "basis": "normalized_extracted_text_lines",
+        "line_count": 3,
+        "possible_artifact_line_count": 1,
+        "possible_artifact_line_ratio": "0.333",
+    }
+
+    markdown = normalize_pdf(
+        {
+            "title": "Report",
+            "canonical_id": DORA_2023_PDF_URL,
+            "source_url": DORA_2023_PDF_URL,
+            "page_count": 2,
+            "content": "## Page 1\n\nMetric   Value",
+            "replay_quality_metadata": first_metadata,
+        }
+    )
+
+    assert "- candidate_status: unreviewed" in markdown
+    assert (
+        "- replay_quality_metadata_note: informational only; does not authorize retention "
+        "or promotion"
+    ) in markdown
+    assert "- replay_quality_url_spacing_normalization_count: 1" in markdown
+    assert "- replay_quality_repeated_footer_suppressed_line_count: 2" in markdown
+    assert "- replay_quality_possible_layout_artifact_lines: 1/3 (0.333)" in markdown
+
+
 def test_public_pdf_page_normalization_keeps_non_repeated_trailing_text() -> None:
     normalized_pages = normalize_pdf_pages(
         [
@@ -341,6 +403,7 @@ def test_public_pdf_cli_keeps_candidate_content_stable_across_fetch_times(
     monkeypatch: MonkeyPatch,
 ) -> None:
     output_dir = tmp_path / "out"
+    replay_quality_metadata = _sample_replay_quality_metadata()
     documents = iter(
         (
             PublicPdfDocument(
@@ -348,16 +411,18 @@ def test_public_pdf_cli_keeps_candidate_content_stable_across_fetch_times(
                 canonical_id=DORA_2023_PDF_URL,
                 source_url=DORA_2023_PDF_URL,
                 fetched_at="2026-05-11T12:00:00Z",
-                content="## Page 1\n\nStable report candidate text.",
-                page_count=1,
+                content="## Page 1\n\nStable report candidate text.\n\n## Page 2\n\nMore text.",
+                page_count=2,
+                replay_quality_metadata=replay_quality_metadata,
             ),
             PublicPdfDocument(
                 title="DORA 2023 Accelerate State of DevOps Report",
                 canonical_id=DORA_2023_PDF_URL,
                 source_url=DORA_2023_PDF_URL,
                 fetched_at="2026-05-11T12:30:00Z",
-                content="## Page 1\n\nStable report candidate text.",
-                page_count=1,
+                content="## Page 1\n\nStable report candidate text.\n\n## Page 2\n\nMore text.",
+                page_count=2,
+                replay_quality_metadata=replay_quality_metadata,
             ),
         )
     )
@@ -403,11 +468,19 @@ def test_public_pdf_cli_keeps_candidate_content_stable_across_fetch_times(
 
     assert first_markdown == second_markdown
     assert STABLE_FETCHED_AT_NOTE in first_markdown
+    assert "replay_quality_metadata_note: informational only" in first_markdown
+    assert "replay_quality_url_spacing_normalization_count: 1" in first_markdown
+    assert "replay_quality_repeated_footer_suppressed_line_count: 2" in first_markdown
     assert "2026-05-11T12:00:00Z" not in first_markdown
     assert "2026-05-11T12:30:00Z" not in second_markdown
     assert first_manifest["files"][0]["content_hash"] == second_manifest["files"][0]["content_hash"]
     assert first_manifest["files"][0]["fetched_at"] == "2026-05-11T12:00:00Z"
     assert second_manifest["files"][0]["fetched_at"] == "2026-05-11T12:30:00Z"
+    assert (
+        first_manifest["files"][0]["replay_quality_metadata"]
+        == second_manifest["files"][0]["replay_quality_metadata"]
+        == replay_quality_metadata
+    )
 
 
 def test_public_pdf_cli_changes_candidate_hash_when_extracted_content_changes(
@@ -600,3 +673,36 @@ def _manifest_payload(manifest_path: Path) -> dict[str, Any]:
     payload = json.loads(manifest_path.read_text(encoding="utf-8"))
     assert isinstance(payload, dict)
     return payload
+
+
+def _sample_replay_quality_metadata() -> dict[str, object]:
+    return {
+        "metadata_scope": "public_pdf_replay_quality",
+        "metadata_note": "informational only; does not authorize retention or promotion",
+        "page_count_context": {
+            "page_count": 2,
+            "pages_with_extracted_text_count": 2,
+            "empty_page_count": 0,
+        },
+        "url_spacing_normalization": {
+            "activity": "normalized",
+            "replacement_count": 1,
+            "affected_page_count": 1,
+        },
+        "repeated_footer_suppression": {
+            "activity": "suppressed",
+            "suppressed_line_count": 2,
+            "affected_page_count": 2,
+            "detected_footer_pattern_count": 1,
+        },
+        "possible_layout_artifact_density": {
+            "basis": "normalized_extracted_text_lines",
+            "line_count": 3,
+            "possible_artifact_line_count": 1,
+            "possible_artifact_line_ratio": "0.333",
+        },
+        "extraction_warnings": [
+            "pdf_layout_tables_figures_footnotes_headers_reading_order_may_be_incomplete",
+            "scanned_image_only_pages_may_be_missing",
+        ],
+    }


### PR DESCRIPTION
## Summary
- Add deterministic public_pdf replay-quality metadata for mechanical extraction conditions: URL spacing repairs, repeated footer suppression, page-count context, possible layout-artifact line density, and adapter-known extraction warnings.
- Expose the metadata in public PDF candidate markdown, CLI plan output, and the manifest entry.
- Document that these fields are informational only and do not approve, retain, promote, rank, or assert semantic correctness.

## Replay-quality metadata example
```json
{
  "metadata_scope": "public_pdf_replay_quality",
  "metadata_note": "informational only; does not authorize retention or promotion",
  "page_count_context": {
    "page_count": 2,
    "pages_with_extracted_text_count": 2,
    "empty_page_count": 0
  },
  "url_spacing_normalization": {
    "activity": "normalized",
    "replacement_count": 1,
    "affected_page_count": 1
  },
  "repeated_footer_suppression": {
    "activity": "suppressed",
    "suppressed_line_count": 2,
    "affected_page_count": 2,
    "detected_footer_pattern_count": 1
  },
  "possible_layout_artifact_density": {
    "basis": "normalized_extracted_text_lines",
    "line_count": 3,
    "possible_artifact_line_count": 1,
    "possible_artifact_line_ratio": "0.333"
  },
  "extraction_warnings": [
    "pdf_layout_tables_figures_footnotes_headers_reading_order_may_be_incomplete",
    "scanned_image_only_pages_may_be_missing"
  ]
}
```

## Why descriptive only
- The signals are mechanical counters and context gathered from extraction and normalization.
- They do not evaluate document quality, retention suitability, correctness, or review outcome.
- The metadata note is rendered with the candidate and stored in the manifest to keep the boundary visible during review.

## Tests added
- Metadata appears when URL normalization and footer suppression occur.
- Metadata is stable across repeated normalization for unchanged extracted pages.
- Candidate markdown and manifest replay-quality metadata stay stable across reruns when extracted content is unchanged.

## Limitations and non-goals
- No semantic document structure inference.
- No auto-promotion or retention behavior changes.
- No overall document score or ranking.
- Possible layout-artifact density is only a line-level mechanical signal, not a correctness judgment.

## Validation
- `make check` passed: 456 tests.
- `git diff --check` passed.

Reference: CAK-15