### PR TITLE
Add conservative public PDF URL path wrap repair

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,20 +116,25 @@ fetched PDF bytes are held only in memory. PDF layout, tables, figures,
 footnotes, headers, reading order, and scanned image-only pages may be incomplete
 or missing, so review against the source PDF before retaining any knowledge. The
 PDF adapter applies only mechanical replay-noise normalization: it repairs
-broken `http://` and `https://` scheme spacing from extraction and suppresses
-short repeated trailing footer lines when they recur by page position across a
-majority of pages. It does not infer sections, rewrite prose, retain source
-PDFs, or auto-promote extracted material. Public PDF candidate markdown omits
-the volatile per-run fetch timestamp and stores it in `manifest.json` instead,
-so rerunning unchanged extracted content keeps the reviewable candidate file and
-its `content_hash` stable; the manifest still includes run metadata such as
-`generated_at`. Public PDF outputs also include descriptive replay-quality
-metadata in the candidate metadata block and manifest entry. These fields report
+broken `http://` and `https://` scheme spacing from extraction, joins clearly
+split URL path line wraps only when an extracted URL path ends a line with `-`
+and the immediately following nonblank line is a standalone URL path fragment,
+and suppresses short repeated trailing footer lines when they recur by page
+position across a majority of pages. It does not repair ordinary prose
+hyphenation, join across blank lines or page boundaries, infer sections, rewrite
+prose, retain source PDFs, or auto-promote extracted material. Public PDF
+candidate markdown omits the volatile per-run fetch timestamp and stores it in
+`manifest.json` instead, so rerunning unchanged extracted content keeps the
+reviewable candidate file and its `content_hash` stable; the manifest still
+includes run metadata such as `generated_at`. Public PDF outputs also include
+descriptive replay-quality metadata in the candidate metadata block and
+manifest entry. These fields report
 mechanical extraction conditions such as footer suppression counts, URL spacing
-normalization counts, page-count context, possible layout-artifact line density,
-and adapter-known extraction warnings. They are informational review aids only:
-they do not approve the candidate, authorize retention, promote content, rank
-documents, or assert semantic correctness.
+normalization counts, URL path line-wrap repair counts, page-count context,
+possible layout-artifact line density, and adapter-known extraction warnings.
+They are informational review aids only: they do not approve the candidate,
+authorize retention, promote content, rank documents, or assert semantic
+correctness.
 
 Recommended Confluence first run:
 

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -1222,6 +1222,7 @@ def print_stale_artifacts(
 def _print_public_pdf_replay_quality_metadata(metadata: Mapping[str, object]) -> None:
     page_context = _metadata_mapping(metadata, "page_count_context")
     url_spacing = _metadata_mapping(metadata, "url_spacing_normalization")
+    url_path_wrap = _metadata_mapping(metadata, "url_path_line_wrap_normalization")
     footer = _metadata_mapping(metadata, "repeated_footer_suppression")
     layout_density = _metadata_mapping(metadata, "possible_layout_artifact_density")
     warnings = metadata.get("extraction_warnings", ())
@@ -1237,6 +1238,10 @@ def _print_public_pdf_replay_quality_metadata(metadata: Mapping[str, object]) ->
     print(
         "    url_spacing_normalization_count: "
         f"{url_spacing.get('replacement_count', '')}"
+    )
+    print(
+        "    url_path_line_wrap_repair_count: "
+        f"{url_path_wrap.get('repair_count', '')}"
     )
     print(
         "    repeated_footer_suppressed_line_count: "

--- a/src/knowledge_adapters/public_pdf/client.py
+++ b/src/knowledge_adapters/public_pdf/client.py
@@ -18,8 +18,9 @@ PDF_EXTRACTION_NOTES = (
     "pypdf. PDF layout, tables, figures, footnotes, headers, reading order, and scanned "
     "image-only pages may be incomplete or missing; review against the source PDF before "
     "retaining any knowledge. Clearly mechanical extraction artifacts may be normalized: "
-    "broken HTTP(S) URL scheme spacing is repaired, and short repeated trailing footer "
-    "lines may be suppressed when they recur by page position."
+    "broken HTTP(S) URL scheme spacing is repaired, clearly split URL path line wraps "
+    "may be joined, and short repeated trailing footer lines may be suppressed when they "
+    "recur by page position."
 )
 
 

--- a/src/knowledge_adapters/public_pdf/normalize.py
+++ b/src/knowledge_adapters/public_pdf/normalize.py
@@ -7,10 +7,19 @@ import re
 from collections.abc import Mapping, Sequence
 
 _BROKEN_URL_SCHEME_RE = re.compile(
-    r"\b(?P<scheme>https?)\s*:\s*/\s*/\s*"
+    r"\b(?P<scheme>https?)"
+    r"(?:\s+:\s*/\s*/\s*|\s*:\s+/\s*/\s*|\s*:\s*/\s+/\s*|\s*:\s*/\s*/\s+)"
     r"(?P<host>[A-Za-z0-9][A-Za-z0-9.-]*(?::\d+)?)"
     r"(?P<path>[/#?][^\s<>()\[\]{}\"']*)?",
     re.IGNORECASE,
+)
+_URL_PATH_LINE_WRAP_RE = re.compile(
+    r"\bhttps?://[A-Za-z0-9][A-Za-z0-9.-]*(?::\d+)?/"
+    r"[^\s<>()\[\]{}\"']*-$",
+    re.IGNORECASE,
+)
+_URL_PATH_CONTINUATION_RE = re.compile(
+    r"(?=.*[-._~/%!$&'()*+,;=:@?#])[a-z0-9][a-z0-9._~%!$&'()*+,;=:@/?#-]*"
 )
 _WIDE_SPACING_RE = re.compile(r"\S\s{3,}\S")
 _HYPHENATED_LINE_BREAK_RE = re.compile(r"[A-Za-z]{2,}-$")
@@ -37,14 +46,22 @@ def normalize_extracted_pages_with_replay_metadata(
 ) -> tuple[list[str], dict[str, object]]:
     """Normalize extracted pages and describe deterministic replay-quality signals."""
     normalized_pages: list[str] = []
-    url_replacement_count = 0
-    url_affected_page_count = 0
+    url_scheme_replacement_count = 0
+    url_scheme_affected_page_count = 0
+    url_path_line_wrap_repair_count = 0
+    url_path_line_wrap_affected_page_count = 0
     for page_text in page_texts:
         normalized_page, replacement_count = _normalize_broken_url_spacing_with_count(page_text)
+        normalized_page, path_repair_count = _normalize_url_path_line_wraps_with_count(
+            normalized_page
+        )
         normalized_pages.append(normalized_page)
-        url_replacement_count += replacement_count
+        url_scheme_replacement_count += replacement_count
         if replacement_count:
-            url_affected_page_count += 1
+            url_scheme_affected_page_count += 1
+        url_path_line_wrap_repair_count += path_repair_count
+        if path_repair_count:
+            url_path_line_wrap_affected_page_count += 1
 
     normalized_pages, footer_metadata = _suppress_repeated_footer_lines_with_metadata(
         normalized_pages
@@ -60,9 +77,14 @@ def normalize_extracted_pages_with_replay_metadata(
             "empty_page_count": empty_page_count,
         },
         "url_spacing_normalization": {
-            "activity": "normalized" if url_replacement_count else "none",
-            "replacement_count": url_replacement_count,
-            "affected_page_count": url_affected_page_count,
+            "activity": "normalized" if url_scheme_replacement_count else "none",
+            "replacement_count": url_scheme_replacement_count,
+            "affected_page_count": url_scheme_affected_page_count,
+        },
+        "url_path_line_wrap_normalization": {
+            "activity": "normalized" if url_path_line_wrap_repair_count else "none",
+            "repair_count": url_path_line_wrap_repair_count,
+            "affected_page_count": url_path_line_wrap_affected_page_count,
         },
         "repeated_footer_suppression": footer_metadata,
         "possible_layout_artifact_density": _possible_layout_artifact_density(
@@ -124,6 +146,39 @@ def _normalize_broken_url_spacing_with_count(text: str) -> tuple[str, int]:
 def _join_broken_url_scheme(match: re.Match[str]) -> str:
     path = match.group("path") or ""
     return f"{match.group('scheme')}://{match.group('host')}{path}"
+
+
+def _normalize_url_path_line_wraps_with_count(text: str) -> tuple[str, int]:
+    lines = text.splitlines()
+    normalized_lines: list[str] = []
+    repair_count = 0
+    index = 0
+    while index < len(lines):
+        line = lines[index].rstrip()
+        if index + 1 >= len(lines):
+            normalized_lines.append(line)
+            index += 1
+            continue
+
+        next_line = lines[index + 1].strip()
+        if _is_url_path_line_wrap_pair(line, next_line):
+            normalized_lines.append(f"{line}{next_line}")
+            repair_count += 1
+            index += 2
+            continue
+
+        normalized_lines.append(line)
+        index += 1
+
+    return "\n".join(normalized_lines).strip(), repair_count
+
+
+def _is_url_path_line_wrap_pair(line: str, next_line: str) -> bool:
+    return bool(
+        next_line
+        and _URL_PATH_LINE_WRAP_RE.search(line)
+        and _URL_PATH_CONTINUATION_RE.fullmatch(next_line)
+    )
 
 
 def _suppress_repeated_footer_lines(page_texts: list[str]) -> list[str]:
@@ -235,6 +290,7 @@ def _extraction_warning_codes(empty_page_count: int) -> list[str]:
 def _render_replay_quality_metadata(metadata: Mapping[str, object]) -> str:
     page_context = _mapping_value(metadata, "page_count_context")
     url_spacing = _mapping_value(metadata, "url_spacing_normalization")
+    url_path_wrap = _mapping_value(metadata, "url_path_line_wrap_normalization")
     footer = _mapping_value(metadata, "repeated_footer_suppression")
     layout_density = _mapping_value(metadata, "possible_layout_artifact_density")
     warnings = metadata.get("extraction_warnings", ())
@@ -254,6 +310,10 @@ def _render_replay_quality_metadata(metadata: Mapping[str, object]) -> str:
             (
                 "- replay_quality_url_spacing_normalization_count: "
                 f"{_metadata_value(url_spacing, 'replacement_count')}"
+            ),
+            (
+                "- replay_quality_url_path_line_wrap_repair_count: "
+                f"{_metadata_value(url_path_wrap, 'repair_count')}"
             ),
             (
                 "- replay_quality_repeated_footer_suppressed_line_count: "

--- a/tests/test_public_sources.py
+++ b/tests/test_public_sources.py
@@ -306,6 +306,75 @@ def test_public_pdf_page_normalization_repairs_broken_url_spacing() -> None:
     ]
 
 
+def test_public_pdf_page_normalization_repairs_url_path_line_wrap() -> None:
+    normalized_pages = normalize_pdf_pages(
+        [
+            (
+                "Source: https://cloud.google.com/resources/content/dora-roi-of-ai-\n"
+                "assisted-software-development"
+            )
+        ]
+    )
+
+    assert normalized_pages == [
+        (
+            "Source: https://cloud.google.com/resources/content/dora-roi-of-ai-"
+            "assisted-software-development"
+        )
+    ]
+
+
+def test_public_pdf_page_normalization_keeps_normal_hyphenated_prose() -> None:
+    normalized_pages = normalize_pdf_pages(
+        [
+            (
+                "The review describes AI-assisted-\n"
+                "software delivery without a URL on the prior line."
+            )
+        ]
+    )
+
+    assert normalized_pages == [
+        (
+            "The review describes AI-assisted-\n"
+            "software delivery without a URL on the prior line."
+        )
+    ]
+
+
+def test_public_pdf_page_normalization_keeps_url_path_split_across_blank_line() -> None:
+    normalized_pages = normalize_pdf_pages(
+        [
+            (
+                "Source: https://cloud.google.com/resources/content/dora-roi-of-ai-\n"
+                "\n"
+                "assisted-software-development"
+            )
+        ]
+    )
+
+    assert normalized_pages == [
+        (
+            "Source: https://cloud.google.com/resources/content/dora-roi-of-ai-\n\n"
+            "assisted-software-development"
+        )
+    ]
+
+
+def test_public_pdf_page_normalization_keeps_url_path_split_across_pages() -> None:
+    normalized_pages = normalize_pdf_pages(
+        [
+            "Source: https://cloud.google.com/resources/content/dora-roi-of-ai-",
+            "assisted-software-development",
+        ]
+    )
+
+    assert normalized_pages == [
+        "Source: https://cloud.google.com/resources/content/dora-roi-of-ai-",
+        "assisted-software-development",
+    ]
+
+
 def test_public_pdf_page_normalization_suppresses_repeated_footer_lines() -> None:
     normalized_pages = normalize_pdf_pages(
         [
@@ -324,7 +393,13 @@ def test_public_pdf_page_normalization_suppresses_repeated_footer_lines() -> Non
 
 def test_public_pdf_page_normalization_reports_replay_quality_metadata() -> None:
     raw_pages = [
-        "Metric   Value\nRead https:/ /example.com/report\nDORA Report | 1",
+        (
+            "Metric   Value\n"
+            "Read https:/ /example.com/report\n"
+            "Source: https://cloud.google.com/resources/content/dora-roi-of-ai-\n"
+            "assisted-software-development\n"
+            "DORA Report | 1"
+        ),
         "Findings\nDORA Report | 2",
     ]
 
@@ -332,7 +407,12 @@ def test_public_pdf_page_normalization_reports_replay_quality_metadata() -> None
     second_pages, second_metadata = normalize_pdf_pages_with_metadata(raw_pages)
 
     assert first_pages == [
-        "Metric   Value\nRead https://example.com/report",
+        (
+            "Metric   Value\n"
+            "Read https://example.com/report\n"
+            "Source: https://cloud.google.com/resources/content/dora-roi-of-ai-"
+            "assisted-software-development"
+        ),
         "Findings",
     ]
     assert first_pages == second_pages
@@ -340,6 +420,11 @@ def test_public_pdf_page_normalization_reports_replay_quality_metadata() -> None
     assert first_metadata["url_spacing_normalization"] == {
         "activity": "normalized",
         "replacement_count": 1,
+        "affected_page_count": 1,
+    }
+    assert first_metadata["url_path_line_wrap_normalization"] == {
+        "activity": "normalized",
+        "repair_count": 1,
         "affected_page_count": 1,
     }
     assert first_metadata["repeated_footer_suppression"] == {
@@ -355,9 +440,9 @@ def test_public_pdf_page_normalization_reports_replay_quality_metadata() -> None
     }
     assert first_metadata["possible_layout_artifact_density"] == {
         "basis": "normalized_extracted_text_lines",
-        "line_count": 3,
+        "line_count": 4,
         "possible_artifact_line_count": 1,
-        "possible_artifact_line_ratio": "0.333",
+        "possible_artifact_line_ratio": "0.250",
     }
 
     markdown = normalize_pdf(
@@ -377,8 +462,9 @@ def test_public_pdf_page_normalization_reports_replay_quality_metadata() -> None
         "or promotion"
     ) in markdown
     assert "- replay_quality_url_spacing_normalization_count: 1" in markdown
+    assert "- replay_quality_url_path_line_wrap_repair_count: 1" in markdown
     assert "- replay_quality_repeated_footer_suppressed_line_count: 2" in markdown
-    assert "- replay_quality_possible_layout_artifact_lines: 1/3 (0.333)" in markdown
+    assert "- replay_quality_possible_layout_artifact_lines: 1/4 (0.250)" in markdown
 
 
 def test_public_pdf_page_normalization_keeps_non_repeated_trailing_text() -> None:
@@ -688,6 +774,11 @@ def _sample_replay_quality_metadata() -> dict[str, object]:
             "activity": "normalized",
             "replacement_count": 1,
             "affected_page_count": 1,
+        },
+        "url_path_line_wrap_normalization": {
+            "activity": "none",
+            "repair_count": 0,
+            "affected_page_count": 0,
         },
         "repeated_footer_suppression": {
             "activity": "suppressed",


### PR DESCRIPTION
## Summary
- Add conservative public_pdf normalization for mechanically clear URL path fragments split across adjacent PDF-extracted lines.
- Track URL path line-wrap repairs separately from URL scheme-spacing normalization in replay-quality metadata and rendered candidate/CLI metadata.
- Document the conservative behavior and limits without changing retention, promotion, or report-structure semantics.

## Before / After
Before:
```text
Source: https://cloud.google.com/resources/content/dora-roi-of-ai-
assisted-software-development
```

After:
```text
Source: https://cloud.google.com/resources/content/dora-roi-of-ai-assisted-software-development
```

Normal prose stays unchanged:
```text
The review describes AI-assisted-
software delivery without a URL on the prior line.
```

## Normalization Rules Implemented
- Runs only in the public_pdf extraction normalization path.
- Repairs only within a single extracted page, on immediately adjacent nonblank lines.
- Requires the first line to end with an HTTP(S) URL path ending in `-`.
- Requires the next line to be a standalone URL path fragment containing path punctuation such as `-`, `.`, `/`, or `%`.
- Keeps URL scheme-spacing repair counting separate from URL path line-wrap repair counting.

## Tests Added
- Repaired URL path split.
- No-op for ordinary hyphenated prose.
- No-op across blank lines.
- No-op across page boundaries.
- Replay-quality metadata count for URL path line-wrap repairs.

## Limitations / Non-goals
- Does not join ordinary prose hyphenation.
- Does not join across blank lines or page boundaries.
- Does not infer headings, report sections, semantic structure, retention status, or promotion eligibility.
- Intentionally skips ambiguous URL wraps whose continuation line is not a standalone URL path fragment.

## Validation
- `make check` passed: ruff, mypy, and 460 tests.
- `git diff --check` passed.

Reference: CAK-15