### PR TITLE
CAK-15 public PDF footer noise diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,10 @@ normalization counts, URL path line-wrap repair counts, page-count context,
 possible layout-artifact line density, and adapter-known extraction warnings.
 They are informational review aids only: they do not approve the candidate,
 authorize retention, promote content, rank documents, or assert semantic
-correctness.
+correctness. Footer and page-number noise measurement is documented in
+`docs/public-pdf-footer-page-number-noise.md`; those diagnostics characterize
+safe-looking repeated footer blocks and risky numeric content shapes without
+adding new suppression behavior.
 
 Recommended Confluence first run:
 

--- a/docs/public-pdf-footer-page-number-noise.md
+++ b/docs/public-pdf-footer-page-number-noise.md
@@ -1,0 +1,100 @@
+# Public PDF Footer And Page-Number Noise
+
+This note records measurement and design guidance for public PDF footer and
+page-number normalization. It is diagnostic only: it does not approve candidate
+content, change retention semantics, promote material, or add new suppression
+rules.
+
+## Current Measurement
+
+Public PDF replay-quality metadata includes
+`footer_page_number_noise_diagnostics`, measured after URL replay-noise repair
+and before the existing repeated footer suppression pass. The diagnostic block
+records:
+
+- repeated trailing footer block and signature counts inside the last three
+  nonempty lines of each extracted page
+- bare numeric line counts, including whether those lines appear in the trailing
+  footer candidate window
+- repeated bare numeric trailing signatures that look page-number-like but are
+  not sufficient by themselves to prove noise
+- bare numeric lines adjacent to meaningful numeric context, such as table,
+  calculator, value, cost, score, or formula-like lines
+- footer-like page-number text that appears before the trailing candidate
+  window, which can happen when `pypdf` places a visual footer in the middle of
+  reading order
+
+The metadata is deterministic and informational. Counts are review aids, not
+retention decisions.
+
+## Synthetic Cases
+
+Safe repeated footer blocks look like a stable report footer plus changing page
+numbers at the bottom of pages:
+
+```text
+Executive summary
+DORA Report
+1
+```
+
+```text
+Key findings
+DORA Report
+2
+```
+
+Unsafe numeric table or calculator rows can look page-number-shaped in extracted
+text even when they are meaningful values:
+
+```text
+Calculator
+Input value 10
+15
+Output value 25
+```
+
+Footer-like text can appear mid-page in `pypdf` reading order:
+
+```text
+Intro
+DORA Report | 1
+Body
+Metric 5
+Detail A
+Closing A
+```
+
+Bare page-number-shaped lines adjacent to report values are risky because the
+same line shape can be either visual page chrome or meaningful numeric content:
+
+```text
+Table
+Metric value 12
+1
+Total value 13
+```
+
+## Proposed Future Rules
+
+A future implementation PR should keep footer/page-number suppression narrow:
+
+- suppress repeated multi-line trailing footer blocks only when the nonnumeric
+  footer text repeats by page position across the required page majority
+- treat bare numeric lines as suppressible only when anchored to a repeated
+  nonnumeric footer block on the same pages and at adjacent trailing positions
+- do not suppress a bare numeric line solely because it repeats as a normalized
+  `#` signature
+- do not suppress footer-like text found outside the trailing candidate window
+  unless a later design can prove the extraction order case without touching
+  table, calculator, figure, or report body content
+- do not suppress numeric lines adjacent to meaningful numeric context unless a
+  stronger source-specific signal exists
+- keep all rules deterministic and source-agnostic unless a future PR
+  explicitly documents source-specific behavior
+
+## Non-Goals
+
+This slice does not add new suppression behavior, repair ordinary prose
+hyphenation, infer semantic sections, auto-promote candidates, rank document
+quality, or assert that a diagnostic count is safe to remove.

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -1223,6 +1223,7 @@ def _print_public_pdf_replay_quality_metadata(metadata: Mapping[str, object]) ->
     page_context = _metadata_mapping(metadata, "page_count_context")
     url_spacing = _metadata_mapping(metadata, "url_spacing_normalization")
     url_path_wrap = _metadata_mapping(metadata, "url_path_line_wrap_normalization")
+    footer_page_noise = _metadata_mapping(metadata, "footer_page_number_noise_diagnostics")
     footer = _metadata_mapping(metadata, "repeated_footer_suppression")
     layout_density = _metadata_mapping(metadata, "possible_layout_artifact_density")
     warnings = metadata.get("extraction_warnings", ())
@@ -1242,6 +1243,22 @@ def _print_public_pdf_replay_quality_metadata(metadata: Mapping[str, object]) ->
     print(
         "    url_path_line_wrap_repair_count: "
         f"{url_path_wrap.get('repair_count', '')}"
+    )
+    print(
+        "    footer_page_number_repeated_trailing_block_count: "
+        f"{footer_page_noise.get('repeated_trailing_footer_block_count', '')}"
+    )
+    print(
+        "    footer_page_number_bare_numeric_line_count: "
+        f"{footer_page_noise.get('bare_numeric_line_count', '')}"
+    )
+    print(
+        "    footer_page_number_numeric_context_risk_count: "
+        f"{footer_page_noise.get('bare_numeric_adjacent_to_numeric_content_count', '')}"
+    )
+    print(
+        "    footer_page_number_mid_page_footer_like_line_count: "
+        f"{footer_page_noise.get('mid_page_footer_like_line_count', '')}"
     )
     print(
         "    repeated_footer_suppressed_line_count: "

--- a/src/knowledge_adapters/public_pdf/normalize.py
+++ b/src/knowledge_adapters/public_pdf/normalize.py
@@ -23,6 +23,17 @@ _URL_PATH_CONTINUATION_RE = re.compile(
 )
 _WIDE_SPACING_RE = re.compile(r"\S\s{3,}\S")
 _HYPHENATED_LINE_BREAK_RE = re.compile(r"[A-Za-z]{2,}-$")
+_BARE_NUMERIC_LINE_RE = re.compile(r"^\d{1,4}$")
+_PAGE_NUMBERED_FOOTER_LIKE_RE = re.compile(
+    r"(\bpage\s+\d+(\s+(of|/)\s+\d+)?\b|\bp\.\s*\d+(\s*/\s*\d+)?\b|"
+    r"\d+\s*(of|/)\s*\d+\b|[|:/-]\s*\d+(\s*(of|/)\s*\d+)?$)",
+    re.IGNORECASE,
+)
+_MEANINGFUL_NUMERIC_CONTEXT_RE = re.compile(
+    r"(\b(total|metric|value|score|cost|savings|roi|result|input|output|"
+    r"calculator|table|baseline|target|year|month|rate|percent)\b|[$%+=*/])",
+    re.IGNORECASE,
+)
 _MAX_FOOTER_CANDIDATE_LINES = 3
 _MAX_FOOTER_LINE_LENGTH = 140
 _BASE_EXTRACTION_WARNINGS = (
@@ -63,6 +74,7 @@ def normalize_extracted_pages_with_replay_metadata(
         if path_repair_count:
             url_path_line_wrap_affected_page_count += 1
 
+    footer_page_number_diagnostics = _diagnose_footer_page_number_noise(normalized_pages)
     normalized_pages, footer_metadata = _suppress_repeated_footer_lines_with_metadata(
         normalized_pages
     )
@@ -86,6 +98,7 @@ def normalize_extracted_pages_with_replay_metadata(
             "repair_count": url_path_line_wrap_repair_count,
             "affected_page_count": url_path_line_wrap_affected_page_count,
         },
+        "footer_page_number_noise_diagnostics": footer_page_number_diagnostics,
         "repeated_footer_suppression": footer_metadata,
         "possible_layout_artifact_density": _possible_layout_artifact_density(
             normalized_pages
@@ -211,7 +224,7 @@ def _suppress_repeated_footer_lines_with_metadata(
             candidates.setdefault(key, set()).add(page_index)
             candidate_indexes.setdefault(key, []).append((page_index, line_index))
 
-    min_repeated_pages = 2 if len(page_texts) == 2 else (len(page_texts) // 2) + 1
+    min_repeated_pages = _min_repeated_footer_pages(len(page_texts))
     indexes_to_remove: set[tuple[int, int]] = set()
     detected_footer_pattern_count = 0
     for key, page_indexes in candidates.items():
@@ -235,6 +248,107 @@ def _suppress_repeated_footer_lines_with_metadata(
     }
 
 
+def _diagnose_footer_page_number_noise(page_texts: Sequence[str]) -> dict[str, object]:
+    page_lines = [
+        [line.strip() for line in page_text.splitlines() if line.strip()]
+        for page_text in page_texts
+    ]
+    trailing_index_sets = [
+        set(range(max(0, len(lines) - _MAX_FOOTER_CANDIDATE_LINES), len(lines)))
+        for lines in page_lines
+    ]
+    min_repeated_pages = _min_repeated_footer_pages(len(page_texts))
+
+    trailing_signature_pages: dict[tuple[int, str], set[int]] = {}
+    trailing_block_pages: dict[tuple[str, ...], set[int]] = {}
+    bare_numeric_trailing_signature_pages: dict[tuple[int, str], set[int]] = {}
+    bare_numeric_line_count = 0
+    bare_numeric_trailing_line_count = 0
+    bare_numeric_adjacent_to_numeric_content_count = 0
+    mid_page_footer_like_line_count = 0
+
+    for page_index, lines in enumerate(page_lines):
+        trailing_indexes = trailing_index_sets[page_index]
+        trailing_signatures: list[str] = []
+
+        for line_index, line in enumerate(lines):
+            is_trailing_candidate = line_index in trailing_indexes
+            if _is_bare_numeric_line(line):
+                bare_numeric_line_count += 1
+                if is_trailing_candidate:
+                    bare_numeric_trailing_line_count += 1
+                if _has_adjacent_meaningful_numeric_context(lines, line_index):
+                    bare_numeric_adjacent_to_numeric_content_count += 1
+
+            if _is_page_numbered_footer_like_line(line) and not is_trailing_candidate:
+                mid_page_footer_like_line_count += 1
+
+            if not is_trailing_candidate:
+                continue
+
+            signature = _footer_signature(line)
+            if signature is None:
+                continue
+
+            depth = len(lines) - line_index
+            key = (depth, signature)
+            trailing_signature_pages.setdefault(key, set()).add(page_index)
+            trailing_signatures.append(signature)
+            if _is_bare_numeric_line(line):
+                bare_numeric_trailing_signature_pages.setdefault(key, set()).add(page_index)
+
+        for block_length in range(1, len(trailing_signatures) + 1):
+            trailing_block_pages.setdefault(
+                tuple(trailing_signatures[-block_length:]), set()
+            ).add(page_index)
+
+    repeated_trailing_signature_count = sum(
+        1
+        for page_indexes in trailing_signature_pages.values()
+        if len(page_indexes) >= min_repeated_pages
+    )
+    repeated_trailing_block_count = sum(
+        1
+        for page_indexes in trailing_block_pages.values()
+        if len(page_indexes) >= min_repeated_pages
+    )
+    repeated_bare_numeric_trailing_signature_count = sum(
+        1
+        for page_indexes in bare_numeric_trailing_signature_pages.values()
+        if len(page_indexes) >= min_repeated_pages
+    )
+
+    return {
+        "activity": "measured",
+        "basis": "post_url_normalization_pre_footer_suppression_extracted_pages",
+        "candidate_window": {
+            "trailing_nonempty_line_count": _MAX_FOOTER_CANDIDATE_LINES,
+            "min_repeated_pages": min_repeated_pages,
+        },
+        "repeated_trailing_footer_block_count": repeated_trailing_block_count,
+        "repeated_trailing_footer_signature_count": repeated_trailing_signature_count,
+        "bare_numeric_line_count": bare_numeric_line_count,
+        "bare_numeric_trailing_line_count": bare_numeric_trailing_line_count,
+        "repeated_bare_numeric_trailing_signature_count": (
+            repeated_bare_numeric_trailing_signature_count
+        ),
+        "bare_numeric_adjacent_to_numeric_content_count": (
+            bare_numeric_adjacent_to_numeric_content_count
+        ),
+        "mid_page_footer_like_line_count": mid_page_footer_like_line_count,
+        "risk_note": (
+            "bare numeric lines may be page numbers or meaningful table, calculator, "
+            "or report values; diagnostics do not authorize suppression"
+        ),
+    }
+
+
+def _min_repeated_footer_pages(page_count: int) -> int:
+    if page_count < 2:
+        return 2
+    return 2 if page_count == 2 else (page_count // 2) + 1
+
+
 def _footer_signature(line: str) -> str | None:
     cleaned = " ".join(line.strip().split())
     if not cleaned or len(cleaned) > _MAX_FOOTER_LINE_LENGTH:
@@ -246,6 +360,35 @@ def _footer_signature(line: str) -> str | None:
     signature = re.sub(r"([|:/-]\s*)\d+(\s*(of|/)\s*\d+)?$", r"\1#", signature)
     signature = re.sub(r"^\d+(\s*/\s*\d+)?$", "#", signature)
     return signature
+
+
+def _is_bare_numeric_line(line: str) -> bool:
+    return bool(_BARE_NUMERIC_LINE_RE.fullmatch(line.strip()))
+
+
+def _is_page_numbered_footer_like_line(line: str) -> bool:
+    return bool(_PAGE_NUMBERED_FOOTER_LIKE_RE.search(" ".join(line.strip().split())))
+
+
+def _has_adjacent_meaningful_numeric_context(lines: Sequence[str], line_index: int) -> bool:
+    adjacent_lines = []
+    if line_index > 0:
+        adjacent_lines.append(lines[line_index - 1])
+    if line_index + 1 < len(lines):
+        adjacent_lines.append(lines[line_index + 1])
+
+    return any(_is_meaningful_numeric_context_line(line) for line in adjacent_lines)
+
+
+def _is_meaningful_numeric_context_line(line: str) -> bool:
+    return bool(
+        re.search(r"\d", line)
+        and (
+            _WIDE_SPACING_RE.search(line)
+            or _MEANINGFUL_NUMERIC_CONTEXT_RE.search(line)
+            or len(re.findall(r"\d+", line)) >= 2
+        )
+    )
 
 
 def _possible_layout_artifact_density(page_texts: Sequence[str]) -> dict[str, object]:
@@ -291,6 +434,7 @@ def _render_replay_quality_metadata(metadata: Mapping[str, object]) -> str:
     page_context = _mapping_value(metadata, "page_count_context")
     url_spacing = _mapping_value(metadata, "url_spacing_normalization")
     url_path_wrap = _mapping_value(metadata, "url_path_line_wrap_normalization")
+    footer_page_noise = _mapping_value(metadata, "footer_page_number_noise_diagnostics")
     footer = _mapping_value(metadata, "repeated_footer_suppression")
     layout_density = _mapping_value(metadata, "possible_layout_artifact_density")
     warnings = metadata.get("extraction_warnings", ())
@@ -298,6 +442,9 @@ def _render_replay_quality_metadata(metadata: Mapping[str, object]) -> str:
         "; ".join(str(warning) for warning in warnings)
         if isinstance(warnings, Sequence) and not isinstance(warnings, str)
         else str(warnings)
+    )
+    numeric_context_risk_count = _metadata_value(
+        footer_page_noise, "bare_numeric_adjacent_to_numeric_content_count"
     )
     return "\n".join(
         (
@@ -314,6 +461,22 @@ def _render_replay_quality_metadata(metadata: Mapping[str, object]) -> str:
             (
                 "- replay_quality_url_path_line_wrap_repair_count: "
                 f"{_metadata_value(url_path_wrap, 'repair_count')}"
+            ),
+            (
+                "- replay_quality_footer_page_number_repeated_trailing_block_count: "
+                f"{_metadata_value(footer_page_noise, 'repeated_trailing_footer_block_count')}"
+            ),
+            (
+                "- replay_quality_footer_page_number_bare_numeric_line_count: "
+                f"{_metadata_value(footer_page_noise, 'bare_numeric_line_count')}"
+            ),
+            (
+                "- replay_quality_footer_page_number_numeric_context_risk_count: "
+                f"{numeric_context_risk_count}"
+            ),
+            (
+                "- replay_quality_footer_page_number_mid_page_footer_like_line_count: "
+                f"{_metadata_value(footer_page_noise, 'mid_page_footer_like_line_count')}"
             ),
             (
                 "- replay_quality_repeated_footer_suppressed_line_count: "

--- a/tests/test_public_sources.py
+++ b/tests/test_public_sources.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from email.message import Message
 from pathlib import Path
 from typing import Any, Literal
@@ -467,6 +468,97 @@ def test_public_pdf_page_normalization_reports_replay_quality_metadata() -> None
     assert "- replay_quality_possible_layout_artifact_lines: 1/4 (0.250)" in markdown
 
 
+def test_public_pdf_footer_page_number_diagnostics_measure_safe_repeated_blocks() -> None:
+    raw_pages = [
+        "Executive summary\nDORA Report\n1",
+        "Key findings\nDORA Report\n2",
+        "Closing notes\nDORA Report\n3",
+    ]
+
+    normalized_pages, metadata = normalize_pdf_pages_with_metadata(raw_pages)
+
+    assert normalized_pages == [
+        "Executive summary",
+        "Key findings",
+        "Closing notes",
+    ]
+    footer_page_noise = _metadata_mapping(
+        metadata, "footer_page_number_noise_diagnostics"
+    )
+    assert footer_page_noise == {
+        "activity": "measured",
+        "basis": "post_url_normalization_pre_footer_suppression_extracted_pages",
+        "candidate_window": {
+            "trailing_nonempty_line_count": 3,
+            "min_repeated_pages": 2,
+        },
+        "repeated_trailing_footer_block_count": 2,
+        "repeated_trailing_footer_signature_count": 2,
+        "bare_numeric_line_count": 3,
+        "bare_numeric_trailing_line_count": 3,
+        "repeated_bare_numeric_trailing_signature_count": 1,
+        "bare_numeric_adjacent_to_numeric_content_count": 0,
+        "mid_page_footer_like_line_count": 0,
+        "risk_note": (
+            "bare numeric lines may be page numbers or meaningful table, calculator, "
+            "or report values; diagnostics do not authorize suppression"
+        ),
+    }
+
+
+def test_public_pdf_footer_page_number_diagnostics_measure_numeric_content_risk() -> None:
+    raw_pages = [
+        "Calculator\nInput value 10\n15\nOutput value 25\nNotes A\nCheck A\nKeep A",
+        "Calculator\nInput value 12\n18\nOutput value 30\nNotes B\nCheck B\nKeep B",
+    ]
+
+    normalized_pages, metadata = normalize_pdf_pages_with_metadata(raw_pages)
+
+    assert normalized_pages == raw_pages
+    footer_page_noise = _metadata_mapping(
+        metadata, "footer_page_number_noise_diagnostics"
+    )
+    assert footer_page_noise["bare_numeric_line_count"] == 2
+    assert footer_page_noise["bare_numeric_trailing_line_count"] == 0
+    assert footer_page_noise["bare_numeric_adjacent_to_numeric_content_count"] == 2
+    assert footer_page_noise["repeated_bare_numeric_trailing_signature_count"] == 0
+
+
+def test_public_pdf_footer_page_number_diagnostics_measure_mid_page_footer_like_text() -> None:
+    raw_pages = [
+        "Intro\nDORA Report | 1\nBody\nMetric 5\nDetail A\nClosing A",
+        "Intro\nDORA Report | 2\nBody\nMetric 6\nDetail B\nClosing B",
+    ]
+
+    normalized_pages, metadata = normalize_pdf_pages_with_metadata(raw_pages)
+
+    assert normalized_pages == raw_pages
+    footer_page_noise = _metadata_mapping(
+        metadata, "footer_page_number_noise_diagnostics"
+    )
+    assert footer_page_noise["mid_page_footer_like_line_count"] == 2
+    assert footer_page_noise["repeated_trailing_footer_block_count"] == 0
+    assert footer_page_noise["bare_numeric_line_count"] == 0
+
+
+def test_public_pdf_footer_page_number_diagnostics_measure_page_numbers_near_values() -> None:
+    raw_pages = [
+        "Table\nMetric value 12\n1\nTotal value 13\nNotes A\nCheck A\nEnd A",
+        "Table\nMetric value 20\n2\nTotal value 22\nNotes B\nCheck B\nEnd B",
+    ]
+
+    normalized_pages, metadata = normalize_pdf_pages_with_metadata(raw_pages)
+
+    assert normalized_pages == raw_pages
+    footer_page_noise = _metadata_mapping(
+        metadata, "footer_page_number_noise_diagnostics"
+    )
+    assert footer_page_noise["bare_numeric_line_count"] == 2
+    assert footer_page_noise["bare_numeric_trailing_line_count"] == 0
+    assert footer_page_noise["bare_numeric_adjacent_to_numeric_content_count"] == 2
+    assert footer_page_noise["mid_page_footer_like_line_count"] == 0
+
+
 def test_public_pdf_page_normalization_keeps_non_repeated_trailing_text() -> None:
     normalized_pages = normalize_pdf_pages(
         [
@@ -759,6 +851,14 @@ def _manifest_payload(manifest_path: Path) -> dict[str, Any]:
     payload = json.loads(manifest_path.read_text(encoding="utf-8"))
     assert isinstance(payload, dict)
     return payload
+
+
+def _metadata_mapping(
+    metadata: Mapping[str, object], key: str
+) -> Mapping[str, object]:
+    value = metadata[key]
+    assert isinstance(value, Mapping)
+    return value
 
 
 def _sample_replay_quality_metadata() -> dict[str, object]:


### PR DESCRIPTION
## Summary

Measurement/design slice for CAK-15 public PDF footer and page-number noise. This PR adds deterministic replay-quality diagnostics for footer/page-number patterns without changing retention semantics or adding new suppression behavior.

Changes:
- add `footer_page_number_noise_diagnostics` metadata measured after URL normalization and before existing repeated-footer suppression
- surface diagnostic counts in candidate markdown metadata and CLI dry-run output
- add synthetic fixtures for safe repeated footer blocks, unsafe numeric table/calculator rows, footer-like text appearing mid-page in pypdf reading order, and page-number-shaped lines adjacent to meaningful numeric content
- document future safety rules and explicit non-goals in `docs/public-pdf-footer-page-number-noise.md`

## Safe vs unsafe examples

Safe-looking repeated footer block:
- repeated nonnumeric footer text such as `DORA Report`
- adjacent trailing bare numeric page lines such as `1`, `2`, `3`
- repeated by trailing page position across the required page majority

Unsafe/risky numeric cases:
- bare numeric rows inside calculator/table content, for example a standalone `15` between `Input value 10` and `Output value 25`
- footer-like text such as `DORA Report | 1` appearing mid-page because pypdf reading order does not match visual layout
- page-number-shaped lines next to meaningful report values such as `Metric value 12`, `1`, `Total value 13`

## Proposed future normalization rules

A future implementation PR should:
- suppress repeated multi-line trailing footer blocks only when a repeated nonnumeric footer anchor is present
- suppress bare numeric page-number lines only when anchored to that repeated nonnumeric trailing footer block on the same pages
- avoid suppressing bare numeric lines solely because they normalize to a repeated `#` signature
- avoid suppressing footer-like mid-page text until the extraction-order risk is better proven
- avoid suppressing numeric lines adjacent to meaningful table, calculator, figure, or report-body numeric context
- keep all behavior deterministic and source-agnostic unless source-specific behavior is explicitly documented later

## Non-goals

This PR does not:
- implement new suppression behavior
- change retention semantics
- add auto-promotion logic
- repair ordinary prose hyphenation
- infer sections, rank document quality, or assert semantic correctness

## Validation

- `make check` passed: Ruff, mypy, and 464 tests
- `git diff --check` passed