### PR TITLE
Add anchored public PDF footer block suppression

### DIFF
--- a/docs/public-pdf-footer-page-number-noise.md
+++ b/docs/public-pdf-footer-page-number-noise.md
@@ -1,9 +1,9 @@
 # Public PDF Footer And Page-Number Noise
 
-This note records measurement and design guidance for public PDF footer and
-page-number normalization. It is diagnostic only: it does not approve candidate
-content, change retention semantics, promote material, or add new suppression
-rules.
+This note records measurement and safety guidance for public PDF footer and
+page-number normalization. It is diagnostic and normalization-scoped only: it
+does not approve candidate content, change retention semantics, promote
+material, or infer report structure.
 
 ## Current Measurement
 
@@ -23,6 +23,13 @@ records:
 - footer-like page-number text that appears before the trailing candidate
   window, which can happen when `pypdf` places a visual footer in the middle of
   reading order
+
+`repeated_footer_suppression` records the narrow suppression pass that runs
+after diagnostics. It only suppresses anchored two-line trailing footer blocks
+where repeated nonnumeric footer text and an adjacent bare numeric page line
+appear in the trailing candidate window on the same required majority of pages.
+The metadata includes detected anchored blocks, suppressed numeric page-line
+counts, and skipped numeric-risk cases.
 
 The metadata is deterministic and informational. Counts are review aids, not
 retention decisions.
@@ -75,26 +82,27 @@ Metric value 12
 Total value 13
 ```
 
-## Proposed Future Rules
+## Implemented Suppression Rules
 
-A future implementation PR should keep footer/page-number suppression narrow:
+Footer/page-number suppression is intentionally narrow:
 
 - suppress repeated multi-line trailing footer blocks only when the nonnumeric
   footer text repeats by page position across the required page majority
 - treat bare numeric lines as suppressible only when anchored to a repeated
   nonnumeric footer block on the same pages and at adjacent trailing positions
+- require anchored bare numeric values to increase in extracted page order
 - do not suppress a bare numeric line solely because it repeats as a normalized
   `#` signature
 - do not suppress footer-like text found outside the trailing candidate window
-  unless a later design can prove the extraction order case without touching
-  table, calculator, figure, or report body content
-- do not suppress numeric lines adjacent to meaningful numeric context unless a
-  stronger source-specific signal exists
-- keep all rules deterministic and source-agnostic unless a future PR
-  explicitly documents source-specific behavior
+  because `pypdf` reading order can place visual footers near report-body text
+- skip anchored numeric page-line suppression when nearby lines contain
+  meaningful table, calculator, figure, cost, value, percentage, formula, metric,
+  or report-body numeric context
+- keep all rules deterministic and source-agnostic
 
 ## Non-Goals
 
-This slice does not add new suppression behavior, repair ordinary prose
-hyphenation, infer semantic sections, auto-promote candidates, rank document
-quality, or assert that a diagnostic count is safe to remove.
+This slice does not suppress standalone bare numeric signatures, suppress
+single-line footer/page strings, repair ordinary prose hyphenation, infer
+semantic sections, auto-promote candidates, rank document quality, or assert
+that a diagnostic count is safe to remove.

--- a/src/knowledge_adapters/public_pdf/client.py
+++ b/src/knowledge_adapters/public_pdf/client.py
@@ -19,8 +19,8 @@ PDF_EXTRACTION_NOTES = (
     "image-only pages may be incomplete or missing; review against the source PDF before "
     "retaining any knowledge. Clearly mechanical extraction artifacts may be normalized: "
     "broken HTTP(S) URL scheme spacing is repaired, clearly split URL path line wraps "
-    "may be joined, and short repeated trailing footer lines may be suppressed when they "
-    "recur by page position."
+    "may be joined, and repeated trailing footer text plus adjacent bare numeric page "
+    "lines may be suppressed when anchored by page position."
 )
 
 

--- a/src/knowledge_adapters/public_pdf/normalize.py
+++ b/src/knowledge_adapters/public_pdf/normalize.py
@@ -31,7 +31,8 @@ _PAGE_NUMBERED_FOOTER_LIKE_RE = re.compile(
 )
 _MEANINGFUL_NUMERIC_CONTEXT_RE = re.compile(
     r"(\b(total|metric|value|score|cost|savings|roi|result|input|output|"
-    r"calculator|table|baseline|target|year|month|rate|percent)\b|[$%+=*/])",
+    r"calculator|table|figure|formula|baseline|target|year|month|rate|percent|"
+    r"percentage)\b|[$%+=*/])",
     re.IGNORECASE,
 )
 _MAX_FOOTER_CANDIDATE_LINES = 3
@@ -204,33 +205,123 @@ def _suppress_repeated_footer_lines_with_metadata(
     if len(page_texts) < 2:
         return [page_text.strip() for page_text in page_texts], {
             "activity": "none",
+            "basis": "anchored_trailing_footer_blocks",
             "suppressed_line_count": 0,
             "affected_page_count": 0,
             "detected_footer_pattern_count": 0,
+            "detected_anchored_footer_block_count": 0,
+            "suppressed_anchored_footer_block_count": 0,
+            "skipped_anchored_footer_block_count": 0,
+            "suppressed_numeric_page_line_count": 0,
+            "skipped_numeric_risk_count": 0,
+            "detected_anchored_footer_blocks": [],
+            "skipped_numeric_risk_cases": [],
         }
 
     page_lines = [page_text.splitlines() for page_text in page_texts]
-    candidates: dict[tuple[int, str], set[int]] = {}
-    candidate_indexes: dict[tuple[int, str], list[tuple[int, int]]] = {}
+    trailing_entries_by_page = [
+        _trailing_footer_candidate_entries(lines) for lines in page_lines
+    ]
+    anchor_candidates: dict[tuple[int, str], dict[int, int]] = {}
 
-    for page_index, lines in enumerate(page_lines):
-        nonempty_indexes = [index for index, line in enumerate(lines) if line.strip()]
-        trailing_indexes = nonempty_indexes[-_MAX_FOOTER_CANDIDATE_LINES:]
-        for depth, line_index in enumerate(reversed(trailing_indexes), start=1):
-            signature = _footer_signature(lines[line_index])
-            if signature is None:
+    for page_index, trailing_entries in enumerate(trailing_entries_by_page):
+        for depth, line_index, line in trailing_entries:
+            anchor_signature = _footer_anchor_signature(line)
+            if anchor_signature is None:
                 continue
-            key = (depth, signature)
-            candidates.setdefault(key, set()).add(page_index)
-            candidate_indexes.setdefault(key, []).append((page_index, line_index))
+            anchor_candidates.setdefault((depth, anchor_signature), {})[
+                page_index
+            ] = line_index
 
     min_repeated_pages = _min_repeated_footer_pages(len(page_texts))
     indexes_to_remove: set[tuple[int, int]] = set()
-    detected_footer_pattern_count = 0
-    for key, page_indexes in candidates.items():
-        if len(page_indexes) >= min_repeated_pages:
-            detected_footer_pattern_count += 1
-            indexes_to_remove.update(candidate_indexes[key])
+    detected_blocks: list[dict[str, object]] = []
+    skipped_numeric_risk_cases: list[dict[str, object]] = []
+    suppressed_numeric_page_line_count = 0
+    skipped_numeric_risk_count = 0
+
+    for (anchor_depth, anchor_signature), page_to_anchor_index in sorted(
+        anchor_candidates.items(), key=lambda item: (item[0][0], item[0][1])
+    ):
+        if len(page_to_anchor_index) < min_repeated_pages:
+            continue
+
+        for numeric_depth in _adjacent_footer_depths(anchor_depth):
+            numeric_occurrences: list[tuple[int, int, int]] = []
+            risk_page_indexes: list[int] = []
+            missing_numeric_line = False
+            for page_index, anchor_line_index in sorted(page_to_anchor_index.items()):
+                numeric_line_index = _line_index_at_trailing_depth(
+                    trailing_entries_by_page[page_index], numeric_depth
+                )
+                if numeric_line_index is None:
+                    missing_numeric_line = True
+                    break
+
+                numeric_line = page_lines[page_index][numeric_line_index].strip()
+                if not _is_bare_numeric_line(numeric_line):
+                    missing_numeric_line = True
+                    break
+
+                numeric_occurrences.append(
+                    (page_index, numeric_line_index, int(numeric_line))
+                )
+                if _has_nearby_meaningful_numeric_context(
+                    page_lines[page_index],
+                    anchor_line_index,
+                    numeric_line_index,
+                ):
+                    risk_page_indexes.append(page_index)
+
+            if missing_numeric_line or len(numeric_occurrences) < min_repeated_pages:
+                continue
+
+            if not _numeric_values_are_in_page_order(numeric_occurrences):
+                skipped_numeric_risk_count += len(numeric_occurrences)
+                skipped_numeric_risk_cases.append(
+                    {
+                        "anchor_signature": anchor_signature,
+                        "anchor_depth": anchor_depth,
+                        "numeric_depth": numeric_depth,
+                        "page_count": len(numeric_occurrences),
+                        "risk_page_count": len(numeric_occurrences),
+                        "reason": "numeric_values_not_in_page_order",
+                    }
+                )
+                continue
+
+            if risk_page_indexes:
+                skipped_numeric_risk_count += len(numeric_occurrences)
+                skipped_numeric_risk_cases.append(
+                    {
+                        "anchor_signature": anchor_signature,
+                        "anchor_depth": anchor_depth,
+                        "numeric_depth": numeric_depth,
+                        "page_count": len(numeric_occurrences),
+                        "risk_page_count": len(risk_page_indexes),
+                        "reason": "meaningful_numeric_context_near_footer_candidate",
+                    }
+                )
+                continue
+
+            for page_index, numeric_line_index, _numeric_value in numeric_occurrences:
+                anchor_line_index = page_to_anchor_index[page_index]
+                indexes_to_remove.add((page_index, anchor_line_index))
+                indexes_to_remove.add((page_index, numeric_line_index))
+            suppressed_numeric_page_line_count += len(numeric_occurrences)
+            detected_blocks.append(
+                {
+                    "anchor_signature": anchor_signature,
+                    "anchor_depth": anchor_depth,
+                    "numeric_depth": numeric_depth,
+                    "page_count": len(numeric_occurrences),
+                    "numeric_values": [
+                        numeric_value
+                        for _page_index, _line_index, numeric_value in numeric_occurrences
+                    ],
+                }
+            )
+            break
 
     normalized_pages: list[str] = []
     for page_index, lines in enumerate(page_lines):
@@ -242,10 +333,80 @@ def _suppress_repeated_footer_lines_with_metadata(
         normalized_pages.append("\n".join(kept_lines).strip())
     return normalized_pages, {
         "activity": "suppressed" if indexes_to_remove else "none",
+        "basis": "anchored_trailing_footer_blocks",
         "suppressed_line_count": len(indexes_to_remove),
         "affected_page_count": len({page_index for page_index, _line_index in indexes_to_remove}),
-        "detected_footer_pattern_count": detected_footer_pattern_count,
+        "detected_footer_pattern_count": len(detected_blocks),
+        "detected_anchored_footer_block_count": (
+            len(detected_blocks) + len(skipped_numeric_risk_cases)
+        ),
+        "suppressed_anchored_footer_block_count": len(detected_blocks),
+        "skipped_anchored_footer_block_count": len(skipped_numeric_risk_cases),
+        "suppressed_numeric_page_line_count": suppressed_numeric_page_line_count,
+        "skipped_numeric_risk_count": skipped_numeric_risk_count,
+        "detected_anchored_footer_blocks": detected_blocks,
+        "skipped_numeric_risk_cases": skipped_numeric_risk_cases,
     }
+
+
+def _trailing_footer_candidate_entries(lines: Sequence[str]) -> list[tuple[int, int, str]]:
+    nonempty_indexes = [index for index, line in enumerate(lines) if line.strip()]
+    trailing_indexes = nonempty_indexes[-_MAX_FOOTER_CANDIDATE_LINES:]
+    return [
+        (depth, line_index, lines[line_index].strip())
+        for depth, line_index in enumerate(reversed(trailing_indexes), start=1)
+    ]
+
+
+def _footer_anchor_signature(line: str) -> str | None:
+    if _is_bare_numeric_line(line) or _is_page_numbered_footer_like_line(line):
+        return None
+    if not any(character.isalpha() for character in line):
+        return None
+    return _footer_signature(line)
+
+
+def _adjacent_footer_depths(anchor_depth: int) -> tuple[int, ...]:
+    candidate_depths = (anchor_depth - 1, anchor_depth + 1)
+    return tuple(
+        depth for depth in candidate_depths if 1 <= depth <= _MAX_FOOTER_CANDIDATE_LINES
+    )
+
+
+def _line_index_at_trailing_depth(
+    trailing_entries: Sequence[tuple[int, int, str]], depth: int
+) -> int | None:
+    for candidate_depth, line_index, _line in trailing_entries:
+        if candidate_depth == depth:
+            return line_index
+    return None
+
+
+def _numeric_values_are_in_page_order(
+    numeric_occurrences: Sequence[tuple[int, int, int]],
+) -> bool:
+    numeric_values = [
+        numeric_value for _page_index, _line_index, numeric_value in numeric_occurrences
+    ]
+    return all(
+        previous_value < next_value
+        for previous_value, next_value in zip(
+            numeric_values, numeric_values[1:], strict=False
+        )
+    )
+
+
+def _has_nearby_meaningful_numeric_context(
+    lines: Sequence[str], anchor_line_index: int, numeric_line_index: int
+) -> bool:
+    first_line_index = max(0, min(anchor_line_index, numeric_line_index) - 1)
+    last_line_index = min(len(lines) - 1, max(anchor_line_index, numeric_line_index) + 1)
+    for line_index in range(first_line_index, last_line_index + 1):
+        if line_index == numeric_line_index:
+            continue
+        if _is_meaningful_numeric_context_line(lines[line_index]):
+            return True
+    return False
 
 
 def _diagnose_footer_page_number_noise(page_texts: Sequence[str]) -> dict[str, object]:
@@ -481,6 +642,26 @@ def _render_replay_quality_metadata(metadata: Mapping[str, object]) -> str:
             (
                 "- replay_quality_repeated_footer_suppressed_line_count: "
                 f"{_metadata_value(footer, 'suppressed_line_count')}"
+            ),
+            (
+                "- replay_quality_repeated_footer_detected_anchored_block_count: "
+                f"{_metadata_value(footer, 'detected_anchored_footer_block_count')}"
+            ),
+            (
+                "- replay_quality_repeated_footer_suppressed_anchored_block_count: "
+                f"{_metadata_value(footer, 'suppressed_anchored_footer_block_count')}"
+            ),
+            (
+                "- replay_quality_repeated_footer_skipped_anchored_block_count: "
+                f"{_metadata_value(footer, 'skipped_anchored_footer_block_count')}"
+            ),
+            (
+                "- replay_quality_repeated_footer_suppressed_numeric_page_line_count: "
+                f"{_metadata_value(footer, 'suppressed_numeric_page_line_count')}"
+            ),
+            (
+                "- replay_quality_repeated_footer_skipped_numeric_risk_count: "
+                f"{_metadata_value(footer, 'skipped_numeric_risk_count')}"
             ),
             (
                 "- replay_quality_possible_layout_artifact_lines: "

--- a/tests/test_public_sources.py
+++ b/tests/test_public_sources.py
@@ -379,9 +379,9 @@ def test_public_pdf_page_normalization_keeps_url_path_split_across_pages() -> No
 def test_public_pdf_page_normalization_suppresses_repeated_footer_lines() -> None:
     normalized_pages = normalize_pdf_pages(
         [
-            "Executive summary\n2023 Accelerate State of DevOps Report | 1",
-            "Key findings\n2023 Accelerate State of DevOps Report | 2",
-            "Closing notes\n2023 Accelerate State of DevOps Report | 3",
+            "Executive summary\n2023 Accelerate State of DevOps Report\n1",
+            "Key findings\n2023 Accelerate State of DevOps Report\n2",
+            "Closing notes\n2023 Accelerate State of DevOps Report\n3",
         ]
     )
 
@@ -399,9 +399,10 @@ def test_public_pdf_page_normalization_reports_replay_quality_metadata() -> None
             "Read https:/ /example.com/report\n"
             "Source: https://cloud.google.com/resources/content/dora-roi-of-ai-\n"
             "assisted-software-development\n"
-            "DORA Report | 1"
+            "DORA Report\n"
+            "1"
         ),
-        "Findings\nDORA Report | 2",
+        "Findings\nDORA Report\n2",
     ]
 
     first_pages, first_metadata = normalize_pdf_pages_with_metadata(raw_pages)
@@ -430,9 +431,25 @@ def test_public_pdf_page_normalization_reports_replay_quality_metadata() -> None
     }
     assert first_metadata["repeated_footer_suppression"] == {
         "activity": "suppressed",
-        "suppressed_line_count": 2,
+        "basis": "anchored_trailing_footer_blocks",
+        "suppressed_line_count": 4,
         "affected_page_count": 2,
         "detected_footer_pattern_count": 1,
+        "detected_anchored_footer_block_count": 1,
+        "suppressed_anchored_footer_block_count": 1,
+        "skipped_anchored_footer_block_count": 0,
+        "suppressed_numeric_page_line_count": 2,
+        "skipped_numeric_risk_count": 0,
+        "detected_anchored_footer_blocks": [
+            {
+                "anchor_signature": "dora report",
+                "anchor_depth": 2,
+                "numeric_depth": 1,
+                "page_count": 2,
+                "numeric_values": [1, 2],
+            }
+        ],
+        "skipped_numeric_risk_cases": [],
     }
     assert first_metadata["page_count_context"] == {
         "page_count": 2,
@@ -464,7 +481,16 @@ def test_public_pdf_page_normalization_reports_replay_quality_metadata() -> None
     ) in markdown
     assert "- replay_quality_url_spacing_normalization_count: 1" in markdown
     assert "- replay_quality_url_path_line_wrap_repair_count: 1" in markdown
-    assert "- replay_quality_repeated_footer_suppressed_line_count: 2" in markdown
+    assert "- replay_quality_repeated_footer_suppressed_line_count: 4" in markdown
+    assert (
+        "- replay_quality_repeated_footer_detected_anchored_block_count: 1"
+        in markdown
+    )
+    assert (
+        "- replay_quality_repeated_footer_suppressed_numeric_page_line_count: 2"
+        in markdown
+    )
+    assert "- replay_quality_repeated_footer_skipped_numeric_risk_count: 0" in markdown
     assert "- replay_quality_possible_layout_artifact_lines: 1/4 (0.250)" in markdown
 
 
@@ -504,6 +530,43 @@ def test_public_pdf_footer_page_number_diagnostics_measure_safe_repeated_blocks(
             "or report values; diagnostics do not authorize suppression"
         ),
     }
+    repeated_footer = _metadata_mapping(metadata, "repeated_footer_suppression")
+    assert repeated_footer["detected_anchored_footer_block_count"] == 1
+    assert repeated_footer["suppressed_numeric_page_line_count"] == 3
+    assert repeated_footer["skipped_numeric_risk_count"] == 0
+
+
+def test_public_pdf_page_normalization_keeps_bare_numeric_calculator_rows() -> None:
+    raw_pages = [
+        "Calculator\nInput value 10\n15\nOutput value 25",
+        "Calculator\nInput value 12\n18\nOutput value 30",
+    ]
+
+    normalized_pages, metadata = normalize_pdf_pages_with_metadata(raw_pages)
+
+    assert normalized_pages == raw_pages
+    repeated_footer = _metadata_mapping(metadata, "repeated_footer_suppression")
+    assert repeated_footer["suppressed_numeric_page_line_count"] == 0
+    assert repeated_footer["skipped_numeric_risk_count"] == 0
+
+
+def test_public_pdf_page_normalization_keeps_bare_numeric_signatures_without_anchor() -> None:
+    raw_pages = [
+        "Executive summary\nImportant row\n1",
+        "Key findings\nDifferent row\n2",
+        "Closing notes\nAnother row\n3",
+    ]
+
+    normalized_pages, metadata = normalize_pdf_pages_with_metadata(raw_pages)
+
+    assert normalized_pages == raw_pages
+    footer_page_noise = _metadata_mapping(
+        metadata, "footer_page_number_noise_diagnostics"
+    )
+    repeated_footer = _metadata_mapping(metadata, "repeated_footer_suppression")
+    assert footer_page_noise["repeated_bare_numeric_trailing_signature_count"] == 1
+    assert repeated_footer["suppressed_numeric_page_line_count"] == 0
+    assert repeated_footer["detected_anchored_footer_block_count"] == 0
 
 
 def test_public_pdf_footer_page_number_diagnostics_measure_numeric_content_risk() -> None:
@@ -557,6 +620,35 @@ def test_public_pdf_footer_page_number_diagnostics_measure_page_numbers_near_val
     assert footer_page_noise["bare_numeric_trailing_line_count"] == 0
     assert footer_page_noise["bare_numeric_adjacent_to_numeric_content_count"] == 2
     assert footer_page_noise["mid_page_footer_like_line_count"] == 0
+
+
+def test_public_pdf_page_normalization_skips_anchored_numeric_lines_near_values() -> None:
+    raw_pages = [
+        "Findings\nMetric value 12\nDORA Report\n1",
+        "Findings\nMetric value 20\nDORA Report\n2",
+        "Findings\nMetric value 30\nDORA Report\n3",
+    ]
+
+    normalized_pages, metadata = normalize_pdf_pages_with_metadata(raw_pages)
+
+    assert normalized_pages == raw_pages
+    repeated_footer = _metadata_mapping(metadata, "repeated_footer_suppression")
+    assert repeated_footer["activity"] == "none"
+    assert repeated_footer["detected_anchored_footer_block_count"] == 1
+    assert repeated_footer["suppressed_anchored_footer_block_count"] == 0
+    assert repeated_footer["skipped_anchored_footer_block_count"] == 1
+    assert repeated_footer["suppressed_numeric_page_line_count"] == 0
+    assert repeated_footer["skipped_numeric_risk_count"] == 3
+    assert repeated_footer["skipped_numeric_risk_cases"] == [
+        {
+            "anchor_signature": "dora report",
+            "anchor_depth": 2,
+            "numeric_depth": 1,
+            "page_count": 3,
+            "risk_page_count": 3,
+            "reason": "meaningful_numeric_context_near_footer_candidate",
+        }
+    ]
 
 
 def test_public_pdf_page_normalization_keeps_non_repeated_trailing_text() -> None:
@@ -882,9 +974,25 @@ def _sample_replay_quality_metadata() -> dict[str, object]:
         },
         "repeated_footer_suppression": {
             "activity": "suppressed",
+            "basis": "anchored_trailing_footer_blocks",
             "suppressed_line_count": 2,
             "affected_page_count": 2,
             "detected_footer_pattern_count": 1,
+            "detected_anchored_footer_block_count": 1,
+            "suppressed_anchored_footer_block_count": 1,
+            "skipped_anchored_footer_block_count": 0,
+            "suppressed_numeric_page_line_count": 1,
+            "skipped_numeric_risk_count": 0,
+            "detected_anchored_footer_blocks": [
+                {
+                    "anchor_signature": "sample report",
+                    "anchor_depth": 2,
+                    "numeric_depth": 1,
+                    "page_count": 1,
+                    "numeric_values": [1],
+                }
+            ],
+            "skipped_numeric_risk_cases": [],
         },
         "possible_layout_artifact_density": {
             "basis": "normalized_extracted_text_lines",


### PR DESCRIPTION
## Summary

- Replace broad repeated trailing footer signature suppression with narrow anchored two-line footer block suppression for `public_pdf`.
- Suppress an adjacent bare numeric page line only when a repeated non-bare-numeric footer text anchor appears at the same trailing page position across the required page majority.
- Add replay-quality metadata for detected anchored blocks, suppressed numeric page lines, skipped anchored blocks, and skipped numeric-risk cases.
- Update public PDF footer/page-number docs to record implemented safety rules and non-goals.

## Before / After Examples

Safe repeated trailing footer block:

```text
Before:
Executive summary
DORA Report
1

After:
Executive summary
```

Bare numeric table/calculator content remains unchanged:

```text
Before and after:
Calculator
Input value 10
15
Output value 25
```

Anchored numeric line near report-body numeric context remains unchanged and is audited as skipped risk:

```text
Before and after:
Findings
Metric value 12
DORA Report
1
```

## Safety Rules Implemented

- Both the repeated text anchor and bare numeric page line must be inside the last three nonempty trailing candidate lines.
- The text anchor must repeat at the same trailing depth across the required page majority.
- The bare numeric line must be adjacent to the anchor on those same pages.
- Bare numeric values must increase in extracted page order.
- Bare numeric signatures alone are never suppressible.
- Footer-like text outside the trailing candidate window is not suppressible.
- Anchored numeric lines are skipped when nearby lines contain meaningful table, calculator, figure, cost, value, percentage, formula, metric, or report-body numeric context.

## Tests Added

- Safe repeated anchored footer block suppression.
- No-op for bare numeric calculator/table-like rows.
- No-op for bare numeric trailing signatures without a repeated text anchor.
- No-op for mid-page footer-like text.
- No-op and skipped-risk metadata for anchored numeric lines near meaningful values.
- Metadata counts for detected, suppressed, and skipped cases.

## Limitations / Non-goals

- Does not change retention semantics or candidate status.
- Does not add auto-promotion logic.
- Does not infer report structure or source-specific page models.
- Does not suppress standalone bare numeric signatures or single-line footer/page strings.

## Validation

- `make check`
- `git diff --check`

Refs CAK-15
