### PR TITLE
Add DORA public PDF regression fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,14 @@ correctness. Footer and page-number noise measurement is documented in
 safe-looking repeated footer blocks and risky numeric content shapes without
 adding new suppression behavior.
 
+For CAK-15 extraction-quality iteration, use the deterministic sanitized
+DORA-derived fixtures in `tests/fixtures/public_pdf/` as the primary feedback
+loop. Add or update a fixture for each replay-observed artifact, validate the
+normalization and replay-quality metadata in `knowledge-adapters`, and reserve
+knowledge-vault replay for milestone or integration validation. See
+`docs/public-pdf-dora-regression-fixtures.md` for when full replay validation is
+still required.
+
 Recommended Confluence first run:
 
 1. Start with the default `stub` client and `--dry-run` to confirm the resolve

--- a/docs/public-pdf-dora-regression-fixtures.md
+++ b/docs/public-pdf-dora-regression-fixtures.md
@@ -1,0 +1,70 @@
+# Public PDF DORA Regression Fixtures
+
+This note defines the CAK-15 extraction-quality iteration workflow for DORA-like
+public PDF replay noise.
+
+## Primary Feedback Loop
+
+Use deterministic, sanitized fixtures in
+`tests/fixtures/public_pdf/dora_regression_cases.json` as the primary
+extraction-quality iteration loop for public PDF normalization changes.
+
+The fixture area captures small DORA-derived extraction shapes for:
+
+- repeated footer blocks
+- leading-space numeric page lines
+- URL scheme-spacing artifacts
+- URL path line-wrap artifacts
+- mid-page footer-like text
+- calculator and table numeric traps
+- fused extraction artifacts such as `roadmap43`
+
+Each case states whether current behavior should normalize the artifact or
+leave it unchanged for safety. Tests in
+`tests/test_public_pdf_dora_regression_fixtures.py` validate the normalized
+pages, no-op safety cases, replay-quality metadata, and previously observed
+DORA replay failures.
+
+When a DORA replay exposes a new extraction-quality problem, reduce it to the
+smallest sanitized fixture first. Iterate in `knowledge-adapters` until the
+fixture and `make check` pass, then use larger replays for integration
+confidence.
+
+## Knowledge-Vault Replay Role
+
+Knowledge-vault replay is milestone and integration validation, not the main
+inner loop for public PDF extraction-quality tuning.
+
+Use full replay validation when the change needs evidence that cannot be proven
+inside fixture tests, including:
+
+- candidate artifact shape across the real destination tree
+- manifest and content-hash behavior over a full run
+- interaction with existing knowledge-vault review workflows
+- source-specific replay diffs before requesting review or merge of a risky
+  extraction-quality change
+- confirmation that a sanitized fixture faithfully represents a newly observed
+  live replay failure
+
+Do not use repeated full replays as the normal way to discover whether a small
+normalization rule works. Keep the fast fixture loop authoritative for unit
+behavior, and treat replay output as end-to-end validation evidence.
+
+## Metadata Expectations
+
+Replay-quality metadata is part of the fixture contract. It remains
+informational only and does not authorize retention or promotion. Fixture tests
+should assert counts and notes that help reviewers understand what mechanical
+conditions were observed, such as URL repairs, footer suppression, numeric-risk
+diagnostics, page-count context, and extraction warnings.
+
+## Limitations And Non-Goals
+
+The fixture workflow does not change retention semantics, add auto-promotion
+logic, broaden ingestion behavior, infer report structure, or repair ambiguous
+body text by default.
+
+Known limitations should be fixture-backed when useful. For example,
+`fused_extraction_artifact_roadmap43` documents that fused body-text/page-number
+artifacts are currently retained unchanged and must be reviewed against the
+source PDF before retention.

--- a/docs/public-pdf-footer-page-number-noise.md
+++ b/docs/public-pdf-footer-page-number-noise.md
@@ -34,6 +34,12 @@ counts, and skipped numeric-risk cases.
 The metadata is deterministic and informational. Counts are review aids, not
 retention decisions.
 
+For DORA-shaped extraction-quality iteration, keep new footer and page-number
+cases in `tests/fixtures/public_pdf/dora_regression_cases.json` first. Full
+knowledge-vault replay should be used as milestone or integration validation,
+not as the repeated inner loop for small normalization changes. See
+`docs/public-pdf-dora-regression-fixtures.md`.
+
 ## Synthetic Cases
 
 Safe repeated footer blocks look like a stable report footer plus changing page

--- a/tests/fixtures/public_pdf/README.md
+++ b/tests/fixtures/public_pdf/README.md
@@ -1,0 +1,12 @@
+# Public PDF DORA Regression Fixtures
+
+This directory contains sanitized, DORA-derived public PDF extraction fixtures
+for deterministic normalization tests.
+
+The fixtures are intentionally small snippets, not retained report content. They
+capture mechanical extraction shapes observed during DORA replay work so
+normalization behavior can be iterated inside `knowledge-adapters` without using
+knowledge-vault replay as the primary feedback loop.
+
+Knowledge-vault replay remains milestone and integration validation for full
+adapter behavior, destination wiring, and end-to-end candidate artifact review.

--- a/tests/fixtures/public_pdf/dora_regression_cases.json
+++ b/tests/fixtures/public_pdf/dora_regression_cases.json
@@ -1,0 +1,208 @@
+{
+  "schema_version": 1,
+  "source": "sanitized_dora_derived_public_pdf_extraction_cases",
+  "cases": [
+    {
+      "id": "repeated_footer_blocks",
+      "description": "Repeated trailing report footer plus bare numeric page lines are suppressed when safely anchored.",
+      "expectation": "normalized",
+      "tags": ["required_case", "previous_dora_replay_failure", "footer"],
+      "raw_pages": [
+        "Executive summary\nDORA Report\n1",
+        "Key findings\nDORA Report\n2",
+        "Closing notes\nDORA Report\n3"
+      ],
+      "expected_pages": [
+        "Executive summary",
+        "Key findings",
+        "Closing notes"
+      ],
+      "expected_metadata": {
+        "repeated_footer_suppression": {
+          "activity": "suppressed",
+          "suppressed_line_count": 6,
+          "affected_page_count": 3,
+          "detected_anchored_footer_block_count": 1,
+          "suppressed_anchored_footer_block_count": 1,
+          "suppressed_numeric_page_line_count": 3,
+          "skipped_numeric_risk_count": 0
+        },
+        "footer_page_number_noise_diagnostics": {
+          "repeated_trailing_footer_block_count": 2,
+          "repeated_bare_numeric_trailing_signature_count": 1,
+          "mid_page_footer_like_line_count": 0
+        }
+      },
+      "expected_markdown_metadata_lines": [
+        "- replay_quality_metadata_note: informational only; does not authorize retention or promotion",
+        "- replay_quality_repeated_footer_suppressed_line_count: 6",
+        "- replay_quality_repeated_footer_suppressed_numeric_page_line_count: 3"
+      ]
+    },
+    {
+      "id": "leading_space_numeric_page_lines",
+      "description": "Leading whitespace before extracted page numbers does not prevent anchored footer suppression.",
+      "expectation": "normalized",
+      "tags": ["required_case", "previous_dora_replay_failure", "footer"],
+      "raw_pages": [
+        "Deployment performance\n2023 Accelerate State of DevOps Report\n  41",
+        "Delivery stability\n2023 Accelerate State of DevOps Report\n  42",
+        "Organizational performance\n2023 Accelerate State of DevOps Report\n  43"
+      ],
+      "expected_pages": [
+        "Deployment performance",
+        "Delivery stability",
+        "Organizational performance"
+      ],
+      "expected_metadata": {
+        "repeated_footer_suppression": {
+          "activity": "suppressed",
+          "suppressed_line_count": 6,
+          "affected_page_count": 3,
+          "detected_anchored_footer_block_count": 1,
+          "suppressed_anchored_footer_block_count": 1,
+          "suppressed_numeric_page_line_count": 3,
+          "skipped_numeric_risk_count": 0
+        },
+        "footer_page_number_noise_diagnostics": {
+          "bare_numeric_line_count": 3,
+          "bare_numeric_trailing_line_count": 3
+        }
+      }
+    },
+    {
+      "id": "url_scheme_spacing_artifacts",
+      "description": "Broken URL scheme spacing from extraction is repaired without changing surrounding prose.",
+      "expectation": "normalized",
+      "tags": ["required_case", "previous_dora_replay_failure", "url"],
+      "raw_pages": [
+        "Read the report at https:/ /dora.dev/research/2023/dora-report/ and mirror https: //example.com/report.pdf."
+      ],
+      "expected_pages": [
+        "Read the report at https://dora.dev/research/2023/dora-report/ and mirror https://example.com/report.pdf."
+      ],
+      "expected_metadata": {
+        "url_spacing_normalization": {
+          "activity": "normalized",
+          "replacement_count": 2,
+          "affected_page_count": 1
+        },
+        "url_path_line_wrap_normalization": {
+          "activity": "none",
+          "repair_count": 0
+        }
+      },
+      "expected_markdown_metadata_lines": [
+        "- replay_quality_url_spacing_normalization_count: 2"
+      ]
+    },
+    {
+      "id": "url_path_line_wrap_artifacts",
+      "description": "A URL path split at a terminal hyphen is joined only when the next line is a path fragment.",
+      "expectation": "normalized",
+      "tags": ["required_case", "previous_dora_replay_failure", "url"],
+      "raw_pages": [
+        "Source: https://cloud.google.com/resources/content/dora-roi-of-ai-\nassisted-software-development"
+      ],
+      "expected_pages": [
+        "Source: https://cloud.google.com/resources/content/dora-roi-of-ai-assisted-software-development"
+      ],
+      "expected_metadata": {
+        "url_path_line_wrap_normalization": {
+          "activity": "normalized",
+          "repair_count": 1,
+          "affected_page_count": 1
+        },
+        "possible_layout_artifact_density": {
+          "possible_artifact_line_count": 0
+        }
+      },
+      "expected_markdown_metadata_lines": [
+        "- replay_quality_url_path_line_wrap_repair_count: 1"
+      ]
+    },
+    {
+      "id": "mid_page_footer_like_text",
+      "description": "Footer-like page-number text in the middle of reading order is measured but not suppressed.",
+      "expectation": "unchanged",
+      "tags": ["required_case", "no_op_safety", "footer"],
+      "raw_pages": [
+        "Intro\nDORA Report | 1\nBody\nMetric 5\nDetail A\nClosing A",
+        "Intro\nDORA Report | 2\nBody\nMetric 6\nDetail B\nClosing B"
+      ],
+      "expected_pages": [
+        "Intro\nDORA Report | 1\nBody\nMetric 5\nDetail A\nClosing A",
+        "Intro\nDORA Report | 2\nBody\nMetric 6\nDetail B\nClosing B"
+      ],
+      "expected_metadata": {
+        "footer_page_number_noise_diagnostics": {
+          "mid_page_footer_like_line_count": 2,
+          "repeated_trailing_footer_block_count": 0,
+          "bare_numeric_line_count": 0
+        },
+        "repeated_footer_suppression": {
+          "activity": "none",
+          "suppressed_line_count": 0
+        }
+      }
+    },
+    {
+      "id": "calculator_table_numeric_traps",
+      "description": "Bare numeric table and calculator values near meaningful numeric context are retained.",
+      "expectation": "unchanged",
+      "tags": ["required_case", "no_op_safety", "numeric"],
+      "raw_pages": [
+        "Calculator\nInput value 10\n15\nOutput value 25\nNotes A\nCheck A\nKeep A",
+        "Calculator\nInput value 12\n18\nOutput value 30\nNotes B\nCheck B\nKeep B"
+      ],
+      "expected_pages": [
+        "Calculator\nInput value 10\n15\nOutput value 25\nNotes A\nCheck A\nKeep A",
+        "Calculator\nInput value 12\n18\nOutput value 30\nNotes B\nCheck B\nKeep B"
+      ],
+      "expected_metadata": {
+        "footer_page_number_noise_diagnostics": {
+          "bare_numeric_line_count": 2,
+          "bare_numeric_trailing_line_count": 0,
+          "bare_numeric_adjacent_to_numeric_content_count": 2
+        },
+        "repeated_footer_suppression": {
+          "activity": "none",
+          "suppressed_numeric_page_line_count": 0,
+          "skipped_numeric_risk_count": 0
+        }
+      }
+    },
+    {
+      "id": "fused_extraction_artifact_roadmap43",
+      "description": "A fused body-text/page-number artifact such as roadmap43 is captured as a known no-op limitation.",
+      "expectation": "unchanged",
+      "tags": ["required_case", "previous_dora_replay_failure", "known_limitation"],
+      "raw_pages": [
+        "Strategy notes\nThe roadmap43 item remains fused in extracted body text.\nReview against source PDF before retention."
+      ],
+      "expected_pages": [
+        "Strategy notes\nThe roadmap43 item remains fused in extracted body text.\nReview against source PDF before retention."
+      ],
+      "expected_metadata": {
+        "url_spacing_normalization": {
+          "activity": "none",
+          "replacement_count": 0
+        },
+        "url_path_line_wrap_normalization": {
+          "activity": "none",
+          "repair_count": 0
+        },
+        "repeated_footer_suppression": {
+          "activity": "none",
+          "suppressed_line_count": 0
+        },
+        "possible_layout_artifact_density": {
+          "possible_artifact_line_count": 0
+        }
+      },
+      "expected_markdown_metadata_lines": [
+        "- replay_quality_metadata_note: informational only; does not authorize retention or promotion"
+      ]
+    }
+  ]
+}

--- a/tests/test_public_pdf_dora_regression_fixtures.py
+++ b/tests/test_public_pdf_dora_regression_fixtures.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from knowledge_adapters.public_pdf.normalize import (
+    normalize_extracted_pages_with_replay_metadata,
+)
+from knowledge_adapters.public_pdf.normalize import normalize_to_markdown as normalize_pdf
+
+FIXTURE_PATH = (
+    Path(__file__).parent
+    / "fixtures"
+    / "public_pdf"
+    / "dora_regression_cases.json"
+)
+REQUIRED_CASE_IDS = {
+    "repeated_footer_blocks",
+    "leading_space_numeric_page_lines",
+    "url_scheme_spacing_artifacts",
+    "url_path_line_wrap_artifacts",
+    "mid_page_footer_like_text",
+    "calculator_table_numeric_traps",
+    "fused_extraction_artifact_roadmap43",
+}
+
+
+def _load_fixture_cases() -> tuple[Mapping[str, object], ...]:
+    payload = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    assert payload["schema_version"] == 1
+    assert payload["source"] == "sanitized_dora_derived_public_pdf_extraction_cases"
+    cases = payload["cases"]
+    assert isinstance(cases, list)
+    return tuple(cast(Mapping[str, object], case) for case in cases)
+
+
+def _case_tags(case: Mapping[str, object]) -> list[str]:
+    value = case["tags"]
+    assert isinstance(value, Sequence)
+    assert not isinstance(value, str)
+    assert all(isinstance(item, str) for item in value)
+    return list(cast(Sequence[str], value))
+
+
+DORA_REGRESSION_CASES = _load_fixture_cases()
+NORMALIZATION_SUCCESS_CASES = tuple(
+    case for case in DORA_REGRESSION_CASES if case["expectation"] == "normalized"
+)
+NO_OP_SAFETY_CASES = tuple(
+    case for case in DORA_REGRESSION_CASES if case["expectation"] == "unchanged"
+)
+PREVIOUS_DORA_REPLAY_FAILURE_CASES = tuple(
+    case
+    for case in DORA_REGRESSION_CASES
+    if "previous_dora_replay_failure" in _case_tags(case)
+)
+
+
+def test_dora_regression_fixture_area_covers_required_cases() -> None:
+    case_ids = {str(case["id"]) for case in DORA_REGRESSION_CASES}
+
+    assert REQUIRED_CASE_IDS <= case_ids
+    assert len(DORA_REGRESSION_CASES) == len(case_ids)
+    assert NORMALIZATION_SUCCESS_CASES
+    assert NO_OP_SAFETY_CASES
+    assert PREVIOUS_DORA_REPLAY_FAILURE_CASES
+
+
+@pytest.mark.parametrize(
+    "case",
+    NORMALIZATION_SUCCESS_CASES,
+    ids=lambda case: str(case["id"]),
+)
+def test_dora_regression_normalization_success_cases(case: Mapping[str, object]) -> None:
+    normalized_pages, metadata = normalize_extracted_pages_with_replay_metadata(
+        _string_sequence(case, "raw_pages")
+    )
+
+    assert normalized_pages == _string_sequence(case, "expected_pages")
+    _assert_metadata_contains(metadata, _mapping(case, "expected_metadata"))
+
+
+@pytest.mark.parametrize(
+    "case",
+    NO_OP_SAFETY_CASES,
+    ids=lambda case: str(case["id"]),
+)
+def test_dora_regression_no_op_safety_cases(case: Mapping[str, object]) -> None:
+    raw_pages = _string_sequence(case, "raw_pages")
+    normalized_pages, metadata = normalize_extracted_pages_with_replay_metadata(raw_pages)
+
+    assert normalized_pages == raw_pages
+    assert normalized_pages == _string_sequence(case, "expected_pages")
+    _assert_metadata_contains(metadata, _mapping(case, "expected_metadata"))
+
+
+@pytest.mark.parametrize(
+    "case",
+    DORA_REGRESSION_CASES,
+    ids=lambda case: str(case["id"]),
+)
+def test_dora_regression_replay_quality_metadata_contract(
+    case: Mapping[str, object],
+) -> None:
+    normalized_pages, metadata = normalize_extracted_pages_with_replay_metadata(
+        _string_sequence(case, "raw_pages")
+    )
+
+    assert metadata["metadata_scope"] == "public_pdf_replay_quality"
+    assert (
+        metadata["metadata_note"]
+        == "informational only; does not authorize retention or promotion"
+    )
+    assert metadata["page_count_context"] == {
+        "page_count": len(_string_sequence(case, "raw_pages")),
+        "pages_with_extracted_text_count": len(
+            [page for page in normalized_pages if page.strip()]
+        ),
+        "empty_page_count": len([page for page in normalized_pages if not page.strip()]),
+    }
+    assert metadata["extraction_warnings"] == [
+        "pdf_layout_tables_figures_footnotes_headers_reading_order_may_be_incomplete",
+        "scanned_image_only_pages_may_be_missing",
+    ]
+
+    markdown = normalize_pdf(
+        {
+            "title": f"Fixture {case['id']}",
+            "canonical_id": f"fixture://{case['id']}",
+            "source_url": f"fixture://{case['id']}",
+            "page_count": len(normalized_pages),
+            "content": _render_fixture_pages(normalized_pages),
+            "replay_quality_metadata": metadata,
+        }
+    )
+    assert "- candidate_status: unreviewed" in markdown
+    for expected_line in _optional_string_sequence(
+        case, "expected_markdown_metadata_lines"
+    ):
+        assert expected_line in markdown
+
+
+@pytest.mark.parametrize(
+    "case",
+    PREVIOUS_DORA_REPLAY_FAILURE_CASES,
+    ids=lambda case: str(case["id"]),
+)
+def test_previous_dora_replay_failures_are_fixture_backed(
+    case: Mapping[str, object],
+) -> None:
+    normalized_pages, metadata = normalize_extracted_pages_with_replay_metadata(
+        _string_sequence(case, "raw_pages")
+    )
+
+    if case["expectation"] == "normalized":
+        assert normalized_pages == _string_sequence(case, "expected_pages")
+    else:
+        assert normalized_pages == _string_sequence(case, "raw_pages")
+    _assert_metadata_contains(metadata, _mapping(case, "expected_metadata"))
+
+
+def _assert_metadata_contains(
+    actual: Mapping[str, object],
+    expected: Mapping[str, object],
+    path: str = "metadata",
+) -> None:
+    for key, expected_value in expected.items():
+        assert key in actual, f"{path}.{key} missing"
+        actual_value = actual[key]
+        if isinstance(expected_value, Mapping):
+            assert isinstance(actual_value, Mapping), f"{path}.{key} is not a mapping"
+            _assert_metadata_contains(
+                cast(Mapping[str, object], actual_value),
+                cast(Mapping[str, object], expected_value),
+                f"{path}.{key}",
+            )
+            continue
+        assert actual_value == expected_value, f"{path}.{key}"
+
+
+def _mapping(case: Mapping[str, object], key: str) -> Mapping[str, object]:
+    value = case[key]
+    assert isinstance(value, Mapping)
+    return cast(Mapping[str, object], value)
+
+
+def _string_sequence(case: Mapping[str, object], key: str) -> list[str]:
+    value = case[key]
+    assert isinstance(value, Sequence)
+    assert not isinstance(value, str)
+    assert all(isinstance(item, str) for item in value)
+    return list(cast(Sequence[str], value))
+
+
+def _optional_string_sequence(case: Mapping[str, object], key: str) -> list[str]:
+    if key not in case:
+        return []
+    return _string_sequence(case, key)
+
+
+def _render_fixture_pages(pages: Sequence[str]) -> str:
+    return "\n\n".join(
+        f"## Page {page_number}\n\n{page}"
+        for page_number, page in enumerate(pages, start=1)
+    )


### PR DESCRIPTION
## Summary
- Add a dedicated sanitized DORA-derived public PDF regression fixture area under tests/fixtures/public_pdf.
- Add deterministic fixture-backed tests for normalization successes, no-op safety cases, replay-quality metadata expectations, and prior DORA replay failure shapes.
- Document fixture-driven iteration as the primary CAK-15 extraction-quality workflow, with knowledge-vault replay reserved for milestone/integration validation.

## Fixture/testing strategy
- Fixtures encode raw extracted pages, expected normalized pages, expected metadata subsets, and optional rendered markdown metadata lines.
- Covered cases: repeated footer blocks, leading-space numeric page lines, URL scheme-spacing artifacts, URL path line-wrap artifacts, mid-page footer-like text, calculator/table numeric traps, and fused artifacts like roadmap43.
- Tests assert both positive normalization behavior and safety-preserving no-op behavior without broadening ingestion or changing retention semantics.

## Workflow rationale
- Fast deterministic fixtures should be the inner loop for public PDF extraction-quality work.
- Full knowledge-vault replay remains useful for destination-tree artifact shape, manifest/content-hash behavior, workflow integration, and milestone confidence, but not repeated small-rule iteration.

## Limitations / non-goals
- Does not change public PDF normalization implementation.
- Does not change retention semantics, add auto-promotion logic, broaden ingestion behavior, infer report structure, or repair ambiguous fused body-text artifacts by default.

## Validation
- make check: 487 passed
- git diff --check

References CAK-15.