### PR TITLE
Fix anchored DORA footer suppression

### DIFF
--- a/docs/public-pdf-dora-regression-fixtures.md
+++ b/docs/public-pdf-dora-regression-fixtures.md
@@ -13,6 +13,8 @@ The fixture area captures small DORA-derived extraction shapes for:
 
 - repeated footer blocks
 - leading-space numeric page lines
+- ordinary page-number/footer pairs
+- repeated multi-line trailing footer blocks
 - URL scheme-spacing artifacts
 - URL path line-wrap artifacts
 - mid-page footer-like text

--- a/docs/public-pdf-footer-page-number-noise.md
+++ b/docs/public-pdf-footer-page-number-noise.md
@@ -12,7 +12,7 @@ Public PDF replay-quality metadata includes
 and before the existing repeated footer suppression pass. The diagnostic block
 records:
 
-- repeated trailing footer block and signature counts inside the last three
+- repeated trailing footer block and signature counts inside the last four
   nonempty lines of each extracted page
 - bare numeric line counts, including whether those lines appear in the trailing
   footer candidate window
@@ -25,11 +25,11 @@ records:
   reading order
 
 `repeated_footer_suppression` records the narrow suppression pass that runs
-after diagnostics. It only suppresses anchored two-line trailing footer blocks
-where repeated nonnumeric footer text and an adjacent bare numeric page line
-appear in the trailing candidate window on the same required majority of pages.
-The metadata includes detected anchored blocks, suppressed numeric page-line
-counts, and skipped numeric-risk cases.
+after diagnostics. It only suppresses anchored trailing footer blocks where
+repeated nonnumeric footer text and an adjacent page-number line appear in the
+trailing candidate window on the same required majority of pages. The metadata
+includes detected anchored blocks, the repeated footer depths removed with each
+anchor, suppressed numeric page-line counts, and skipped numeric-risk cases.
 
 The metadata is deterministic and informational. Counts are review aids, not
 retention decisions.
@@ -94,9 +94,10 @@ Footer/page-number suppression is intentionally narrow:
 
 - suppress repeated multi-line trailing footer blocks only when the nonnumeric
   footer text repeats by page position across the required page majority
-- treat bare numeric lines as suppressible only when anchored to a repeated
-  nonnumeric footer block on the same pages and at adjacent trailing positions
-- require anchored bare numeric values to increase in extracted page order
+- treat bare numeric lines and ordinary `Page 1`/`1 of 10` page-number lines as
+  suppressible only when anchored to a repeated nonnumeric footer block on the
+  same pages and at adjacent trailing positions
+- require anchored page-number values to increase in extracted page order
 - do not suppress a bare numeric line solely because it repeats as a normalized
   `#` signature
 - do not suppress footer-like text found outside the trailing candidate window
@@ -109,6 +110,6 @@ Footer/page-number suppression is intentionally narrow:
 ## Non-Goals
 
 This slice does not suppress standalone bare numeric signatures, suppress
-single-line footer/page strings, repair ordinary prose hyphenation, infer
+single-line fused footer/page strings, repair ordinary prose hyphenation, infer
 semantic sections, auto-promote candidates, rank document quality, or assert
 that a diagnostic count is safe to remove.

--- a/src/knowledge_adapters/public_pdf/normalize.py
+++ b/src/knowledge_adapters/public_pdf/normalize.py
@@ -29,13 +29,17 @@ _PAGE_NUMBERED_FOOTER_LIKE_RE = re.compile(
     r"\d+\s*(of|/)\s*\d+\b|[|:/-]\s*\d+(\s*(of|/)\s*\d+)?$)",
     re.IGNORECASE,
 )
+_PAGE_NUMBER_LINE_RE = re.compile(
+    r"^(?:page\s+|p\.\s*)?(?P<page>\d{1,4})(?:\s*(?:of|/)\s*\d{1,4})?$",
+    re.IGNORECASE,
+)
 _MEANINGFUL_NUMERIC_CONTEXT_RE = re.compile(
     r"(\b(total|metric|value|score|cost|savings|roi|result|input|output|"
     r"calculator|table|figure|formula|baseline|target|year|month|rate|percent|"
     r"percentage)\b|[$%+=*/])",
     re.IGNORECASE,
 )
-_MAX_FOOTER_CANDIDATE_LINES = 3
+_MAX_FOOTER_CANDIDATE_LINES = 4
 _MAX_FOOTER_LINE_LENGTH = 140
 _BASE_EXTRACTION_WARNINGS = (
     "pdf_layout_tables_figures_footnotes_headers_reading_order_may_be_incomplete",
@@ -259,12 +263,13 @@ def _suppress_repeated_footer_lines_with_metadata(
                     break
 
                 numeric_line = page_lines[page_index][numeric_line_index].strip()
-                if not _is_bare_numeric_line(numeric_line):
+                numeric_value = _page_number_line_value(numeric_line)
+                if numeric_value is None:
                     missing_numeric_line = True
                     break
 
                 numeric_occurrences.append(
-                    (page_index, numeric_line_index, int(numeric_line))
+                    (page_index, numeric_line_index, numeric_value)
                 )
                 if _has_nearby_meaningful_numeric_context(
                     page_lines[page_index],
@@ -304,9 +309,22 @@ def _suppress_repeated_footer_lines_with_metadata(
                 )
                 continue
 
+            footer_depths = _repeated_footer_block_depths(
+                trailing_entries_by_page,
+                tuple(page_to_anchor_index),
+                anchor_depth,
+                numeric_depth,
+            )
+            if not footer_depths:
+                continue
+
             for page_index, numeric_line_index, _numeric_value in numeric_occurrences:
-                anchor_line_index = page_to_anchor_index[page_index]
-                indexes_to_remove.add((page_index, anchor_line_index))
+                for footer_depth in footer_depths:
+                    footer_line_index = _line_index_at_trailing_depth(
+                        trailing_entries_by_page[page_index], footer_depth
+                    )
+                    if footer_line_index is not None:
+                        indexes_to_remove.add((page_index, footer_line_index))
                 indexes_to_remove.add((page_index, numeric_line_index))
             suppressed_numeric_page_line_count += len(numeric_occurrences)
             detected_blocks.append(
@@ -314,6 +332,7 @@ def _suppress_repeated_footer_lines_with_metadata(
                     "anchor_signature": anchor_signature,
                     "anchor_depth": anchor_depth,
                     "numeric_depth": numeric_depth,
+                    "footer_depths": footer_depths,
                     "page_count": len(numeric_occurrences),
                     "numeric_values": [
                         numeric_value
@@ -379,6 +398,44 @@ def _line_index_at_trailing_depth(
     for candidate_depth, line_index, _line in trailing_entries:
         if candidate_depth == depth:
             return line_index
+    return None
+
+
+def _repeated_footer_block_depths(
+    trailing_entries_by_page: Sequence[Sequence[tuple[int, int, str]]],
+    page_indexes: Sequence[int],
+    anchor_depth: int,
+    numeric_depth: int,
+) -> list[int]:
+    page_index_set = set(page_indexes)
+    if numeric_depth < anchor_depth:
+        candidate_depths = range(anchor_depth, _MAX_FOOTER_CANDIDATE_LINES + 1)
+    else:
+        candidate_depths = range(anchor_depth, 0, -1)
+
+    footer_depths: list[int] = []
+    for candidate_depth in candidate_depths:
+        signatures = {
+            _signature_at_trailing_depth(
+                trailing_entries_by_page[page_index], candidate_depth
+            )
+            for page_index in page_index_set
+        }
+        if len(signatures) != 1:
+            break
+        signature = next(iter(signatures))
+        if signature is None:
+            break
+        footer_depths.append(candidate_depth)
+    return footer_depths
+
+
+def _signature_at_trailing_depth(
+    trailing_entries: Sequence[tuple[int, int, str]], depth: int
+) -> str | None:
+    for candidate_depth, _line_index, line in trailing_entries:
+        if candidate_depth == depth:
+            return _footer_anchor_signature(line)
     return None
 
 
@@ -525,6 +582,11 @@ def _footer_signature(line: str) -> str | None:
 
 def _is_bare_numeric_line(line: str) -> bool:
     return bool(_BARE_NUMERIC_LINE_RE.fullmatch(line.strip()))
+
+
+def _page_number_line_value(line: str) -> int | None:
+    match = _PAGE_NUMBER_LINE_RE.fullmatch(" ".join(line.strip().split()))
+    return int(match.group("page")) if match else None
 
 
 def _is_page_numbered_footer_like_line(line: str) -> bool:

--- a/tests/fixtures/public_pdf/dora_regression_cases.json
+++ b/tests/fixtures/public_pdf/dora_regression_cases.json
@@ -71,6 +71,74 @@
       }
     },
     {
+      "id": "page_number_footer_pairs",
+      "description": "Ordinary page-number lines paired with a repeated trailing footer are suppressed only when anchored.",
+      "expectation": "normalized",
+      "tags": ["required_case", "previous_dora_replay_failure", "footer"],
+      "raw_pages": [
+        "Executive summary\nPage 1\n2023 Accelerate State of DevOps Report",
+        "Key findings\nPage 2\n2023 Accelerate State of DevOps Report",
+        "Closing notes\nPage 3\n2023 Accelerate State of DevOps Report"
+      ],
+      "expected_pages": [
+        "Executive summary",
+        "Key findings",
+        "Closing notes"
+      ],
+      "expected_metadata": {
+        "repeated_footer_suppression": {
+          "activity": "suppressed",
+          "suppressed_line_count": 6,
+          "affected_page_count": 3,
+          "detected_anchored_footer_block_count": 1,
+          "suppressed_anchored_footer_block_count": 1,
+          "suppressed_numeric_page_line_count": 3,
+          "skipped_numeric_risk_count": 0
+        },
+        "footer_page_number_noise_diagnostics": {
+          "bare_numeric_line_count": 0,
+          "repeated_trailing_footer_block_count": 2,
+          "mid_page_footer_like_line_count": 0
+        }
+      }
+    },
+    {
+      "id": "repeated_trailing_footer_blocks",
+      "description": "DORA-shaped repeated multi-line trailing footer blocks are suppressed with their anchored page numbers.",
+      "expectation": "normalized",
+      "tags": ["required_case", "previous_dora_replay_failure", "footer"],
+      "raw_pages": [
+        "Deployment performance\nGoogle Cloud DORA\n2023 Accelerate State of DevOps Report\n  41",
+        "Delivery stability\nGoogle Cloud DORA\n2023 Accelerate State of DevOps Report\n  42",
+        "Organizational performance\nGoogle Cloud DORA\n2023 Accelerate State of DevOps Report\n  43"
+      ],
+      "expected_pages": [
+        "Deployment performance",
+        "Delivery stability",
+        "Organizational performance"
+      ],
+      "expected_metadata": {
+        "repeated_footer_suppression": {
+          "activity": "suppressed",
+          "suppressed_line_count": 9,
+          "affected_page_count": 3,
+          "detected_anchored_footer_block_count": 1,
+          "suppressed_anchored_footer_block_count": 1,
+          "suppressed_numeric_page_line_count": 3,
+          "skipped_numeric_risk_count": 0
+        },
+        "footer_page_number_noise_diagnostics": {
+          "repeated_trailing_footer_block_count": 3,
+          "repeated_bare_numeric_trailing_signature_count": 1,
+          "mid_page_footer_like_line_count": 0
+        }
+      },
+      "expected_markdown_metadata_lines": [
+        "- replay_quality_repeated_footer_suppressed_line_count: 9",
+        "- replay_quality_repeated_footer_suppressed_numeric_page_line_count: 3"
+      ]
+    },
+    {
       "id": "url_scheme_spacing_artifacts",
       "description": "Broken URL scheme spacing from extraction is repaired without changing surrounding prose.",
       "expectation": "normalized",

--- a/tests/test_public_pdf_dora_regression_fixtures.py
+++ b/tests/test_public_pdf_dora_regression_fixtures.py
@@ -21,6 +21,8 @@ FIXTURE_PATH = (
 REQUIRED_CASE_IDS = {
     "repeated_footer_blocks",
     "leading_space_numeric_page_lines",
+    "page_number_footer_pairs",
+    "repeated_trailing_footer_blocks",
     "url_scheme_spacing_artifacts",
     "url_path_line_wrap_artifacts",
     "mid_page_footer_like_text",

--- a/tests/test_public_sources.py
+++ b/tests/test_public_sources.py
@@ -445,6 +445,7 @@ def test_public_pdf_page_normalization_reports_replay_quality_metadata() -> None
                 "anchor_signature": "dora report",
                 "anchor_depth": 2,
                 "numeric_depth": 1,
+                "footer_depths": [2],
                 "page_count": 2,
                 "numeric_values": [1, 2],
             }
@@ -515,7 +516,7 @@ def test_public_pdf_footer_page_number_diagnostics_measure_safe_repeated_blocks(
         "activity": "measured",
         "basis": "post_url_normalization_pre_footer_suppression_extracted_pages",
         "candidate_window": {
-            "trailing_nonempty_line_count": 3,
+            "trailing_nonempty_line_count": 4,
             "min_repeated_pages": 2,
         },
         "repeated_trailing_footer_block_count": 2,
@@ -988,6 +989,7 @@ def _sample_replay_quality_metadata() -> dict[str, object]:
                     "anchor_signature": "sample report",
                     "anchor_depth": 2,
                     "numeric_depth": 1,
+                    "footer_depths": [2],
                     "page_count": 1,
                     "numeric_values": [1],
                 }


### PR DESCRIPTION
## Summary
- Repair anchored public PDF footer suppression so adjacent page-number lines such as `Page 1` are handled without standalone numeric suppression.
- Extend anchored removal from a single repeated footer line to a contiguous repeated trailing footer block inside a bounded four-line candidate window.
- Add DORA regression fixture coverage for ordinary page-number/footer pairs and repeated multi-line trailing footer blocks, while preserving no-op coverage for mid-page footer-like text, calculator/table numeric traps, nearby meaningful numeric values, and the `fused_extraction_artifact_roadmap43` known limitation.

## Replay-quality metadata
- `footer_page_number_noise_diagnostics.candidate_window.trailing_nonempty_line_count` now reports `4`.
- Detected anchored footer blocks include `footer_depths` so reviewers can see which repeated footer depths were removed with the anchor.

## Safety notes
- Suppression still requires a repeated nonnumeric footer anchor, an adjacent page-number line, increasing page-number values, and no nearby meaningful numeric context.
- This does not change retention semantics, add auto-promotion, infer report structure, or suppress fused single-line artifacts such as `roadmap43`.
- Knowledge-vault replay was not used for the inner loop because CAK-15 directs DORA-shaped extraction-quality iteration through the sanitized public PDF fixture file; full replay remains milestone/integration validation rather than the primary feedback loop for this deterministic normalization repair.

## Validation
- `make test PYTEST=.venv/bin/pytest\ tests/test_public_pdf_dora_regression_fixtures.py`
- `make test PYTEST=.venv/bin/pytest\ tests/test_public_sources.py`
- `make check`
- `git diff --check`

Refs CAK-15