### PR TITLE
Fix DORA version footer suppression

### DIFF
--- a/src/knowledge_adapters/public_pdf/normalize.py
+++ b/src/knowledge_adapters/public_pdf/normalize.py
@@ -459,7 +459,7 @@ def _has_nearby_meaningful_numeric_context(
     first_line_index = max(0, min(anchor_line_index, numeric_line_index) - 1)
     last_line_index = min(len(lines) - 1, max(anchor_line_index, numeric_line_index) + 1)
     for line_index in range(first_line_index, last_line_index + 1):
-        if line_index == numeric_line_index:
+        if line_index in {anchor_line_index, numeric_line_index}:
             continue
         if _is_meaningful_numeric_context_line(lines[line_index]):
             return True

--- a/tests/fixtures/public_pdf/dora_regression_cases.json
+++ b/tests/fixtures/public_pdf/dora_regression_cases.json
@@ -139,6 +139,42 @@
       ]
     },
     {
+      "id": "version_footer_after_bare_page_number",
+      "description": "Real DORA ROI replay shape with the bare page number before the short repeated version footer is suppressed when safely anchored.",
+      "expectation": "normalized",
+      "tags": ["required_case", "previous_dora_replay_failure", "footer"],
+      "raw_pages": [
+        "ROI calculation and\nfinancial modeling\n2\nv. 2026.1",
+        "Generating more code\nwithout proper oversight can\nincrease verification overhead and\nlead to long-term technical debt.\n3\nv. 2026.1",
+        "Track delivery performance\nto manage risk and velocity\n5\nv. 2026.1"
+      ],
+      "expected_pages": [
+        "ROI calculation and\nfinancial modeling",
+        "Generating more code\nwithout proper oversight can\nincrease verification overhead and\nlead to long-term technical debt.",
+        "Track delivery performance\nto manage risk and velocity"
+      ],
+      "expected_metadata": {
+        "repeated_footer_suppression": {
+          "activity": "suppressed",
+          "suppressed_line_count": 6,
+          "affected_page_count": 3,
+          "detected_anchored_footer_block_count": 1,
+          "suppressed_anchored_footer_block_count": 1,
+          "suppressed_numeric_page_line_count": 3,
+          "skipped_numeric_risk_count": 0
+        },
+        "footer_page_number_noise_diagnostics": {
+          "repeated_trailing_footer_block_count": 2,
+          "repeated_bare_numeric_trailing_signature_count": 1,
+          "mid_page_footer_like_line_count": 0
+        }
+      },
+      "expected_markdown_metadata_lines": [
+        "- replay_quality_repeated_footer_suppressed_line_count: 6",
+        "- replay_quality_repeated_footer_suppressed_numeric_page_line_count: 3"
+      ]
+    },
+    {
       "id": "url_scheme_spacing_artifacts",
       "description": "Broken URL scheme spacing from extraction is repaired without changing surrounding prose.",
       "expectation": "normalized",
@@ -211,6 +247,25 @@
         "repeated_footer_suppression": {
           "activity": "none",
           "suppressed_line_count": 0
+        }
+      }
+    },
+    {
+      "id": "in_reading_order_version_footer_pair",
+      "description": "Real DORA ROI replay page-6 shape with a repeated version footer pair before later body text stays unchanged without a stronger deterministic rule.",
+      "expectation": "unchanged",
+      "tags": ["required_case", "no_op_safety", "footer"],
+      "raw_pages": [
+        "Executive summary\nStart the conversation about ROI\n6\nv. 2026.1\nMeasuring software delivery performance\nUnderstanding performance tiers"
+      ],
+      "expected_pages": [
+        "Executive summary\nStart the conversation about ROI\n6\nv. 2026.1\nMeasuring software delivery performance\nUnderstanding performance tiers"
+      ],
+      "expected_metadata": {
+        "repeated_footer_suppression": {
+          "activity": "none",
+          "suppressed_line_count": 0,
+          "suppressed_numeric_page_line_count": 0
         }
       }
     },

--- a/tests/test_public_pdf_dora_regression_fixtures.py
+++ b/tests/test_public_pdf_dora_regression_fixtures.py
@@ -23,9 +23,11 @@ REQUIRED_CASE_IDS = {
     "leading_space_numeric_page_lines",
     "page_number_footer_pairs",
     "repeated_trailing_footer_blocks",
+    "version_footer_after_bare_page_number",
     "url_scheme_spacing_artifacts",
     "url_path_line_wrap_artifacts",
     "mid_page_footer_like_text",
+    "in_reading_order_version_footer_pair",
     "calculator_table_numeric_traps",
     "fused_extraction_artifact_roadmap43",
 }


### PR DESCRIPTION
## Summary
- Adds a sanitized DORA ROI regression fixture for the real milestone replay shape that was missing: a bare page-number line immediately before the short repeated version footer, for example `2` followed by `v. 2026.1`.
- Adds a companion no-op fixture for the page-6 in-reading-order shape where `6` / `v. 2026.1` appears before later body text, preserving the mid-page boundary without inferring report structure.
- Repairs anchored footer suppression by keeping meaningful numeric-context checks on surrounding body/table lines while not treating the repeated footer anchor line itself as evidence against its own page-number pair.

## Fail Before / Pass After
- Before the implementation fix, the new `version_footer_after_bare_page_number` fixture failed: the normalized pages still retained `2\nv. 2026.1`, `3\nv. 2026.1`, and `5\nv. 2026.1`.
- The failing targeted run produced 3 fixture-test failures against current main after adding the faithful fixture.
- After the fix, the same DORA fixture test passes and reports the repeated footer block as suppressed with 6 suppressed lines and 3 suppressed numeric page lines.

## Safety
- Preserves no-op behavior for mid-page footer-like text and the real page-6 in-reading-order version-footer pair.
- Preserves calculator/table numeric traps and numeric lines near meaningful values by continuing to inspect surrounding non-footer context.
- Leaves fused `roadmap43`-style artifacts unchanged unless a separate deterministic rule is proven.
- Does not change retention semantics, add auto-promotion logic, or infer report structure.

## Validation
- Red check first: `PYTHONPATH=src python -m pytest tests/test_public_pdf_dora_regression_fixtures.py -q` failed with 3 failures before the implementation fix.
- Green targeted DORA fixture: `PYTHONPATH=src python -m pytest tests/test_public_pdf_dora_regression_fixtures.py -q` -> 31 passed.
- Public PDF safety coverage: `PYTHONPATH=src python -m pytest tests/test_public_sources.py -q` -> 51 passed.
- Canonical validation: `make check` -> 498 passed.
- Whitespace validation: `git diff --check` -> passed.

Reference: CAK-15