### PR TITLE
Fix DORA public PDF footer suppression divergence

### DIFF
--- a/docs/cak-15-public-pdf-footer-divergence-audit.md
+++ b/docs/cak-15-public-pdf-footer-divergence-audit.md
@@ -24,6 +24,11 @@ That made diagnostics report repeated trailing footer signatures while anchored
 suppression reported zero detected blocks and the candidate body stayed
 unchanged.
 
+The post-review observability update records those retained near misses as
+informational replay-quality metadata: page 43 is reported as a non-parseable
+adjacent numeric candidate, and page 59 is reported as meaningful numeric
+context near the footer candidate.
+
 ## Execution Path Evidence
 
 Stage ordering for `public_pdf` is:
@@ -39,6 +44,10 @@ Stage ordering for `public_pdf` is:
    stores replay-quality metadata in the manifest entry.
 8. `run` invokes the configured adapter by calling the same in-process
    `main(argv)` entry point and captures its summary for the run report.
+9. Config-driven `run` output and optional run reports include
+   `runtime_identity_json` with package version, module/source path, git SHA
+   when available, executable path, and entry point. This is runtime
+   diagnostics only; it is not written into retained candidate content.
 
 The fixture suite directly exercises the page normalizer, so it covers the
 same normalization and suppression function as real replay. It does not cover
@@ -63,6 +72,11 @@ Version `0.8.0` alone is not sufficient proof of the code path because several
 CAK-15 changes shared that version. The replay note's commit and entry-point
 path were enough to rule out a stale installed package for this audit.
 
+PR #286 now also emits machine-readable runtime identity in config-driven
+`run` output and reports so future replay notes do not have to rely on prose
+alone. The field is intentionally diagnostic and may contain machine-local
+paths only in ignored staging/run-report surfaces.
+
 ## Live Source Evidence
 
 Before the fix, a live DORA ROI inspection on current main produced:
@@ -80,8 +94,8 @@ Shape inspection found:
 
 - `(numeric_depth=2, anchor_depth=1)` on 56 pages
 - `(numeric_depth=20, anchor_depth=19)` on page 6
-- one missing adjacent numeric line in the trailing anchor group on page 43:
-  `Map your AI investment roadmap43` followed by `v. 2026.1`
+- one non-parseable adjacent numeric candidate in the trailing anchor group on
+  page 43: `Map your AI investment roadmap43` followed by `v. 2026.1`
 - one numeric-risk page in the trailing anchor group on page 59, where the
   candidate page number follows reference-list numeric content
 
@@ -95,9 +109,24 @@ reported:
 - suppressed anchored footer block count: 1
 - suppressed numeric page-line count: 55
 - skipped numeric risk count: 1
+- accepted/suppressed page count: 55
+- rejected/skipped page count: 2
+- missing adjacent numeric line count: 0
+- non-parseable adjacent numeric line count: 1
+- rejected/skipped page counts by reason:
+  `meaningful_numeric_context_near_footer_candidate=1`,
+  `nonparseable_adjacent_numeric_line=1`
 - `v. 2026.1` lines in content: 3
 - numeric lines immediately before `v. 2026.1`: 2
 - `roadmap43` followed by `v. 2026.1` retained
+
+The rejected candidate examples are deterministic, short excerpts only:
+
+- page 59: anchor `v. 2026.1`, adjacent `59`, reason
+  `meaningful_numeric_context_near_footer_candidate`
+- page 43: anchor `v. 2026.1`, adjacent
+  `Map your AI investment roadmap43`, reason
+  `nonparseable_adjacent_numeric_line`
 
 ## Fix Summary
 
@@ -113,10 +142,28 @@ individually:
 - numeric page values must still increase in extracted page order
 - footer lines are removed only from the safe pages included in the accepted
   majority
+- rejected near misses are counted by reason, with up to five short diagnostic
+  examples
 
 This keeps the existing trailing-window, anchor, majority, page-order, and
 numeric-risk safety boundaries. It does not change retention semantics,
 auto-promote output, or broaden ingestion.
+
+## Observability Fields
+
+`repeated_footer_suppression` includes these informational fields:
+
+- `accepted_suppressed_page_count`
+- `rejected_skipped_page_count`
+- `missing_adjacent_numeric_line_count`
+- `nonparseable_adjacent_numeric_line_count`
+- `numeric_risk_skipped_count`
+- `rejected_skipped_page_counts_by_reason`
+- `rejected_footer_candidate_examples`
+
+The candidate metadata continues to include
+`replay_quality_metadata_note: informational only; does not authorize retention
+or promotion`.
 
 ## Commands Run
 
@@ -129,6 +176,7 @@ auto-promote output, or broaden ingestion.
   paths
 - live DORA PDF inspection scripts against the public source URL
 - `make test PYTEST='.venv/bin/pytest tests/test_public_pdf_dora_regression_fixtures.py'`
+- `make test PYTEST='.venv/bin/pytest tests/test_public_pdf_dora_regression_fixtures.py tests/test_public_sources.py tests/test_cli_run.py'`
 
 ## Recommended Next Action
 
@@ -136,4 +184,3 @@ Run the knowledge-vault milestone replay again from the updated branch after
 merge, using the same one-source DORA ROI run config. Expected result:
 candidate body output should change by removing 110 footer lines while
 retaining the fused page-43 artifact and page-59 numeric-risk footer pair.
-

--- a/docs/cak-15-public-pdf-footer-divergence-audit.md
+++ b/docs/cak-15-public-pdf-footer-divergence-audit.md
@@ -1,0 +1,139 @@
+# CAK-15 Public PDF Footer Divergence Audit
+
+Date: 2026-05-13
+
+Scope: focused execution-path audit for the DORA ROI public PDF footer
+suppression divergence after PR #285.
+
+## Root Cause
+
+The DORA-derived fixture tests and the real public PDF replay use the same
+normalization function:
+`knowledge_adapters.public_pdf.normalize.normalize_extracted_pages_with_replay_metadata`.
+
+The divergence was inside anchored footer suppression, not in the replay entry
+point or metadata/body split. The real DORA ROI extraction has a repeated
+`v. 2026.1` footer anchor on 57 pages, but not every anchor occurrence has a
+safe adjacent bare numeric page line:
+
+- page 43 has the fused body/footer artifact `roadmap43` before `v. 2026.1`
+- page 59 has an adjacent numeric line near reference-list numeric content
+
+Before this fix, either condition cancelled the entire repeated anchor group.
+That made diagnostics report repeated trailing footer signatures while anchored
+suppression reported zero detected blocks and the candidate body stayed
+unchanged.
+
+## Execution Path Evidence
+
+Stage ordering for `public_pdf` is:
+
+1. `fetch_pdf()` fetches the PDF and extracts page text with `pypdf`.
+2. `normalize_extracted_pages_with_replay_metadata()` repairs URL spacing and
+   URL path line wraps.
+3. Footer diagnostics run on post-URL-normalized page text before suppression.
+4. Anchored footer suppression runs on that same normalized page list.
+5. `fetch_pdf()` renders one `## Page N` block per suppressed page.
+6. CLI `public_pdf` passes that candidate content to `normalize_to_markdown()`.
+7. The CLI hashes the same rendered markdown used for the candidate body and
+   stores replay-quality metadata in the manifest entry.
+8. `run` invokes the configured adapter by calling the same in-process
+   `main(argv)` entry point and captures its summary for the run report.
+
+The fixture suite directly exercises the page normalizer, so it covers the
+same normalization and suppression function as real replay. It does not cover
+`pypdf` extraction, fetching, config-driven `run`, or installed-entry-point
+selection.
+
+## Installed Path Evidence
+
+The replay note said it used
+`/Users/keith/src/ctrl-alt-keith/knowledge-adapters/.venv/bin/knowledge-adapters`
+at commit `4ceebb6`. Local inspection of that environment showed:
+
+- distribution version: `knowledge-adapters` 0.8.0
+- package path:
+  `/Users/keith/src/ctrl-alt-keith/knowledge-adapters/src/knowledge_adapters`
+- normalize path:
+  `/Users/keith/src/ctrl-alt-keith/knowledge-adapters/src/knowledge_adapters/public_pdf/normalize.py`
+- entry point imports `knowledge_adapters.cli:main`
+- checkout HEAD: `4ceebb6cfa0a0955425b72c76655250958bcc0fb`
+
+Version `0.8.0` alone is not sufficient proof of the code path because several
+CAK-15 changes shared that version. The replay note's commit and entry-point
+path were enough to rule out a stale installed package for this audit.
+
+## Live Source Evidence
+
+Before the fix, a live DORA ROI inspection on current main produced:
+
+- page count: 60
+- repeated trailing footer block count: 2
+- bare numeric trailing line count: 57
+- suppression activity: none
+- suppressed line count: 0
+- detected anchored footer block count: 0
+- `v. 2026.1` lines in content: 58
+- numeric lines immediately before `v. 2026.1`: 57
+
+Shape inspection found:
+
+- `(numeric_depth=2, anchor_depth=1)` on 56 pages
+- `(numeric_depth=20, anchor_depth=19)` on page 6
+- one missing adjacent numeric line in the trailing anchor group on page 43:
+  `Map your AI investment roadmap43` followed by `v. 2026.1`
+- one numeric-risk page in the trailing anchor group on page 59, where the
+  candidate page number follows reference-list numeric content
+
+After the fix, the same live source through the worktree editable install
+reported:
+
+- suppression activity: suppressed
+- suppressed line count: 110
+- affected page count: 55
+- detected anchored footer block count: 1
+- suppressed anchored footer block count: 1
+- suppressed numeric page-line count: 55
+- skipped numeric risk count: 1
+- `v. 2026.1` lines in content: 3
+- numeric lines immediately before `v. 2026.1`: 2
+- `roadmap43` followed by `v. 2026.1` retained
+
+## Fix Summary
+
+Anchored suppression now classifies pages within a repeated anchor group
+individually:
+
+- pages without an adjacent numeric line no longer cancel the whole anchor
+  group
+- pages with nearby meaningful numeric context are counted as skipped numeric
+  risk and retained
+- suppression proceeds only when the remaining safe adjacent numeric
+  occurrences still meet the existing repeated-page majority threshold
+- numeric page values must still increase in extracted page order
+- footer lines are removed only from the safe pages included in the accepted
+  majority
+
+This keeps the existing trailing-window, anchor, majority, page-order, and
+numeric-risk safety boundaries. It does not change retention semantics,
+auto-promote output, or broaden ingestion.
+
+## Commands Run
+
+- `git fetch origin main`
+- `git merge --ff-only origin/main`
+- `git worktree add .worktrees/cak-15-public-pdf-footer-audit -b audit/cak-15-public-pdf-footer-path origin/main`
+- inspected `public_pdf` client, normalizer, CLI, run config, and DORA replay
+  notes
+- inspected the installed `knowledge-adapters/.venv` entry point and module
+  paths
+- live DORA PDF inspection scripts against the public source URL
+- `make test PYTEST='.venv/bin/pytest tests/test_public_pdf_dora_regression_fixtures.py'`
+
+## Recommended Next Action
+
+Run the knowledge-vault milestone replay again from the updated branch after
+merge, using the same one-source DORA ROI run config. Expected result:
+candidate body output should change by removing 110 footer lines while
+retaining the fused page-43 artifact and page-59 numeric-risk footer pair.
+

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import io
+import json
 import math
 import re
 import shlex
@@ -33,6 +34,7 @@ from knowledge_adapters.run_report import (
     SkippedRunRecord,
     render_run_report_markdown,
 )
+from knowledge_adapters.runtime_identity import adapter_runtime_identity
 
 TOP_LEVEL_HELP_EXAMPLES = """First steps:
   knowledge-adapters --help
@@ -1265,6 +1267,26 @@ def _print_public_pdf_replay_quality_metadata(metadata: Mapping[str, object]) ->
         f"{footer.get('suppressed_line_count', '')}"
     )
     print(
+        "    repeated_footer_accepted_suppressed_page_count: "
+        f"{footer.get('accepted_suppressed_page_count', '')}"
+    )
+    print(
+        "    repeated_footer_rejected_skipped_page_count: "
+        f"{footer.get('rejected_skipped_page_count', '')}"
+    )
+    print(
+        "    repeated_footer_missing_adjacent_numeric_line_count: "
+        f"{footer.get('missing_adjacent_numeric_line_count', '')}"
+    )
+    print(
+        "    repeated_footer_nonparseable_adjacent_numeric_line_count: "
+        f"{footer.get('nonparseable_adjacent_numeric_line_count', '')}"
+    )
+    print(
+        "    repeated_footer_numeric_risk_skipped_count: "
+        f"{footer.get('numeric_risk_skipped_count', '')}"
+    )
+    print(
         "    possible_layout_artifact_lines: "
         f"{layout_density.get('possible_artifact_line_count', '')}/"
         f"{layout_density.get('line_count', '')} "
@@ -1399,6 +1421,7 @@ def _write_run_report(
     *,
     report_output_path: Path,
     config_path: Path,
+    runtime_identity: Mapping[str, object],
     selected_run_count: int,
     skipped_disabled_runs: tuple[SkippedRunRecord, ...],
     records: tuple[RunReportRecord, ...],
@@ -1409,6 +1432,7 @@ def _write_run_report(
         report_output_path.write_text(
             render_run_report_markdown(
                 config_path=config_path,
+                runtime_identity=runtime_identity,
                 selected_run_count=selected_run_count,
                 skipped_disabled_runs=skipped_disabled_runs,
                 records=records,
@@ -1458,10 +1482,15 @@ def main(argv: Sequence[str] | None = None) -> int:
             if args.report_output is not None
             else None
         )
+        runtime_identity = adapter_runtime_identity()
         run_report_records: list[RunReportRecord] = []
 
         print("Config-driven run invoked")
         print(f"  config_path: {render_user_path(run_config.config_path)}")
+        print(
+            "  runtime_identity_json: "
+            f"{json.dumps(runtime_identity, sort_keys=True, separators=(',', ':'))}"
+        )
         print(f"  runs_in_config: {len(run_config.runs)}")
         if args.only is not None:
             print(f"  only: {', '.join(args.only)}")
@@ -1555,6 +1584,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                         _write_run_report(
                             report_output_path=report_output_path,
                             config_path=run_config.config_path,
+                            runtime_identity=runtime_identity,
                             selected_run_count=len(selected_runs),
                             skipped_disabled_runs=skipped_disabled_report_runs,
                             records=tuple(run_report_records),
@@ -1597,6 +1627,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                         _write_run_report(
                             report_output_path=report_output_path,
                             config_path=run_config.config_path,
+                            runtime_identity=runtime_identity,
                             selected_run_count=len(selected_runs),
                             skipped_disabled_runs=skipped_disabled_report_runs,
                             records=tuple(run_report_records),
@@ -1662,6 +1693,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             _write_run_report(
                 report_output_path=report_output_path,
                 config_path=run_config.config_path,
+                runtime_identity=runtime_identity,
                 selected_run_count=len(selected_runs),
                 skipped_disabled_runs=skipped_disabled_report_runs,
                 records=tuple(run_report_records),

--- a/src/knowledge_adapters/public_pdf/normalize.py
+++ b/src/knowledge_adapters/public_pdf/normalize.py
@@ -218,8 +218,15 @@ def _suppress_repeated_footer_lines_with_metadata(
             "skipped_anchored_footer_block_count": 0,
             "suppressed_numeric_page_line_count": 0,
             "skipped_numeric_risk_count": 0,
+            "accepted_suppressed_page_count": 0,
+            "rejected_skipped_page_count": 0,
+            "missing_adjacent_numeric_line_count": 0,
+            "nonparseable_adjacent_numeric_line_count": 0,
+            "numeric_risk_skipped_count": 0,
+            "rejected_skipped_page_counts_by_reason": {},
             "detected_anchored_footer_blocks": [],
             "skipped_numeric_risk_cases": [],
+            "rejected_footer_candidate_examples": [],
         }
 
     page_lines = [page_text.splitlines() for page_text in page_texts]
@@ -241,8 +248,11 @@ def _suppress_repeated_footer_lines_with_metadata(
     indexes_to_remove: set[tuple[int, int]] = set()
     detected_blocks: list[dict[str, object]] = []
     skipped_numeric_risk_cases: list[dict[str, object]] = []
+    rejected_footer_candidate_examples: list[dict[str, object]] = []
+    rejected_skipped_page_counts_by_reason: dict[str, int] = {}
     suppressed_numeric_page_line_count = 0
     skipped_numeric_risk_count = 0
+    accepted_suppressed_page_count = 0
 
     for (anchor_depth, anchor_signature), page_to_anchor_index in sorted(
         anchor_candidates.items(), key=lambda item: (item[0][0], item[0][1])
@@ -253,17 +263,23 @@ def _suppress_repeated_footer_lines_with_metadata(
         for numeric_depth in _adjacent_footer_depths(anchor_depth):
             numeric_occurrences: list[tuple[int, int, int]] = []
             risk_occurrences: list[tuple[int, int, int]] = []
+            missing_numeric_page_indexes: list[int] = []
+            nonparseable_numeric_occurrences: list[tuple[int, int, str]] = []
             risk_page_indexes: list[int] = []
             for page_index, anchor_line_index in sorted(page_to_anchor_index.items()):
                 numeric_line_index = _line_index_at_trailing_depth(
                     trailing_entries_by_page[page_index], numeric_depth
                 )
                 if numeric_line_index is None:
+                    missing_numeric_page_indexes.append(page_index)
                     continue
 
                 numeric_line = page_lines[page_index][numeric_line_index].strip()
                 numeric_value = _page_number_line_value(numeric_line)
                 if numeric_value is None:
+                    nonparseable_numeric_occurrences.append(
+                        (page_index, numeric_line_index, numeric_line)
+                    )
                     continue
 
                 if _has_nearby_meaningful_numeric_context(
@@ -284,6 +300,18 @@ def _suppress_repeated_footer_lines_with_metadata(
             if len(numeric_occurrences) < min_repeated_pages:
                 if risk_page_indexes:
                     skipped_numeric_risk_count += len(risk_occurrences)
+                    _increment_reason_count(
+                        rejected_skipped_page_counts_by_reason,
+                        "meaningful_numeric_context_near_footer_candidate",
+                        len(risk_occurrences),
+                    )
+                    _extend_rejected_footer_candidate_examples(
+                        rejected_footer_candidate_examples,
+                        page_lines=page_lines,
+                        page_to_anchor_index=page_to_anchor_index,
+                        occurrences=risk_occurrences,
+                        reason="meaningful_numeric_context_near_footer_candidate",
+                    )
                     skipped_numeric_risk_cases.append(
                         {
                             "anchor_signature": anchor_signature,
@@ -298,6 +326,11 @@ def _suppress_repeated_footer_lines_with_metadata(
 
             if not _numeric_values_are_in_page_order(numeric_occurrences):
                 skipped_numeric_risk_count += len(numeric_occurrences)
+                _increment_reason_count(
+                    rejected_skipped_page_counts_by_reason,
+                    "numeric_values_not_in_page_order",
+                    len(numeric_occurrences),
+                )
                 skipped_numeric_risk_cases.append(
                     {
                         "anchor_signature": anchor_signature,
@@ -309,9 +342,6 @@ def _suppress_repeated_footer_lines_with_metadata(
                     }
                 )
                 continue
-
-            if risk_page_indexes:
-                skipped_numeric_risk_count += len(risk_occurrences)
 
             footer_depths = _repeated_footer_block_depths(
                 trailing_entries_by_page,
@@ -325,6 +355,21 @@ def _suppress_repeated_footer_lines_with_metadata(
             if not footer_depths:
                 continue
 
+            if risk_page_indexes:
+                skipped_numeric_risk_count += len(risk_occurrences)
+                _increment_reason_count(
+                    rejected_skipped_page_counts_by_reason,
+                    "meaningful_numeric_context_near_footer_candidate",
+                    len(risk_occurrences),
+                )
+                _extend_rejected_footer_candidate_examples(
+                    rejected_footer_candidate_examples,
+                    page_lines=page_lines,
+                    page_to_anchor_index=page_to_anchor_index,
+                    occurrences=risk_occurrences,
+                    reason="meaningful_numeric_context_near_footer_candidate",
+                )
+
             for page_index, numeric_line_index, _numeric_value in numeric_occurrences:
                 for footer_depth in footer_depths:
                     footer_line_index = _line_index_at_trailing_depth(
@@ -334,6 +379,31 @@ def _suppress_repeated_footer_lines_with_metadata(
                         indexes_to_remove.add((page_index, footer_line_index))
                 indexes_to_remove.add((page_index, numeric_line_index))
             suppressed_numeric_page_line_count += len(numeric_occurrences)
+            accepted_suppressed_page_count += len(numeric_occurrences)
+            _increment_reason_count(
+                rejected_skipped_page_counts_by_reason,
+                "missing_adjacent_numeric_line",
+                len(missing_numeric_page_indexes),
+            )
+            _increment_reason_count(
+                rejected_skipped_page_counts_by_reason,
+                "nonparseable_adjacent_numeric_line",
+                len(nonparseable_numeric_occurrences),
+            )
+            _extend_missing_numeric_footer_candidate_examples(
+                rejected_footer_candidate_examples,
+                page_lines=page_lines,
+                page_to_anchor_index=page_to_anchor_index,
+                page_indexes=missing_numeric_page_indexes,
+                reason="missing_adjacent_numeric_line",
+            )
+            _extend_nonparseable_numeric_footer_candidate_examples(
+                rejected_footer_candidate_examples,
+                page_lines=page_lines,
+                page_to_anchor_index=page_to_anchor_index,
+                occurrences=nonparseable_numeric_occurrences,
+                reason="nonparseable_adjacent_numeric_line",
+            )
             detected_blocks.append(
                 {
                     "anchor_signature": anchor_signature,
@@ -370,9 +440,115 @@ def _suppress_repeated_footer_lines_with_metadata(
         "skipped_anchored_footer_block_count": len(skipped_numeric_risk_cases),
         "suppressed_numeric_page_line_count": suppressed_numeric_page_line_count,
         "skipped_numeric_risk_count": skipped_numeric_risk_count,
+        "accepted_suppressed_page_count": accepted_suppressed_page_count,
+        "rejected_skipped_page_count": sum(rejected_skipped_page_counts_by_reason.values()),
+        "missing_adjacent_numeric_line_count": rejected_skipped_page_counts_by_reason.get(
+            "missing_adjacent_numeric_line", 0
+        ),
+        "nonparseable_adjacent_numeric_line_count": (
+            rejected_skipped_page_counts_by_reason.get(
+                "nonparseable_adjacent_numeric_line", 0
+            )
+        ),
+        "numeric_risk_skipped_count": rejected_skipped_page_counts_by_reason.get(
+            "meaningful_numeric_context_near_footer_candidate", 0
+        ),
+        "rejected_skipped_page_counts_by_reason": rejected_skipped_page_counts_by_reason,
         "detected_anchored_footer_blocks": detected_blocks,
         "skipped_numeric_risk_cases": skipped_numeric_risk_cases,
+        "rejected_footer_candidate_examples": rejected_footer_candidate_examples,
     }
+
+
+def _increment_reason_count(
+    counts_by_reason: dict[str, int], reason: str, count: int
+) -> None:
+    if count:
+        counts_by_reason[reason] = counts_by_reason.get(reason, 0) + count
+
+
+def _extend_rejected_footer_candidate_examples(
+    examples: list[dict[str, object]],
+    *,
+    page_lines: Sequence[Sequence[str]],
+    page_to_anchor_index: Mapping[int, int],
+    occurrences: Sequence[tuple[int, int, int]],
+    reason: str,
+) -> None:
+    for page_index, numeric_line_index, _numeric_value in occurrences:
+        anchor_line_index = page_to_anchor_index[page_index]
+        _append_rejected_footer_candidate_example(
+            examples,
+            page_number=page_index + 1,
+            reason=reason,
+            anchor_line=page_lines[page_index][anchor_line_index],
+            adjacent_line=page_lines[page_index][numeric_line_index],
+        )
+
+
+def _extend_missing_numeric_footer_candidate_examples(
+    examples: list[dict[str, object]],
+    *,
+    page_lines: Sequence[Sequence[str]],
+    page_to_anchor_index: Mapping[int, int],
+    page_indexes: Sequence[int],
+    reason: str,
+) -> None:
+    for page_index in page_indexes:
+        anchor_line_index = page_to_anchor_index[page_index]
+        _append_rejected_footer_candidate_example(
+            examples,
+            page_number=page_index + 1,
+            reason=reason,
+            anchor_line=page_lines[page_index][anchor_line_index],
+            adjacent_line="",
+        )
+
+
+def _extend_nonparseable_numeric_footer_candidate_examples(
+    examples: list[dict[str, object]],
+    *,
+    page_lines: Sequence[Sequence[str]],
+    page_to_anchor_index: Mapping[int, int],
+    occurrences: Sequence[tuple[int, int, str]],
+    reason: str,
+) -> None:
+    for page_index, numeric_line_index, _numeric_line in occurrences:
+        anchor_line_index = page_to_anchor_index[page_index]
+        _append_rejected_footer_candidate_example(
+            examples,
+            page_number=page_index + 1,
+            reason=reason,
+            anchor_line=page_lines[page_index][anchor_line_index],
+            adjacent_line=page_lines[page_index][numeric_line_index],
+        )
+
+
+def _append_rejected_footer_candidate_example(
+    examples: list[dict[str, object]],
+    *,
+    page_number: int,
+    reason: str,
+    anchor_line: str,
+    adjacent_line: str,
+) -> None:
+    if len(examples) >= 5:
+        return
+    example: dict[str, object] = {
+        "page_number": page_number,
+        "reason": reason,
+        "anchor_excerpt": _short_diagnostic_excerpt(anchor_line),
+    }
+    if adjacent_line:
+        example["adjacent_excerpt"] = _short_diagnostic_excerpt(adjacent_line)
+    examples.append(example)
+
+
+def _short_diagnostic_excerpt(line: str) -> str:
+    excerpt = " ".join(line.strip().split())
+    if len(excerpt) <= 80:
+        return excerpt
+    return f"{excerpt[:77].rstrip()}..."
 
 
 def _trailing_footer_candidate_entries(lines: Sequence[str]) -> list[tuple[int, int, str]]:
@@ -727,6 +903,22 @@ def _render_replay_quality_metadata(metadata: Mapping[str, object]) -> str:
             (
                 "- replay_quality_repeated_footer_suppressed_numeric_page_line_count: "
                 f"{_metadata_value(footer, 'suppressed_numeric_page_line_count')}"
+            ),
+            (
+                "- replay_quality_repeated_footer_accepted_suppressed_page_count: "
+                f"{_metadata_value(footer, 'accepted_suppressed_page_count')}"
+            ),
+            (
+                "- replay_quality_repeated_footer_rejected_skipped_page_count: "
+                f"{_metadata_value(footer, 'rejected_skipped_page_count')}"
+            ),
+            (
+                "- replay_quality_repeated_footer_missing_adjacent_numeric_line_count: "
+                f"{_metadata_value(footer, 'missing_adjacent_numeric_line_count')}"
+            ),
+            (
+                "- replay_quality_repeated_footer_nonparseable_adjacent_numeric_line_count: "
+                f"{_metadata_value(footer, 'nonparseable_adjacent_numeric_line_count')}"
             ),
             (
                 "- replay_quality_repeated_footer_skipped_numeric_risk_count: "

--- a/src/knowledge_adapters/public_pdf/normalize.py
+++ b/src/knowledge_adapters/public_pdf/normalize.py
@@ -252,33 +252,48 @@ def _suppress_repeated_footer_lines_with_metadata(
 
         for numeric_depth in _adjacent_footer_depths(anchor_depth):
             numeric_occurrences: list[tuple[int, int, int]] = []
+            risk_occurrences: list[tuple[int, int, int]] = []
             risk_page_indexes: list[int] = []
-            missing_numeric_line = False
             for page_index, anchor_line_index in sorted(page_to_anchor_index.items()):
                 numeric_line_index = _line_index_at_trailing_depth(
                     trailing_entries_by_page[page_index], numeric_depth
                 )
                 if numeric_line_index is None:
-                    missing_numeric_line = True
-                    break
+                    continue
 
                 numeric_line = page_lines[page_index][numeric_line_index].strip()
                 numeric_value = _page_number_line_value(numeric_line)
                 if numeric_value is None:
-                    missing_numeric_line = True
-                    break
+                    continue
 
-                numeric_occurrences.append(
-                    (page_index, numeric_line_index, numeric_value)
-                )
                 if _has_nearby_meaningful_numeric_context(
                     page_lines[page_index],
                     anchor_line_index,
                     numeric_line_index,
                 ):
+                    risk_occurrences.append(
+                        (page_index, numeric_line_index, numeric_value)
+                    )
                     risk_page_indexes.append(page_index)
+                    continue
 
-            if missing_numeric_line or len(numeric_occurrences) < min_repeated_pages:
+                numeric_occurrences.append(
+                    (page_index, numeric_line_index, numeric_value)
+                )
+
+            if len(numeric_occurrences) < min_repeated_pages:
+                if risk_page_indexes:
+                    skipped_numeric_risk_count += len(risk_occurrences)
+                    skipped_numeric_risk_cases.append(
+                        {
+                            "anchor_signature": anchor_signature,
+                            "anchor_depth": anchor_depth,
+                            "numeric_depth": numeric_depth,
+                            "page_count": len(numeric_occurrences) + len(risk_occurrences),
+                            "risk_page_count": len(risk_page_indexes),
+                            "reason": "meaningful_numeric_context_near_footer_candidate",
+                        }
+                    )
                 continue
 
             if not _numeric_values_are_in_page_order(numeric_occurrences):
@@ -296,22 +311,14 @@ def _suppress_repeated_footer_lines_with_metadata(
                 continue
 
             if risk_page_indexes:
-                skipped_numeric_risk_count += len(numeric_occurrences)
-                skipped_numeric_risk_cases.append(
-                    {
-                        "anchor_signature": anchor_signature,
-                        "anchor_depth": anchor_depth,
-                        "numeric_depth": numeric_depth,
-                        "page_count": len(numeric_occurrences),
-                        "risk_page_count": len(risk_page_indexes),
-                        "reason": "meaningful_numeric_context_near_footer_candidate",
-                    }
-                )
-                continue
+                skipped_numeric_risk_count += len(risk_occurrences)
 
             footer_depths = _repeated_footer_block_depths(
                 trailing_entries_by_page,
-                tuple(page_to_anchor_index),
+                tuple(
+                    page_index
+                    for page_index, _line_index, _numeric_value in numeric_occurrences
+                ),
                 anchor_depth,
                 numeric_depth,
             )

--- a/src/knowledge_adapters/run_report.py
+++ b/src/knowledge_adapters/run_report.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
@@ -40,6 +42,7 @@ def render_run_report_markdown(
     selected_run_count: int,
     skipped_disabled_runs: tuple[SkippedRunRecord, ...],
     records: tuple[RunReportRecord, ...],
+    runtime_identity: Mapping[str, object] | None = None,
 ) -> str:
     """Render a concise, human-readable Markdown report."""
     completed_runs = sum(1 for record in records if record.status == "completed")
@@ -75,6 +78,13 @@ def render_run_report_markdown(
             [
                 f"- Would write: {would_write}",
                 f"- Would skip: {would_skip}",
+            ]
+        )
+    if runtime_identity is not None:
+        runtime_identity_json = _runtime_identity_json(runtime_identity)
+        lines.extend(
+            [
+                f"- Runtime identity: `{_markdown_inline(runtime_identity_json)}`",
             ]
         )
 
@@ -165,3 +175,7 @@ def _markdown_cell(value: str) -> str:
 
 def _markdown_inline(value: str) -> str:
     return value.replace("`", "\\`")
+
+
+def _runtime_identity_json(runtime_identity: Mapping[str, object]) -> str:
+    return json.dumps(dict(runtime_identity), sort_keys=True, separators=(",", ":"))

--- a/src/knowledge_adapters/runtime_identity.py
+++ b/src/knowledge_adapters/runtime_identity.py
@@ -1,0 +1,48 @@
+"""Runtime source identity diagnostics for adapter run reports."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from importlib import metadata
+from pathlib import Path
+
+import knowledge_adapters
+
+
+def adapter_runtime_identity() -> dict[str, object]:
+    """Return machine-readable runtime identity for diagnostic run output."""
+    module_path = Path(knowledge_adapters.__file__).resolve()
+    return {
+        "package_name": "knowledge-adapters",
+        "package_version": _package_version(),
+        "module": "knowledge_adapters.cli:main",
+        "module_path": module_path.as_posix(),
+        "git_sha": _git_sha(module_path.parent),
+        "executable_path": Path(sys.executable).resolve().as_posix(),
+        "entry_point": "knowledge-adapters",
+    }
+
+
+def _package_version() -> str:
+    try:
+        return metadata.version("knowledge-adapters")
+    except metadata.PackageNotFoundError:
+        return getattr(knowledge_adapters, "__version__", "unknown")
+
+
+def _git_sha(path: Path) -> str | None:
+    try:
+        completed = subprocess.run(
+            ("git", "-C", str(path), "rev-parse", "HEAD"),
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return None
+    if completed.returncode != 0:
+        return None
+    sha = completed.stdout.strip()
+    return sha or None
+

--- a/tests/fixtures/public_pdf/dora_regression_cases.json
+++ b/tests/fixtures/public_pdf/dora_regression_cases.json
@@ -201,7 +201,16 @@
           "detected_anchored_footer_block_count": 1,
           "suppressed_anchored_footer_block_count": 1,
           "suppressed_numeric_page_line_count": 3,
-          "skipped_numeric_risk_count": 1
+          "skipped_numeric_risk_count": 1,
+          "accepted_suppressed_page_count": 3,
+          "rejected_skipped_page_count": 2,
+          "missing_adjacent_numeric_line_count": 0,
+          "nonparseable_adjacent_numeric_line_count": 1,
+          "numeric_risk_skipped_count": 1,
+          "rejected_skipped_page_counts_by_reason": {
+            "meaningful_numeric_context_near_footer_candidate": 1,
+            "nonparseable_adjacent_numeric_line": 1
+          }
         },
         "footer_page_number_noise_diagnostics": {
           "repeated_trailing_footer_block_count": 2,
@@ -213,6 +222,9 @@
       "expected_markdown_metadata_lines": [
         "- replay_quality_repeated_footer_suppressed_line_count: 6",
         "- replay_quality_repeated_footer_suppressed_numeric_page_line_count: 3",
+        "- replay_quality_repeated_footer_accepted_suppressed_page_count: 3",
+        "- replay_quality_repeated_footer_rejected_skipped_page_count: 2",
+        "- replay_quality_repeated_footer_nonparseable_adjacent_numeric_line_count: 1",
         "- replay_quality_repeated_footer_skipped_numeric_risk_count: 1"
       ]
     },

--- a/tests/fixtures/public_pdf/dora_regression_cases.json
+++ b/tests/fixtures/public_pdf/dora_regression_cases.json
@@ -175,6 +175,48 @@
       ]
     },
     {
+      "id": "version_footer_missing_one_adjacent_page_number",
+      "description": "Real DORA ROI replay shape where one repeated version footer follows a fused page-number artifact; the majority of safely anchored numeric pairs is still suppressed while the fused line is retained.",
+      "expectation": "normalized",
+      "tags": ["required_case", "previous_dora_replay_failure", "footer"],
+      "raw_pages": [
+        "ROI calculation and\nfinancial modeling\n2\nv. 2026.1",
+        "Generating more code\nwithout proper oversight can\nincrease verification overhead and\nlead to long-term technical debt.\n3\nv. 2026.1",
+        "Capabilities guidance\nMap your AI investment roadmap43\nv. 2026.1",
+        "References\n4. \"DORA Community.\"\n5. \"DORA ROI of AI-assisted software development calculator.\"\n59\nv. 2026.1",
+        "Track delivery performance\nto manage risk and velocity\n60\nv. 2026.1"
+      ],
+      "expected_pages": [
+        "ROI calculation and\nfinancial modeling",
+        "Generating more code\nwithout proper oversight can\nincrease verification overhead and\nlead to long-term technical debt.",
+        "Capabilities guidance\nMap your AI investment roadmap43\nv. 2026.1",
+        "References\n4. \"DORA Community.\"\n5. \"DORA ROI of AI-assisted software development calculator.\"\n59\nv. 2026.1",
+        "Track delivery performance\nto manage risk and velocity"
+      ],
+      "expected_metadata": {
+        "repeated_footer_suppression": {
+          "activity": "suppressed",
+          "suppressed_line_count": 6,
+          "affected_page_count": 3,
+          "detected_anchored_footer_block_count": 1,
+          "suppressed_anchored_footer_block_count": 1,
+          "suppressed_numeric_page_line_count": 3,
+          "skipped_numeric_risk_count": 1
+        },
+        "footer_page_number_noise_diagnostics": {
+          "repeated_trailing_footer_block_count": 2,
+          "repeated_bare_numeric_trailing_signature_count": 1,
+          "bare_numeric_trailing_line_count": 4,
+          "mid_page_footer_like_line_count": 0
+        }
+      },
+      "expected_markdown_metadata_lines": [
+        "- replay_quality_repeated_footer_suppressed_line_count: 6",
+        "- replay_quality_repeated_footer_suppressed_numeric_page_line_count: 3",
+        "- replay_quality_repeated_footer_skipped_numeric_risk_count: 1"
+      ]
+    },
+    {
       "id": "url_scheme_spacing_artifacts",
       "description": "Broken URL scheme spacing from extraction is repaired without changing surrounding prose.",
       "expectation": "normalized",

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from tests.cli_helpers import run_cli
@@ -32,6 +33,17 @@ runs:
 
     assert result.returncode == 0, result.stderr
     assert "Config-driven run invoked" in result.stdout
+    runtime_line = next(
+        line.strip()
+        for line in result.stdout.splitlines()
+        if line.strip().startswith("runtime_identity_json:")
+    )
+    runtime_identity = json.loads(runtime_line.partition(": ")[2])
+    assert runtime_identity["package_name"] == "knowledge-adapters"
+    assert runtime_identity["package_version"]
+    assert runtime_identity["module"] == "knowledge_adapters.cli:main"
+    assert runtime_identity["module_path"].endswith("knowledge_adapters/__init__.py")
+    assert runtime_identity["entry_point"] == "knowledge-adapters"
     assert "Run 1/2 started: team-notes (local_files)" in result.stdout
     assert "Run 1/2 completed: team-notes (local_files)" in result.stdout
     assert "Run 2/2 started: docs-home (confluence)" in result.stdout
@@ -87,6 +99,9 @@ runs:
     assert "- Runs selected: 2" in report
     assert "- Runs completed: 2" in report
     assert "- Runs failed: 0" in report
+    assert "- Runtime identity: `" in report
+    assert '"package_name":"knowledge-adapters"' in report
+    assert '"module":"knowledge_adapters.cli:main"' in report
     assert "| 1/2 | team-notes | local_files | completed | wrote 1, skipped 0 | - |" in report
     assert "| 2/2 | docs-home | confluence | completed | wrote 1, skipped 0 | - |" in report
 

--- a/tests/test_public_pdf_dora_regression_fixtures.py
+++ b/tests/test_public_pdf_dora_regression_fixtures.py
@@ -169,6 +169,51 @@ def test_previous_dora_replay_failures_are_fixture_backed(
     _assert_metadata_contains(metadata, _mapping(case, "expected_metadata"))
 
 
+def test_mixed_dora_version_footer_fixture_reports_retained_near_misses() -> None:
+    case = _case_by_id("version_footer_missing_one_adjacent_page_number")
+
+    normalized_pages, metadata = normalize_extracted_pages_with_replay_metadata(
+        _string_sequence(case, "raw_pages")
+    )
+
+    assert normalized_pages[0] == "ROI calculation and\nfinancial modeling"
+    assert "lead to long-term technical debt.\n3\nv. 2026.1" not in normalized_pages[1]
+    assert normalized_pages[2] == (
+        "Capabilities guidance\nMap your AI investment roadmap43\nv. 2026.1"
+    )
+    assert normalized_pages[3] == (
+        'References\n4. "DORA Community."\n'
+        '5. "DORA ROI of AI-assisted software development calculator."\n'
+        "59\nv. 2026.1"
+    )
+    assert normalized_pages[4] == "Track delivery performance\nto manage risk and velocity"
+
+    repeated_footer = _mapping(metadata, "repeated_footer_suppression")
+    assert repeated_footer["accepted_suppressed_page_count"] == 3
+    assert repeated_footer["rejected_skipped_page_count"] == 2
+    assert repeated_footer["missing_adjacent_numeric_line_count"] == 0
+    assert repeated_footer["nonparseable_adjacent_numeric_line_count"] == 1
+    assert repeated_footer["numeric_risk_skipped_count"] == 1
+    assert repeated_footer["rejected_skipped_page_counts_by_reason"] == {
+        "meaningful_numeric_context_near_footer_candidate": 1,
+        "nonparseable_adjacent_numeric_line": 1,
+    }
+    assert repeated_footer["rejected_footer_candidate_examples"] == [
+        {
+            "page_number": 4,
+            "reason": "meaningful_numeric_context_near_footer_candidate",
+            "anchor_excerpt": "v. 2026.1",
+            "adjacent_excerpt": "59",
+        },
+        {
+            "page_number": 3,
+            "reason": "nonparseable_adjacent_numeric_line",
+            "anchor_excerpt": "v. 2026.1",
+            "adjacent_excerpt": "Map your AI investment roadmap43",
+        },
+    ]
+
+
 def _assert_metadata_contains(
     actual: Mapping[str, object],
     expected: Mapping[str, object],
@@ -192,6 +237,13 @@ def _mapping(case: Mapping[str, object], key: str) -> Mapping[str, object]:
     value = case[key]
     assert isinstance(value, Mapping)
     return cast(Mapping[str, object], value)
+
+
+def _case_by_id(case_id: str) -> Mapping[str, object]:
+    for case in DORA_REGRESSION_CASES:
+        if case["id"] == case_id:
+            return case
+    raise AssertionError(f"Unknown DORA regression fixture case: {case_id}")
 
 
 def _string_sequence(case: Mapping[str, object], key: str) -> list[str]:

--- a/tests/test_public_pdf_dora_regression_fixtures.py
+++ b/tests/test_public_pdf_dora_regression_fixtures.py
@@ -24,6 +24,7 @@ REQUIRED_CASE_IDS = {
     "page_number_footer_pairs",
     "repeated_trailing_footer_blocks",
     "version_footer_after_bare_page_number",
+    "version_footer_missing_one_adjacent_page_number",
     "url_scheme_spacing_artifacts",
     "url_path_line_wrap_artifacts",
     "mid_page_footer_like_text",

--- a/tests/test_public_sources.py
+++ b/tests/test_public_sources.py
@@ -440,6 +440,12 @@ def test_public_pdf_page_normalization_reports_replay_quality_metadata() -> None
         "skipped_anchored_footer_block_count": 0,
         "suppressed_numeric_page_line_count": 2,
         "skipped_numeric_risk_count": 0,
+        "accepted_suppressed_page_count": 2,
+        "rejected_skipped_page_count": 0,
+        "missing_adjacent_numeric_line_count": 0,
+        "nonparseable_adjacent_numeric_line_count": 0,
+        "numeric_risk_skipped_count": 0,
+        "rejected_skipped_page_counts_by_reason": {},
         "detected_anchored_footer_blocks": [
             {
                 "anchor_signature": "dora report",
@@ -451,6 +457,7 @@ def test_public_pdf_page_normalization_reports_replay_quality_metadata() -> None
             }
         ],
         "skipped_numeric_risk_cases": [],
+        "rejected_footer_candidate_examples": [],
     }
     assert first_metadata["page_count_context"] == {
         "page_count": 2,
@@ -640,6 +647,12 @@ def test_public_pdf_page_normalization_skips_anchored_numeric_lines_near_values(
     assert repeated_footer["skipped_anchored_footer_block_count"] == 1
     assert repeated_footer["suppressed_numeric_page_line_count"] == 0
     assert repeated_footer["skipped_numeric_risk_count"] == 3
+    assert repeated_footer["accepted_suppressed_page_count"] == 0
+    assert repeated_footer["rejected_skipped_page_count"] == 3
+    assert repeated_footer["rejected_skipped_page_counts_by_reason"] == {
+        "meaningful_numeric_context_near_footer_candidate": 3
+    }
+    assert repeated_footer["numeric_risk_skipped_count"] == 3
     assert repeated_footer["skipped_numeric_risk_cases"] == [
         {
             "anchor_signature": "dora report",


### PR DESCRIPTION
## Summary
- fix anchored public PDF footer suppression so one missing/non-parseable adjacent page-number candidate or one numeric-risk page no longer cancels the whole repeated footer anchor group
- add DORA-shaped regression coverage that suppresses the safe majority while retaining the fused roadmap43 artifact and a numeric-risk reference page
- add CAK-15 observability for rejected/near-miss footer candidates and config-run runtime identity
- update docs/cak-15-public-pdf-footer-divergence-audit.md with execution-path evidence, observability fields, commands, and replay recommendations

## Observability Fields Added
`repeated_footer_suppression` now reports informational replay-quality fields:
- `accepted_suppressed_page_count`
- `rejected_skipped_page_count`
- `missing_adjacent_numeric_line_count`
- `nonparseable_adjacent_numeric_line_count`
- `numeric_risk_skipped_count`
- `rejected_skipped_page_counts_by_reason`
- `rejected_footer_candidate_examples` with deterministic short excerpts only

Config-driven `knowledge-adapters run` output and optional run reports now include `runtime_identity_json` with package version, module/source path, git SHA when available, executable path, and entry point. This is runtime diagnostics only and is not written into retained candidate content.

## What This Proves
The fixture tests and real replay both use `knowledge_adapters.public_pdf.normalize.normalize_extracted_pages_with_replay_metadata`; the divergence was inside anchored suppression. The real DORA ROI extraction has a repeated `v. 2026.1` anchor, but page 43 has fused `roadmap43` before the anchor and page 59 has a numeric-risk reference-list footer pair. The new metadata explains why those pages are retained while the safe majority suppresses.

Live worktree validation against the public DORA PDF reported: `suppression_activity=suppressed`, `suppressed_line_count=110`, `affected_page_count=55`, `accepted_suppressed_page_count=55`, `rejected_skipped_page_count=2`, `nonparseable_adjacent_numeric_line_count=1`, `numeric_risk_skipped_count=1`, reasons `meaningful_numeric_context_near_footer_candidate=1` and `nonparseable_adjacent_numeric_line=1`, retained `roadmap43/v. 2026.1`, and reduced content `v. 2026.1` lines from 58 to 3.

## Out Of Scope
- no retention semantics changed
- no auto-promotion logic added
- no ingestion behavior broadened
- no broad numeric suppression safeguards loosened
- no retained content changes

## Validation
- `make test PYTEST='.venv/bin/pytest tests/test_public_pdf_dora_regression_fixtures.py tests/test_public_sources.py tests/test_cli_run.py'`
- `make check` (502 passed)
- `git diff --check`
- live public DORA PDF inspection with the worktree editable install

## Next Milestone Replay Expectation
After merge, rerun the one-source knowledge-vault DORA ROI milestone replay. Expected behavior: candidate body changes by footer-only suppression of 110 lines, with page 43 fused `roadmap43` and page 59 numeric-risk footer pair retained and explained in replay-quality metadata.
