### PR TITLE
[codex] Clean public replay extraction noise

### DIFF
--- a/docs/public-pdf-dora-regression-fixtures.md
+++ b/docs/public-pdf-dora-regression-fixtures.md
@@ -18,7 +18,8 @@ The fixture area captures small DORA-derived extraction shapes for:
 - large-document high-coverage repeated trailing title/version footer blocks
 - URL scheme-spacing artifacts
 - URL path line-wrap artifacts
-- one-letter split-word line wraps
+- one-letter split-word line wraps in known PDF extraction context, plus
+  standalone one-letter no-op safety cases
 - mid-page footer-like text
 - calculator and table numeric traps
 - fused extraction artifacts such as `roadmap43`

--- a/docs/public-pdf-dora-regression-fixtures.md
+++ b/docs/public-pdf-dora-regression-fixtures.md
@@ -15,8 +15,10 @@ The fixture area captures small DORA-derived extraction shapes for:
 - leading-space numeric page lines
 - ordinary page-number/footer pairs
 - repeated multi-line trailing footer blocks
+- large-document high-coverage repeated trailing title/version footer blocks
 - URL scheme-spacing artifacts
 - URL path line-wrap artifacts
+- one-letter split-word line wraps
 - mid-page footer-like text
 - calculator and table numeric traps
 - fused extraction artifacts such as `roadmap43`

--- a/docs/public-webpage-chrome-fixtures.md
+++ b/docs/public-webpage-chrome-fixtures.md
@@ -1,0 +1,20 @@
+# Public Webpage Chrome Regression Fixtures
+
+Use deterministic, sanitized fixtures in
+`tests/fixtures/public_webpage/article_chrome_cases.json` as the primary
+iteration loop for public webpage chrome suppression.
+
+The fixture area captures small article-body-plus-chrome shapes for:
+
+- subscription and sign-in prompts
+- share prompts
+- comments and discussion placeholders
+- footer/legal text
+- platform promotion text
+- retained article body text with replay-quality boundary metadata
+
+The adapter does not summarize article bodies, claim copyright or reuse
+permission, change retention semantics, or make near-full article extraction
+promotion-ready. Replay-quality metadata is informational only and helps
+reviewers distinguish deterministic page-chrome suppression from retained
+candidate article body text.

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -1295,6 +1295,30 @@ def _print_public_pdf_replay_quality_metadata(metadata: Mapping[str, object]) ->
     print(f"    extraction_warnings: {warning_text}")
 
 
+def _print_public_webpage_replay_quality_metadata(metadata: Mapping[str, object]) -> None:
+    profile = _metadata_mapping(metadata, "content_profile")
+    boundary = _metadata_mapping(metadata, "extraction_boundary")
+    chrome = _metadata_mapping(metadata, "page_chrome_suppression")
+    reasons = chrome.get("suppressed_reasons_by_code", {})
+    if isinstance(reasons, Mapping) and reasons:
+        reason_text = ", ".join(f"{key}={value}" for key, value in sorted(reasons.items()))
+    else:
+        reason_text = "none"
+
+    print("  replay_quality_metadata:")
+    print("    metadata_note: informational only; does not authorize retention or promotion")
+    print(f"    extraction_boundary: {boundary.get('basis', '')}")
+    print(
+        "    article_body_text_retained_for_review: "
+        f"{profile.get('article_body_text_retained_for_review', '')}"
+    )
+    print(
+        "    chrome_suppressed_paragraph_count: "
+        f"{chrome.get('suppressed_paragraph_count', '')}"
+    )
+    print(f"    chrome_suppressed_reasons: {reason_text}")
+
+
 def _metadata_mapping(metadata: Mapping[str, object], key: str) -> Mapping[str, object]:
     value = metadata.get(key, {})
     return value if isinstance(value, Mapping) else {}
@@ -3479,7 +3503,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 content = webpage_document.content
                 extraction_notes = webpage_document.extraction_notes
                 page_count: int | None = None
-                replay_quality_metadata: Mapping[str, object] | None = None
+                replay_quality_metadata = webpage_document.replay_quality_metadata
                 source = webpage_document.source
                 adapter = webpage_document.adapter
                 adapter_title = "Public webpage"
@@ -3575,8 +3599,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"  Manifest path: {render_user_path(manifest_output_path)}")
         print("  candidate_status: unreviewed")
         print(f"  extraction_notes: {extraction_notes}")
-        if replay_quality_metadata:
+        if command == "public_pdf" and replay_quality_metadata:
             _print_public_pdf_replay_quality_metadata(replay_quality_metadata)
+        elif replay_quality_metadata:
+            _print_public_webpage_replay_quality_metadata(replay_quality_metadata)
         if content:
             print("  content_status: extracted text with content")
         else:

--- a/src/knowledge_adapters/public_pdf/client.py
+++ b/src/knowledge_adapters/public_pdf/client.py
@@ -19,8 +19,9 @@ PDF_EXTRACTION_NOTES = (
     "image-only pages may be incomplete or missing; review against the source PDF before "
     "retaining any knowledge. Clearly mechanical extraction artifacts may be normalized: "
     "broken HTTP(S) URL scheme spacing is repaired, clearly split URL path line wraps "
-    "may be joined, and repeated trailing footer text plus adjacent bare numeric page "
-    "lines may be suppressed when anchored by page position."
+    "may be joined, one-letter split-word line wraps may be repaired, high-coverage "
+    "repeated trailing text footers may be suppressed in large documents, and adjacent "
+    "bare numeric page lines may be suppressed when anchored by page position."
 )
 
 

--- a/src/knowledge_adapters/public_pdf/normalize.py
+++ b/src/knowledge_adapters/public_pdf/normalize.py
@@ -35,6 +35,9 @@ _PAGE_NUMBER_LINE_RE = re.compile(
     re.IGNORECASE,
 )
 _VERSION_FOOTER_LINE_RE = re.compile(r"^v\.\s*\d{4}(?:[-.]\d{1,4})?$", re.IGNORECASE)
+_ONE_LETTER_LINE_WRAP_PREVIOUS_CONTEXT_RE = re.compile(
+    r"^(?:[\u2022*-]\s+|\d+[.)]?$|authors$)", re.IGNORECASE
+)
 _MEANINGFUL_NUMERIC_CONTEXT_RE = re.compile(
     r"(\b(total|metric|value|score|cost|savings|roi|result|input|output|"
     r"calculator|table|figure|formula|baseline|target|year|month|rate|percent|"
@@ -233,7 +236,8 @@ def _normalize_one_letter_split_word_lines_with_count(text: str) -> tuple[str, i
             continue
 
         next_line = lines[index + 1].strip()
-        if _is_one_letter_split_word_pair(line, next_line):
+        previous_line = lines[index - 1].strip() if index > 0 else ""
+        if _is_one_letter_split_word_pair(previous_line, line, next_line):
             normalized_lines.append(f"{line}{next_line}")
             repair_count += 1
             index += 2
@@ -245,9 +249,12 @@ def _normalize_one_letter_split_word_lines_with_count(text: str) -> tuple[str, i
     return "\n".join(normalized_lines).strip(), repair_count
 
 
-def _is_one_letter_split_word_pair(line: str, next_line: str) -> bool:
+def _is_one_letter_split_word_pair(
+    previous_line: str, line: str, next_line: str
+) -> bool:
     return bool(
-        len(line) == 1
+        _ONE_LETTER_LINE_WRAP_PREVIOUS_CONTEXT_RE.match(previous_line)
+        and len(line) == 1
         and line.isalpha()
         and next_line
         and next_line[0].islower()

--- a/src/knowledge_adapters/public_pdf/normalize.py
+++ b/src/knowledge_adapters/public_pdf/normalize.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import re
 from collections.abc import Mapping, Sequence
+from math import ceil
 
 _BROKEN_URL_SCHEME_RE = re.compile(
     r"\b(?P<scheme>https?)"
@@ -33,6 +34,7 @@ _PAGE_NUMBER_LINE_RE = re.compile(
     r"^(?:page\s+|p\.\s*)?(?P<page>\d{1,4})(?:\s*(?:of|/)\s*\d{1,4})?$",
     re.IGNORECASE,
 )
+_VERSION_FOOTER_LINE_RE = re.compile(r"^v\.\s*\d{4}(?:[-.]\d{1,4})?$", re.IGNORECASE)
 _MEANINGFUL_NUMERIC_CONTEXT_RE = re.compile(
     r"(\b(total|metric|value|score|cost|savings|roi|result|input|output|"
     r"calculator|table|figure|formula|baseline|target|year|month|rate|percent|"
@@ -41,6 +43,8 @@ _MEANINGFUL_NUMERIC_CONTEXT_RE = re.compile(
 )
 _MAX_FOOTER_CANDIDATE_LINES = 4
 _MAX_FOOTER_LINE_LENGTH = 140
+_MIN_HIGH_COVERAGE_TEXT_FOOTER_PAGES = 10
+_HIGH_COVERAGE_TEXT_FOOTER_RATIO = 0.60
 _BASE_EXTRACTION_WARNINGS = (
     "pdf_layout_tables_figures_footnotes_headers_reading_order_may_be_incomplete",
     "scanned_image_only_pages_may_be_missing",
@@ -66,10 +70,15 @@ def normalize_extracted_pages_with_replay_metadata(
     url_scheme_affected_page_count = 0
     url_path_line_wrap_repair_count = 0
     url_path_line_wrap_affected_page_count = 0
+    one_letter_line_wrap_repair_count = 0
+    one_letter_line_wrap_affected_page_count = 0
     for page_text in page_texts:
         normalized_page, replacement_count = _normalize_broken_url_spacing_with_count(page_text)
         normalized_page, path_repair_count = _normalize_url_path_line_wraps_with_count(
             normalized_page
+        )
+        normalized_page, one_letter_repair_count = (
+            _normalize_one_letter_split_word_lines_with_count(normalized_page)
         )
         normalized_pages.append(normalized_page)
         url_scheme_replacement_count += replacement_count
@@ -78,8 +87,14 @@ def normalize_extracted_pages_with_replay_metadata(
         url_path_line_wrap_repair_count += path_repair_count
         if path_repair_count:
             url_path_line_wrap_affected_page_count += 1
+        one_letter_line_wrap_repair_count += one_letter_repair_count
+        if one_letter_repair_count:
+            one_letter_line_wrap_affected_page_count += 1
 
     footer_page_number_diagnostics = _diagnose_footer_page_number_noise(normalized_pages)
+    normalized_pages, repeated_text_footer_metadata = (
+        _suppress_high_coverage_text_footer_lines_with_metadata(normalized_pages)
+    )
     normalized_pages, footer_metadata = _suppress_repeated_footer_lines_with_metadata(
         normalized_pages
     )
@@ -103,7 +118,13 @@ def normalize_extracted_pages_with_replay_metadata(
             "repair_count": url_path_line_wrap_repair_count,
             "affected_page_count": url_path_line_wrap_affected_page_count,
         },
+        "one_letter_line_wrap_normalization": {
+            "activity": "normalized" if one_letter_line_wrap_repair_count else "none",
+            "repair_count": one_letter_line_wrap_repair_count,
+            "affected_page_count": one_letter_line_wrap_affected_page_count,
+        },
         "footer_page_number_noise_diagnostics": footer_page_number_diagnostics,
+        "repeated_text_footer_suppression": repeated_text_footer_metadata,
         "repeated_footer_suppression": footer_metadata,
         "possible_layout_artifact_density": _possible_layout_artifact_density(
             normalized_pages
@@ -199,8 +220,259 @@ def _is_url_path_line_wrap_pair(line: str, next_line: str) -> bool:
     )
 
 
+def _normalize_one_letter_split_word_lines_with_count(text: str) -> tuple[str, int]:
+    lines = text.splitlines()
+    normalized_lines: list[str] = []
+    repair_count = 0
+    index = 0
+    while index < len(lines):
+        line = lines[index].strip()
+        if index + 1 >= len(lines):
+            normalized_lines.append(lines[index].rstrip())
+            index += 1
+            continue
+
+        next_line = lines[index + 1].strip()
+        if _is_one_letter_split_word_pair(line, next_line):
+            normalized_lines.append(f"{line}{next_line}")
+            repair_count += 1
+            index += 2
+            continue
+
+        normalized_lines.append(lines[index].rstrip())
+        index += 1
+
+    return "\n".join(normalized_lines).strip(), repair_count
+
+
+def _is_one_letter_split_word_pair(line: str, next_line: str) -> bool:
+    return bool(
+        len(line) == 1
+        and line.isalpha()
+        and next_line
+        and next_line[0].islower()
+        and any(character.isalpha() for character in next_line[1:])
+    )
+
+
 def _suppress_repeated_footer_lines(page_texts: list[str]) -> list[str]:
     return _suppress_repeated_footer_lines_with_metadata(page_texts)[0]
+
+
+def _suppress_high_coverage_text_footer_lines_with_metadata(
+    page_texts: list[str],
+) -> tuple[list[str], dict[str, object]]:
+    base_metadata: dict[str, object] = {
+        "activity": "none",
+        "basis": "high_coverage_trailing_text_footer_blocks",
+        "min_page_count": _MIN_HIGH_COVERAGE_TEXT_FOOTER_PAGES,
+        "min_coverage_ratio": f"{_HIGH_COVERAGE_TEXT_FOOTER_RATIO:.2f}",
+        "suppressed_line_count": 0,
+        "affected_page_count": 0,
+        "detected_repeated_text_footer_block_count": 0,
+        "suppressed_repeated_text_footer_block_count": 0,
+        "suppressed_adjacent_page_number_line_count": 0,
+        "skipped_adjacent_numeric_line_count": 0,
+        "skipped_adjacent_numeric_reasons_by_code": {},
+        "detected_repeated_text_footer_blocks": [],
+        "skipped_adjacent_numeric_examples": [],
+    }
+    if len(page_texts) < _MIN_HIGH_COVERAGE_TEXT_FOOTER_PAGES:
+        return [page_text.strip() for page_text in page_texts], base_metadata
+
+    page_lines = [page_text.splitlines() for page_text in page_texts]
+    trailing_entries_by_page = [
+        _trailing_footer_candidate_entries(lines) for lines in page_lines
+    ]
+    block_pages: dict[tuple[str, ...], dict[int, tuple[int, ...]]] = {}
+    for page_index, trailing_entries in enumerate(trailing_entries_by_page):
+        block_signatures: list[str] = []
+        block_line_indexes: list[int] = []
+        for depth in range(1, _MAX_FOOTER_CANDIDATE_LINES + 1):
+            entry = _trailing_entry_at_depth(trailing_entries, depth)
+            if entry is None:
+                break
+            _entry_depth, line_index, line = entry
+            signature = _repeated_text_footer_line_signature(line)
+            if signature is None:
+                break
+            block_signatures.append(signature)
+            block_line_indexes.append(line_index)
+            block_pages.setdefault(tuple(block_signatures), {})[page_index] = tuple(
+                block_line_indexes
+            )
+
+    min_repeated_pages = _min_high_coverage_text_footer_pages(len(page_texts))
+    repeated_blocks = [
+        (signature, page_to_line_indexes)
+        for signature, page_to_line_indexes in block_pages.items()
+        if len(page_to_line_indexes) >= min_repeated_pages
+    ]
+    repeated_blocks.sort(key=lambda item: (-len(item[0]), -len(item[1]), item[0]))
+
+    indexes_to_remove: set[tuple[int, int]] = set()
+    detected_blocks: list[dict[str, object]] = []
+    skipped_examples: list[dict[str, object]] = []
+    skipped_reasons: dict[str, int] = {}
+    suppressed_adjacent_numeric_count = 0
+    accepted_repeated_block_signatures: list[tuple[str, ...]] = []
+
+    for block_signature, page_to_line_indexes in repeated_blocks:
+        if len(block_signature) == 1 and not _has_accepted_longer_footer_family_signature(
+            block_signature, accepted_repeated_block_signatures
+        ):
+            continue
+        new_footer_indexes = {
+            (page_index, line_index)
+            for page_index, line_indexes in page_to_line_indexes.items()
+            for line_index in line_indexes
+            if (page_index, line_index) not in indexes_to_remove
+        }
+        if not new_footer_indexes:
+            continue
+
+        indexes_to_remove.update(new_footer_indexes)
+        accepted_repeated_block_signatures.append(block_signature)
+        adjacent_numeric_values: list[int] = []
+        skipped_adjacent_numeric_count = 0
+        block_length = len(block_signature)
+        if block_length > 1:
+            for page_index, line_indexes in page_to_line_indexes.items():
+                top_line_index = min(line_indexes)
+                adjacent_line_index = top_line_index - 1
+                if adjacent_line_index < 0:
+                    continue
+                adjacent_line = page_lines[page_index][adjacent_line_index].strip()
+                numeric_value = _page_number_line_value(adjacent_line)
+                if numeric_value is None:
+                    if re.search(r"\d", adjacent_line):
+                        skipped_adjacent_numeric_count += 1
+                        _increment_reason_count(
+                            skipped_reasons, "non_page_number_adjacent_numeric_line", 1
+                        )
+                        _append_skipped_adjacent_numeric_example(
+                            skipped_examples,
+                            page_number=page_index + 1,
+                            reason="non_page_number_adjacent_numeric_line",
+                            adjacent_line=adjacent_line,
+                        )
+                    continue
+                if numeric_value != page_index + 1:
+                    skipped_adjacent_numeric_count += 1
+                    _increment_reason_count(
+                        skipped_reasons,
+                        "adjacent_numeric_value_not_extracted_page",
+                        1,
+                    )
+                    _append_skipped_adjacent_numeric_example(
+                        skipped_examples,
+                        page_number=page_index + 1,
+                        reason="adjacent_numeric_value_not_extracted_page",
+                        adjacent_line=adjacent_line,
+                    )
+                    continue
+                indexes_to_remove.add((page_index, adjacent_line_index))
+                adjacent_numeric_values.append(numeric_value)
+                suppressed_adjacent_numeric_count += 1
+
+        detected_blocks.append(
+            {
+                "footer_signature": list(reversed(block_signature)),
+                "footer_depths": list(range(block_length, 0, -1)),
+                "page_count": len(page_to_line_indexes),
+                "suppressed_line_count": len(new_footer_indexes),
+                "suppressed_adjacent_page_number_line_count": len(
+                    adjacent_numeric_values
+                ),
+                "skipped_adjacent_numeric_line_count": skipped_adjacent_numeric_count,
+                "adjacent_numeric_values": adjacent_numeric_values[:10],
+            }
+        )
+
+    normalized_pages: list[str] = []
+    for page_index, lines in enumerate(page_lines):
+        kept_lines = [
+            line.rstrip()
+            for line_index, line in enumerate(lines)
+            if (page_index, line_index) not in indexes_to_remove
+        ]
+        normalized_pages.append("\n".join(kept_lines).strip())
+
+    if not indexes_to_remove:
+        base_metadata["detected_repeated_text_footer_block_count"] = len(repeated_blocks)
+        return normalized_pages, base_metadata
+
+    return normalized_pages, {
+        **base_metadata,
+        "activity": "suppressed",
+        "suppressed_line_count": len(indexes_to_remove),
+        "affected_page_count": len(
+            {page_index for page_index, _line_index in indexes_to_remove}
+        ),
+        "detected_repeated_text_footer_block_count": len(repeated_blocks),
+        "suppressed_repeated_text_footer_block_count": len(detected_blocks),
+        "suppressed_adjacent_page_number_line_count": suppressed_adjacent_numeric_count,
+        "skipped_adjacent_numeric_line_count": sum(skipped_reasons.values()),
+        "skipped_adjacent_numeric_reasons_by_code": skipped_reasons,
+        "detected_repeated_text_footer_blocks": detected_blocks,
+        "skipped_adjacent_numeric_examples": skipped_examples,
+    }
+
+
+def _min_high_coverage_text_footer_pages(page_count: int) -> int:
+    return max(
+        _MIN_HIGH_COVERAGE_TEXT_FOOTER_PAGES,
+        _min_repeated_footer_pages(page_count),
+        ceil(page_count * _HIGH_COVERAGE_TEXT_FOOTER_RATIO),
+    )
+
+
+def _has_accepted_longer_footer_family_signature(
+    signature: tuple[str, ...], accepted_signatures: Sequence[tuple[str, ...]]
+) -> bool:
+    return any(
+        len(accepted_signature) > len(signature)
+        and accepted_signature[: len(signature)] == signature
+        for accepted_signature in accepted_signatures
+    )
+
+
+def _trailing_entry_at_depth(
+    trailing_entries: Sequence[tuple[int, int, str]], depth: int
+) -> tuple[int, int, str] | None:
+    for entry in trailing_entries:
+        candidate_depth, _line_index, _line = entry
+        if candidate_depth == depth:
+            return entry
+    return None
+
+
+def _repeated_text_footer_line_signature(line: str) -> str | None:
+    if _is_bare_numeric_line(line):
+        return None
+    if _is_page_numbered_footer_like_line(line) and not _is_version_footer_line(line):
+        return None
+    if not any(character.isalpha() for character in line):
+        return None
+    return _footer_signature(line)
+
+
+def _append_skipped_adjacent_numeric_example(
+    examples: list[dict[str, object]],
+    *,
+    page_number: int,
+    reason: str,
+    adjacent_line: str,
+) -> None:
+    if len(examples) >= 5:
+        return
+    examples.append(
+        {
+            "page_number": page_number,
+            "reason": reason,
+            "adjacent_excerpt": _short_diagnostic_excerpt(adjacent_line),
+        }
+    )
 
 
 def _suppress_repeated_footer_lines_with_metadata(
@@ -776,6 +1048,10 @@ def _is_page_numbered_footer_like_line(line: str) -> bool:
     return bool(_PAGE_NUMBERED_FOOTER_LIKE_RE.search(" ".join(line.strip().split())))
 
 
+def _is_version_footer_line(line: str) -> bool:
+    return bool(_VERSION_FOOTER_LINE_RE.fullmatch(" ".join(line.strip().split())))
+
+
 def _has_adjacent_meaningful_numeric_context(lines: Sequence[str], line_index: int) -> bool:
     adjacent_lines = []
     if line_index > 0:
@@ -840,7 +1116,9 @@ def _render_replay_quality_metadata(metadata: Mapping[str, object]) -> str:
     page_context = _mapping_value(metadata, "page_count_context")
     url_spacing = _mapping_value(metadata, "url_spacing_normalization")
     url_path_wrap = _mapping_value(metadata, "url_path_line_wrap_normalization")
+    one_letter_wrap = _mapping_value(metadata, "one_letter_line_wrap_normalization")
     footer_page_noise = _mapping_value(metadata, "footer_page_number_noise_diagnostics")
+    text_footer = _mapping_value(metadata, "repeated_text_footer_suppression")
     footer = _mapping_value(metadata, "repeated_footer_suppression")
     layout_density = _mapping_value(metadata, "possible_layout_artifact_density")
     warnings = metadata.get("extraction_warnings", ())
@@ -869,6 +1147,10 @@ def _render_replay_quality_metadata(metadata: Mapping[str, object]) -> str:
                 f"{_metadata_value(url_path_wrap, 'repair_count')}"
             ),
             (
+                "- replay_quality_one_letter_line_wrap_repair_count: "
+                f"{_metadata_value(one_letter_wrap, 'repair_count')}"
+            ),
+            (
                 "- replay_quality_footer_page_number_repeated_trailing_block_count: "
                 f"{_metadata_value(footer_page_noise, 'repeated_trailing_footer_block_count')}"
             ),
@@ -883,6 +1165,22 @@ def _render_replay_quality_metadata(metadata: Mapping[str, object]) -> str:
             (
                 "- replay_quality_footer_page_number_mid_page_footer_like_line_count: "
                 f"{_metadata_value(footer_page_noise, 'mid_page_footer_like_line_count')}"
+            ),
+            (
+                "- replay_quality_repeated_text_footer_suppressed_line_count: "
+                f"{_metadata_value(text_footer, 'suppressed_line_count')}"
+            ),
+            (
+                "- replay_quality_repeated_text_footer_suppressed_block_count: "
+                f"{_metadata_value(text_footer, 'suppressed_repeated_text_footer_block_count')}"
+            ),
+            (
+                "- replay_quality_repeated_text_footer_suppressed_adjacent_page_number_count: "
+                f"{_metadata_value(text_footer, 'suppressed_adjacent_page_number_line_count')}"
+            ),
+            (
+                "- replay_quality_repeated_text_footer_skipped_adjacent_numeric_count: "
+                f"{_metadata_value(text_footer, 'skipped_adjacent_numeric_line_count')}"
             ),
             (
                 "- replay_quality_repeated_footer_suppressed_line_count: "

--- a/src/knowledge_adapters/public_webpage/client.py
+++ b/src/knowledge_adapters/public_webpage/client.py
@@ -2,16 +2,22 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from html.parser import HTMLParser
 
 from knowledge_adapters.public_sources import decode_text_response, fetch_public_url
+from knowledge_adapters.public_webpage.normalize import (
+    normalize_extracted_text_with_replay_metadata,
+)
 
 MAX_WEBPAGE_BYTES = 5_000_000
 WEBPAGE_EXTRACTION_NOTES = (
     "Unreviewed candidate material. Fetched a public webpage and extracted visible text "
     "with the Python standard-library HTML parser. Scripts and styles are omitted; "
-    "links, images, tables, comments, and publication metadata may be incomplete."
+    "links, images, tables, comments, and publication metadata may be incomplete. "
+    "Clearly mechanical page chrome such as subscription, sign-in, sharing, discussion, "
+    "footer/legal, and platform-promotion prompts may be suppressed; article body text "
+    "remains unreviewed candidate material."
 )
 
 
@@ -24,6 +30,7 @@ class PublicWebpageDocument:
     source_url: str
     fetched_at: str
     content: str
+    replay_quality_metadata: dict[str, object] = field(default_factory=dict)
     extraction_notes: str = WEBPAGE_EXTRACTION_NOTES
     source: str = "public_webpage"
     adapter: str = "public_webpage"
@@ -41,13 +48,16 @@ def fetch_webpage(url: str) -> PublicWebpageDocument:
     extractor.feed(html)
     extractor.close()
     title = extractor.title.strip() or fetched.final_url
-    content = extractor.markdown_text()
+    content, replay_quality_metadata = normalize_extracted_text_with_replay_metadata(
+        extractor.markdown_text()
+    )
     return PublicWebpageDocument(
         title=title,
         canonical_id=fetched.final_url,
         source_url=fetched.final_url,
         fetched_at=fetched.retrieved_at,
         content=content,
+        replay_quality_metadata=replay_quality_metadata,
     )
 
 

--- a/src/knowledge_adapters/public_webpage/normalize.py
+++ b/src/knowledge_adapters/public_webpage/normalize.py
@@ -2,7 +2,92 @@
 
 from __future__ import annotations
 
+import json
+import re
 from collections.abc import Mapping
+
+REPLAY_QUALITY_METADATA_NOTE = (
+    "informational only; does not authorize retention or promotion"
+)
+_CHROME_EXACT_PARAGRAPHS_BY_REASON = {
+    "subscription_sign_in_prompt": {
+        "subscribe sign in",
+        "sign in",
+    },
+    "share_prompt": {
+        "share",
+    },
+    "comments_discussion_placeholder": {
+        "comments restacks",
+        "top latest",
+        "no posts",
+    },
+    "subscription_prompt": {
+        "ready for more?",
+        "subscribe",
+    },
+    "platform_promotion": {
+        "start your substack get the app",
+        "substack is the home for great culture",
+    },
+}
+_LEGAL_FOOTER_RE = re.compile(r"(©|copyright).*privacy.*terms", re.IGNORECASE)
+
+
+def normalize_extracted_text_with_replay_metadata(
+    content: str,
+) -> tuple[str, dict[str, object]]:
+    """Remove clearly mechanical webpage chrome and describe review boundaries."""
+    paragraphs = [paragraph.strip() for paragraph in content.split("\n\n")]
+    retained_paragraphs: list[str] = []
+    suppressed_examples: list[dict[str, object]] = []
+    suppressed_reasons: dict[str, int] = {}
+    suppressed_character_count = 0
+
+    for paragraph in paragraphs:
+        if not paragraph:
+            continue
+        reason = _webpage_chrome_reason(paragraph)
+        if reason is None:
+            retained_paragraphs.append(paragraph)
+            continue
+        suppressed_character_count += len(paragraph)
+        suppressed_reasons[reason] = suppressed_reasons.get(reason, 0) + 1
+        if len(suppressed_examples) < 8:
+            suppressed_examples.append(
+                {
+                    "reason": reason,
+                    "excerpt": _short_diagnostic_excerpt(paragraph),
+                }
+            )
+
+    retained_content = "\n\n".join(retained_paragraphs)
+    metadata: dict[str, object] = {
+        "metadata_scope": "public_webpage_replay_quality",
+        "metadata_note": REPLAY_QUALITY_METADATA_NOTE,
+        "content_profile": {
+            "extracted_paragraph_count": len(
+                [paragraph for paragraph in paragraphs if paragraph]
+            ),
+            "retained_paragraph_count": len(retained_paragraphs),
+            "retained_character_count": len(retained_content),
+            "article_body_text_retained_for_review": True,
+        },
+        "extraction_boundary": {
+            "basis": "visible_text_after_deterministic_page_chrome_suppression",
+            "retention_boundary_review_required": True,
+            "does_not_claim_copyright_or_reuse_permission": True,
+            "does_not_summarize_or_shorten_article_body": True,
+        },
+        "page_chrome_suppression": {
+            "activity": "suppressed" if suppressed_reasons else "none",
+            "suppressed_paragraph_count": sum(suppressed_reasons.values()),
+            "suppressed_character_count": suppressed_character_count,
+            "suppressed_reasons_by_code": suppressed_reasons,
+            "suppressed_examples": suppressed_examples,
+        },
+    }
+    return retained_content, metadata
 
 
 def normalize_to_markdown(page: Mapping[str, object]) -> str:
@@ -14,6 +99,12 @@ def normalize_to_markdown(page: Mapping[str, object]) -> str:
     source = str(page.get("source", "public_webpage"))
     adapter = str(page.get("adapter", "public_webpage"))
     extraction_notes = str(page.get("extraction_notes", "Unreviewed candidate material."))
+    replay_quality_metadata = page.get("replay_quality_metadata")
+    replay_quality_lines = (
+        _render_replay_quality_metadata(replay_quality_metadata)
+        if isinstance(replay_quality_metadata, Mapping) and replay_quality_metadata
+        else ""
+    )
     content = str(page.get("content", "")).rstrip("\n")
 
     return f"""# {title}
@@ -28,6 +119,7 @@ def normalize_to_markdown(page: Mapping[str, object]) -> str:
 - adapter: {adapter}
 - candidate_status: unreviewed
 - extraction_notes: {extraction_notes}
+{replay_quality_lines}
 
 ## Content
 
@@ -35,3 +127,69 @@ def normalize_to_markdown(page: Mapping[str, object]) -> str:
 
 {content}
 """
+
+
+def _webpage_chrome_reason(paragraph: str) -> str | None:
+    normalized = _normalized_prompt_text(paragraph)
+    for reason, prompts in _CHROME_EXACT_PARAGRAPHS_BY_REASON.items():
+        if normalized in prompts:
+            return reason
+    if _LEGAL_FOOTER_RE.search(paragraph):
+        return "footer_legal_text"
+    if normalized.startswith("discussion about this post"):
+        return "comments_discussion_placeholder"
+    return None
+
+
+def _normalized_prompt_text(paragraph: str) -> str:
+    return " ".join(paragraph.casefold().split())
+
+
+def _short_diagnostic_excerpt(paragraph: str) -> str:
+    excerpt = " ".join(paragraph.strip().split())
+    if len(excerpt) <= 80:
+        return excerpt
+    return f"{excerpt[:77].rstrip()}..."
+
+
+def _render_replay_quality_metadata(metadata: Mapping[str, object]) -> str:
+    profile = _mapping_value(metadata, "content_profile")
+    boundary = _mapping_value(metadata, "extraction_boundary")
+    chrome = _mapping_value(metadata, "page_chrome_suppression")
+    reasons = chrome.get("suppressed_reasons_by_code", {})
+    reason_text = (
+        "; ".join(f"{key}={value}" for key, value in sorted(reasons.items()))
+        if isinstance(reasons, Mapping) and reasons
+        else "none"
+    )
+    return "\n".join(
+        (
+            f"- replay_quality_metadata_note: {REPLAY_QUALITY_METADATA_NOTE}",
+            (
+                "- replay_quality_webpage_extraction_boundary: "
+                f"{_metadata_value(boundary, 'basis')}"
+            ),
+            (
+                "- replay_quality_webpage_article_body_text_retained_for_review: "
+                f"{_metadata_value(profile, 'article_body_text_retained_for_review')}"
+            ),
+            (
+                "- replay_quality_webpage_chrome_suppressed_paragraph_count: "
+                f"{_metadata_value(chrome, 'suppressed_paragraph_count')}"
+            ),
+            f"- replay_quality_webpage_chrome_suppressed_reasons: {reason_text}",
+            (
+                "- replay_quality_metadata_json: "
+                f"{json.dumps(dict(metadata), sort_keys=True, separators=(',', ':'))}"
+            ),
+        )
+    )
+
+
+def _mapping_value(metadata: Mapping[str, object], key: str) -> Mapping[str, object]:
+    value = metadata.get(key, {})
+    return value if isinstance(value, Mapping) else {}
+
+
+def _metadata_value(metadata: Mapping[str, object], key: str) -> object:
+    return metadata.get(key, "")

--- a/tests/fixtures/public_pdf/dora_regression_cases.json
+++ b/tests/fixtures/public_pdf/dora_regression_cases.json
@@ -380,6 +380,94 @@
       "expected_markdown_metadata_lines": [
         "- replay_quality_metadata_note: informational only; does not authorize retention or promotion"
       ]
+    },
+    {
+      "id": "dora_2023_large_repeated_title_version_footer",
+      "description": "Large DORA 2023 replay shape with high-coverage repeated trailing title/version footers, conforming page-number pages, and outlier adjacent numeric lines.",
+      "expectation": "normalized",
+      "tags": ["required_case", "previous_dora_replay_failure", "footer", "large_document_shape"],
+      "raw_pages": [
+        "Cover\nAccelerate State of DevOps 2023\nv. 2023-12",
+        "Contents\nAll citations retrieved 27 September 2023\nAccelerate State of DevOps 2023\nv. 2023-12",
+        "Executive summary03\nAccelerate State of DevOps 2023\nv. 2023-12",
+        "Delivery outcomes\n4\nAccelerate State of DevOps 2023\nv. 2023-12",
+        "Metric table\nMetric value 4\n44\nAccelerate State of DevOps 2023\nv. 2023-12",
+        "Roadmap note\nThe roadmap43 marker remains fused.\nAccelerate State of DevOps 2023\nv. 2023-12",
+        "Reliability chapter\n7\nAccelerate State of DevOps 2023\nv. 2023-12",
+        "Operational performance\n8\nAccelerate State of DevOps 2023\nv. 2023-12",
+        "Appendix note\n9\nAccelerate State of DevOps 2023\nv. 2023-12",
+        "Closing section\n10\nAccelerate State of DevOps 2023\nv. 2023-12"
+      ],
+      "expected_pages": [
+        "Cover",
+        "Contents\nAll citations retrieved 27 September 2023",
+        "Executive summary03",
+        "Delivery outcomes",
+        "Metric table\nMetric value 4\n44",
+        "Roadmap note\nThe roadmap43 marker remains fused.",
+        "Reliability chapter",
+        "Operational performance",
+        "Appendix note",
+        "Closing section"
+      ],
+      "expected_metadata": {
+        "repeated_text_footer_suppression": {
+          "activity": "suppressed",
+          "suppressed_line_count": 25,
+          "affected_page_count": 10,
+          "detected_repeated_text_footer_block_count": 2,
+          "suppressed_repeated_text_footer_block_count": 1,
+          "suppressed_adjacent_page_number_line_count": 5,
+          "skipped_adjacent_numeric_line_count": 4,
+          "skipped_adjacent_numeric_reasons_by_code": {
+            "non_page_number_adjacent_numeric_line": 3,
+            "adjacent_numeric_value_not_extracted_page": 1
+          }
+        },
+        "repeated_footer_suppression": {
+          "activity": "none",
+          "suppressed_line_count": 0
+        },
+        "footer_page_number_noise_diagnostics": {
+          "repeated_trailing_footer_block_count": 3,
+          "repeated_bare_numeric_trailing_signature_count": 1
+        }
+      },
+      "expected_markdown_metadata_lines": [
+        "- replay_quality_repeated_text_footer_suppressed_line_count: 25",
+        "- replay_quality_repeated_text_footer_suppressed_block_count: 1",
+        "- replay_quality_repeated_text_footer_suppressed_adjacent_page_number_count: 5",
+        "- replay_quality_repeated_text_footer_skipped_adjacent_numeric_count: 4"
+      ]
+    },
+    {
+      "id": "one_letter_split_word_lines",
+      "description": "One-letter split-word lines are joined to the following lowercase fragment.",
+      "expectation": "normalized",
+      "tags": ["required_case", "previous_dora_replay_failure", "line_wrap"],
+      "raw_pages": [
+        "Teams can\ns\nafely improve delivery.\nDORA Report\n1",
+        "The service\np\nrovides reliable behavior.\nDORA Report\n2"
+      ],
+      "expected_pages": [
+        "Teams can\nsafely improve delivery.",
+        "The service\nprovides reliable behavior."
+      ],
+      "expected_metadata": {
+        "one_letter_line_wrap_normalization": {
+          "activity": "normalized",
+          "repair_count": 2,
+          "affected_page_count": 2
+        },
+        "repeated_footer_suppression": {
+          "activity": "suppressed",
+          "suppressed_line_count": 4,
+          "suppressed_numeric_page_line_count": 2
+        }
+      },
+      "expected_markdown_metadata_lines": [
+        "- replay_quality_one_letter_line_wrap_repair_count: 2"
+      ]
     }
   ]
 }

--- a/tests/fixtures/public_pdf/dora_regression_cases.json
+++ b/tests/fixtures/public_pdf/dora_regression_cases.json
@@ -446,12 +446,12 @@
       "expectation": "normalized",
       "tags": ["required_case", "previous_dora_replay_failure", "line_wrap"],
       "raw_pages": [
-        "Teams can\ns\nafely improve delivery.\nDORA Report\n1",
-        "The service\np\nrovides reliable behavior.\nDORA Report\n2"
+        "• Software delivery performance—Teams can\ns\nafely improve delivery.\nDORA Report\n1",
+        "• Operational performance—The service\np\nrovides reliable behavior.\nDORA Report\n2"
       ],
       "expected_pages": [
-        "Teams can\nsafely improve delivery.",
-        "The service\nprovides reliable behavior."
+        "• Software delivery performance—Teams can\nsafely improve delivery.",
+        "• Operational performance—The service\nprovides reliable behavior."
       ],
       "expected_metadata": {
         "one_letter_line_wrap_normalization": {
@@ -467,6 +467,32 @@
       },
       "expected_markdown_metadata_lines": [
         "- replay_quality_one_letter_line_wrap_repair_count: 2"
+      ]
+    },
+    {
+      "id": "standalone_one_letter_lines",
+      "description": "Legitimate standalone one-letter lines such as headings, pronouns, and list markers are retained.",
+      "expectation": "unchanged",
+      "tags": ["required_case", "no_op_safety", "line_wrap"],
+      "raw_pages": [
+        "Appendix marker\nA\nabout the cohort\nPronoun marker\nI\nintend to keep this line separate\nList marker\nb\nlowercase list item text"
+      ],
+      "expected_pages": [
+        "Appendix marker\nA\nabout the cohort\nPronoun marker\nI\nintend to keep this line separate\nList marker\nb\nlowercase list item text"
+      ],
+      "expected_metadata": {
+        "one_letter_line_wrap_normalization": {
+          "activity": "none",
+          "repair_count": 0,
+          "affected_page_count": 0
+        },
+        "repeated_footer_suppression": {
+          "activity": "none",
+          "suppressed_line_count": 0
+        }
+      },
+      "expected_markdown_metadata_lines": [
+        "- replay_quality_one_letter_line_wrap_repair_count: 0"
       ]
     }
   ]

--- a/tests/fixtures/public_webpage/article_chrome_cases.json
+++ b/tests/fixtures/public_webpage/article_chrome_cases.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": 1,
+  "source": "sanitized_public_webpage_article_chrome_cases",
+  "cases": [
+    {
+      "id": "article_body_plus_substack_chrome",
+      "description": "Article body is retained while obvious subscription, sharing, discussion, legal, and platform chrome is removed.",
+      "raw_content": "Subscribe Sign in\n\nExample Article Title\n\nSynthetic byline\n\nShare\n\nArticle paragraph one with reviewable source material.\n\nArticle paragraph two remains intentionally retained for review.\n\nDiscussion about this post\n\nComments Restacks\n\nTop Latest\n\nNo posts\n\nReady for more?\n\nSubscribe\n\n© 2026 Example Author · Privacy ∙ Terms ∙ Collection notice\n\nStart your Substack Get the app\n\nSubstack is the home for great culture",
+      "expected_content": "Example Article Title\n\nSynthetic byline\n\nArticle paragraph one with reviewable source material.\n\nArticle paragraph two remains intentionally retained for review.",
+      "expected_metadata": {
+        "page_chrome_suppression": {
+          "activity": "suppressed",
+          "suppressed_paragraph_count": 11,
+          "suppressed_reasons_by_code": {
+            "subscription_sign_in_prompt": 1,
+            "share_prompt": 1,
+            "comments_discussion_placeholder": 4,
+            "subscription_prompt": 2,
+            "footer_legal_text": 1,
+            "platform_promotion": 2
+          }
+        },
+        "extraction_boundary": {
+          "retention_boundary_review_required": true,
+          "does_not_claim_copyright_or_reuse_permission": true,
+          "does_not_summarize_or_shorten_article_body": true
+        },
+        "content_profile": {
+          "article_body_text_retained_for_review": true
+        }
+      },
+      "expected_markdown_metadata_lines": [
+        "- replay_quality_metadata_note: informational only; does not authorize retention or promotion",
+        "- replay_quality_webpage_chrome_suppressed_paragraph_count: 11",
+        "- replay_quality_webpage_article_body_text_retained_for_review: True"
+      ]
+    }
+  ]
+}

--- a/tests/test_public_pdf_dora_regression_fixtures.py
+++ b/tests/test_public_pdf_dora_regression_fixtures.py
@@ -31,6 +31,8 @@ REQUIRED_CASE_IDS = {
     "in_reading_order_version_footer_pair",
     "calculator_table_numeric_traps",
     "fused_extraction_artifact_roadmap43",
+    "dora_2023_large_repeated_title_version_footer",
+    "one_letter_split_word_lines",
 }
 
 

--- a/tests/test_public_pdf_dora_regression_fixtures.py
+++ b/tests/test_public_pdf_dora_regression_fixtures.py
@@ -33,6 +33,7 @@ REQUIRED_CASE_IDS = {
     "fused_extraction_artifact_roadmap43",
     "dora_2023_large_repeated_title_version_footer",
     "one_letter_split_word_lines",
+    "standalone_one_letter_lines",
 }
 
 

--- a/tests/test_public_webpage_chrome_fixtures.py
+++ b/tests/test_public_webpage_chrome_fixtures.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import cast
+
+from knowledge_adapters.public_webpage.normalize import (
+    normalize_extracted_text_with_replay_metadata,
+    normalize_to_markdown,
+)
+from tests.artifact_assertions import parse_markdown_document
+
+FIXTURE_PATH = (
+    Path(__file__).parent
+    / "fixtures"
+    / "public_webpage"
+    / "article_chrome_cases.json"
+)
+
+
+def _load_fixture_cases() -> tuple[Mapping[str, object], ...]:
+    payload = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    assert payload["schema_version"] == 1
+    assert payload["source"] == "sanitized_public_webpage_article_chrome_cases"
+    cases = payload["cases"]
+    assert isinstance(cases, list)
+    return tuple(cast(Mapping[str, object], case) for case in cases)
+
+
+ARTICLE_CHROME_CASES = _load_fixture_cases()
+
+
+def test_public_webpage_article_chrome_fixture_area_is_present() -> None:
+    case_ids = {str(case["id"]) for case in ARTICLE_CHROME_CASES}
+
+    assert case_ids == {"article_body_plus_substack_chrome"}
+
+
+def test_public_webpage_chrome_suppression_keeps_article_body_with_metadata() -> None:
+    case = ARTICLE_CHROME_CASES[0]
+
+    content, metadata = normalize_extracted_text_with_replay_metadata(
+        str(case["raw_content"])
+    )
+
+    assert content == case["expected_content"]
+    _assert_metadata_contains(metadata, _mapping(case, "expected_metadata"))
+
+    markdown = normalize_to_markdown(
+        {
+            "title": "Example Article Title",
+            "canonical_id": "fixture://article",
+            "source_url": "fixture://article",
+            "fetched_at": "2026-05-13T12:00:00Z",
+            "content": content,
+            "replay_quality_metadata": metadata,
+        }
+    )
+
+    assert "- candidate_status: unreviewed" in markdown
+    for expected_line in _string_sequence(case, "expected_markdown_metadata_lines"):
+        assert expected_line in markdown
+    _title, _metadata, markdown_content = parse_markdown_document(markdown)
+    assert "Article paragraph one with reviewable source material." in markdown
+    assert "Subscribe Sign in" not in markdown_content
+    assert "Substack is the home for great culture" not in markdown_content
+    assert "Privacy" not in markdown_content
+
+
+def _assert_metadata_contains(
+    actual: Mapping[str, object],
+    expected: Mapping[str, object],
+    path: str = "metadata",
+) -> None:
+    for key, expected_value in expected.items():
+        assert key in actual, f"{path}.{key} missing"
+        actual_value = actual[key]
+        if isinstance(expected_value, Mapping):
+            assert isinstance(actual_value, Mapping), f"{path}.{key} is not a mapping"
+            _assert_metadata_contains(
+                cast(Mapping[str, object], actual_value),
+                cast(Mapping[str, object], expected_value),
+                f"{path}.{key}",
+            )
+            continue
+        assert actual_value == expected_value, f"{path}.{key}"
+
+
+def _mapping(case: Mapping[str, object], key: str) -> Mapping[str, object]:
+    value = case[key]
+    assert isinstance(value, Mapping)
+    return cast(Mapping[str, object], value)
+
+
+def _string_sequence(case: Mapping[str, object], key: str) -> list[str]:
+    value = case[key]
+    assert isinstance(value, list)
+    assert all(isinstance(item, str) for item in value)
+    return cast(list[str], value)


### PR DESCRIPTION
## Summary

Improves adapter-side extraction cleanup for the two noisy public-source replay shapes before returning to knowledge-vault milestone validation.

## Root Cause Findings

- DORA 2023 PDF extraction produced repeated high-coverage trailing footer families that were not handled by the existing anchored numeric footer suppressor because many pages had no adjacent parseable page number and some adjacent numeric-looking lines were body artifacts.
- DORA 2023 also exposed deterministic one-letter split-word line wraps, for example a single extracted letter followed by the rest of the word on the next line.
- MeaningfulTech/Substack extraction was retaining article body text plus obvious page chrome because the public webpage adapter only omitted script/style-like HTML and did not do visible-text chrome suppression or boundary diagnostics.

## Fixtures And Diagnostics Added

- Added DORA 2023 large-document mixed/cohort fixture coverage for repeated title/version footer families, conforming adjacent page-number lines, adjacent numeric outliers, and fused body/page artifacts that should remain retained.
- Added DORA one-letter split-word fixture coverage.
- Added sanitized public webpage article-body-plus-chrome fixtures for subscription/sign-in/share prompts, discussion placeholders, footer/legal text, platform promotion text, and retained article body text.
- Added public webpage replay-quality metadata documenting deterministic chrome suppression and explicitly marking retained article body text as review-boundary material only.

## Implementation Changes

- Public PDF normalization now repairs one-letter split-word line wraps.
- Public PDF normalization now suppresses high-coverage repeated trailing text footer blocks in large documents, with version-only suppression limited to a proven longer footer family in the same document.
- Adjacent numeric suppression in that path is limited to a directly adjacent page-number line that equals the extracted page index; adjacent numeric outliers are retained and reported.
- Public webpage normalization now removes only deterministic chrome prompt paragraphs and emits replay-quality metadata in markdown and dry-run output.

## Live Source Checks

Checked against the public sources on 2026-05-13:

- DORA 2023 PDF: `v. 2023-12` lines dropped from 95 to 0; exact trailing `Accelerate State of DevOps 2023` footer-title lines dropped to 0; one-letter split-word lines dropped from 27 to 0; bare numeric lines are not broadly suppressed and remained at 101 after only four page-index-matching adjacent footer numbers were removed.
- MeaningfulTech page: obvious chrome prompts were suppressed: subscription/sign-in/share prompts, discussion placeholders, footer/legal text, and Substack promotion text. Article body text remains retained as unreviewed candidate material with boundary metadata.
- DORA ROI 2026 non-regression: the prior anchored footer path still handles the ROI footer shape; `repeated_footer_suppression` suppressed 110 lines across 55 pages and retained the known risk/outlier cases, while the new high-coverage text-footer path reported `activity: none`.

## Out Of Scope

- No knowledge-vault changes.
- No auto-promotion logic.
- No retention semantics changes.
- No retention-aware summarizer and no claim of copyright or reuse permission.
- No broad bare-number suppression.
- Fused body/page artifacts remain retained unless fixture-backed safe repair is added later.

## Validation

- `make test PYTEST='.venv/bin/pytest tests/test_public_pdf_dora_regression_fixtures.py tests/test_public_webpage_chrome_fixtures.py tests/test_public_sources.py'` passed: 94 tests.
- `make check` passed: Ruff, MyPy, and 510 tests.
- `git diff --check` passed.
- Branch verified current with `origin/main` before PR creation.