### PR TITLE
Add public replay quality classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,11 @@ does not write files in dry-run mode. Localhost, `.local`, private, link-local,
 multicast, unspecified, reserved, and credential-bearing targets are rejected
 before fetch and after redirects. Raw fetched HTML is held only in memory. The
 output is explicitly unreviewed candidate material; links, images, tables,
-comments, and publication metadata may be incomplete.
+comments, and publication metadata may be incomplete. Public webpage outputs
+include replay-quality metadata and the same normalized replay classification
+shape as public PDFs, so reviewers can distinguish `review-ready` candidates
+from `diagnostic-only` extractions while seeing that unreviewed public-source
+material remains `unsafe-to-promote`.
 
 Public PDF/report first run:
 
@@ -132,6 +136,10 @@ manifest entry. These fields report
 mechanical extraction conditions such as footer suppression counts, URL spacing
 normalization counts, URL path line-wrap repair counts, page-count context,
 possible layout-artifact line density, and adapter-known extraction warnings.
+They also include a normalized replay classification that separates the
+candidate's operational state from promotion safety: for example,
+`review-ready` can still be paired with `unsafe-to-promote` when public-source
+retention review is required, while empty extraction is `diagnostic-only`.
 They are informational review aids only: they do not approve the candidate,
 authorize retention, promote content, rank documents, or assert semantic
 correctness. Footer and page-number noise measurement is documented in

--- a/docs/public-pdf-dora-regression-fixtures.md
+++ b/docs/public-pdf-dora-regression-fixtures.md
@@ -61,7 +61,11 @@ Replay-quality metadata is part of the fixture contract. It remains
 informational only and does not authorize retention or promotion. Fixture tests
 should assert counts and notes that help reviewers understand what mechanical
 conditions were observed, such as URL repairs, footer suppression, numeric-risk
-diagnostics, page-count context, and extraction warnings.
+diagnostics, page-count context, and extraction warnings. Public PDF fixtures
+also assert the shared replay classification shape so reviewers can see whether
+the replay is `review-ready` or `diagnostic-only`, whether review economics are
+bounded, what remaining artifacts were intentionally retained, and why
+unreviewed public-source candidates remain `unsafe-to-promote`.
 
 ## Limitations And Non-Goals
 

--- a/docs/public-webpage-chrome-fixtures.md
+++ b/docs/public-webpage-chrome-fixtures.md
@@ -12,9 +12,13 @@ The fixture area captures small article-body-plus-chrome shapes for:
 - footer/legal text
 - platform promotion text
 - retained article body text with replay-quality boundary metadata
+- chrome-only diagnostic replay shapes where no reviewable article text remains
 
 The adapter does not summarize article bodies, claim copyright or reuse
 permission, change retention semantics, or make near-full article extraction
 promotion-ready. Replay-quality metadata is informational only and helps
 reviewers distinguish deterministic page-chrome suppression from retained
-candidate article body text.
+candidate article body text. The shared replay classification reports
+`review-ready` for retained article text and `diagnostic-only` when suppression
+leaves no content worth reviewing; unreviewed public webpage candidates remain
+`unsafe-to-promote`.

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -1222,6 +1222,9 @@ def print_stale_artifacts(
 
 
 def _print_public_pdf_replay_quality_metadata(metadata: Mapping[str, object]) -> None:
+    classification = _metadata_mapping(metadata, "replay_classification")
+    reviewability = _metadata_mapping(classification, "reviewability_assessment")
+    remaining = _metadata_mapping(classification, "remaining_artifacts")
     page_context = _metadata_mapping(metadata, "page_count_context")
     url_spacing = _metadata_mapping(metadata, "url_spacing_normalization")
     url_path_wrap = _metadata_mapping(metadata, "url_path_line_wrap_normalization")
@@ -1236,6 +1239,18 @@ def _print_public_pdf_replay_quality_metadata(metadata: Mapping[str, object]) ->
 
     print("  replay_quality_metadata:")
     print("    metadata_note: informational only; does not authorize retention or promotion")
+    print(f"    operational_state: {classification.get('operational_state', '')}")
+    print(f"    promotion_state: {classification.get('promotion_state', '')}")
+    print(f"    review_effort: {reviewability.get('review_effort', '')}")
+    print(
+        "    bounded_review_economics: "
+        f"{reviewability.get('bounded_review_economics', '')}"
+    )
+    print(
+        "    deterministic_cleanup_count: "
+        f"{reviewability.get('deterministic_cleanup_count', '')}"
+    )
+    print(f"    remaining_artifact_count: {remaining.get('total_count', '')}")
     print(f"    page_count: {page_context.get('page_count', '')}")
     print(f"    empty_page_count: {page_context.get('empty_page_count', '')}")
     print(
@@ -1296,6 +1311,9 @@ def _print_public_pdf_replay_quality_metadata(metadata: Mapping[str, object]) ->
 
 
 def _print_public_webpage_replay_quality_metadata(metadata: Mapping[str, object]) -> None:
+    classification = _metadata_mapping(metadata, "replay_classification")
+    reviewability = _metadata_mapping(classification, "reviewability_assessment")
+    remaining = _metadata_mapping(classification, "remaining_artifacts")
     profile = _metadata_mapping(metadata, "content_profile")
     boundary = _metadata_mapping(metadata, "extraction_boundary")
     chrome = _metadata_mapping(metadata, "page_chrome_suppression")
@@ -1307,6 +1325,18 @@ def _print_public_webpage_replay_quality_metadata(metadata: Mapping[str, object]
 
     print("  replay_quality_metadata:")
     print("    metadata_note: informational only; does not authorize retention or promotion")
+    print(f"    operational_state: {classification.get('operational_state', '')}")
+    print(f"    promotion_state: {classification.get('promotion_state', '')}")
+    print(f"    review_effort: {reviewability.get('review_effort', '')}")
+    print(
+        "    bounded_review_economics: "
+        f"{reviewability.get('bounded_review_economics', '')}"
+    )
+    print(
+        "    deterministic_cleanup_count: "
+        f"{reviewability.get('deterministic_cleanup_count', '')}"
+    )
+    print(f"    remaining_artifact_count: {remaining.get('total_count', '')}")
     print(f"    extraction_boundary: {boundary.get('basis', '')}")
     print(
         "    article_body_text_retained_for_review: "

--- a/src/knowledge_adapters/public_pdf/normalize.py
+++ b/src/knowledge_adapters/public_pdf/normalize.py
@@ -7,6 +7,8 @@ import re
 from collections.abc import Mapping, Sequence
 from math import ceil
 
+from knowledge_adapters.replay_quality import build_public_source_replay_classification
+
 _BROKEN_URL_SCHEME_RE = re.compile(
     r"\b(?P<scheme>https?)"
     r"(?:\s+:\s*/\s*/\s*|\s*:\s+/\s*/\s*|\s*:\s*/\s+/\s*|\s*:\s*/\s*/\s+)"
@@ -134,6 +136,7 @@ def normalize_extracted_pages_with_replay_metadata(
         ),
         "extraction_warnings": _extraction_warning_codes(empty_page_count),
     }
+    metadata["replay_classification"] = _build_public_pdf_replay_classification(metadata)
     return normalized_pages, metadata
 
 
@@ -1119,7 +1122,91 @@ def _extraction_warning_codes(empty_page_count: int) -> list[str]:
     return warnings
 
 
+def _build_public_pdf_replay_classification(
+    metadata: Mapping[str, object],
+) -> dict[str, object]:
+    page_context = _mapping_value(metadata, "page_count_context")
+    url_spacing = _mapping_value(metadata, "url_spacing_normalization")
+    url_path_wrap = _mapping_value(metadata, "url_path_line_wrap_normalization")
+    one_letter_wrap = _mapping_value(metadata, "one_letter_line_wrap_normalization")
+    footer_page_noise = _mapping_value(metadata, "footer_page_number_noise_diagnostics")
+    text_footer = _mapping_value(metadata, "repeated_text_footer_suppression")
+    footer = _mapping_value(metadata, "repeated_footer_suppression")
+    layout_density = _mapping_value(metadata, "possible_layout_artifact_density")
+    warnings = _string_sequence(metadata.get("extraction_warnings", ()))
+    empty_page_count = _int_metadata_value(page_context, "empty_page_count")
+    remaining_artifact_counts = {
+        "bare_numeric_lines_adjacent_to_numeric_content": _int_metadata_value(
+            footer_page_noise, "bare_numeric_adjacent_to_numeric_content_count"
+        ),
+        "empty_pages_without_extracted_text": empty_page_count,
+        "mid_page_footer_like_lines": _int_metadata_value(
+            footer_page_noise, "mid_page_footer_like_line_count"
+        ),
+        "possible_layout_artifact_lines": _int_metadata_value(
+            layout_density, "possible_artifact_line_count"
+        ),
+        "repeated_footer_missing_adjacent_numeric_lines": _int_metadata_value(
+            footer, "missing_adjacent_numeric_line_count"
+        ),
+        "repeated_footer_nonparseable_adjacent_numeric_lines": _int_metadata_value(
+            footer, "nonparseable_adjacent_numeric_line_count"
+        ),
+        "repeated_footer_numeric_risk_skipped": _int_metadata_value(
+            footer, "numeric_risk_skipped_count"
+        ),
+        "repeated_text_footer_skipped_adjacent_numeric_lines": _int_metadata_value(
+            text_footer, "skipped_adjacent_numeric_line_count"
+        ),
+    }
+    promotion_blockers = ["public_source_candidate_requires_human_retention_review"]
+    if empty_page_count:
+        promotion_blockers.append("empty_pages_without_extracted_text")
+
+    intentionally_retained_markers = [
+        "full_text_extraction_retained_intentionally_for_review",
+    ]
+    if any(remaining_artifact_counts.values()):
+        intentionally_retained_markers.append(
+            "uncertain_extraction_artifacts_retained_for_review"
+        )
+
+    return build_public_source_replay_classification(
+        source_type="public_pdf",
+        retained_content_units=_int_metadata_value(layout_density, "line_count"),
+        retained_content_unit="normalized_nonempty_text_line",
+        deterministic_cleanup_counts_by_category={
+            "one_letter_line_wrap_repairs": _int_metadata_value(
+                one_letter_wrap, "repair_count"
+            ),
+            "repeated_footer_lines_suppressed": _int_metadata_value(
+                footer, "suppressed_line_count"
+            ),
+            "repeated_text_footer_lines_suppressed": _int_metadata_value(
+                text_footer, "suppressed_line_count"
+            ),
+            "url_path_line_wrap_repairs": _int_metadata_value(
+                url_path_wrap, "repair_count"
+            ),
+            "url_spacing_normalizations": _int_metadata_value(
+                url_spacing, "replacement_count"
+            ),
+        },
+        remaining_artifact_counts_by_category=remaining_artifact_counts,
+        known_limitation_codes=[
+            *warnings,
+            "public_pdf_full_text_extraction_requires_source_review",
+        ],
+        intentionally_retained_markers=intentionally_retained_markers,
+        promotion_blocker_codes=promotion_blockers,
+    )
+
+
 def _render_replay_quality_metadata(metadata: Mapping[str, object]) -> str:
+    classification = _mapping_value(metadata, "replay_classification")
+    reviewability = _mapping_value(classification, "reviewability_assessment")
+    cleanup = _mapping_value(classification, "deterministic_cleanup")
+    remaining = _mapping_value(classification, "remaining_artifacts")
     page_context = _mapping_value(metadata, "page_count_context")
     url_spacing = _mapping_value(metadata, "url_spacing_normalization")
     url_path_wrap = _mapping_value(metadata, "url_path_line_wrap_normalization")
@@ -1140,6 +1227,30 @@ def _render_replay_quality_metadata(metadata: Mapping[str, object]) -> str:
     return "\n".join(
         (
             f"- replay_quality_metadata_note: {REPLAY_QUALITY_METADATA_NOTE}",
+            (
+                "- replay_quality_operational_state: "
+                f"{_metadata_value(classification, 'operational_state')}"
+            ),
+            (
+                "- replay_quality_promotion_state: "
+                f"{_metadata_value(classification, 'promotion_state')}"
+            ),
+            (
+                "- replay_quality_review_effort: "
+                f"{_metadata_value(reviewability, 'review_effort')}"
+            ),
+            (
+                "- replay_quality_bounded_review_economics: "
+                f"{_metadata_value(reviewability, 'bounded_review_economics')}"
+            ),
+            (
+                "- replay_quality_deterministic_cleanup_count: "
+                f"{_metadata_value(reviewability, 'deterministic_cleanup_count')}"
+            ),
+            (
+                "- replay_quality_remaining_artifact_count: "
+                f"{_metadata_value(remaining, 'total_count')}"
+            ),
             f"- replay_quality_page_count: {_metadata_value(page_context, 'page_count')}",
             (
                 "- replay_quality_empty_page_count: "
@@ -1237,6 +1348,10 @@ def _render_replay_quality_metadata(metadata: Mapping[str, object]) -> str:
             ),
             f"- replay_quality_extraction_warnings: {warning_text}",
             (
+                "- replay_quality_deterministic_cleanup_scope: "
+                f"{_metadata_value(cleanup, 'scope')}"
+            ),
+            (
                 "- replay_quality_metadata_json: "
                 f"{json.dumps(dict(metadata), sort_keys=True, separators=(',', ':'))}"
             ),
@@ -1251,3 +1366,16 @@ def _mapping_value(metadata: Mapping[str, object], key: str) -> Mapping[str, obj
 
 def _metadata_value(metadata: Mapping[str, object], key: str) -> object:
     return metadata.get(key, "")
+
+
+def _int_metadata_value(metadata: Mapping[str, object], key: str) -> int:
+    value = metadata.get(key, 0)
+    return value if isinstance(value, int) else 0
+
+
+def _string_sequence(value: object) -> list[str]:
+    if isinstance(value, Sequence) and not isinstance(value, str):
+        return [str(item) for item in value]
+    if value:
+        return [str(value)]
+    return []

--- a/src/knowledge_adapters/public_webpage/normalize.py
+++ b/src/knowledge_adapters/public_webpage/normalize.py
@@ -6,6 +6,8 @@ import json
 import re
 from collections.abc import Mapping
 
+from knowledge_adapters.replay_quality import build_public_source_replay_classification
+
 REPLAY_QUALITY_METADATA_NOTE = (
     "informational only; does not authorize retention or promotion"
 )
@@ -87,6 +89,9 @@ def normalize_extracted_text_with_replay_metadata(
             "suppressed_examples": suppressed_examples,
         },
     }
+    metadata["replay_classification"] = _build_public_webpage_replay_classification(
+        metadata
+    )
     return retained_content, metadata
 
 
@@ -153,6 +158,10 @@ def _short_diagnostic_excerpt(paragraph: str) -> str:
 
 
 def _render_replay_quality_metadata(metadata: Mapping[str, object]) -> str:
+    classification = _mapping_value(metadata, "replay_classification")
+    reviewability = _mapping_value(classification, "reviewability_assessment")
+    cleanup = _mapping_value(classification, "deterministic_cleanup")
+    remaining = _mapping_value(classification, "remaining_artifacts")
     profile = _mapping_value(metadata, "content_profile")
     boundary = _mapping_value(metadata, "extraction_boundary")
     chrome = _mapping_value(metadata, "page_chrome_suppression")
@@ -166,6 +175,30 @@ def _render_replay_quality_metadata(metadata: Mapping[str, object]) -> str:
         (
             f"- replay_quality_metadata_note: {REPLAY_QUALITY_METADATA_NOTE}",
             (
+                "- replay_quality_operational_state: "
+                f"{_metadata_value(classification, 'operational_state')}"
+            ),
+            (
+                "- replay_quality_promotion_state: "
+                f"{_metadata_value(classification, 'promotion_state')}"
+            ),
+            (
+                "- replay_quality_review_effort: "
+                f"{_metadata_value(reviewability, 'review_effort')}"
+            ),
+            (
+                "- replay_quality_bounded_review_economics: "
+                f"{_metadata_value(reviewability, 'bounded_review_economics')}"
+            ),
+            (
+                "- replay_quality_deterministic_cleanup_count: "
+                f"{_metadata_value(reviewability, 'deterministic_cleanup_count')}"
+            ),
+            (
+                "- replay_quality_remaining_artifact_count: "
+                f"{_metadata_value(remaining, 'total_count')}"
+            ),
+            (
                 "- replay_quality_webpage_extraction_boundary: "
                 f"{_metadata_value(boundary, 'basis')}"
             ),
@@ -178,6 +211,10 @@ def _render_replay_quality_metadata(metadata: Mapping[str, object]) -> str:
                 f"{_metadata_value(chrome, 'suppressed_paragraph_count')}"
             ),
             f"- replay_quality_webpage_chrome_suppressed_reasons: {reason_text}",
+            (
+                "- replay_quality_deterministic_cleanup_scope: "
+                f"{_metadata_value(cleanup, 'scope')}"
+            ),
             (
                 "- replay_quality_metadata_json: "
                 f"{json.dumps(dict(metadata), sort_keys=True, separators=(',', ':'))}"
@@ -193,3 +230,44 @@ def _mapping_value(metadata: Mapping[str, object], key: str) -> Mapping[str, obj
 
 def _metadata_value(metadata: Mapping[str, object], key: str) -> object:
     return metadata.get(key, "")
+
+
+def _build_public_webpage_replay_classification(
+    metadata: Mapping[str, object],
+) -> dict[str, object]:
+    profile = _mapping_value(metadata, "content_profile")
+    chrome = _mapping_value(metadata, "page_chrome_suppression")
+    retained_character_count = _int_metadata_value(profile, "retained_character_count")
+    known_limitation_codes = [
+        "public_webpage_visible_text_extraction_requires_source_review",
+        "links_images_tables_comments_and_publication_metadata_may_be_incomplete",
+    ]
+    intentionally_retained_markers: list[str] = []
+    if retained_character_count:
+        known_limitation_codes.append("article_body_text_is_retained_not_summarized")
+        intentionally_retained_markers.append(
+            "article_body_text_retained_intentionally_for_review"
+        )
+    else:
+        known_limitation_codes.append("no_article_body_text_retained_after_cleanup")
+
+    return build_public_source_replay_classification(
+        source_type="public_webpage",
+        retained_content_units=retained_character_count,
+        retained_content_unit="retained_visible_text_character",
+        deterministic_cleanup_counts_by_category={
+            "page_chrome_paragraphs_suppressed": _int_metadata_value(
+                chrome, "suppressed_paragraph_count"
+            ),
+        },
+        remaining_artifact_counts_by_category={
+            "reported_remaining_webpage_chrome_artifacts": 0,
+        },
+        known_limitation_codes=known_limitation_codes,
+        intentionally_retained_markers=intentionally_retained_markers,
+    )
+
+
+def _int_metadata_value(metadata: Mapping[str, object], key: str) -> int:
+    value = metadata.get(key, 0)
+    return value if isinstance(value, int) else 0

--- a/src/knowledge_adapters/replay_quality.py
+++ b/src/knowledge_adapters/replay_quality.py
@@ -1,0 +1,120 @@
+"""Shared replay-quality classification helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+PUBLIC_SOURCE_REVIEW_BLOCKER = "public_source_candidate_requires_human_retention_review"
+
+
+def build_public_source_replay_classification(
+    *,
+    source_type: str,
+    retained_content_units: int,
+    retained_content_unit: str,
+    deterministic_cleanup_counts_by_category: Mapping[str, int],
+    remaining_artifact_counts_by_category: Mapping[str, int],
+    known_limitation_codes: Sequence[str],
+    intentionally_retained_markers: Sequence[str],
+    promotion_blocker_codes: Sequence[str] = (PUBLIC_SOURCE_REVIEW_BLOCKER,),
+) -> dict[str, object]:
+    """Build a stable, cross-source replay classification for public candidates."""
+    cleanup_counts = _ordered_count_mapping(deterministic_cleanup_counts_by_category)
+    remaining_counts = _ordered_count_mapping(remaining_artifact_counts_by_category)
+    deterministic_cleanup_count = sum(cleanup_counts.values())
+    remaining_artifact_count = sum(remaining_counts.values())
+    has_retained_content = retained_content_units > 0
+    operational_state = "review-ready" if has_retained_content else "diagnostic-only"
+    promotion_blockers = list(dict.fromkeys(promotion_blocker_codes))
+    if not has_retained_content:
+        promotion_blockers.append("no_retained_content")
+    promotion_state = "unsafe-to-promote" if promotion_blockers else "promotion-capable"
+
+    return {
+        "schema_version": 1,
+        "source_type": source_type,
+        "operational_state": operational_state,
+        "promotion_state": promotion_state,
+        "classification_labels": [operational_state, promotion_state],
+        "state_reason_codes": _state_reason_codes(
+            has_retained_content=has_retained_content,
+            remaining_artifact_count=remaining_artifact_count,
+        ),
+        "reviewability_assessment": {
+            "review_worth_doing": has_retained_content,
+            "review_effort": _review_effort(
+                has_retained_content=has_retained_content,
+                retained_content_units=retained_content_units,
+                remaining_artifact_count=remaining_artifact_count,
+            ),
+            "bounded_review_economics": _has_bounded_review_economics(
+                has_retained_content=has_retained_content,
+                retained_content_units=retained_content_units,
+                remaining_artifact_count=remaining_artifact_count,
+            ),
+            "retained_content_units": retained_content_units,
+            "retained_content_unit": retained_content_unit,
+            "deterministic_cleanup_count": deterministic_cleanup_count,
+            "remaining_artifact_count": remaining_artifact_count,
+        },
+        "deterministic_cleanup": {
+            "scope": "bounded_deterministic_only",
+            "counts_by_category": cleanup_counts,
+        },
+        "remaining_artifacts": {
+            "total_count": remaining_artifact_count,
+            "counts_by_category": remaining_counts,
+        },
+        "known_limitation_codes": list(known_limitation_codes),
+        "intentional_retention": {
+            "markers": list(intentionally_retained_markers),
+        },
+        "promotion_safety": {
+            "promotion_capable": promotion_state == "promotion-capable",
+            "blocker_codes": promotion_blockers,
+        },
+    }
+
+
+def _state_reason_codes(
+    *, has_retained_content: bool, remaining_artifact_count: int
+) -> list[str]:
+    if not has_retained_content:
+        return ["no_retained_content"]
+    if remaining_artifact_count:
+        return ["retained_content_with_reported_remaining_artifacts"]
+    return ["retained_content_with_no_reported_artifacts"]
+
+
+def _review_effort(
+    *,
+    has_retained_content: bool,
+    retained_content_units: int,
+    remaining_artifact_count: int,
+) -> str:
+    if not has_retained_content:
+        return "not_useful"
+    if remaining_artifact_count == 0:
+        return "bounded"
+    if remaining_artifact_count <= _focused_review_threshold(retained_content_units):
+        return "focused"
+    return "extended"
+
+
+def _has_bounded_review_economics(
+    *,
+    has_retained_content: bool,
+    retained_content_units: int,
+    remaining_artifact_count: int,
+) -> bool:
+    if not has_retained_content:
+        return False
+    return remaining_artifact_count <= _focused_review_threshold(retained_content_units)
+
+
+def _focused_review_threshold(retained_content_units: int) -> int:
+    return max(5, retained_content_units // 20)
+
+
+def _ordered_count_mapping(counts: Mapping[str, int]) -> dict[str, int]:
+    return {key: max(0, int(counts[key])) for key in sorted(counts)}

--- a/tests/fixtures/public_pdf/dora_regression_cases.json
+++ b/tests/fixtures/public_pdf/dora_regression_cases.json
@@ -494,6 +494,57 @@
       "expected_markdown_metadata_lines": [
         "- replay_quality_one_letter_line_wrap_repair_count: 0"
       ]
+    },
+    {
+      "id": "empty_extraction_diagnostic_only",
+      "description": "A sanitized public PDF replay shape with no extracted text is classified as diagnostic-only and unsafe to promote.",
+      "expectation": "unchanged",
+      "tags": ["required_case", "review_classification", "empty_extraction"],
+      "raw_pages": [
+        "",
+        ""
+      ],
+      "expected_pages": [
+        "",
+        ""
+      ],
+      "expected_metadata": {
+        "page_count_context": {
+          "page_count": 2,
+          "pages_with_extracted_text_count": 0,
+          "empty_page_count": 2
+        },
+        "replay_classification": {
+          "operational_state": "diagnostic-only",
+          "promotion_state": "unsafe-to-promote",
+          "state_reason_codes": ["no_retained_content"],
+          "reviewability_assessment": {
+            "review_worth_doing": false,
+            "review_effort": "not_useful",
+            "bounded_review_economics": false
+          },
+          "promotion_safety": {
+            "promotion_capable": false,
+            "blocker_codes": [
+              "public_source_candidate_requires_human_retention_review",
+              "empty_pages_without_extracted_text",
+              "no_retained_content"
+            ]
+          }
+        },
+        "extraction_warnings": [
+          "pdf_layout_tables_figures_footnotes_headers_reading_order_may_be_incomplete",
+          "scanned_image_only_pages_may_be_missing",
+          "empty_pages_without_extracted_text"
+        ]
+      },
+      "expected_markdown_metadata_lines": [
+        "- replay_quality_operational_state: diagnostic-only",
+        "- replay_quality_promotion_state: unsafe-to-promote",
+        "- replay_quality_review_effort: not_useful",
+        "- replay_quality_bounded_review_economics: False",
+        "- replay_quality_empty_page_count: 2"
+      ]
     }
   ]
 }

--- a/tests/fixtures/public_webpage/article_chrome_cases.json
+++ b/tests/fixtures/public_webpage/article_chrome_cases.json
@@ -31,8 +31,53 @@
       },
       "expected_markdown_metadata_lines": [
         "- replay_quality_metadata_note: informational only; does not authorize retention or promotion",
+        "- replay_quality_operational_state: review-ready",
+        "- replay_quality_promotion_state: unsafe-to-promote",
+        "- replay_quality_review_effort: bounded",
         "- replay_quality_webpage_chrome_suppressed_paragraph_count: 11",
         "- replay_quality_webpage_article_body_text_retained_for_review: True"
+      ]
+    },
+    {
+      "id": "chrome_only_diagnostic_replay",
+      "description": "A sanitized page shape with only known chrome is classified as diagnostic-only because no reviewable source text remains.",
+      "raw_content": "Subscribe Sign in\n\nShare\n\nReady for more?\n\nSubscribe\n\n© 2026 Example Author · Privacy ∙ Terms ∙ Collection notice",
+      "expected_content": "",
+      "expected_metadata": {
+        "page_chrome_suppression": {
+          "activity": "suppressed",
+          "suppressed_paragraph_count": 5,
+          "suppressed_reasons_by_code": {
+            "subscription_sign_in_prompt": 1,
+            "share_prompt": 1,
+            "subscription_prompt": 2,
+            "footer_legal_text": 1
+          }
+        },
+        "replay_classification": {
+          "operational_state": "diagnostic-only",
+          "promotion_state": "unsafe-to-promote",
+          "state_reason_codes": ["no_retained_content"],
+          "reviewability_assessment": {
+            "review_worth_doing": false,
+            "review_effort": "not_useful",
+            "bounded_review_economics": false
+          },
+          "promotion_safety": {
+            "promotion_capable": false,
+            "blocker_codes": [
+              "public_source_candidate_requires_human_retention_review",
+              "no_retained_content"
+            ]
+          }
+        }
+      },
+      "expected_markdown_metadata_lines": [
+        "- replay_quality_operational_state: diagnostic-only",
+        "- replay_quality_promotion_state: unsafe-to-promote",
+        "- replay_quality_review_effort: not_useful",
+        "- replay_quality_bounded_review_economics: False",
+        "- replay_quality_webpage_chrome_suppressed_paragraph_count: 5"
       ]
     }
   ]

--- a/tests/test_public_pdf_dora_regression_fixtures.py
+++ b/tests/test_public_pdf_dora_regression_fixtures.py
@@ -34,6 +34,7 @@ REQUIRED_CASE_IDS = {
     "dora_2023_large_repeated_title_version_footer",
     "one_letter_split_word_lines",
     "standalone_one_letter_lines",
+    "empty_extraction_diagnostic_only",
 }
 
 
@@ -131,10 +132,23 @@ def test_dora_regression_replay_quality_metadata_contract(
         ),
         "empty_page_count": len([page for page in normalized_pages if not page.strip()]),
     }
-    assert metadata["extraction_warnings"] == [
+    expected_warnings = [
         "pdf_layout_tables_figures_footnotes_headers_reading_order_may_be_incomplete",
         "scanned_image_only_pages_may_be_missing",
     ]
+    if not any(page.strip() for page in normalized_pages):
+        expected_warnings.append("empty_pages_without_extracted_text")
+    assert metadata["extraction_warnings"] == expected_warnings
+    classification = _mapping(metadata, "replay_classification")
+    reviewability = _mapping(classification, "reviewability_assessment")
+    promotion_safety = _mapping(classification, "promotion_safety")
+    assert classification["source_type"] == "public_pdf"
+    assert classification["operational_state"] in {"review-ready", "diagnostic-only"}
+    assert classification["promotion_state"] == "unsafe-to-promote"
+    assert reviewability["review_worth_doing"] == any(
+        page.strip() for page in normalized_pages
+    )
+    assert promotion_safety["promotion_capable"] is False
 
     markdown = normalize_pdf(
         {
@@ -147,6 +161,7 @@ def test_dora_regression_replay_quality_metadata_contract(
         }
     )
     assert "- candidate_status: unreviewed" in markdown
+    assert "- replay_quality_promotion_state: unsafe-to-promote" in markdown
     for expected_line in _optional_string_sequence(
         case, "expected_markdown_metadata_lines"
     ):

--- a/tests/test_public_sources.py
+++ b/tests/test_public_sources.py
@@ -470,6 +470,21 @@ def test_public_pdf_page_normalization_reports_replay_quality_metadata() -> None
         "possible_artifact_line_count": 1,
         "possible_artifact_line_ratio": "0.250",
     }
+    classification = _metadata_mapping(first_metadata, "replay_classification")
+    reviewability = _metadata_mapping(classification, "reviewability_assessment")
+    promotion_safety = _metadata_mapping(classification, "promotion_safety")
+    assert classification["operational_state"] == "review-ready"
+    assert classification["promotion_state"] == "unsafe-to-promote"
+    assert classification["classification_labels"] == [
+        "review-ready",
+        "unsafe-to-promote",
+    ]
+    assert reviewability["review_worth_doing"] is True
+    assert reviewability["deterministic_cleanup_count"] == 6
+    assert reviewability["remaining_artifact_count"] == 1
+    assert promotion_safety["blocker_codes"] == [
+        "public_source_candidate_requires_human_retention_review"
+    ]
 
     markdown = normalize_pdf(
         {
@@ -488,6 +503,10 @@ def test_public_pdf_page_normalization_reports_replay_quality_metadata() -> None
         "or promotion"
     ) in markdown
     assert "- replay_quality_url_spacing_normalization_count: 1" in markdown
+    assert "- replay_quality_operational_state: review-ready" in markdown
+    assert "- replay_quality_promotion_state: unsafe-to-promote" in markdown
+    assert "- replay_quality_review_effort: focused" in markdown
+    assert "- replay_quality_remaining_artifact_count: 1" in markdown
     assert "- replay_quality_url_path_line_wrap_repair_count: 1" in markdown
     assert "- replay_quality_repeated_footer_suppressed_line_count: 4" in markdown
     assert (

--- a/tests/test_public_webpage_chrome_fixtures.py
+++ b/tests/test_public_webpage_chrome_fixtures.py
@@ -35,12 +35,14 @@ ARTICLE_CHROME_CASES = _load_fixture_cases()
 def test_public_webpage_article_chrome_fixture_area_is_present() -> None:
     case_ids = {str(case["id"]) for case in ARTICLE_CHROME_CASES}
 
-    assert case_ids == {"article_body_plus_substack_chrome"}
+    assert case_ids == {
+        "article_body_plus_substack_chrome",
+        "chrome_only_diagnostic_replay",
+    }
 
 
 def test_public_webpage_chrome_suppression_keeps_article_body_with_metadata() -> None:
-    case = ARTICLE_CHROME_CASES[0]
-
+    case = _case_by_id("article_body_plus_substack_chrome")
     content, metadata = normalize_extracted_text_with_replay_metadata(
         str(case["raw_content"])
     )
@@ -69,6 +71,31 @@ def test_public_webpage_chrome_suppression_keeps_article_body_with_metadata() ->
     assert "Privacy" not in markdown_content
 
 
+def test_public_webpage_chrome_only_fixture_is_diagnostic_only() -> None:
+    case = _case_by_id("chrome_only_diagnostic_replay")
+
+    content, metadata = normalize_extracted_text_with_replay_metadata(
+        str(case["raw_content"])
+    )
+
+    assert content == ""
+    _assert_metadata_contains(metadata, _mapping(case, "expected_metadata"))
+
+    markdown = normalize_to_markdown(
+        {
+            "title": "Chrome Only",
+            "canonical_id": "fixture://chrome-only",
+            "source_url": "fixture://chrome-only",
+            "fetched_at": "2026-05-13T12:00:00Z",
+            "content": content,
+            "replay_quality_metadata": metadata,
+        }
+    )
+
+    for expected_line in _string_sequence(case, "expected_markdown_metadata_lines"):
+        assert expected_line in markdown
+
+
 def _assert_metadata_contains(
     actual: Mapping[str, object],
     expected: Mapping[str, object],
@@ -92,6 +119,13 @@ def _mapping(case: Mapping[str, object], key: str) -> Mapping[str, object]:
     value = case[key]
     assert isinstance(value, Mapping)
     return cast(Mapping[str, object], value)
+
+
+def _case_by_id(case_id: str) -> Mapping[str, object]:
+    for case in ARTICLE_CHROME_CASES:
+        if case["id"] == case_id:
+            return case
+    raise AssertionError(f"Unknown public webpage fixture case: {case_id}")
 
 
 def _string_sequence(case: Mapping[str, object], key: str) -> list[str]:


### PR DESCRIPTION
## Summary
- add a shared public-source replay classification block with operational state, promotion safety, reviewability, bounded cleanup counts, remaining-artifact counters, known limitations, and intentional-retention markers
- wire the classification into public PDF and public webpage replay-quality metadata, candidate markdown, manifest metadata, and CLI replay-quality summaries
- add sanitized diagnostic fixtures for empty public PDF extraction and chrome-only public webpage extraction, while preserving existing DORA and MeaningfulTech fixture behavior

## Root-cause observations
- Public-source replay outputs already had useful cleanup diagnostics, but reviewers still had to infer whether an output was diagnostic-only, worth reviewing, or obviously unsafe to promote.
- PDF and webpage replay metadata described different local details but did not share a normalized operational classification surface.
- Existing cleanup is intentionally bounded; the missing piece was making retained uncertainty and promotion blockers explicit rather than adding broader suppression heuristics.

## New replay-quality/reporting behavior
- `replay_classification.operational_state` reports `review-ready` when retained content exists and `diagnostic-only` when no reviewable content remains.
- `replay_classification.promotion_state` remains `unsafe-to-promote` for unreviewed public-source candidates because human retention/source review is still required.
- `reviewability_assessment` reports whether review is worth doing, the review effort bucket, bounded-review-economics boolean, deterministic cleanup count, and remaining artifact count.
- `deterministic_cleanup`, `remaining_artifacts`, `known_limitation_codes`, `intentional_retention`, and `promotion_safety` make cleanup boundaries, retained uncertainty, and blockers auditable in both candidate markdown and manifest metadata.

## Fixtures
- Public PDF: added `empty_extraction_diagnostic_only` to classify empty extraction as `diagnostic-only` and `unsafe-to-promote` with empty-page warnings.
- Public webpage: added `chrome_only_diagnostic_replay` to classify chrome-only extraction as `diagnostic-only` and not worth review.
- Existing DORA-derived PDF fixtures and the MeaningfulTech-style webpage fixture now assert the shared classification surface without broadening cleanup behavior.

## Live-source observations
- MeaningfulTech webpage: `review-ready`, `unsafe-to-promote`, `bounded`; retained 17,683 visible-text characters, suppressed 12 chrome paragraphs, 0 reported remaining chrome artifacts.
- DORA 2023 PDF: `review-ready`, `unsafe-to-promote`, `focused`; 95 pages, 294 deterministic cleanup actions, 174 remaining reported artifacts, no empty pages.
- DORA ROI 2026 PDF: `review-ready`, `unsafe-to-promote`, `focused`; 60 pages, 199 deterministic cleanup actions, 84 remaining reported artifacts, no empty pages, 110 footer lines suppressed while retaining reported uncertainty.

## Non-regression evidence
- DORA ROI 2026 replay still reports bounded footer suppression with retained uncertainty rather than broader cleanup.
- DORA 2023 replay still has complete extracted page coverage and reports remaining layout/numeric artifacts instead of hiding them.
- MeaningfulTech webpage remains review-ready with deterministic chrome suppression and full article text retained for review.

## Out of scope
- No retention policy.
- No auto-promotion.
- No summarizer.
- No aggressive broadening of suppression heuristics.

## Validation
- `make check` passed: 515 tests passed.
- `git diff --check` passed.
