### PR TITLE
Add public replay acceptance checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ knowledge-adapters --help
 knowledge-adapters local_files --help
 knowledge-adapters public_webpage --help
 knowledge-adapters public_pdf --help
+knowledge-adapters public_replay_acceptance --help
 knowledge-adapters confluence --help
 ```
 
@@ -154,6 +155,14 @@ normalization and replay-quality metadata in `knowledge-adapters`, and reserve
 knowledge-vault replay for milestone or integration validation. See
 `docs/public-pdf-dora-regression-fixtures.md` for when full replay validation is
 still required.
+
+Known public-source shapes also have a local replay acceptance contract. Run
+`knowledge-adapters public_replay_acceptance` as an intentional live milestone
+check before returning to knowledge-vault replay; it reports whether DORA 2023,
+MeaningfulTech, and DORA ROI 2026 still match expected classification,
+reviewability, cleanup, remaining-artifact, limitation, retention, and promotion
+blocker ranges. The deterministic fixture-backed contract is documented in
+`docs/public-source-replay-acceptance.md`.
 
 Recommended Confluence first run:
 

--- a/docs/public-source-replay-acceptance.md
+++ b/docs/public-source-replay-acceptance.md
@@ -1,0 +1,68 @@
+# Public Source Replay Acceptance
+
+This note defines the local acceptance contract for known public-source replay
+shapes before returning to knowledge-vault replay.
+
+The goal is not perfect extraction. The goal is for `knowledge-adapters` to
+assert that the known public-source shapes are behaving predictably enough that
+knowledge-vault replay can be used as confirmation and provenance, not as the
+primary discovery loop.
+
+## Known Sources
+
+The current acceptance contract covers:
+
+- DORA 2023 public PDF
+- MeaningfulTech webpage
+- DORA ROI 2026 public PDF non-regression
+
+Each source has a stable source key in
+`knowledge_adapters.public_replay_acceptance` and a deterministic fixture in
+`tests/fixtures/public_replay_acceptance/source_acceptance_metadata.json`.
+
+## Contract Shape
+
+Each known source asserts:
+
+- replay classification, including `review-ready` vs `diagnostic-only`
+- promotion state and promotion blockers
+- reviewability assessment, including bounded review economics
+- deterministic cleanup counts or ranges
+- remaining artifact counts or ranges
+- known limitation codes
+- intentional-retention markers
+
+The numeric checks intentionally use bounded ranges, not exact hashes. They
+should fail when expected cleanup disappears, remaining artifacts regress
+sharply, or a source shape changes enough that review economics are no longer
+trusted.
+
+## Report Surface
+
+Use the live milestone check intentionally:
+
+```bash
+knowledge-adapters public_replay_acceptance
+```
+
+To check one source:
+
+```bash
+knowledge-adapters public_replay_acceptance --source dora_2023_public_pdf
+knowledge-adapters public_replay_acceptance --source meaningfultech_webpage
+knowledge-adapters public_replay_acceptance --source dora_roi_2026_public_pdf
+```
+
+The command prints one `stable` or `unexpected` section per source with the
+observed acceptance metrics and expected ranges. It returns nonzero when any
+known source violates the local contract.
+
+This command fetches live public sources and is not part of `make check`.
+Canonical local validation remains deterministic and fixture-backed.
+
+## Non-Goals
+
+This acceptance contract does not implement retention policy, auto-promotion,
+summarization, or broader cleanup heuristics. Public-source candidates remain
+unreviewed and `unsafe-to-promote` until a human retention/source review
+decision is made outside this adapter.

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -29,6 +29,13 @@ from knowledge_adapters.bundle import (
 )
 from knowledge_adapters.confluence.auth import SUPPORTED_AUTH_METHODS, resolve_tls_inputs
 from knowledge_adapters.failures import adapter_failure_lines, response_or_config_failure
+from knowledge_adapters.public_replay_acceptance import (
+    evaluate_public_source_replay_acceptance,
+    known_public_source_replay_acceptance_specs,
+    public_source_replay_acceptance_keys,
+    public_source_replay_acceptance_spec,
+    render_public_source_replay_acceptance_report,
+)
 from knowledge_adapters.run_report import (
     RunReportRecord,
     SkippedRunRecord,
@@ -42,6 +49,7 @@ TOP_LEVEL_HELP_EXAMPLES = """First steps:
   knowledge-adapters local_files --help
   knowledge-adapters public_webpage --help
   knowledge-adapters public_pdf --help
+  knowledge-adapters public_replay_acceptance --help
   knowledge-adapters git_repo --help
   knowledge-adapters github_metadata --help
   knowledge-adapters confluence --help
@@ -116,6 +124,13 @@ PUBLIC_PDF_HELP_EXAMPLES = (
     "2023-dora-accelerate-state-of-devops-report.pdf \\\n"
     "    --output-dir ./artifacts/public-pdf/dora-2023\n"
 )
+
+PUBLIC_REPLAY_ACCEPTANCE_HELP_EXAMPLES = """Examples:
+  knowledge-adapters public_replay_acceptance
+  knowledge-adapters public_replay_acceptance --source dora_2023_public_pdf
+  knowledge-adapters public_replay_acceptance --source meaningfultech_webpage
+  knowledge-adapters public_replay_acceptance --source dora_roi_2026_public_pdf
+"""
 
 GIT_REPO_HELP_EXAMPLES = """Examples:
   knowledge-adapters git_repo \\
@@ -810,6 +825,26 @@ def build_parser() -> argparse.ArgumentParser:
             "Fetch and extract the source, then preview artifact path, manifest path, "
             "extraction limitations, and normalized candidate markdown without writing files."
         ),
+    )
+
+    public_replay_acceptance_parser = subparsers.add_parser(
+        "public_replay_acceptance",
+        help="Check known public-source replay acceptance contracts.",
+        description=(
+            "Fetch known public-source replay shapes and compare their replay-quality "
+            "metadata against the local acceptance contract. This command is an "
+            "intentional live-source milestone check; it is not part of make check and "
+            "does not write artifacts or modify retention state."
+        ),
+        epilog=PUBLIC_REPLAY_ACCEPTANCE_HELP_EXAMPLES,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    add_verbose_argument(public_replay_acceptance_parser)
+    public_replay_acceptance_parser.add_argument(
+        "--source",
+        choices=("all", *public_source_replay_acceptance_keys()),
+        default="all",
+        help="Known public source to check, or all configured known sources.",
     )
 
     git_repo_parser = subparsers.add_parser(
@@ -3480,6 +3515,39 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"Manifest path: {render_user_path(manifest)}")
         print_write_complete(output_dir)
         return 0
+
+    if args.command == "public_replay_acceptance":
+        source = str(args.source)
+        specs = (
+            known_public_source_replay_acceptance_specs()
+            if source == "all"
+            else (public_source_replay_acceptance_spec(source),)
+        )
+        results = []
+        for spec in specs:
+            try:
+                if spec.source_type == "public_pdf":
+                    from knowledge_adapters.public_pdf.client import fetch_pdf
+
+                    metadata = fetch_pdf(spec.url).replay_quality_metadata
+                elif spec.source_type == "public_webpage":
+                    from knowledge_adapters.public_webpage.client import fetch_webpage
+
+                    metadata = fetch_webpage(spec.url).replay_quality_metadata
+                else:
+                    exit_with_cli_error(
+                        f"Unsupported public replay acceptance source type: {spec.source_type}",
+                        command="public_replay_acceptance",
+                    )
+            except ValueError as exc:
+                exit_with_cli_error(str(exc), command="public_replay_acceptance")
+            results.append(
+                evaluate_public_source_replay_acceptance(spec.source_key, metadata)
+            )
+
+        report = render_public_source_replay_acceptance_report(results)
+        print(report)
+        return 0 if all(result.stable for result in results) else 1
 
     if args.command in {"public_webpage", "public_pdf"}:
         import hashlib

--- a/src/knowledge_adapters/public_replay_acceptance.py
+++ b/src/knowledge_adapters/public_replay_acceptance.py
@@ -1,0 +1,656 @@
+"""Replay acceptance contracts for known public-source shapes."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+DORA_2023_PDF_URL = (
+    "https://dora.dev/research/2023/dora-report/"
+    "2023-dora-accelerate-state-of-devops-report.pdf"
+)
+DORA_ROI_2026_PDF_URL = (
+    "https://services.google.com/fh/files/misc/"
+    "dora-roi-of-ai-assisted-software-development-2026.pdf"
+)
+MEANINGFULTECH_URL = "https://meaningfultech.com/p/the-vibe-coding-illusion-why-faster"
+
+
+@dataclass(frozen=True)
+class NumericRangeExpectation:
+    """Expected numeric range for one replay-quality metadata path."""
+
+    label: str
+    path: tuple[str, ...]
+    minimum: int
+    maximum: int
+
+
+@dataclass(frozen=True)
+class PublicSourceReplayAcceptanceSpec:
+    """Stable acceptance contract for one known public source shape."""
+
+    source_key: str
+    label: str
+    source_type: str
+    url: str
+    expected_operational_state: str
+    expected_promotion_state: str
+    expected_review_effort: str
+    expected_review_worth_doing: bool
+    expected_bounded_review_economics: bool
+    numeric_ranges: tuple[NumericRangeExpectation, ...]
+    required_known_limitation_codes: tuple[str, ...]
+    required_intentional_retention_markers: tuple[str, ...]
+    required_promotion_blocker_codes: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class PublicSourceReplayAcceptanceResult:
+    """Evaluation result for one known public-source replay acceptance spec."""
+
+    source_key: str
+    label: str
+    source_type: str
+    url: str
+    stable: bool
+    failures: tuple[str, ...]
+    summary_lines: tuple[str, ...]
+
+
+class PublicReplayAcceptanceError(ValueError):
+    """Raised when replay metadata does not satisfy a known-source contract."""
+
+
+KNOWN_PUBLIC_SOURCE_REPLAY_ACCEPTANCE_SPECS = (
+    PublicSourceReplayAcceptanceSpec(
+        source_key="dora_2023_public_pdf",
+        label="DORA 2023 public PDF",
+        source_type="public_pdf",
+        url=DORA_2023_PDF_URL,
+        expected_operational_state="review-ready",
+        expected_promotion_state="unsafe-to-promote",
+        expected_review_effort="focused",
+        expected_review_worth_doing=True,
+        expected_bounded_review_economics=True,
+        numeric_ranges=(
+            NumericRangeExpectation(
+                "retained normalized text lines",
+                (
+                    "replay_classification",
+                    "reviewability_assessment",
+                    "retained_content_units",
+                ),
+                3800,
+                5000,
+            ),
+            NumericRangeExpectation(
+                "deterministic cleanup count",
+                (
+                    "replay_classification",
+                    "reviewability_assessment",
+                    "deterministic_cleanup_count",
+                ),
+                250,
+                340,
+            ),
+            NumericRangeExpectation(
+                "remaining artifact count",
+                (
+                    "replay_classification",
+                    "reviewability_assessment",
+                    "remaining_artifact_count",
+                ),
+                100,
+                260,
+            ),
+            NumericRangeExpectation(
+                "URL spacing normalizations",
+                (
+                    "replay_classification",
+                    "deterministic_cleanup",
+                    "counts_by_category",
+                    "url_spacing_normalizations",
+                ),
+                70,
+                110,
+            ),
+            NumericRangeExpectation(
+                "URL path line-wrap repairs",
+                (
+                    "replay_classification",
+                    "deterministic_cleanup",
+                    "counts_by_category",
+                    "url_path_line_wrap_repairs",
+                ),
+                3,
+                12,
+            ),
+            NumericRangeExpectation(
+                "one-letter line-wrap repairs",
+                (
+                    "replay_classification",
+                    "deterministic_cleanup",
+                    "counts_by_category",
+                    "one_letter_line_wrap_repairs",
+                ),
+                15,
+                40,
+            ),
+            NumericRangeExpectation(
+                "high-coverage text footer lines suppressed",
+                (
+                    "replay_classification",
+                    "deterministic_cleanup",
+                    "counts_by_category",
+                    "repeated_text_footer_lines_suppressed",
+                ),
+                150,
+                210,
+            ),
+            NumericRangeExpectation(
+                "anchored footer lines suppressed",
+                (
+                    "replay_classification",
+                    "deterministic_cleanup",
+                    "counts_by_category",
+                    "repeated_footer_lines_suppressed",
+                ),
+                0,
+                10,
+            ),
+            NumericRangeExpectation(
+                "possible layout artifact lines",
+                (
+                    "replay_classification",
+                    "remaining_artifacts",
+                    "counts_by_category",
+                    "possible_layout_artifact_lines",
+                ),
+                80,
+                160,
+            ),
+            NumericRangeExpectation(
+                "numeric content risk lines",
+                (
+                    "replay_classification",
+                    "remaining_artifacts",
+                    "counts_by_category",
+                    "bare_numeric_lines_adjacent_to_numeric_content",
+                ),
+                5,
+                30,
+            ),
+            NumericRangeExpectation(
+                "mid-page footer-like lines",
+                (
+                    "replay_classification",
+                    "remaining_artifacts",
+                    "counts_by_category",
+                    "mid_page_footer_like_lines",
+                ),
+                10,
+                35,
+            ),
+            NumericRangeExpectation(
+                "skipped adjacent numeric lines",
+                (
+                    "replay_classification",
+                    "remaining_artifacts",
+                    "counts_by_category",
+                    "repeated_text_footer_skipped_adjacent_numeric_lines",
+                ),
+                15,
+                45,
+            ),
+        ),
+        required_known_limitation_codes=(
+            "pdf_layout_tables_figures_footnotes_headers_reading_order_may_be_incomplete",
+            "scanned_image_only_pages_may_be_missing",
+            "public_pdf_full_text_extraction_requires_source_review",
+        ),
+        required_intentional_retention_markers=(
+            "full_text_extraction_retained_intentionally_for_review",
+            "uncertain_extraction_artifacts_retained_for_review",
+        ),
+        required_promotion_blocker_codes=(
+            "public_source_candidate_requires_human_retention_review",
+        ),
+    ),
+    PublicSourceReplayAcceptanceSpec(
+        source_key="meaningfultech_webpage",
+        label="MeaningfulTech webpage",
+        source_type="public_webpage",
+        url=MEANINGFULTECH_URL,
+        expected_operational_state="review-ready",
+        expected_promotion_state="unsafe-to-promote",
+        expected_review_effort="bounded",
+        expected_review_worth_doing=True,
+        expected_bounded_review_economics=True,
+        numeric_ranges=(
+            NumericRangeExpectation(
+                "retained visible-text characters",
+                (
+                    "replay_classification",
+                    "reviewability_assessment",
+                    "retained_content_units",
+                ),
+                15000,
+                22000,
+            ),
+            NumericRangeExpectation(
+                "deterministic cleanup count",
+                (
+                    "replay_classification",
+                    "reviewability_assessment",
+                    "deterministic_cleanup_count",
+                ),
+                8,
+                20,
+            ),
+            NumericRangeExpectation(
+                "remaining artifact count",
+                (
+                    "replay_classification",
+                    "reviewability_assessment",
+                    "remaining_artifact_count",
+                ),
+                0,
+                2,
+            ),
+            NumericRangeExpectation(
+                "page chrome paragraphs suppressed",
+                (
+                    "replay_classification",
+                    "deterministic_cleanup",
+                    "counts_by_category",
+                    "page_chrome_paragraphs_suppressed",
+                ),
+                8,
+                20,
+            ),
+        ),
+        required_known_limitation_codes=(
+            "public_webpage_visible_text_extraction_requires_source_review",
+            "links_images_tables_comments_and_publication_metadata_may_be_incomplete",
+            "article_body_text_is_retained_not_summarized",
+        ),
+        required_intentional_retention_markers=(
+            "article_body_text_retained_intentionally_for_review",
+        ),
+        required_promotion_blocker_codes=(
+            "public_source_candidate_requires_human_retention_review",
+        ),
+    ),
+    PublicSourceReplayAcceptanceSpec(
+        source_key="dora_roi_2026_public_pdf",
+        label="DORA ROI 2026 public PDF",
+        source_type="public_pdf",
+        url=DORA_ROI_2026_PDF_URL,
+        expected_operational_state="review-ready",
+        expected_promotion_state="unsafe-to-promote",
+        expected_review_effort="focused",
+        expected_review_worth_doing=True,
+        expected_bounded_review_economics=True,
+        numeric_ranges=(
+            NumericRangeExpectation(
+                "retained normalized text lines",
+                (
+                    "replay_classification",
+                    "reviewability_assessment",
+                    "retained_content_units",
+                ),
+                2800,
+                3600,
+            ),
+            NumericRangeExpectation(
+                "deterministic cleanup count",
+                (
+                    "replay_classification",
+                    "reviewability_assessment",
+                    "deterministic_cleanup_count",
+                ),
+                170,
+                230,
+            ),
+            NumericRangeExpectation(
+                "remaining artifact count",
+                (
+                    "replay_classification",
+                    "reviewability_assessment",
+                    "remaining_artifact_count",
+                ),
+                50,
+                130,
+            ),
+            NumericRangeExpectation(
+                "anchored footer lines suppressed",
+                (
+                    "replay_classification",
+                    "deterministic_cleanup",
+                    "counts_by_category",
+                    "repeated_footer_lines_suppressed",
+                ),
+                100,
+                120,
+            ),
+            NumericRangeExpectation(
+                "URL spacing normalizations",
+                (
+                    "replay_classification",
+                    "deterministic_cleanup",
+                    "counts_by_category",
+                    "url_spacing_normalizations",
+                ),
+                70,
+                100,
+            ),
+            NumericRangeExpectation(
+                "URL path line-wrap repairs",
+                (
+                    "replay_classification",
+                    "deterministic_cleanup",
+                    "counts_by_category",
+                    "url_path_line_wrap_repairs",
+                ),
+                4,
+                12,
+            ),
+            NumericRangeExpectation(
+                "nonparseable adjacent numeric lines",
+                (
+                    "replay_classification",
+                    "remaining_artifacts",
+                    "counts_by_category",
+                    "repeated_footer_nonparseable_adjacent_numeric_lines",
+                ),
+                1,
+                3,
+            ),
+            NumericRangeExpectation(
+                "numeric-risk skipped footer lines",
+                (
+                    "replay_classification",
+                    "remaining_artifacts",
+                    "counts_by_category",
+                    "repeated_footer_numeric_risk_skipped",
+                ),
+                1,
+                3,
+            ),
+            NumericRangeExpectation(
+                "possible layout artifact lines",
+                (
+                    "replay_classification",
+                    "remaining_artifacts",
+                    "counts_by_category",
+                    "possible_layout_artifact_lines",
+                ),
+                5,
+                30,
+            ),
+            NumericRangeExpectation(
+                "numeric content risk lines",
+                (
+                    "replay_classification",
+                    "remaining_artifacts",
+                    "counts_by_category",
+                    "bare_numeric_lines_adjacent_to_numeric_content",
+                ),
+                40,
+                80,
+            ),
+            NumericRangeExpectation(
+                "mid-page footer-like lines",
+                (
+                    "replay_classification",
+                    "remaining_artifacts",
+                    "counts_by_category",
+                    "mid_page_footer_like_lines",
+                ),
+                4,
+                20,
+            ),
+        ),
+        required_known_limitation_codes=(
+            "pdf_layout_tables_figures_footnotes_headers_reading_order_may_be_incomplete",
+            "scanned_image_only_pages_may_be_missing",
+            "public_pdf_full_text_extraction_requires_source_review",
+        ),
+        required_intentional_retention_markers=(
+            "full_text_extraction_retained_intentionally_for_review",
+            "uncertain_extraction_artifacts_retained_for_review",
+        ),
+        required_promotion_blocker_codes=(
+            "public_source_candidate_requires_human_retention_review",
+        ),
+    ),
+)
+
+_SPECS_BY_KEY = {
+    spec.source_key: spec for spec in KNOWN_PUBLIC_SOURCE_REPLAY_ACCEPTANCE_SPECS
+}
+
+
+def known_public_source_replay_acceptance_specs() -> tuple[
+    PublicSourceReplayAcceptanceSpec, ...
+]:
+    """Return the stable known-source public replay acceptance specs."""
+    return KNOWN_PUBLIC_SOURCE_REPLAY_ACCEPTANCE_SPECS
+
+
+def public_source_replay_acceptance_keys() -> tuple[str, ...]:
+    """Return known public-source acceptance keys in display order."""
+    return tuple(spec.source_key for spec in KNOWN_PUBLIC_SOURCE_REPLAY_ACCEPTANCE_SPECS)
+
+
+def public_source_replay_acceptance_spec(
+    source_key: str,
+) -> PublicSourceReplayAcceptanceSpec:
+    """Return the acceptance spec for a known source key."""
+    try:
+        return _SPECS_BY_KEY[source_key]
+    except KeyError as exc:
+        known_keys = ", ".join(public_source_replay_acceptance_keys())
+        raise KeyError(
+            f"Unknown public replay acceptance source {source_key!r}: {known_keys}"
+        ) from exc
+
+
+def evaluate_public_source_replay_acceptance(
+    source_key: str,
+    replay_quality_metadata: Mapping[str, object],
+) -> PublicSourceReplayAcceptanceResult:
+    """Evaluate replay-quality metadata against a known-source acceptance contract."""
+    spec = public_source_replay_acceptance_spec(source_key)
+    failures: list[str] = []
+    summary_lines: list[str] = []
+    classification = _mapping_at(replay_quality_metadata, ("replay_classification",))
+    reviewability = _mapping_at(
+        replay_quality_metadata,
+        ("replay_classification", "reviewability_assessment"),
+    )
+    promotion_safety = _mapping_at(
+        replay_quality_metadata,
+        ("replay_classification", "promotion_safety"),
+    )
+    intentional_retention = _mapping_at(
+        replay_quality_metadata,
+        ("replay_classification", "intentional_retention"),
+    )
+
+    _expect_string(
+        failures,
+        "source type",
+        classification.get("source_type"),
+        spec.source_type,
+    )
+    _expect_string(
+        failures,
+        "operational state",
+        classification.get("operational_state"),
+        spec.expected_operational_state,
+    )
+    _expect_string(
+        failures,
+        "promotion state",
+        classification.get("promotion_state"),
+        spec.expected_promotion_state,
+    )
+    _expect_string(
+        failures,
+        "review effort",
+        reviewability.get("review_effort"),
+        spec.expected_review_effort,
+    )
+    _expect_bool(
+        failures,
+        "review worth doing",
+        reviewability.get("review_worth_doing"),
+        spec.expected_review_worth_doing,
+    )
+    _expect_bool(
+        failures,
+        "bounded review economics",
+        reviewability.get("bounded_review_economics"),
+        spec.expected_bounded_review_economics,
+    )
+
+    for expectation in spec.numeric_ranges:
+        observed = _integer_at(replay_quality_metadata, expectation.path)
+        if observed < expectation.minimum or observed > expectation.maximum:
+            failures.append(
+                f"{expectation.label}: expected {expectation.minimum}.."
+                f"{expectation.maximum}, observed {observed}"
+            )
+        summary_lines.append(
+            f"{expectation.label}: {observed} "
+            f"(expected {expectation.minimum}..{expectation.maximum})"
+        )
+
+    _expect_contains_all(
+        failures,
+        "known limitation codes",
+        _string_sequence(classification.get("known_limitation_codes")),
+        spec.required_known_limitation_codes,
+    )
+    _expect_contains_all(
+        failures,
+        "intentional-retention markers",
+        _string_sequence(intentional_retention.get("markers")),
+        spec.required_intentional_retention_markers,
+    )
+    _expect_contains_all(
+        failures,
+        "promotion blocker codes",
+        _string_sequence(promotion_safety.get("blocker_codes")),
+        spec.required_promotion_blocker_codes,
+    )
+
+    return PublicSourceReplayAcceptanceResult(
+        source_key=spec.source_key,
+        label=spec.label,
+        source_type=spec.source_type,
+        url=spec.url,
+        stable=not failures,
+        failures=tuple(failures),
+        summary_lines=tuple(summary_lines),
+    )
+
+
+def assert_public_source_replay_acceptance(
+    source_key: str,
+    replay_quality_metadata: Mapping[str, object],
+) -> PublicSourceReplayAcceptanceResult:
+    """Return the acceptance result or raise with all observed contract failures."""
+    result = evaluate_public_source_replay_acceptance(source_key, replay_quality_metadata)
+    if result.stable:
+        return result
+    failure_text = "\n".join(f"- {failure}" for failure in result.failures)
+    raise PublicReplayAcceptanceError(
+        f"{result.label} public replay acceptance failed:\n{failure_text}"
+    )
+
+
+def render_public_source_replay_acceptance_report(
+    results: Sequence[PublicSourceReplayAcceptanceResult],
+) -> str:
+    """Render a compact source-level replay acceptance report."""
+    lines = ["Public source replay acceptance"]
+    for result in results:
+        status = "stable" if result.stable else "unexpected"
+        lines.extend(
+            (
+                "",
+                f"{result.label}: {status}",
+                f"  source_key: {result.source_key}",
+                f"  source_type: {result.source_type}",
+                f"  url: {result.url}",
+            )
+        )
+        if result.failures:
+            lines.append("  unexpected_behavior:")
+            lines.extend(f"    - {failure}" for failure in result.failures)
+        lines.append("  observed_acceptance_metrics:")
+        lines.extend(f"    - {line}" for line in result.summary_lines)
+    return "\n".join(lines)
+
+
+def _mapping_at(
+    mapping: Mapping[str, object],
+    path: Sequence[str],
+) -> Mapping[str, object]:
+    value: object = mapping
+    for segment in path:
+        if not isinstance(value, Mapping):
+            return {}
+        value = value.get(segment, {})
+    return value if isinstance(value, Mapping) else {}
+
+
+def _integer_at(mapping: Mapping[str, object], path: Sequence[str]) -> int:
+    value: object = mapping
+    for segment in path:
+        if not isinstance(value, Mapping):
+            return 0
+        value = value.get(segment, 0)
+    return value if isinstance(value, int) else 0
+
+
+def _expect_string(
+    failures: list[str],
+    label: str,
+    observed: object,
+    expected: str,
+) -> None:
+    if observed != expected:
+        failures.append(f"{label}: expected {expected!r}, observed {observed!r}")
+
+
+def _expect_bool(
+    failures: list[str],
+    label: str,
+    observed: object,
+    expected: bool,
+) -> None:
+    if observed is not expected:
+        failures.append(f"{label}: expected {expected!r}, observed {observed!r}")
+
+
+def _expect_contains_all(
+    failures: list[str],
+    label: str,
+    observed: Sequence[str],
+    expected_values: Sequence[str],
+) -> None:
+    missing = [value for value in expected_values if value not in observed]
+    if missing:
+        failures.append(f"{label}: missing {', '.join(missing)}")
+
+
+def _string_sequence(value: object) -> tuple[str, ...]:
+    if isinstance(value, Sequence) and not isinstance(value, str):
+        return tuple(str(item) for item in value)
+    if value:
+        return (str(value),)
+    return ()

--- a/tests/fixtures/public_replay_acceptance/source_acceptance_metadata.json
+++ b/tests/fixtures/public_replay_acceptance/source_acceptance_metadata.json
@@ -1,0 +1,174 @@
+{
+  "schema_version": 1,
+  "source": "known_public_source_replay_acceptance_metadata",
+  "cases": [
+    {
+      "source_key": "dora_2023_public_pdf",
+      "description": "Live-observed DORA 2023 public PDF replay-quality shape after public-source replay classification.",
+      "replay_quality_metadata": {
+        "replay_classification": {
+          "source_type": "public_pdf",
+          "operational_state": "review-ready",
+          "promotion_state": "unsafe-to-promote",
+          "known_limitation_codes": [
+            "pdf_layout_tables_figures_footnotes_headers_reading_order_may_be_incomplete",
+            "scanned_image_only_pages_may_be_missing",
+            "public_pdf_full_text_extraction_requires_source_review"
+          ],
+          "reviewability_assessment": {
+            "review_worth_doing": true,
+            "review_effort": "focused",
+            "bounded_review_economics": true,
+            "retained_content_units": 4363,
+            "retained_content_unit": "normalized_nonempty_text_line",
+            "deterministic_cleanup_count": 294,
+            "remaining_artifact_count": 174
+          },
+          "deterministic_cleanup": {
+            "scope": "bounded_deterministic_only",
+            "counts_by_category": {
+              "one_letter_line_wrap_repairs": 27,
+              "repeated_footer_lines_suppressed": 0,
+              "repeated_text_footer_lines_suppressed": 174,
+              "url_path_line_wrap_repairs": 6,
+              "url_spacing_normalizations": 87
+            }
+          },
+          "remaining_artifacts": {
+            "total_count": 174,
+            "counts_by_category": {
+              "bare_numeric_lines_adjacent_to_numeric_content": 14,
+              "empty_pages_without_extracted_text": 0,
+              "mid_page_footer_like_lines": 19,
+              "possible_layout_artifact_lines": 114,
+              "repeated_footer_missing_adjacent_numeric_lines": 0,
+              "repeated_footer_nonparseable_adjacent_numeric_lines": 0,
+              "repeated_footer_numeric_risk_skipped": 0,
+              "repeated_text_footer_skipped_adjacent_numeric_lines": 27
+            }
+          },
+          "intentional_retention": {
+            "markers": [
+              "full_text_extraction_retained_intentionally_for_review",
+              "uncertain_extraction_artifacts_retained_for_review"
+            ]
+          },
+          "promotion_safety": {
+            "promotion_capable": false,
+            "blocker_codes": [
+              "public_source_candidate_requires_human_retention_review"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "source_key": "meaningfultech_webpage",
+      "description": "Live-observed MeaningfulTech webpage replay-quality shape after public webpage chrome suppression.",
+      "replay_quality_metadata": {
+        "replay_classification": {
+          "source_type": "public_webpage",
+          "operational_state": "review-ready",
+          "promotion_state": "unsafe-to-promote",
+          "known_limitation_codes": [
+            "public_webpage_visible_text_extraction_requires_source_review",
+            "links_images_tables_comments_and_publication_metadata_may_be_incomplete",
+            "article_body_text_is_retained_not_summarized"
+          ],
+          "reviewability_assessment": {
+            "review_worth_doing": true,
+            "review_effort": "bounded",
+            "bounded_review_economics": true,
+            "retained_content_units": 17683,
+            "retained_content_unit": "retained_visible_text_character",
+            "deterministic_cleanup_count": 12,
+            "remaining_artifact_count": 0
+          },
+          "deterministic_cleanup": {
+            "scope": "bounded_deterministic_only",
+            "counts_by_category": {
+              "page_chrome_paragraphs_suppressed": 12
+            }
+          },
+          "remaining_artifacts": {
+            "total_count": 0,
+            "counts_by_category": {
+              "reported_remaining_webpage_chrome_artifacts": 0
+            }
+          },
+          "intentional_retention": {
+            "markers": [
+              "article_body_text_retained_intentionally_for_review"
+            ]
+          },
+          "promotion_safety": {
+            "promotion_capable": false,
+            "blocker_codes": [
+              "public_source_candidate_requires_human_retention_review"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "source_key": "dora_roi_2026_public_pdf",
+      "description": "Live-observed DORA ROI 2026 public PDF replay-quality non-regression shape.",
+      "replay_quality_metadata": {
+        "replay_classification": {
+          "source_type": "public_pdf",
+          "operational_state": "review-ready",
+          "promotion_state": "unsafe-to-promote",
+          "known_limitation_codes": [
+            "pdf_layout_tables_figures_footnotes_headers_reading_order_may_be_incomplete",
+            "scanned_image_only_pages_may_be_missing",
+            "public_pdf_full_text_extraction_requires_source_review"
+          ],
+          "reviewability_assessment": {
+            "review_worth_doing": true,
+            "review_effort": "focused",
+            "bounded_review_economics": true,
+            "retained_content_units": 3154,
+            "retained_content_unit": "normalized_nonempty_text_line",
+            "deterministic_cleanup_count": 199,
+            "remaining_artifact_count": 84
+          },
+          "deterministic_cleanup": {
+            "scope": "bounded_deterministic_only",
+            "counts_by_category": {
+              "one_letter_line_wrap_repairs": 0,
+              "repeated_footer_lines_suppressed": 110,
+              "repeated_text_footer_lines_suppressed": 0,
+              "url_path_line_wrap_repairs": 7,
+              "url_spacing_normalizations": 82
+            }
+          },
+          "remaining_artifacts": {
+            "total_count": 84,
+            "counts_by_category": {
+              "bare_numeric_lines_adjacent_to_numeric_content": 60,
+              "empty_pages_without_extracted_text": 0,
+              "mid_page_footer_like_lines": 8,
+              "possible_layout_artifact_lines": 14,
+              "repeated_footer_missing_adjacent_numeric_lines": 0,
+              "repeated_footer_nonparseable_adjacent_numeric_lines": 1,
+              "repeated_footer_numeric_risk_skipped": 1,
+              "repeated_text_footer_skipped_adjacent_numeric_lines": 0
+            }
+          },
+          "intentional_retention": {
+            "markers": [
+              "full_text_extraction_retained_intentionally_for_review",
+              "uncertain_extraction_artifacts_retained_for_review"
+            ]
+          },
+          "promotion_safety": {
+            "promotion_capable": false,
+            "blocker_codes": [
+              "public_source_candidate_requires_human_retention_review"
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/test_adapter_readiness.py
+++ b/tests/test_adapter_readiness.py
@@ -13,7 +13,7 @@ from knowledge_adapters.adapter_readiness import (
 )
 from knowledge_adapters.cli import build_parser
 
-NON_ADAPTER_CLI_COMMANDS = {"bundle", "run"}
+NON_ADAPTER_CLI_COMMANDS = {"bundle", "public_replay_acceptance", "run"}
 REPO_ROOT = Path(__file__).resolve().parents[1]
 EVIDENCE_PATH_RE = re.compile(
     r"\b(?:[A-Za-z0-9_.-]+/)+[A-Za-z0-9_.-]+\.(?:md|py)\b|\bMakefile\b"

--- a/tests/test_public_replay_acceptance.py
+++ b/tests/test_public_replay_acceptance.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import copy
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import cast
+
+from pytest import CaptureFixture, MonkeyPatch
+
+from knowledge_adapters.cli import main
+from knowledge_adapters.public_pdf.client import PublicPdfDocument
+from knowledge_adapters.public_replay_acceptance import (
+    DORA_ROI_2026_PDF_URL,
+    MEANINGFULTECH_URL,
+    PublicReplayAcceptanceError,
+    assert_public_source_replay_acceptance,
+    evaluate_public_source_replay_acceptance,
+    public_source_replay_acceptance_keys,
+    render_public_source_replay_acceptance_report,
+)
+from knowledge_adapters.public_webpage.client import PublicWebpageDocument
+
+FIXTURE_PATH = (
+    Path(__file__).parent
+    / "fixtures"
+    / "public_replay_acceptance"
+    / "source_acceptance_metadata.json"
+)
+
+
+def _load_fixture_cases() -> tuple[Mapping[str, object], ...]:
+    payload = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    assert payload["schema_version"] == 1
+    assert payload["source"] == "known_public_source_replay_acceptance_metadata"
+    cases = payload["cases"]
+    assert isinstance(cases, list)
+    return tuple(cast(Mapping[str, object], case) for case in cases)
+
+
+SOURCE_ACCEPTANCE_CASES = _load_fixture_cases()
+
+
+def test_public_replay_acceptance_fixture_area_covers_known_sources() -> None:
+    case_ids = {str(case["source_key"]) for case in SOURCE_ACCEPTANCE_CASES}
+
+    assert case_ids == set(public_source_replay_acceptance_keys())
+
+
+def test_known_public_source_replay_acceptance_cases_are_stable() -> None:
+    results = []
+    for case in SOURCE_ACCEPTANCE_CASES:
+        result = assert_public_source_replay_acceptance(
+            str(case["source_key"]),
+            _mapping(case, "replay_quality_metadata"),
+        )
+        assert result.stable is True
+        results.append(result)
+
+    report = render_public_source_replay_acceptance_report(results)
+    assert "DORA 2023 public PDF: stable" in report
+    assert "MeaningfulTech webpage: stable" in report
+    assert "DORA ROI 2026 public PDF: stable" in report
+    assert "deterministic cleanup count" in report
+    assert "remaining artifact count" in report
+
+
+def test_public_replay_acceptance_fails_when_expected_cleanup_disappears() -> None:
+    metadata = _metadata_by_source_key("dora_roi_2026_public_pdf")
+    cleanup = _nested_mapping(
+        metadata,
+        (
+            "replay_classification",
+            "deterministic_cleanup",
+            "counts_by_category",
+        ),
+    )
+    cleanup["repeated_footer_lines_suppressed"] = 0
+
+    result = evaluate_public_source_replay_acceptance(
+        "dora_roi_2026_public_pdf",
+        metadata,
+    )
+
+    assert result.stable is False
+    assert any("anchored footer lines suppressed" in failure for failure in result.failures)
+
+
+def test_public_replay_acceptance_fails_when_classification_changes() -> None:
+    metadata = _metadata_by_source_key("meaningfultech_webpage")
+    classification = _nested_mapping(metadata, ("replay_classification",))
+    classification["operational_state"] = "diagnostic-only"
+
+    try:
+        assert_public_source_replay_acceptance("meaningfultech_webpage", metadata)
+    except PublicReplayAcceptanceError as exc:
+        assert "operational state" in str(exc)
+        assert "diagnostic-only" in str(exc)
+    else:
+        raise AssertionError("Expected public replay acceptance to fail")
+
+
+def test_public_replay_acceptance_fails_when_artifact_count_regresses() -> None:
+    metadata = _metadata_by_source_key("dora_2023_public_pdf")
+    reviewability = _nested_mapping(
+        metadata,
+        ("replay_classification", "reviewability_assessment"),
+    )
+    reviewability["remaining_artifact_count"] = 999
+
+    result = evaluate_public_source_replay_acceptance("dora_2023_public_pdf", metadata)
+
+    assert result.stable is False
+    assert any("remaining artifact count" in failure for failure in result.failures)
+
+
+def test_public_replay_acceptance_cli_reports_stable_source(
+    capsys: CaptureFixture[str],
+    monkeypatch: MonkeyPatch,
+) -> None:
+    def fake_fetch_webpage(url: str) -> PublicWebpageDocument:
+        assert url == MEANINGFULTECH_URL
+        return PublicWebpageDocument(
+            title="The Vibe Coding Illusion",
+            canonical_id=url,
+            source_url=url,
+            fetched_at="2026-05-13T12:00:00Z",
+            content="Article text.",
+            replay_quality_metadata=_metadata_by_source_key("meaningfultech_webpage"),
+        )
+
+    monkeypatch.setattr(
+        "knowledge_adapters.public_webpage.client.fetch_webpage",
+        fake_fetch_webpage,
+    )
+
+    assert main(["public_replay_acceptance", "--source", "meaningfultech_webpage"]) == 0
+    captured = capsys.readouterr()
+    assert "MeaningfulTech webpage: stable" in captured.out
+    assert "remaining artifact count: 0 (expected 0..2)" in captured.out
+
+
+def test_public_replay_acceptance_cli_returns_nonzero_for_unexpected_source(
+    capsys: CaptureFixture[str],
+    monkeypatch: MonkeyPatch,
+) -> None:
+    metadata = _metadata_by_source_key("dora_roi_2026_public_pdf")
+    reviewability = _nested_mapping(
+        metadata,
+        ("replay_classification", "reviewability_assessment"),
+    )
+    reviewability["review_effort"] = "extended"
+
+    def fake_fetch_pdf(url: str) -> PublicPdfDocument:
+        assert url == DORA_ROI_2026_PDF_URL
+        return PublicPdfDocument(
+            title="DORA ROI 2026",
+            canonical_id=url,
+            source_url=url,
+            fetched_at="2026-05-13T12:00:00Z",
+            content="## Page 1\n\nReport text.",
+            page_count=60,
+            replay_quality_metadata=metadata,
+        )
+
+    monkeypatch.setattr("knowledge_adapters.public_pdf.client.fetch_pdf", fake_fetch_pdf)
+
+    assert main(["public_replay_acceptance", "--source", "dora_roi_2026_public_pdf"]) == 1
+    captured = capsys.readouterr()
+    assert "DORA ROI 2026 public PDF: unexpected" in captured.out
+    assert "review effort: expected 'focused', observed 'extended'" in captured.out
+
+
+def _metadata_by_source_key(source_key: str) -> dict[str, object]:
+    for case in SOURCE_ACCEPTANCE_CASES:
+        if case["source_key"] == source_key:
+            return copy.deepcopy(dict(_mapping(case, "replay_quality_metadata")))
+    raise AssertionError(f"Unknown source acceptance case: {source_key}")
+
+
+def _mapping(case: Mapping[str, object], key: str) -> Mapping[str, object]:
+    value = case[key]
+    assert isinstance(value, Mapping)
+    return cast(Mapping[str, object], value)
+
+
+def _nested_mapping(
+    metadata: dict[str, object],
+    path: tuple[str, ...],
+) -> dict[str, object]:
+    value: object = metadata
+    for segment in path:
+        assert isinstance(value, dict)
+        value = value[segment]
+    assert isinstance(value, dict)
+    return cast(dict[str, object], value)


### PR DESCRIPTION
## Summary
- add a source-level public replay acceptance contract for the known DORA 2023 PDF, MeaningfulTech webpage, and DORA ROI 2026 PDF shapes
- add deterministic fixture metadata and tests that fail on classification drift, reviewability drift, missing expected cleanup, and sharp remaining-artifact regressions
- add `knowledge-adapters public_replay_acceptance` as an intentional live milestone report command for checking known public sources before returning to knowledge-vault replay

## Source-level replay acceptance behavior
- Known sources are keyed as `dora_2023_public_pdf`, `meaningfultech_webpage`, and `dora_roi_2026_public_pdf`.
- Each source asserts replay classification, promotion state/blockers, reviewability assessment, deterministic cleanup ranges, remaining-artifact ranges, known limitation codes, and intentional-retention markers.
- The live command prints one `stable` or `unexpected` section per source with observed values and expected ranges, and returns nonzero if any known source violates the contract.

## Fixtures
- Added `tests/fixtures/public_replay_acceptance/source_acceptance_metadata.json`.
- Fixture metadata is derived from live-observed replay-quality outputs after PR #288 and stays deterministic for `make check`.
- New tests cover the stable path and explicit failure modes for expected cleanup disappearing, classification changes, reviewability changes, and artifact-count regression.

## Report/assessment improvements
- Added `docs/public-source-replay-acceptance.md` to document the acceptance workflow, known sources, expected contract shape, and non-goals.
- README now points operators to `knowledge-adapters public_replay_acceptance` as the KA-side check before using knowledge-vault replay for confirmation/provenance.
- Adapter-readiness discovery now treats `public_replay_acceptance` as a non-adapter diagnostic command, like `run` and `bundle`.

## Live-source observations
- `knowledge-adapters public_replay_acceptance` passed against all three live public sources.
- DORA 2023: `stable`; 4,363 retained normalized text lines, 294 deterministic cleanup actions, 174 remaining artifacts, 174 high-coverage text footer lines suppressed.
- MeaningfulTech: `stable`; 17,683 retained visible-text characters, 12 deterministic chrome paragraphs suppressed, 0 remaining artifacts.
- DORA ROI 2026: `stable`; 3,154 retained normalized text lines, 199 deterministic cleanup actions, 84 remaining artifacts, 110 anchored footer lines suppressed.

## Non-regression evidence
- DORA ROI 2026 still requires 100..120 anchored footer suppressions and retains the known nonparseable/numeric-risk uncertainty ranges.
- DORA 2023 still requires high-coverage text-footer suppression plus bounded remaining layout/numeric artifacts.
- MeaningfulTech still requires retained article-body text and bounded chrome suppression without summarization or promotion.

## Known remaining limitations
- The acceptance contract uses bounded ranges rather than exact artifact hashes, so it detects meaningful replay-quality drift without treating minor upstream/source extraction variance as an automatic failure.
- The live acceptance command intentionally fetches public sources and is not part of `make check`.
- This PR does not add retention policy, auto-promotion, summarization, or broader cleanup heuristics.

## Validation
- `make check` passed: 522 tests passed.
- `git diff --check` passed.
- Live `knowledge-adapters public_replay_acceptance` passed for all known sources.
