### PR TITLE
Add public webpage source-intent target selection

### DIFF
--- a/docs/public-source-replay-acceptance.md
+++ b/docs/public-source-replay-acceptance.md
@@ -25,6 +25,8 @@ Each source has a stable source key in
 Each known source asserts:
 
 - replay classification, including `review-ready` vs `diagnostic-only`
+- public webpage source-intent state, including wrapper/target-mismatch
+  signals when present
 - promotion state and promotion blockers
 - reviewability assessment, including bounded review economics
 - deterministic cleanup counts or ranges
@@ -59,6 +61,12 @@ known source violates the local contract.
 
 This command fetches live public sources and is not part of `make check`.
 Canonical local validation remains deterministic and fixture-backed.
+
+For public webpages, the acceptance check continues to assert the known
+MeaningfulTech substantive article shape. Wrapper-page and target-discovery
+coverage lives in the deterministic public webpage fixtures so the known-source
+acceptance contract does not depend on a gated marketing page or on a specific
+download asset remaining live.
 
 ## Non-Goals
 

--- a/docs/public-webpage-chrome-fixtures.md
+++ b/docs/public-webpage-chrome-fixtures.md
@@ -1,8 +1,10 @@
 # Public Webpage Chrome Regression Fixtures
 
 Use deterministic, sanitized fixtures in
-`tests/fixtures/public_webpage/article_chrome_cases.json` as the primary
-iteration loop for public webpage chrome suppression.
+`tests/fixtures/public_webpage/article_chrome_cases.json` and
+`tests/test_public_webpage_target_discovery.py` as the primary iteration loop
+for public webpage chrome suppression, source-intent assessment, and bounded
+target discovery.
 
 The fixture area captures small article-body-plus-chrome shapes for:
 
@@ -13,12 +15,52 @@ The fixture area captures small article-body-plus-chrome shapes for:
 - platform promotion text
 - retained article body text with replay-quality boundary metadata
 - chrome-only diagnostic replay shapes where no reviewable article text remains
+- wrapper, lead-form, download-landing, and resource-catalog page shapes
+- same-page target discovery when exactly one high-confidence report asset is
+  present
+- no-selection safety when targets are missing or ambiguous
+- false-positive safety for substantive pages that mention downloads, contact
+  sales, navigation, or footer links in ordinary body context
 
 The adapter does not summarize article bodies, claim copyright or reuse
 permission, change retention semantics, or make near-full article extraction
 promotion-ready. Replay-quality metadata is informational only and helps
 reviewers distinguish deterministic page-chrome suppression from retained
-candidate article body text. The shared replay classification reports
-`review-ready` for retained article text and `diagnostic-only` when suppression
-leaves no content worth reviewing; unreviewed public webpage candidates remain
+candidate article body text and from likely wrong capture targets.
+
+The source-intent assessment reports bounded operational labels such as
+`target_shape_assessment`, `possible_wrapper_page`,
+`possible_lead_form_page`, `possible_download_landing_page`,
+`substantive_content_confidence`, and `likely_target_mismatch`. When a mismatch
+is detected, target discovery is limited to links and metadata already present
+on the fetched page. It does not crawl, search, summarize, or choose among
+ambiguous candidates.
+
+Automatic target fetch is allowed only when one same-page target satisfies the
+selection guards:
+
+- public HTTP(S) URL
+- same official host family as the fetched page
+- report, document, download, or PDF semantics
+- high-confidence title or identity match
+- one clear winner after rejecting marketing, nav, social, legal, and catalog
+  links
+
+Selected PDFs route through the existing `public_pdf` adapter. Selected HTML
+targets route through `public_webpage` with target discovery disabled to avoid
+multi-hop crawling. If no high-confidence target exists, or multiple plausible
+targets conflict, the adapter keeps the wrapper capture as
+`likely-wrong-capture-target` and records candidate targets plus the selection
+reason for operator review.
+
+Live observation on May 13, 2026: the Google Cloud 2025 DORA page at
+`https://cloud.google.com/devops/state-of-devops` was detected as
+`likely_wrong_capture_target`, selected exactly one embedded same-page PDF
+target, and routed replay through the public PDF adapter:
+`https://services.google.com/fh/files/misc/2025_state_of_ai_assisted_software_development.pdf`.
+
+The shared replay classification reports `review-ready` for retained or routed
+substantive target content, `likely-wrong-capture-target` for retained wrapper
+content that needs source-target review, and `diagnostic-only` when suppression
+leaves no content worth reviewing. Unreviewed public-source candidates remain
 `unsafe-to-promote`.

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -1266,6 +1266,7 @@ def _print_public_pdf_replay_quality_metadata(metadata: Mapping[str, object]) ->
     footer_page_noise = _metadata_mapping(metadata, "footer_page_number_noise_diagnostics")
     footer = _metadata_mapping(metadata, "repeated_footer_suppression")
     layout_density = _metadata_mapping(metadata, "possible_layout_artifact_density")
+    source_intent = _metadata_mapping(metadata, "source_intent_assessment")
     warnings = metadata.get("extraction_warnings", ())
     if isinstance(warnings, Sequence) and not isinstance(warnings, str):
         warning_text = ", ".join(str(warning) for warning in warnings)
@@ -1342,6 +1343,30 @@ def _print_public_pdf_replay_quality_metadata(metadata: Mapping[str, object]) ->
         f"{layout_density.get('line_count', '')} "
         f"({layout_density.get('possible_artifact_line_ratio', '')})"
     )
+    if source_intent:
+        candidate_links = source_intent.get("candidate_target_links", ())
+        candidate_count = len(candidate_links) if isinstance(candidate_links, Sequence) else 0
+        print(
+            "    target_shape_assessment: "
+            f"{source_intent.get('target_shape_assessment', '')}"
+        )
+        print(
+            "    likely_target_mismatch: "
+            f"{source_intent.get('likely_target_mismatch', '')}"
+        )
+        print(
+            "    selected_target_url: "
+            f"{source_intent.get('selected_target_url', '')}"
+        )
+        print(
+            "    target_selection_status: "
+            f"{source_intent.get('target_selection_status', '')}"
+        )
+        print(
+            "    target_selection_reason: "
+            f"{source_intent.get('target_selection_reason', '')}"
+        )
+        print(f"    candidate_target_link_count: {candidate_count}")
     print(f"    extraction_warnings: {warning_text}")
 
 
@@ -1352,6 +1377,7 @@ def _print_public_webpage_replay_quality_metadata(metadata: Mapping[str, object]
     profile = _metadata_mapping(metadata, "content_profile")
     boundary = _metadata_mapping(metadata, "extraction_boundary")
     chrome = _metadata_mapping(metadata, "page_chrome_suppression")
+    source_intent = _metadata_mapping(metadata, "source_intent_assessment")
     reasons = chrome.get("suppressed_reasons_by_code", {})
     if isinstance(reasons, Mapping) and reasons:
         reason_text = ", ".join(f"{key}={value}" for key, value in sorted(reasons.items()))
@@ -1382,6 +1408,33 @@ def _print_public_webpage_replay_quality_metadata(metadata: Mapping[str, object]
         f"{chrome.get('suppressed_paragraph_count', '')}"
     )
     print(f"    chrome_suppressed_reasons: {reason_text}")
+    print(
+        "    target_shape_assessment: "
+        f"{source_intent.get('target_shape_assessment', '')}"
+    )
+    print(f"    possible_wrapper_page: {source_intent.get('possible_wrapper_page', '')}")
+    print(f"    possible_lead_form_page: {source_intent.get('possible_lead_form_page', '')}")
+    print(
+        "    possible_download_landing_page: "
+        f"{source_intent.get('possible_download_landing_page', '')}"
+    )
+    print(
+        "    substantive_content_confidence: "
+        f"{source_intent.get('substantive_content_confidence', '')}"
+    )
+    print(f"    likely_target_mismatch: {source_intent.get('likely_target_mismatch', '')}")
+    print(f"    selected_target_url: {source_intent.get('selected_target_url', '')}")
+    print(
+        "    target_selection_status: "
+        f"{source_intent.get('target_selection_status', '')}"
+    )
+    print(
+        "    target_selection_reason: "
+        f"{source_intent.get('target_selection_reason', '')}"
+    )
+    candidate_links = source_intent.get("candidate_target_links", ())
+    candidate_count = len(candidate_links) if isinstance(candidate_links, Sequence) else 0
+    print(f"    candidate_target_link_count: {candidate_count}")
 
 
 def _metadata_mapping(metadata: Mapping[str, object], key: str) -> Mapping[str, object]:
@@ -3578,14 +3631,29 @@ def main(argv: Sequence[str] | None = None) -> int:
 
         try:
             if command == "public_webpage":
-                from knowledge_adapters.public_webpage.client import fetch_webpage
+                from knowledge_adapters.public_pdf.client import PublicPdfDocument
+                from knowledge_adapters.public_pdf.normalize import (
+                    normalize_to_markdown as normalize_pdf_to_markdown,
+                )
+                from knowledge_adapters.public_pdf.writer import (
+                    markdown_path as public_pdf_markdown_path,
+                )
+                from knowledge_adapters.public_pdf.writer import (
+                    write_markdown as public_pdf_write_markdown,
+                )
+                from knowledge_adapters.public_webpage.client import (
+                    PublicWebpageDocument,
+                    fetch_webpage,
+                )
                 from knowledge_adapters.public_webpage.config import PublicWebpageConfig
-                from knowledge_adapters.public_webpage.normalize import normalize_to_markdown
-                from knowledge_adapters.public_webpage.writer import (
-                    markdown_path as public_markdown_path,
+                from knowledge_adapters.public_webpage.normalize import (
+                    normalize_to_markdown as normalize_webpage_to_markdown,
                 )
                 from knowledge_adapters.public_webpage.writer import (
-                    write_markdown as public_write_markdown,
+                    markdown_path as public_webpage_markdown_path,
+                )
+                from knowledge_adapters.public_webpage.writer import (
+                    write_markdown as public_webpage_write_markdown,
                 )
 
                 public_webpage_config = PublicWebpageConfig(
@@ -3594,18 +3662,32 @@ def main(argv: Sequence[str] | None = None) -> int:
                     dry_run=dry_run,
                 )
                 webpage_document = fetch_webpage(public_webpage_config.url)
+                if isinstance(webpage_document, PublicPdfDocument):
+                    normalize_to_markdown = normalize_pdf_to_markdown
+                    public_markdown_path = public_pdf_markdown_path
+                    public_write_markdown = public_pdf_write_markdown
+                    adapter_title = "Public webpage adapter invoked; selected public PDF target"
+                    plan_title = "Public webpage run with selected public PDF target"
+                elif isinstance(webpage_document, PublicWebpageDocument):
+                    normalize_to_markdown = normalize_webpage_to_markdown
+                    public_markdown_path = public_webpage_markdown_path
+                    public_write_markdown = public_webpage_write_markdown
+                    adapter_title = "Public webpage adapter invoked"
+                    plan_title = "Public webpage run"
                 title = webpage_document.title
                 canonical_id = webpage_document.canonical_id
                 source_url = webpage_document.source_url
                 fetched_at = webpage_document.fetched_at
                 content = webpage_document.content
                 extraction_notes = webpage_document.extraction_notes
-                page_count: int | None = None
+                page_count = (
+                    webpage_document.page_count
+                    if isinstance(webpage_document, PublicPdfDocument)
+                    else None
+                )
                 replay_quality_metadata = webpage_document.replay_quality_metadata
                 source = webpage_document.source
                 adapter = webpage_document.adapter
-                adapter_title = "Public webpage"
-                plan_title = "Public webpage run"
             else:
                 from knowledge_adapters.public_pdf.client import fetch_pdf
                 from knowledge_adapters.public_pdf.config import PublicPdfConfig
@@ -3674,7 +3756,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             title=title,
             content_hash=hashlib.sha256(markdown.encode("utf-8")).hexdigest(),
         )
-        if command == "public_pdf":
+        if adapter == "public_pdf":
             manifest_entry["fetched_at"] = fetched_at
             if replay_quality_metadata:
                 manifest_entry["replay_quality_metadata"] = dict(replay_quality_metadata)
@@ -3697,7 +3779,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"  Manifest path: {render_user_path(manifest_output_path)}")
         print("  candidate_status: unreviewed")
         print(f"  extraction_notes: {extraction_notes}")
-        if command == "public_pdf" and replay_quality_metadata:
+        if adapter == "public_pdf" and replay_quality_metadata:
             _print_public_pdf_replay_quality_metadata(replay_quality_metadata)
         elif replay_quality_metadata:
             _print_public_webpage_replay_quality_metadata(replay_quality_metadata)

--- a/src/knowledge_adapters/public_pdf/normalize.py
+++ b/src/knowledge_adapters/public_pdf/normalize.py
@@ -1215,6 +1215,7 @@ def _render_replay_quality_metadata(metadata: Mapping[str, object]) -> str:
     text_footer = _mapping_value(metadata, "repeated_text_footer_suppression")
     footer = _mapping_value(metadata, "repeated_footer_suppression")
     layout_density = _mapping_value(metadata, "possible_layout_artifact_density")
+    source_intent = _mapping_value(metadata, "source_intent_assessment")
     warnings = metadata.get("extraction_warnings", ())
     warning_text = (
         "; ".join(str(warning) for warning in warnings)
@@ -1347,6 +1348,32 @@ def _render_replay_quality_metadata(metadata: Mapping[str, object]) -> str:
                 f"({_metadata_value(layout_density, 'possible_artifact_line_ratio')})"
             ),
             f"- replay_quality_extraction_warnings: {warning_text}",
+            *(
+                (
+                    (
+                        "- replay_quality_webpage_target_shape_assessment: "
+                        f"{_metadata_value(source_intent, 'target_shape_assessment')}"
+                    ),
+                    (
+                        "- replay_quality_webpage_likely_target_mismatch: "
+                        f"{_metadata_value(source_intent, 'likely_target_mismatch')}"
+                    ),
+                    (
+                        "- replay_quality_webpage_selected_target_url: "
+                        f"{_metadata_value(source_intent, 'selected_target_url')}"
+                    ),
+                    (
+                        "- replay_quality_webpage_target_selection_status: "
+                        f"{_metadata_value(source_intent, 'target_selection_status')}"
+                    ),
+                    (
+                        "- replay_quality_webpage_target_selection_reason: "
+                        f"{_metadata_value(source_intent, 'target_selection_reason')}"
+                    ),
+                )
+                if source_intent
+                else ()
+            ),
             (
                 "- replay_quality_deterministic_cleanup_scope: "
                 f"{_metadata_value(cleanup, 'scope')}"

--- a/src/knowledge_adapters/public_replay_acceptance.py
+++ b/src/knowledge_adapters/public_replay_acceptance.py
@@ -273,6 +273,7 @@ KNOWN_PUBLIC_SOURCE_REPLAY_ACCEPTANCE_SPECS = (
         required_known_limitation_codes=(
             "public_webpage_visible_text_extraction_requires_source_review",
             "links_images_tables_comments_and_publication_metadata_may_be_incomplete",
+            "public_webpage_source_intent_shape_requires_operator_review",
             "article_body_text_is_retained_not_summarized",
         ),
         required_intentional_retention_markers=(

--- a/src/knowledge_adapters/public_webpage/client.py
+++ b/src/knowledge_adapters/public_webpage/client.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from html.parser import HTMLParser
+from typing import Literal
 
+from knowledge_adapters.public_pdf.client import PublicPdfDocument, fetch_pdf
 from knowledge_adapters.public_sources import decode_text_response, fetch_public_url
 from knowledge_adapters.public_webpage.normalize import (
     normalize_extracted_text_with_replay_metadata,
+)
+from knowledge_adapters.public_webpage.targets import (
+    PublicWebpageTargetLink,
+    discover_target_links,
 )
 
 MAX_WEBPAGE_BYTES = 5_000_000
@@ -36,8 +42,19 @@ class PublicWebpageDocument:
     adapter: str = "public_webpage"
 
 
-def fetch_webpage(url: str) -> PublicWebpageDocument:
+PublicWebpageFetchDocument = PublicWebpageDocument | PublicPdfDocument
+
+
+def fetch_webpage(url: str) -> PublicWebpageFetchDocument:
     """Fetch and extract one public webpage URL."""
+    return _fetch_webpage(url, target_discovery="enabled")
+
+
+def _fetch_webpage(
+    url: str,
+    *,
+    target_discovery: Literal["enabled", "disabled"],
+) -> PublicWebpageFetchDocument:
     fetched = fetch_public_url(
         url,
         accepted_content_types=("text/html", "application/xhtml+xml"),
@@ -49,8 +66,33 @@ def fetch_webpage(url: str) -> PublicWebpageDocument:
     extractor.close()
     title = extractor.title.strip() or fetched.final_url
     content, replay_quality_metadata = normalize_extracted_text_with_replay_metadata(
-        extractor.markdown_text()
+        extractor.markdown_text(),
+        requested_url=fetched.url,
+        resolved_url=fetched.final_url,
     )
+    if target_discovery == "enabled":
+        source_intent = replay_quality_metadata.get("source_intent_assessment", {})
+        if isinstance(source_intent, dict):
+            target_selection = discover_target_links(
+                requested_url=fetched.url,
+                resolved_url=fetched.final_url,
+                page_title=title,
+                visible_text=extractor.markdown_text(),
+                observed_links=extractor.target_links(),
+                raw_html=html,
+                source_intent_assessment=source_intent,
+            )
+            source_intent.update(target_selection)
+            selected_url = str(target_selection.get("selected_target_url", ""))
+            selected_content_type = str(
+                target_selection.get("selected_target_content_type", "")
+            )
+            if target_selection.get("target_selection_status") == "selected":
+                return _fetch_selected_target(
+                    selected_url=selected_url,
+                    selected_content_type=selected_content_type,
+                    source_intent_assessment=dict(source_intent),
+                )
     return PublicWebpageDocument(
         title=title,
         canonical_id=fetched.final_url,
@@ -106,12 +148,40 @@ class _ReadableHTMLExtractor(HTMLParser):
         self._in_title = False
         self._ignored_depth = 0
         self._parts: list[str] = []
+        self._links: list[PublicWebpageTargetLink] = []
+        self._active_link_href = ""
+        self._active_link_text: list[str] = []
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
-        del attrs
         normalized_tag = tag.lower()
+        attr_map = {key.lower(): value or "" for key, value in attrs}
         if normalized_tag == "title":
             self._in_title = True
+        if normalized_tag == "a":
+            self._active_link_href = attr_map.get("href", "")
+            self._active_link_text = []
+        if normalized_tag == "link":
+            href = attr_map.get("href", "")
+            rel = attr_map.get("rel", "")
+            if href:
+                self._links.append(
+                    PublicWebpageTargetLink(
+                        url=href,
+                        label=rel,
+                        source="link_href",
+                    )
+                )
+        if normalized_tag == "meta":
+            content = attr_map.get("content", "")
+            label = attr_map.get("property", "") or attr_map.get("name", "")
+            if content:
+                self._links.append(
+                    PublicWebpageTargetLink(
+                        url=content,
+                        label=label,
+                        source="meta_url",
+                    )
+                )
         if normalized_tag in self._IGNORED_TAGS:
             self._ignored_depth += 1
             return
@@ -122,6 +192,17 @@ class _ReadableHTMLExtractor(HTMLParser):
         normalized_tag = tag.lower()
         if normalized_tag == "title":
             self._in_title = False
+        if normalized_tag == "a":
+            if self._active_link_href:
+                self._links.append(
+                    PublicWebpageTargetLink(
+                        url=self._active_link_href,
+                        label=" ".join(self._active_link_text),
+                        source="anchor_href",
+                    )
+                )
+            self._active_link_href = ""
+            self._active_link_text = []
         if normalized_tag in self._IGNORED_TAGS and self._ignored_depth > 0:
             self._ignored_depth -= 1
             return
@@ -137,6 +218,8 @@ class _ReadableHTMLExtractor(HTMLParser):
         if self._in_title:
             self.title = f"{self.title} {text}".strip()
             return
+        if self._active_link_href:
+            self._active_link_text.append(text)
         self._parts.append(text)
 
     def markdown_text(self) -> str:
@@ -157,3 +240,24 @@ class _ReadableHTMLExtractor(HTMLParser):
     def _append_break(self) -> None:
         if self._parts and self._parts[-1] != "\n":
             self._parts.append("\n")
+
+    def target_links(self) -> tuple[PublicWebpageTargetLink, ...]:
+        """Return page-local links and metadata URLs for bounded target discovery."""
+        return tuple(self._links)
+
+
+def _fetch_selected_target(
+    *,
+    selected_url: str,
+    selected_content_type: str,
+    source_intent_assessment: dict[str, object],
+) -> PublicWebpageFetchDocument:
+    if selected_content_type == "pdf":
+        pdf_document = fetch_pdf(selected_url)
+        metadata = dict(pdf_document.replay_quality_metadata)
+        metadata["source_intent_assessment"] = source_intent_assessment
+        return replace(pdf_document, replay_quality_metadata=metadata)
+    webpage_document = _fetch_webpage(selected_url, target_discovery="disabled")
+    metadata = dict(webpage_document.replay_quality_metadata)
+    metadata["source_intent_assessment"] = source_intent_assessment
+    return replace(webpage_document, replay_quality_metadata=metadata)

--- a/src/knowledge_adapters/public_webpage/normalize.py
+++ b/src/knowledge_adapters/public_webpage/normalize.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import re
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 
 from knowledge_adapters.replay_quality import build_public_source_replay_classification
 
@@ -38,6 +38,9 @@ _LEGAL_FOOTER_RE = re.compile(r"(©|copyright).*privacy.*terms", re.IGNORECASE)
 
 def normalize_extracted_text_with_replay_metadata(
     content: str,
+    *,
+    requested_url: str | None = None,
+    resolved_url: str | None = None,
 ) -> tuple[str, dict[str, object]]:
     """Remove clearly mechanical webpage chrome and describe review boundaries."""
     paragraphs = [paragraph.strip() for paragraph in content.split("\n\n")]
@@ -64,6 +67,14 @@ def normalize_extracted_text_with_replay_metadata(
             )
 
     retained_content = "\n\n".join(retained_paragraphs)
+    source_intent_assessment = _assess_source_intent(
+        extracted_paragraphs=paragraphs,
+        retained_paragraphs=retained_paragraphs,
+        retained_content=retained_content,
+        suppressed_character_count=suppressed_character_count,
+        requested_url=requested_url,
+        resolved_url=resolved_url,
+    )
     metadata: dict[str, object] = {
         "metadata_scope": "public_webpage_replay_quality",
         "metadata_note": REPLAY_QUALITY_METADATA_NOTE,
@@ -88,6 +99,7 @@ def normalize_extracted_text_with_replay_metadata(
             "suppressed_reasons_by_code": suppressed_reasons,
             "suppressed_examples": suppressed_examples,
         },
+        "source_intent_assessment": source_intent_assessment,
     }
     metadata["replay_classification"] = _build_public_webpage_replay_classification(
         metadata
@@ -157,6 +169,302 @@ def _short_diagnostic_excerpt(paragraph: str) -> str:
     return f"{excerpt[:77].rstrip()}..."
 
 
+_FORM_FIELD_LABELS = {
+    "business email",
+    "business phone",
+    "calling code",
+    "company",
+    "company name",
+    "country",
+    "email",
+    "first name",
+    "job title",
+    "last name",
+    "phone",
+    "phone number",
+    "state",
+    "work email",
+}
+_CTA_PHRASES = {
+    "access the report",
+    "book a meeting",
+    "contact sales",
+    "download now",
+    "download report",
+    "download the report",
+    "get the report",
+    "request a demo",
+    "request demo",
+    "submit",
+}
+_DOWNLOAD_CTA_PHRASES = {
+    "access the report",
+    "download now",
+    "download report",
+    "download the report",
+    "get the report",
+}
+_LEGAL_OR_CONSENT_PHRASES = {
+    "by submitting this form",
+    "i agree to receive",
+    "privacy policy",
+    "terms of service",
+    "unsubscribe",
+    "your personal data",
+}
+_CATALOG_NAVIGATION_TERMS = {
+    "blog",
+    "case studies",
+    "contact us",
+    "docs",
+    "documentation",
+    "events",
+    "partners",
+    "pricing",
+    "products",
+    "reports",
+    "resources",
+    "solutions",
+    "support",
+    "training",
+    "webinars",
+    "whitepapers",
+}
+_REPORT_TITLE_TERMS = {"report", "research", "state of devops", "dora"}
+
+
+def _assess_source_intent(
+    *,
+    extracted_paragraphs: Sequence[str],
+    retained_paragraphs: Sequence[str],
+    retained_content: str,
+    suppressed_character_count: int,
+    requested_url: str | None,
+    resolved_url: str | None,
+) -> dict[str, object]:
+    retained_character_count = len(retained_content)
+    total_character_count = retained_character_count + suppressed_character_count
+    retained_content_ratio = _rounded_ratio(
+        retained_character_count,
+        total_character_count,
+    )
+    substantive_paragraph_count = sum(
+        1 for paragraph in retained_paragraphs if _is_substantive_body_paragraph(paragraph)
+    )
+    form_field_count = sum(1 for paragraph in extracted_paragraphs if _is_form_field(paragraph))
+    cta_count = sum(
+        1 for paragraph in extracted_paragraphs if _contains_phrase(paragraph, _CTA_PHRASES)
+    )
+    download_cta_count = sum(
+        1
+        for paragraph in extracted_paragraphs
+        if _contains_phrase(paragraph, _DOWNLOAD_CTA_PHRASES)
+    )
+    legal_or_consent_count = sum(
+        1
+        for paragraph in extracted_paragraphs
+        if _contains_phrase(paragraph, _LEGAL_OR_CONSENT_PHRASES)
+    )
+    catalog_navigation_count = sum(
+        1 for paragraph in extracted_paragraphs if _is_catalog_navigation(paragraph)
+    )
+    report_title_mention_count = sum(
+        1
+        for paragraph in retained_paragraphs[:12]
+        if _contains_phrase(paragraph, _REPORT_TITLE_TERMS)
+    )
+    short_selector_like_paragraph_count = sum(
+        1 for paragraph in extracted_paragraphs if _is_selector_like_paragraph(paragraph)
+    )
+
+    possible_lead_form_page = form_field_count >= 3 and (
+        download_cta_count >= 1 or legal_or_consent_count >= 1
+    )
+    possible_download_landing_page = download_cta_count >= 1 and (
+        possible_lead_form_page
+        or (substantive_paragraph_count < 3 and retained_character_count < 3000)
+        or cta_count >= 3
+    )
+    possible_resource_catalog_page = (
+        catalog_navigation_count >= 8
+        and substantive_paragraph_count < 4
+        and short_selector_like_paragraph_count >= 12
+    )
+    high_chrome_to_substance_ratio = (
+        total_character_count > 0
+        and retained_character_count > 0
+        and retained_content_ratio < 0.45
+        and substantive_paragraph_count < 3
+        and (
+            download_cta_count > 0
+            or catalog_navigation_count >= 4
+            or form_field_count >= 2
+        )
+    )
+    report_title_with_little_body = (
+        report_title_mention_count > 0
+        and download_cta_count >= 1
+        and substantive_paragraph_count < 2
+        and retained_character_count < 2500
+    )
+    possible_wrapper_page = (
+        possible_lead_form_page
+        or possible_download_landing_page
+        or possible_resource_catalog_page
+        or high_chrome_to_substance_ratio
+        or report_title_with_little_body
+    )
+    insufficient_substantive_body = (
+        retained_character_count < 700 or substantive_paragraph_count < 2
+    )
+    likely_target_mismatch = possible_wrapper_page or (
+        insufficient_substantive_body
+        and retained_character_count > 0
+        and (download_cta_count > 0 or catalog_navigation_count >= 4)
+    )
+    substantive_content_confidence = _substantive_content_confidence(
+        likely_target_mismatch=likely_target_mismatch,
+        retained_character_count=retained_character_count,
+        substantive_paragraph_count=substantive_paragraph_count,
+    )
+    reason_codes = _source_intent_reason_codes(
+        possible_wrapper_page=possible_wrapper_page,
+        possible_lead_form_page=possible_lead_form_page,
+        possible_download_landing_page=possible_download_landing_page,
+        possible_resource_catalog_page=possible_resource_catalog_page,
+        insufficient_substantive_body=insufficient_substantive_body,
+        high_chrome_to_substance_ratio=high_chrome_to_substance_ratio,
+        report_title_with_little_body=report_title_with_little_body,
+    )
+
+    if likely_target_mismatch:
+        target_shape_assessment = "likely_wrong_capture_target"
+    elif retained_character_count == 0:
+        target_shape_assessment = "no_retained_content"
+    elif substantive_content_confidence in {"high", "medium"}:
+        target_shape_assessment = "substantive_content_page"
+    else:
+        target_shape_assessment = "insufficient_substantive_body"
+
+    return {
+        "schema_version": 1,
+        "target_shape_assessment": target_shape_assessment,
+        "possible_wrapper_page": possible_wrapper_page,
+        "possible_lead_form_page": possible_lead_form_page,
+        "possible_download_landing_page": possible_download_landing_page,
+        "possible_resource_catalog_page": possible_resource_catalog_page,
+        "substantive_content_confidence": substantive_content_confidence,
+        "likely_target_mismatch": likely_target_mismatch,
+        "reason_codes": reason_codes,
+        "retained_content_ratio": retained_content_ratio,
+        "input_url": requested_url or "",
+        "resolved_url": resolved_url or "",
+        "resolved_url_changed": bool(
+            requested_url and resolved_url and requested_url != resolved_url
+        ),
+        "signal_counts": {
+            "catalog_navigation_paragraphs": catalog_navigation_count,
+            "cta_paragraphs": cta_count,
+            "download_cta_paragraphs": download_cta_count,
+            "form_field_paragraphs": form_field_count,
+            "legal_or_consent_paragraphs": legal_or_consent_count,
+            "report_title_mentions_near_top": report_title_mention_count,
+            "short_selector_like_paragraphs": short_selector_like_paragraph_count,
+            "substantive_body_paragraphs": substantive_paragraph_count,
+        },
+    }
+
+
+def _is_substantive_body_paragraph(paragraph: str) -> bool:
+    text = " ".join(paragraph.split())
+    if len(text) < 140:
+        return False
+    if len(text.split()) < 24:
+        return False
+    sentence_mark_count = sum(text.count(mark) for mark in (".", "?", "!"))
+    return sentence_mark_count >= 2
+
+
+def _is_form_field(paragraph: str) -> bool:
+    normalized = _normalized_prompt_text(paragraph).replace("*", "").strip(": ")
+    if normalized in _FORM_FIELD_LABELS:
+        return True
+    words = normalized.split()
+    if len(words) <= 6:
+        return any(label in normalized for label in _FORM_FIELD_LABELS)
+    return False
+
+
+def _contains_phrase(paragraph: str, phrases: set[str]) -> bool:
+    normalized = _normalized_prompt_text(paragraph)
+    return any(phrase in normalized for phrase in phrases)
+
+
+def _is_catalog_navigation(paragraph: str) -> bool:
+    normalized = _normalized_prompt_text(paragraph)
+    if len(normalized) > 100:
+        return False
+    if normalized in _CATALOG_NAVIGATION_TERMS:
+        return True
+    return sum(1 for term in _CATALOG_NAVIGATION_TERMS if term in normalized) >= 3
+
+
+def _is_selector_like_paragraph(paragraph: str) -> bool:
+    text = " ".join(paragraph.split())
+    if not text or len(text) > 80:
+        return False
+    if text.endswith((".", "?", "!")):
+        return False
+    return True
+
+
+def _rounded_ratio(numerator: int, denominator: int) -> float:
+    if denominator <= 0:
+        return 0.0
+    return round(numerator / denominator, 3)
+
+
+def _substantive_content_confidence(
+    *,
+    likely_target_mismatch: bool,
+    retained_character_count: int,
+    substantive_paragraph_count: int,
+) -> str:
+    if likely_target_mismatch or retained_character_count < 700 or substantive_paragraph_count < 2:
+        return "low"
+    if retained_character_count >= 8000 and substantive_paragraph_count >= 5:
+        return "high"
+    return "medium"
+
+
+def _source_intent_reason_codes(
+    *,
+    possible_wrapper_page: bool,
+    possible_lead_form_page: bool,
+    possible_download_landing_page: bool,
+    possible_resource_catalog_page: bool,
+    insufficient_substantive_body: bool,
+    high_chrome_to_substance_ratio: bool,
+    report_title_with_little_body: bool,
+) -> list[str]:
+    reason_codes: list[str] = []
+    if possible_wrapper_page:
+        reason_codes.append("possible_wrapper_page")
+    if possible_lead_form_page:
+        reason_codes.append("possible_lead_form_page")
+    if possible_download_landing_page:
+        reason_codes.append("possible_download_landing_page")
+    if possible_resource_catalog_page:
+        reason_codes.append("possible_resource_catalog_page")
+    if insufficient_substantive_body:
+        reason_codes.append("insufficient_substantive_body")
+    if high_chrome_to_substance_ratio:
+        reason_codes.append("high_chrome_to_substantive_content_ratio")
+    if report_title_with_little_body:
+        reason_codes.append("report_title_mention_with_little_adjacent_substance")
+    return reason_codes
+
+
 def _render_replay_quality_metadata(metadata: Mapping[str, object]) -> str:
     classification = _mapping_value(metadata, "replay_classification")
     reviewability = _mapping_value(classification, "reviewability_assessment")
@@ -165,6 +473,7 @@ def _render_replay_quality_metadata(metadata: Mapping[str, object]) -> str:
     profile = _mapping_value(metadata, "content_profile")
     boundary = _mapping_value(metadata, "extraction_boundary")
     chrome = _mapping_value(metadata, "page_chrome_suppression")
+    source_intent = _mapping_value(metadata, "source_intent_assessment")
     reasons = chrome.get("suppressed_reasons_by_code", {})
     reason_text = (
         "; ".join(f"{key}={value}" for key, value in sorted(reasons.items()))
@@ -212,6 +521,42 @@ def _render_replay_quality_metadata(metadata: Mapping[str, object]) -> str:
             ),
             f"- replay_quality_webpage_chrome_suppressed_reasons: {reason_text}",
             (
+                "- replay_quality_webpage_target_shape_assessment: "
+                f"{_metadata_value(source_intent, 'target_shape_assessment')}"
+            ),
+            (
+                "- replay_quality_webpage_possible_wrapper_page: "
+                f"{_metadata_value(source_intent, 'possible_wrapper_page')}"
+            ),
+            (
+                "- replay_quality_webpage_possible_lead_form_page: "
+                f"{_metadata_value(source_intent, 'possible_lead_form_page')}"
+            ),
+            (
+                "- replay_quality_webpage_possible_download_landing_page: "
+                f"{_metadata_value(source_intent, 'possible_download_landing_page')}"
+            ),
+            (
+                "- replay_quality_webpage_substantive_content_confidence: "
+                f"{_metadata_value(source_intent, 'substantive_content_confidence')}"
+            ),
+            (
+                "- replay_quality_webpage_likely_target_mismatch: "
+                f"{_metadata_value(source_intent, 'likely_target_mismatch')}"
+            ),
+            (
+                "- replay_quality_webpage_selected_target_url: "
+                f"{_metadata_value(source_intent, 'selected_target_url')}"
+            ),
+            (
+                "- replay_quality_webpage_target_selection_status: "
+                f"{_metadata_value(source_intent, 'target_selection_status')}"
+            ),
+            (
+                "- replay_quality_webpage_target_selection_reason: "
+                f"{_metadata_value(source_intent, 'target_selection_reason')}"
+            ),
+            (
                 "- replay_quality_deterministic_cleanup_scope: "
                 f"{_metadata_value(cleanup, 'scope')}"
             ),
@@ -237,10 +582,13 @@ def _build_public_webpage_replay_classification(
 ) -> dict[str, object]:
     profile = _mapping_value(metadata, "content_profile")
     chrome = _mapping_value(metadata, "page_chrome_suppression")
+    source_intent = _mapping_value(metadata, "source_intent_assessment")
     retained_character_count = _int_metadata_value(profile, "retained_character_count")
+    likely_target_mismatch = _bool_metadata_value(source_intent, "likely_target_mismatch")
     known_limitation_codes = [
         "public_webpage_visible_text_extraction_requires_source_review",
         "links_images_tables_comments_and_publication_metadata_may_be_incomplete",
+        "public_webpage_source_intent_shape_requires_operator_review",
     ]
     intentionally_retained_markers: list[str] = []
     if retained_character_count:
@@ -250,8 +598,15 @@ def _build_public_webpage_replay_classification(
         )
     else:
         known_limitation_codes.append("no_article_body_text_retained_after_cleanup")
+    if likely_target_mismatch:
+        known_limitation_codes.extend(
+            (
+                "possible_wrapper_or_gated_source_page_detected",
+                "likely_target_mismatch_review_required",
+            )
+        )
 
-    return build_public_source_replay_classification(
+    classification = build_public_source_replay_classification(
         source_type="public_webpage",
         retained_content_units=retained_character_count,
         retained_content_unit="retained_visible_text_character",
@@ -261,13 +616,59 @@ def _build_public_webpage_replay_classification(
             ),
         },
         remaining_artifact_counts_by_category={
+            "possible_source_intent_mismatch": 1 if likely_target_mismatch else 0,
             "reported_remaining_webpage_chrome_artifacts": 0,
         },
         known_limitation_codes=known_limitation_codes,
         intentionally_retained_markers=intentionally_retained_markers,
     )
+    if likely_target_mismatch and retained_character_count:
+        _mark_classification_as_likely_wrong_target(classification, source_intent)
+    return classification
+
+
+def _mark_classification_as_likely_wrong_target(
+    classification: dict[str, object],
+    source_intent: Mapping[str, object],
+) -> None:
+    classification["operational_state"] = "likely-wrong-capture-target"
+    classification["classification_labels"] = [
+        "likely-wrong-capture-target",
+        classification.get("promotion_state", ""),
+    ]
+    reason_codes = _string_list_value(source_intent, "reason_codes")
+    classification["state_reason_codes"] = [
+        "likely_target_mismatch",
+        *reason_codes,
+    ]
+    reviewability = classification.get("reviewability_assessment", {})
+    if isinstance(reviewability, dict):
+        reviewability["review_effort"] = "source_target_review"
+        reviewability["bounded_review_economics"] = False
+    promotion_safety = classification.get("promotion_safety", {})
+    if isinstance(promotion_safety, dict):
+        blockers = _string_sequence_value(promotion_safety.get("blocker_codes"))
+        blockers.append("likely_target_mismatch_requires_source_review")
+        promotion_safety["blocker_codes"] = list(dict.fromkeys(blockers))
 
 
 def _int_metadata_value(metadata: Mapping[str, object], key: str) -> int:
     value = metadata.get(key, 0)
     return value if isinstance(value, int) else 0
+
+
+def _bool_metadata_value(metadata: Mapping[str, object], key: str) -> bool:
+    value = metadata.get(key, False)
+    return value if isinstance(value, bool) else False
+
+
+def _string_list_value(metadata: Mapping[str, object], key: str) -> list[str]:
+    return _string_sequence_value(metadata.get(key, ()))
+
+
+def _string_sequence_value(value: object) -> list[str]:
+    if isinstance(value, Sequence) and not isinstance(value, str):
+        return [str(item) for item in value]
+    if value:
+        return [str(value)]
+    return []

--- a/src/knowledge_adapters/public_webpage/targets.py
+++ b/src/knowledge_adapters/public_webpage/targets.py
@@ -1,0 +1,381 @@
+"""Bounded target discovery for public webpage wrapper captures."""
+
+from __future__ import annotations
+
+import html
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from urllib.parse import ParseResult, parse_qs, urljoin, urlparse
+
+from knowledge_adapters.public_sources import validate_public_http_url
+
+
+@dataclass(frozen=True)
+class PublicWebpageTargetLink:
+    """One URL observed on the fetched page itself."""
+
+    url: str
+    label: str
+    source: str
+
+
+_URL_RE = re.compile(r"https?://[^\s\"'<>\\]+")
+_STOPWORDS = {
+    "about",
+    "after",
+    "and",
+    "assisted",
+    "cloud",
+    "content",
+    "development",
+    "download",
+    "google",
+    "report",
+    "resources",
+    "software",
+    "state",
+    "the",
+    "with",
+}
+_IDENTITY_KEEPWORDS = {
+    "2025",
+    "ai",
+    "dora",
+    "devops",
+}
+_REPORT_TERMS = {
+    "abridged",
+    "accelerate",
+    "ai",
+    "assisted",
+    "development",
+    "devops",
+    "dora",
+    "download",
+    "pdf",
+    "report",
+    "research",
+    "software",
+    "state",
+    "whitepaper",
+}
+_REJECT_HOST_PARTS = {
+    "accounts.google.com",
+    "facebook.com",
+    "linkedin.com",
+    "policies.google.com",
+    "twitter.com",
+    "x.com",
+    "youtube.com",
+}
+_REJECT_PATH_PARTS = {
+    "/privacy",
+    "/terms",
+    "/support",
+    "/contact",
+    "/pricing",
+    "/docs",
+    "/blog",
+}
+
+
+def discover_target_links(
+    *,
+    requested_url: str,
+    resolved_url: str,
+    page_title: str,
+    visible_text: str,
+    observed_links: Sequence[PublicWebpageTargetLink],
+    raw_html: str,
+    source_intent_assessment: Mapping[str, object],
+) -> dict[str, object]:
+    """Select one high-confidence same-page report target when it is unambiguous."""
+    if not _bool_value(source_intent_assessment, "likely_target_mismatch"):
+        return _target_selection(
+            status="not_applicable_no_target_mismatch",
+            reason="source_intent_assessment_did_not_flag_target_mismatch",
+            candidate_links=(),
+        )
+
+    candidates = _candidate_links(
+        requested_url=requested_url,
+        resolved_url=resolved_url,
+        page_title=page_title,
+        visible_text=visible_text,
+        observed_links=observed_links,
+        raw_html=raw_html,
+    )
+    high_confidence_candidates = [
+        candidate for candidate in candidates if _int_value(candidate, "confidence_score") >= 70
+    ]
+    if not high_confidence_candidates:
+        return _target_selection(
+            status="no_high_confidence_target",
+            reason="no_same_page_report_asset_met_selection_guards",
+            candidate_links=candidates,
+        )
+    if len(high_confidence_candidates) > 1:
+        return _target_selection(
+            status="ambiguous_multiple_high_confidence_targets",
+            reason="multiple_same_page_report_assets_met_selection_guards",
+            candidate_links=candidates,
+        )
+
+    selected = high_confidence_candidates[0]
+    return _target_selection(
+        status="selected",
+        reason=str(selected["selection_reason"]),
+        candidate_links=candidates,
+        selected_url=str(selected["url"]),
+        selected_content_type=str(selected["content_type"]),
+    )
+
+
+def embedded_target_links(raw_html: str) -> tuple[PublicWebpageTargetLink, ...]:
+    """Return report-like URLs found in escaped same-page href or URL text."""
+    decoded = _decode_embedded_html(raw_html)
+    links: dict[str, PublicWebpageTargetLink] = {}
+    for url in _URL_RE.findall(decoded):
+        cleaned_url = html.unescape(url).rstrip(".,;)").replace("\\/", "/")
+        if not _has_report_semantics(cleaned_url, ""):
+            continue
+        links[cleaned_url] = PublicWebpageTargetLink(
+            url=cleaned_url,
+            label="",
+            source="embedded_page_url",
+        )
+    return tuple(links.values())
+
+
+def _candidate_links(
+    *,
+    requested_url: str,
+    resolved_url: str,
+    page_title: str,
+    visible_text: str,
+    observed_links: Sequence[PublicWebpageTargetLink],
+    raw_html: str,
+) -> tuple[dict[str, object], ...]:
+    page_identity = _identity_tokens(f"{page_title} {visible_text[:2000]}")
+    links_by_url: dict[str, PublicWebpageTargetLink] = {}
+    for link in (*observed_links, *embedded_target_links(raw_html)):
+        absolute_url = _absolute_url(link.url, resolved_url)
+        if not absolute_url:
+            continue
+        previous = links_by_url.get(absolute_url)
+        if previous is not None and previous.label:
+            continue
+        links_by_url[absolute_url] = PublicWebpageTargetLink(
+            url=absolute_url,
+            label=link.label,
+            source=link.source,
+        )
+
+    candidates: list[dict[str, object]] = []
+    for link in links_by_url.values():
+        candidate = _score_candidate_link(
+            link=link,
+            requested_url=requested_url,
+            resolved_url=resolved_url,
+            page_identity=page_identity,
+        )
+        if candidate is not None:
+            candidates.append(candidate)
+    return tuple(
+        sorted(
+            candidates,
+            key=lambda candidate: (
+                -_int_value(candidate, "confidence_score"),
+                str(candidate["url"]),
+            ),
+        )[:12]
+    )
+
+
+def _score_candidate_link(
+    *,
+    link: PublicWebpageTargetLink,
+    requested_url: str,
+    resolved_url: str,
+    page_identity: set[str],
+) -> dict[str, object] | None:
+    try:
+        validate_public_http_url(link.url)
+    except ValueError:
+        return None
+    if not _allowed_host_relationship(resolved_url, link.url):
+        return None
+    parsed = urlparse(link.url)
+    normalized_url_text = _normalized_url_text(link.url)
+    label = _normalize_text(link.label)
+    if _is_rejected_target(parsed):
+        return None
+    if not _has_report_semantics(normalized_url_text, label):
+        return None
+
+    candidate_tokens = _identity_tokens(f"{normalized_url_text} {label}")
+    identity_matches = sorted(page_identity & candidate_tokens)
+    if len(identity_matches) < 2 and not {"dora", "2025"} <= set(identity_matches):
+        return None
+
+    is_pdf = parsed.path.lower().endswith(".pdf")
+    score = 0
+    reasons: list[str] = []
+    if is_pdf:
+        score += 48
+        reasons.append("pdf_asset")
+    elif any(term in normalized_url_text for term in ("report", "whitepaper", "download")):
+        score += 28
+        reasons.append("report_like_html_target")
+    if link.source in {"anchor_href", "link_href", "meta_url"}:
+        score += 8
+        reasons.append(f"observed_in_{link.source}")
+    if link.source == "embedded_page_url":
+        score += 6
+        reasons.append("observed_in_embedded_page_url")
+    score += min(36, len(identity_matches) * 6)
+    if "dora" in identity_matches:
+        score += 8
+    if "2025" in identity_matches:
+        score += 8
+    if "abridged" in normalized_url_text:
+        score -= 35
+        reasons.append("abridged_asset_penalty")
+    if re.search(r"_(de|es|fr|id|it|ja|ko|pt-br|zh-cn|zh-tw)(\.pdf|$)", normalized_url_text):
+        score -= 20
+        reasons.append("localized_asset_penalty")
+    if _points_back_to_requested_page(link.url, requested_url, resolved_url):
+        score -= 40
+        reasons.append("points_back_to_wrapper_page_penalty")
+    if score < 35:
+        return None
+
+    content_type = "pdf" if is_pdf else "html"
+    return {
+        "url": link.url,
+        "label": link.label,
+        "source": link.source,
+        "content_type": content_type,
+        "confidence_score": score,
+        "identity_matches": identity_matches,
+        "selection_reason": ",".join(reasons),
+    }
+
+
+def _target_selection(
+    *,
+    status: str,
+    reason: str,
+    candidate_links: Sequence[Mapping[str, object]],
+    selected_url: str = "",
+    selected_content_type: str = "",
+) -> dict[str, object]:
+    return {
+        "candidate_target_links": [dict(candidate) for candidate in candidate_links],
+        "selected_target_url": selected_url,
+        "selected_target_content_type": selected_content_type,
+        "target_selection_reason": reason,
+        "target_selection_status": status,
+    }
+
+
+def _decode_embedded_html(raw_html: str) -> str:
+    decoded = raw_html
+    replacements = {
+        "\\u0026": "&",
+        "\\u003a": ":",
+        "\\u003c": "<",
+        "\\u003d": "=",
+        "\\u003e": ">",
+        '\\"': '"',
+        "\\/": "/",
+    }
+    for old, new in replacements.items():
+        decoded = decoded.replace(old, new)
+    return html.unescape(decoded)
+
+
+def _absolute_url(url: str, base_url: str) -> str:
+    if not url:
+        return ""
+    if url.startswith("#") or url.lower().startswith(("mailto:", "tel:", "javascript:")):
+        return ""
+    return urljoin(base_url, html.unescape(url.strip()))
+
+
+def _allowed_host_relationship(base_url: str, candidate_url: str) -> bool:
+    base_host = (urlparse(base_url).hostname or "").lower()
+    candidate_host = (urlparse(candidate_url).hostname or "").lower()
+    if not base_host or not candidate_host:
+        return False
+    if base_host == candidate_host:
+        return True
+    return _registrable_domain(base_host) == _registrable_domain(candidate_host)
+
+
+def _registrable_domain(hostname: str) -> str:
+    parts = hostname.rsplit(".", maxsplit=2)
+    if len(parts) < 2:
+        return hostname
+    return ".".join(parts[-2:])
+
+
+def _is_rejected_target(parsed_url: ParseResult) -> bool:
+    hostname = str(parsed_url.hostname or "").lower()
+    path = str(parsed_url.path or "").lower()
+    if hostname in _REJECT_HOST_PARTS:
+        return True
+    if any(path_part in path for path_part in _REJECT_PATH_PARTS):
+        return True
+    query = parse_qs(str(getattr(parsed_url, "query", "")))
+    return bool({"continue", "redirectPath"} & set(query))
+
+
+def _has_report_semantics(url_text: str, label: str) -> bool:
+    text = _normalize_text(f"{url_text} {label}")
+    return any(term in text for term in _REPORT_TERMS)
+
+
+def _identity_tokens(text: str) -> set[str]:
+    tokens = set(re.findall(r"[a-z0-9]+", _normalize_text(text)))
+    return {
+        token
+        for token in tokens
+        if token in _IDENTITY_KEEPWORDS or (len(token) >= 4 and token not in _STOPWORDS)
+    }
+
+
+def _normalize_text(text: str) -> str:
+    return " ".join(text.casefold().replace("_", " ").replace("-", " ").split())
+
+
+def _normalized_url_text(url: str) -> str:
+    parsed = urlparse(url)
+    return _normalize_text(f"{parsed.netloc} {parsed.path} {parsed.query}")
+
+
+def _points_back_to_requested_page(
+    candidate_url: str,
+    requested_url: str,
+    resolved_url: str,
+) -> bool:
+    candidate = urlparse(candidate_url)
+    for url in (requested_url, resolved_url):
+        parsed = urlparse(url)
+        if (
+            candidate.netloc == parsed.netloc
+            and candidate.path.rstrip("/") == parsed.path.rstrip("/")
+        ):
+            return True
+    return False
+
+
+def _bool_value(metadata: Mapping[str, object], key: str) -> bool:
+    value = metadata.get(key, False)
+    return value if isinstance(value, bool) else False
+
+
+def _int_value(metadata: Mapping[str, object], key: str) -> int:
+    value = metadata.get(key, 0)
+    return value if isinstance(value, int) else 0

--- a/tests/fixtures/public_replay_acceptance/source_acceptance_metadata.json
+++ b/tests/fixtures/public_replay_acceptance/source_acceptance_metadata.json
@@ -73,6 +73,7 @@
           "known_limitation_codes": [
             "public_webpage_visible_text_extraction_requires_source_review",
             "links_images_tables_comments_and_publication_metadata_may_be_incomplete",
+            "public_webpage_source_intent_shape_requires_operator_review",
             "article_body_text_is_retained_not_summarized"
           ],
           "reviewability_assessment": {
@@ -93,6 +94,7 @@
           "remaining_artifacts": {
             "total_count": 0,
             "counts_by_category": {
+              "possible_source_intent_mismatch": 0,
               "reported_remaining_webpage_chrome_artifacts": 0
             }
           },

--- a/tests/fixtures/public_webpage/article_chrome_cases.json
+++ b/tests/fixtures/public_webpage/article_chrome_cases.json
@@ -27,6 +27,14 @@
         },
         "content_profile": {
           "article_body_text_retained_for_review": true
+        },
+        "source_intent_assessment": {
+          "target_shape_assessment": "insufficient_substantive_body",
+          "possible_wrapper_page": false,
+          "possible_lead_form_page": false,
+          "possible_download_landing_page": false,
+          "substantive_content_confidence": "low",
+          "likely_target_mismatch": false
         }
       },
       "expected_markdown_metadata_lines": [
@@ -35,7 +43,9 @@
         "- replay_quality_promotion_state: unsafe-to-promote",
         "- replay_quality_review_effort: bounded",
         "- replay_quality_webpage_chrome_suppressed_paragraph_count: 11",
-        "- replay_quality_webpage_article_body_text_retained_for_review: True"
+        "- replay_quality_webpage_article_body_text_retained_for_review: True",
+        "- replay_quality_webpage_target_shape_assessment: insufficient_substantive_body",
+        "- replay_quality_webpage_likely_target_mismatch: False"
       ]
     },
     {
@@ -53,6 +63,14 @@
             "subscription_prompt": 2,
             "footer_legal_text": 1
           }
+        },
+        "source_intent_assessment": {
+          "target_shape_assessment": "no_retained_content",
+          "possible_wrapper_page": false,
+          "possible_lead_form_page": false,
+          "possible_download_landing_page": false,
+          "substantive_content_confidence": "low",
+          "likely_target_mismatch": false
         },
         "replay_classification": {
           "operational_state": "diagnostic-only",
@@ -77,7 +95,161 @@
         "- replay_quality_promotion_state: unsafe-to-promote",
         "- replay_quality_review_effort: not_useful",
         "- replay_quality_bounded_review_economics: False",
-        "- replay_quality_webpage_chrome_suppressed_paragraph_count: 5"
+        "- replay_quality_webpage_chrome_suppressed_paragraph_count: 5",
+        "- replay_quality_webpage_target_shape_assessment: no_retained_content"
+      ]
+    },
+    {
+      "id": "clean_substantive_report_page",
+      "description": "A clean report body has enough long paragraph structure to remain a substantive content page.",
+      "raw_content": "2025 Example Engineering Report\n\nExecutive summary\n\nThis report analyzes delivery performance across many software organizations. It explains the research population, the survey frame, and the operational measures used in the study. The body text is long enough to look like a document section rather than a navigation label.\n\nThe findings describe how deployment frequency, change lead time, reliability, and recovery practices varied across respondent groups. The paragraph includes multiple complete sentences. It provides adjacent body substance around the report title without asking the reader to submit a form.\n\nMethodology notes clarify that the reported observations come from a structured survey and supporting operational evidence. The section discusses inclusion rules, measurement limitations, and interpretation boundaries. It does not contain a lead form or a repeated country selector.",
+      "expected_content": "2025 Example Engineering Report\n\nExecutive summary\n\nThis report analyzes delivery performance across many software organizations. It explains the research population, the survey frame, and the operational measures used in the study. The body text is long enough to look like a document section rather than a navigation label.\n\nThe findings describe how deployment frequency, change lead time, reliability, and recovery practices varied across respondent groups. The paragraph includes multiple complete sentences. It provides adjacent body substance around the report title without asking the reader to submit a form.\n\nMethodology notes clarify that the reported observations come from a structured survey and supporting operational evidence. The section discusses inclusion rules, measurement limitations, and interpretation boundaries. It does not contain a lead form or a repeated country selector.",
+      "expected_metadata": {
+        "source_intent_assessment": {
+          "target_shape_assessment": "substantive_content_page",
+          "possible_wrapper_page": false,
+          "possible_lead_form_page": false,
+          "possible_download_landing_page": false,
+          "substantive_content_confidence": "medium",
+          "likely_target_mismatch": false
+        },
+        "replay_classification": {
+          "operational_state": "review-ready",
+          "reviewability_assessment": {
+            "review_effort": "bounded",
+            "bounded_review_economics": true
+          }
+        }
+      },
+      "expected_markdown_metadata_lines": [
+        "- replay_quality_operational_state: review-ready",
+        "- replay_quality_webpage_target_shape_assessment: substantive_content_page",
+        "- replay_quality_webpage_possible_wrapper_page: False",
+        "- replay_quality_webpage_substantive_content_confidence: medium",
+        "- replay_quality_webpage_likely_target_mismatch: False"
+      ]
+    },
+    {
+      "id": "dora_style_download_landing_page",
+      "description": "A DORA-style report landing page with CTA and form labels is marked as likely the wrong capture target.",
+      "raw_content": "DORA 2025 AI-assisted Software Development Report\n\nBridge engineering speed and business impact.\n\nDownload the report\n\nFirst name\n\nLast name\n\nBusiness email\n\nCompany name\n\nJob title\n\nCountry\n\nBy submitting this form, you agree that your personal data will be processed according to the privacy policy.\n\nResources\n\nReports\n\nWebinars\n\nCase studies",
+      "expected_content": "DORA 2025 AI-assisted Software Development Report\n\nBridge engineering speed and business impact.\n\nDownload the report\n\nFirst name\n\nLast name\n\nBusiness email\n\nCompany name\n\nJob title\n\nCountry\n\nBy submitting this form, you agree that your personal data will be processed according to the privacy policy.\n\nResources\n\nReports\n\nWebinars\n\nCase studies",
+      "expected_metadata": {
+        "source_intent_assessment": {
+          "target_shape_assessment": "likely_wrong_capture_target",
+          "possible_wrapper_page": true,
+          "possible_lead_form_page": true,
+          "possible_download_landing_page": true,
+          "substantive_content_confidence": "low",
+          "likely_target_mismatch": true
+        },
+        "replay_classification": {
+          "operational_state": "likely-wrong-capture-target",
+          "reviewability_assessment": {
+            "review_effort": "source_target_review",
+            "bounded_review_economics": false
+          }
+        }
+      },
+      "expected_markdown_metadata_lines": [
+        "- replay_quality_operational_state: likely-wrong-capture-target",
+        "- replay_quality_review_effort: source_target_review",
+        "- replay_quality_webpage_target_shape_assessment: likely_wrong_capture_target",
+        "- replay_quality_webpage_possible_wrapper_page: True",
+        "- replay_quality_webpage_possible_lead_form_page: True",
+        "- replay_quality_webpage_possible_download_landing_page: True",
+        "- replay_quality_webpage_likely_target_mismatch: True"
+      ]
+    },
+    {
+      "id": "google_cloud_lead_form_resources_page",
+      "description": "A sanitized Google Cloud resources page shape with a DORA report title, lead form, country selector, legal text, and catalog navigation is marked as a likely target mismatch.",
+      "requested_url": "https://cloud.google.com/resources/content/dora-roi-of-ai-assisted-software-development",
+      "resolved_url": "https://cloud.google.com/resources/content/dora-roi-of-ai-assisted-software-development",
+      "raw_content": "DORA: ROI of AI-assisted Software Development report\n\nBridge the gap between engineering speed and financial impact.\n\nDownload the report\n\nFirst name First name First name\n\nLast name Last name Last name\n\nBusiness email Business email Business email\n\nBusiness phone Business phone Business phone\n\nJob title Job title Job title\n\nCompany name Company name Company name\n\nCountry Country Country Country United States\n\nAfghanistan\n\nAlbania\n\nAlgeria\n\nAmerican Samoa\n\nAndorra\n\nAngola\n\nAustralia\n\nAustria\n\nBrazil\n\nCanada\n\nFrance\n\nGermany\n\nIndia\n\nJapan\n\nUnited Kingdom\n\nBy submitting this form, I agree to receive communications and understand that my personal data will be handled according to the privacy policy.\n\nProducts\n\nSolutions\n\nPricing\n\nResources\n\nDocs\n\nContact us\n\nGet started\n\nReports\n\nWebinars\n\nCase studies\n\nTraining\n\nSupport",
+      "expected_content": "DORA: ROI of AI-assisted Software Development report\n\nBridge the gap between engineering speed and financial impact.\n\nDownload the report\n\nFirst name First name First name\n\nLast name Last name Last name\n\nBusiness email Business email Business email\n\nBusiness phone Business phone Business phone\n\nJob title Job title Job title\n\nCompany name Company name Company name\n\nCountry Country Country Country United States\n\nAfghanistan\n\nAlbania\n\nAlgeria\n\nAmerican Samoa\n\nAndorra\n\nAngola\n\nAustralia\n\nAustria\n\nBrazil\n\nCanada\n\nFrance\n\nGermany\n\nIndia\n\nJapan\n\nUnited Kingdom\n\nBy submitting this form, I agree to receive communications and understand that my personal data will be handled according to the privacy policy.\n\nProducts\n\nSolutions\n\nPricing\n\nResources\n\nDocs\n\nContact us\n\nGet started\n\nReports\n\nWebinars\n\nCase studies\n\nTraining\n\nSupport",
+      "expected_metadata": {
+        "source_intent_assessment": {
+          "target_shape_assessment": "likely_wrong_capture_target",
+          "possible_wrapper_page": true,
+          "possible_lead_form_page": true,
+          "possible_download_landing_page": true,
+          "possible_resource_catalog_page": true,
+          "substantive_content_confidence": "low",
+          "likely_target_mismatch": true,
+          "resolved_url_changed": false
+        },
+        "replay_classification": {
+          "operational_state": "likely-wrong-capture-target",
+          "reviewability_assessment": {
+            "review_effort": "source_target_review",
+            "bounded_review_economics": false
+          },
+          "promotion_safety": {
+            "blocker_codes": [
+              "public_source_candidate_requires_human_retention_review",
+              "likely_target_mismatch_requires_source_review"
+            ]
+          }
+        }
+      },
+      "expected_markdown_metadata_lines": [
+        "- replay_quality_operational_state: likely-wrong-capture-target",
+        "- replay_quality_webpage_target_shape_assessment: likely_wrong_capture_target",
+        "- replay_quality_webpage_possible_wrapper_page: True",
+        "- replay_quality_webpage_possible_lead_form_page: True",
+        "- replay_quality_webpage_possible_download_landing_page: True",
+        "- replay_quality_webpage_likely_target_mismatch: True"
+      ]
+    },
+    {
+      "id": "false_positive_report_body_with_download_reference",
+      "description": "A substantive report page can mention a downloadable appendix without becoming a download landing page.",
+      "raw_content": "Example Resilience Report\n\nThe report body describes incident response patterns across several teams. It includes enough context to explain the research questions, the sample boundaries, and the way each measure was collected. Download the appendix is mentioned once as a supporting artifact, not as the main page structure.\n\nThe next section compares reliability outcomes across services and deployment models. It uses complete sentences, describes the interpretation limits, and gives reviewers a real body of text to inspect. Contact information is not presented as a form and there is no country selector.\n\nThe conclusion explains where the evidence is strongest and where additional review is needed. It distinguishes operational observations from recommendations. It keeps the source material in paragraph form so the adapter should not treat it as a resource catalog.",
+      "expected_content": "Example Resilience Report\n\nThe report body describes incident response patterns across several teams. It includes enough context to explain the research questions, the sample boundaries, and the way each measure was collected. Download the appendix is mentioned once as a supporting artifact, not as the main page structure.\n\nThe next section compares reliability outcomes across services and deployment models. It uses complete sentences, describes the interpretation limits, and gives reviewers a real body of text to inspect. Contact information is not presented as a form and there is no country selector.\n\nThe conclusion explains where the evidence is strongest and where additional review is needed. It distinguishes operational observations from recommendations. It keeps the source material in paragraph form so the adapter should not treat it as a resource catalog.",
+      "expected_metadata": {
+        "source_intent_assessment": {
+          "target_shape_assessment": "substantive_content_page",
+          "possible_wrapper_page": false,
+          "possible_lead_form_page": false,
+          "possible_download_landing_page": false,
+          "substantive_content_confidence": "medium",
+          "likely_target_mismatch": false
+        },
+        "replay_classification": {
+          "operational_state": "review-ready"
+        }
+      },
+      "expected_markdown_metadata_lines": [
+        "- replay_quality_operational_state: review-ready",
+        "- replay_quality_webpage_target_shape_assessment: substantive_content_page",
+        "- replay_quality_webpage_possible_download_landing_page: False",
+        "- replay_quality_webpage_likely_target_mismatch: False"
+      ]
+    },
+    {
+      "id": "false_positive_article_body_with_contact_sales_phrase",
+      "description": "A long article paragraph that says contact sales should not be treated as a lead form without form-field structure.",
+      "raw_content": "Example Platform Article\n\nSome teams say contact sales is the phrase they expect to see near pricing details, but the article is analyzing product-led adoption rather than presenting a form. It has complete sentences, tradeoff discussion, and surrounding explanation that a reviewer can inspect. The phrase appears as content, not as a call-to-action block.\n\nThe analysis continues with a comparison of onboarding paths and support practices. It explains how buyer expectations change when technical evaluators join a trial. It avoids repeated navigation labels, catalog menus, and selector lists that would otherwise dominate the extracted text.\n\nThe final section describes limitations in the observed examples. It tells readers that the evidence is anecdotal and should be treated carefully. The paragraph structure remains article-like even though one commercial phrase appears in the body.",
+      "expected_content": "Example Platform Article\n\nSome teams say contact sales is the phrase they expect to see near pricing details, but the article is analyzing product-led adoption rather than presenting a form. It has complete sentences, tradeoff discussion, and surrounding explanation that a reviewer can inspect. The phrase appears as content, not as a call-to-action block.\n\nThe analysis continues with a comparison of onboarding paths and support practices. It explains how buyer expectations change when technical evaluators join a trial. It avoids repeated navigation labels, catalog menus, and selector lists that would otherwise dominate the extracted text.\n\nThe final section describes limitations in the observed examples. It tells readers that the evidence is anecdotal and should be treated carefully. The paragraph structure remains article-like even though one commercial phrase appears in the body.",
+      "expected_metadata": {
+        "source_intent_assessment": {
+          "target_shape_assessment": "substantive_content_page",
+          "possible_wrapper_page": false,
+          "possible_lead_form_page": false,
+          "possible_download_landing_page": false,
+          "substantive_content_confidence": "medium",
+          "likely_target_mismatch": false
+        },
+        "replay_classification": {
+          "operational_state": "review-ready"
+        }
+      },
+      "expected_markdown_metadata_lines": [
+        "- replay_quality_operational_state: review-ready",
+        "- replay_quality_webpage_target_shape_assessment: substantive_content_page",
+        "- replay_quality_webpage_possible_wrapper_page: False",
+        "- replay_quality_webpage_likely_target_mismatch: False"
       ]
     }
   ]

--- a/tests/test_public_webpage_chrome_fixtures.py
+++ b/tests/test_public_webpage_chrome_fixtures.py
@@ -38,6 +38,11 @@ def test_public_webpage_article_chrome_fixture_area_is_present() -> None:
     assert case_ids == {
         "article_body_plus_substack_chrome",
         "chrome_only_diagnostic_replay",
+        "clean_substantive_report_page",
+        "dora_style_download_landing_page",
+        "google_cloud_lead_form_resources_page",
+        "false_positive_report_body_with_download_reference",
+        "false_positive_article_body_with_contact_sales_phrase",
     }
 
 
@@ -94,6 +99,32 @@ def test_public_webpage_chrome_only_fixture_is_diagnostic_only() -> None:
 
     for expected_line in _string_sequence(case, "expected_markdown_metadata_lines"):
         assert expected_line in markdown
+
+
+def test_public_webpage_source_intent_fixtures_are_classified() -> None:
+    for case in ARTICLE_CHROME_CASES:
+        content, metadata = normalize_extracted_text_with_replay_metadata(
+            str(case["raw_content"]),
+            requested_url=str(case.get("requested_url", "")) or None,
+            resolved_url=str(case.get("resolved_url", "")) or None,
+        )
+
+        assert content == case["expected_content"]
+        _assert_metadata_contains(metadata, _mapping(case, "expected_metadata"))
+
+        markdown = normalize_to_markdown(
+            {
+                "title": str(case["id"]),
+                "canonical_id": "fixture://source-intent",
+                "source_url": "fixture://source-intent",
+                "fetched_at": "2026-05-13T12:00:00Z",
+                "content": content,
+                "replay_quality_metadata": metadata,
+            }
+        )
+
+        for expected_line in _string_sequence(case, "expected_markdown_metadata_lines"):
+            assert expected_line in markdown
 
 
 def _assert_metadata_contains(

--- a/tests/test_public_webpage_target_discovery.py
+++ b/tests/test_public_webpage_target_discovery.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pytest import MonkeyPatch
+
+from knowledge_adapters.public_pdf.client import PublicPdfDocument
+from knowledge_adapters.public_sources import FetchedPublicResource
+from knowledge_adapters.public_webpage.client import PublicWebpageDocument, fetch_webpage
+
+WRAPPER_URL = "https://cloud.example.com/devops/state-of-devops"
+PDF_URL = "https://services.example.com/fh/files/misc/2025_state_of_ai_assisted_software_development.pdf"
+
+
+def test_public_webpage_wrapper_with_one_clear_pdf_target_is_fetched(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    def fake_fetch_public_url(url: str, **kwargs: Any) -> FetchedPublicResource:
+        calls.append(url)
+        return _html_response(
+            url,
+            f"""
+            <html>
+              <head><title>2025 DORA State of AI Assisted Software Development</title></head>
+              <body>
+                <h1>2025 DORA State of AI-Assisted Software Development report</h1>
+                <p>Bridge engineering speed and business impact.</p>
+                <a href="{PDF_URL}">Download the report</a>
+                <p>First name</p><p>Last name</p><p>Business email</p>
+                <p>Company name</p><p>Country</p>
+                <p>By submitting this form, you agree to the privacy policy.</p>
+              </body>
+            </html>
+            """,
+        )
+
+    def fake_fetch_pdf(url: str) -> PublicPdfDocument:
+        assert url == PDF_URL
+        return PublicPdfDocument(
+            title="2025 DORA State of AI Assisted Software Development",
+            canonical_id=PDF_URL,
+            source_url=PDF_URL,
+            fetched_at="2026-05-13T12:00:00Z",
+            content="PDF report body.",
+            page_count=42,
+            replay_quality_metadata={
+                "replay_classification": {
+                    "source_type": "public_pdf",
+                    "operational_state": "review-ready",
+                    "promotion_state": "unsafe-to-promote",
+                }
+            },
+        )
+
+    monkeypatch.setattr(
+        "knowledge_adapters.public_webpage.client.fetch_public_url",
+        fake_fetch_public_url,
+    )
+    monkeypatch.setattr("knowledge_adapters.public_webpage.client.fetch_pdf", fake_fetch_pdf)
+
+    document = fetch_webpage(WRAPPER_URL)
+
+    assert isinstance(document, PublicPdfDocument)
+    assert calls == [WRAPPER_URL]
+    assert document.source_url == PDF_URL
+    source_intent = document.replay_quality_metadata["source_intent_assessment"]
+    assert isinstance(source_intent, dict)
+    assert source_intent["target_shape_assessment"] == "likely_wrong_capture_target"
+    assert source_intent["target_selection_status"] == "selected"
+    assert source_intent["selected_target_url"] == PDF_URL
+    assert source_intent["selected_target_content_type"] == "pdf"
+
+
+def test_public_webpage_wrapper_with_no_clear_target_reports_mismatch(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "knowledge_adapters.public_webpage.client.fetch_public_url",
+        lambda url, **kwargs: _html_response(
+            url,
+            """
+            <html><head><title>2025 DORA State of AI Assisted Software Development</title></head>
+            <body>
+              <h1>2025 DORA State of AI-Assisted Software Development report</h1>
+              <p>Download the report</p>
+              <p>First name</p><p>Last name</p><p>Business email</p><p>Country</p>
+              <a href="https://cloud.example.com/contact">Contact sales</a>
+            </body></html>
+            """,
+        ),
+    )
+    monkeypatch.setattr(
+        "knowledge_adapters.public_webpage.client.fetch_pdf",
+        lambda url: (_ for _ in ()).throw(AssertionError("unexpected PDF fetch")),
+    )
+
+    document = fetch_webpage(WRAPPER_URL)
+
+    assert isinstance(document, PublicWebpageDocument)
+    source_intent = document.replay_quality_metadata["source_intent_assessment"]
+    assert isinstance(source_intent, dict)
+    assert source_intent["likely_target_mismatch"] is True
+    assert source_intent["target_selection_status"] == "no_high_confidence_target"
+    assert source_intent["selected_target_url"] == ""
+
+
+def test_public_webpage_wrapper_with_conflicting_targets_does_not_fetch(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    second_pdf = (
+        "https://services.example.com/fh/files/misc/"
+        "2025_state_of_ai_assisted_delivery_report.pdf"
+    )
+    monkeypatch.setattr(
+        "knowledge_adapters.public_webpage.client.fetch_public_url",
+        lambda url, **kwargs: _html_response(
+            url,
+            f"""
+            <html><head><title>2025 DORA State of AI Assisted Software Development</title></head>
+            <body>
+              <h1>2025 DORA State of AI-Assisted Software Development report</h1>
+              <a href="{PDF_URL}">Download the report</a>
+              <a href="{second_pdf}">Download the report PDF</a>
+              <p>First name</p><p>Last name</p><p>Business email</p><p>Country</p>
+              <p>By submitting this form, you agree to the privacy policy.</p>
+            </body></html>
+            """,
+        ),
+    )
+    monkeypatch.setattr(
+        "knowledge_adapters.public_webpage.client.fetch_pdf",
+        lambda url: (_ for _ in ()).throw(AssertionError("unexpected PDF fetch")),
+    )
+
+    document = fetch_webpage(WRAPPER_URL)
+
+    assert isinstance(document, PublicWebpageDocument)
+    source_intent = document.replay_quality_metadata["source_intent_assessment"]
+    assert isinstance(source_intent, dict)
+    assert source_intent["target_selection_status"] == (
+        "ambiguous_multiple_high_confidence_targets"
+    )
+    assert source_intent["selected_target_url"] == ""
+
+
+def test_public_webpage_substantive_page_does_not_select_alternate_target(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "knowledge_adapters.public_webpage.client.fetch_public_url",
+        lambda url, **kwargs: _html_response(
+            url,
+            f"""
+            <html><head><title>Example Engineering Report</title></head>
+            <body>
+              <h1>Example Engineering Report</h1>
+              <p>This report analyzes delivery performance across many software
+              organizations. It explains the survey frame and operational measures.
+              The body text is long enough to look like a document section rather
+              than a navigation label.</p>
+              <p>The findings describe deployment frequency, change lead time,
+              reliability, and recovery practices. The paragraph includes multiple
+              complete sentences. It provides adjacent body substance around the
+              report title without asking the reader to submit a form.</p>
+              <p>The conclusion explains where the evidence is strongest and where
+              additional review is needed. It distinguishes observations from
+              recommendations. <a href="{PDF_URL}">Download appendix</a></p>
+            </body></html>
+            """,
+        ),
+    )
+    monkeypatch.setattr(
+        "knowledge_adapters.public_webpage.client.fetch_pdf",
+        lambda url: (_ for _ in ()).throw(AssertionError("unexpected PDF fetch")),
+    )
+
+    document = fetch_webpage(WRAPPER_URL)
+
+    assert isinstance(document, PublicWebpageDocument)
+    source_intent = document.replay_quality_metadata["source_intent_assessment"]
+    assert isinstance(source_intent, dict)
+    assert source_intent["likely_target_mismatch"] is False
+    assert source_intent["target_selection_status"] == "not_applicable_no_target_mismatch"
+    assert source_intent["selected_target_url"] == ""
+
+
+def _html_response(url: str, html: str) -> FetchedPublicResource:
+    return FetchedPublicResource(
+        url=url,
+        final_url=url,
+        content=html.encode("utf-8"),
+        content_type="text/html",
+        content_charset="utf-8",
+        retrieved_at="2026-05-13T12:00:00Z",
+    )


### PR DESCRIPTION
## Summary
- add deterministic public webpage source-intent assessment for wrapper, lead-form, download landing, resource catalog, and insufficient-body shapes
- add bounded same-page target discovery with one-clear-winner selection, same host-family guardrails, PDF routing through public_pdf, and no multi-hop crawling
- surface target-selection metadata in CLI and markdown replay-quality output, with fixtures for clear target, missing target, ambiguous targets, normal pages, false positives, and sanitized Google Cloud lead-form shape

## Live-source observation
- https://cloud.google.com/devops/state-of-devops was detected as likely_wrong_capture_target
- selected exactly one embedded same-page PDF target: https://services.google.com/fh/files/misc/2025_state_of_ai_assisted_software_development.pdf
- routed replay through public_pdf and observed 142 pages

## Non-regression evidence
- public_replay_acceptance remained stable for DORA 2023 public PDF, MeaningfulTech webpage, and DORA ROI 2026 public PDF
- public-source candidates remain unreviewed and unsafe-to-promote; this does not add summarization, retention semantics, broad crawling, site search, or LLM classification

## Validation
- make test PYTEST=.venv/bin/pytest\ tests/test_public_webpage_chrome_fixtures.py\ tests/test_public_webpage_target_discovery.py\ tests/test_public_replay_acceptance.py\ tests/test_public_sources.py
- .venv/bin/knowledge-adapters public_replay_acceptance
- make check
- git diff --check

## Remaining limitations
- target discovery only uses URLs present in the fetched page HTML, anchors, link/meta tags, or embedded same-page URL text
- no target is selected when candidates are absent or when multiple high-confidence candidates conflict
- host-family matching is deliberately conservative and may require future allowlist handling for other official report CDNs