### PR TITLE
Improve canonical source resolution for operational research replay

### DIFF
--- a/docs/public-operational-research-live-proof.md
+++ b/docs/public-operational-research-live-proof.md
@@ -1,0 +1,69 @@
+# Public Operational-Research Live Proof
+
+Run date: 2026-05-13
+
+Branch: `feat/canonical-source-resolution`
+
+Purpose: record a bounded public-source replay/probe of the exact
+knowledge-vault PR #35 operational-research URLs with the PR #291 code. This
+is current-source availability evidence only; it does not promote, retain, or
+replace any knowledge-vault source.
+
+The probe used the repository's normal `public_webpage` fetch path and did not
+use external search, recursive traversal, browser automation, or alternate
+source discovery.
+
+## Summary
+
+No previously failed or diagnostic operational-research source became a proven
+selected-target live success in this pass.
+
+The PR improves classification and reporting clarity for several live sources,
+but current bounded replay still gives a conservative no-go signal for returning
+these sources to knowledge-vault retention/retry as stable canonical assets.
+
+## Proven Live-Success Targets
+
+None.
+
+## Improved Diagnostic Or Classification Only
+
+| Source | URL | Fetch result | Final URL | Effective adapter | Canonical target status | Selected target | Selected target fetched | Operational classification | KV retry signal |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Puppet 2021 State of DevOps | `https://puppet.com/resources/report/2021-state-of-devops-report/` | success | `https://www.puppet.com/resources/state-of-devops-report` | `public_webpage` | `ambiguous` | none | no | `likely-wrong-capture-target` | No. Historical redirect is detected, but no single stable 2021 asset was selected. |
+| GitHub Research/Octoverse | `https://github.blog/news-insights/research/` | success | `https://github.blog/news-insights/research/` | `public_webpage` | `ambiguous` | none | no | `likely-wrong-capture-target` | No. It is now labeled `mutable_index_page`, not a stable report asset. |
+| METR | `https://metr.org/` | success | `https://metr.org/` | `public_webpage` | `no_selection` | none | no | `likely-wrong-capture-target` | No. It is now labeled `mutable_index_page`, not a stable report asset. |
+| Google SRE Workbook TOC | `https://sre.google/workbook/table-of-contents/` | success | `https://sre.google/workbook/table-of-contents/` | `public_webpage` | `no_selection` | none | no | `likely-wrong-capture-target` | No for retained content retry. It is correctly labeled `chapter_navigation_source` and remains inventory/navigation only. |
+
+## Still Blocked By HTTP Availability
+
+| Source | URL | Fetch result | Final URL | Effective adapter | Canonical target status | Selected target | Selected target fetched | Operational classification | KV retry signal |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Accelerate | `https://itrevolution.com/product/accelerate/` | error: HTTP 403 | none from adapter fetch | none | `not_available_fetch_failed` | none | no | `not_available_fetch_failed` | No. Keep queued/manual-summary-only unless a source owner or human reviewer selects a reachable canonical target. |
+| SPACE framework paper | `https://queue.acm.org/detail.cfm?id=3454124` | error: HTTP 403 | none from adapter fetch | none | `not_available_fetch_failed` | none | no | `not_available_fetch_failed` | No. The stable URL shape is fixture-covered, but the live source is not proven by bounded replay. |
+| Microsoft Research developer tools | `https://www.microsoft.com/en-us/research/research-area/developer-tools/` | error: HTTP 404 | none from adapter fetch | none | `not_available_fetch_failed` | none | no | `not_available_fetch_failed` | No. Needs source replacement or manual target selection. |
+
+## Intentionally No-Selection
+
+| Source | URL | Fetch result | Final URL | Effective adapter | Canonical target status | Selected target | Selected target fetched | Operational classification | KV retry signal |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Team Topologies | `https://teamtopologies.com/book` | success | `https://teamtopologies.com/book` | `public_webpage` | `no_selection` | none | no | `likely-wrong-capture-target` | No. It is now labeled `commercial_landing_page`; no automatic target selection is intended. |
+
+## Go/No-Go For Knowledge-Vault PR #35
+
+- Do not mark Accelerate, SPACE, Microsoft Research, Puppet 2021, GitHub
+  Research/Octoverse, METR, Team Topologies, or SRE Workbook TOC as proven
+  replay-successful stable canonical assets based on PR #291.
+- Puppet is operationally clearer than before: the historical redirect is
+  explicit, but current bounded replay still does not select or fetch a stable
+  2021 report asset.
+- GitHub Research/Octoverse and METR are operationally clearer than before:
+  they are classified as mutable index/portal sources and remain diagnostic.
+- Team Topologies is operationally clearer than before: it is classified as a
+  commercial landing page and intentionally no-selection.
+- SRE Workbook TOC is operationally clearer than before: it is classified as
+  chapter navigation/inventory, not retained chapter content.
+
+The next knowledge-vault move should keep these entries queued or
+diagnostic-only unless a human reviewer supplies a stable canonical target that
+the bounded adapter path can fetch successfully.

--- a/docs/public-webpage-chrome-fixtures.md
+++ b/docs/public-webpage-chrome-fixtures.md
@@ -65,13 +65,12 @@ Live observation on May 13, 2026: the Google Cloud 2025 DORA page at
 target, and routed replay through the public PDF adapter:
 `https://services.google.com/fh/files/misc/2025_state_of_ai_assisted_software_development.pdf`.
 
-Operational-research observations on May 13, 2026: IT Revolution Accelerate and
-ACM Queue SPACE returned HTTP 403 challenge pages to direct replay requests;
-the Puppet 2021 State of DevOps URL redirected to the current State of DevOps
-hub; Microsoft Research developer tools returned HTTP 403; Team Topologies
-served a commercial/book landing shape; METR research and GitHub Octoverse
-served mutable research/index pages; and the Google SRE workbook table of
-contents served a stable chapter-navigation page.
+Operational-research observations on May 13, 2026 are recorded in
+`docs/public-operational-research-live-proof.md`. The short version: no
+previously failed or diagnostic source became a proven selected-target live
+success in PR #291; the PR improves classification clarity while preserving
+conservative no-selection behavior for ambiguous, mutable, commercial, and
+chapter-navigation sources.
 
 The shared replay classification reports `review-ready` for retained or routed
 substantive target content, `likely-wrong-capture-target` for retained wrapper

--- a/docs/public-webpage-chrome-fixtures.md
+++ b/docs/public-webpage-chrome-fixtures.md
@@ -16,6 +16,9 @@ The fixture area captures small article-body-plus-chrome shapes for:
 - retained article body text with replay-quality boundary metadata
 - chrome-only diagnostic replay shapes where no reviewable article text remains
 - wrapper, lead-form, download-landing, and resource-catalog page shapes
+- operational-research source shapes such as redirected historical reports,
+  mutable research indexes, commercial book landings, stable publication URLs,
+  and table-of-contents/chapter navigation pages
 - same-page target discovery when exactly one high-confidence report asset is
   present
 - no-selection safety when targets are missing or ambiguous
@@ -31,10 +34,13 @@ candidate article body text and from likely wrong capture targets.
 The source-intent assessment reports bounded operational labels such as
 `target_shape_assessment`, `possible_wrapper_page`,
 `possible_lead_form_page`, `possible_download_landing_page`,
-`substantive_content_confidence`, and `likely_target_mismatch`. When a mismatch
-is detected, target discovery is limited to links and metadata already present
-on the fetched page. It does not crawl, search, summarize, or choose among
-ambiguous candidates.
+`commercial_landing_page_detected`, `mutable_index_page_detected`,
+`chapter_navigation_source_detected`, `historical_report_redirect_detected`,
+`stable_research_asset_detected`, `canonical_target_resolution_status`,
+`canonical_source_confidence`, `substantive_content_confidence`, and
+`likely_target_mismatch`. When a mismatch is detected, target discovery is
+limited to links and metadata already present on the fetched page. It does not
+crawl, search, summarize, or choose among ambiguous candidates.
 
 Automatic target fetch is allowed only when one same-page target satisfies the
 selection guards:
@@ -58,6 +64,14 @@ Live observation on May 13, 2026: the Google Cloud 2025 DORA page at
 `likely_wrong_capture_target`, selected exactly one embedded same-page PDF
 target, and routed replay through the public PDF adapter:
 `https://services.google.com/fh/files/misc/2025_state_of_ai_assisted_software_development.pdf`.
+
+Operational-research observations on May 13, 2026: IT Revolution Accelerate and
+ACM Queue SPACE returned HTTP 403 challenge pages to direct replay requests;
+the Puppet 2021 State of DevOps URL redirected to the current State of DevOps
+hub; Microsoft Research developer tools returned HTTP 403; Team Topologies
+served a commercial/book landing shape; METR research and GitHub Octoverse
+served mutable research/index pages; and the Google SRE workbook table of
+contents served a stable chapter-navigation page.
 
 The shared replay classification reports `review-ready` for retained or routed
 substantive target content, `likely-wrong-capture-target` for retained wrapper

--- a/src/knowledge_adapters/public_pdf/normalize.py
+++ b/src/knowledge_adapters/public_pdf/normalize.py
@@ -1359,6 +1359,22 @@ def _render_replay_quality_metadata(metadata: Mapping[str, object]) -> str:
                         f"{_metadata_value(source_intent, 'likely_target_mismatch')}"
                     ),
                     (
+                        "- replay_quality_webpage_historical_report_redirect_detected: "
+                        f"{_metadata_value(source_intent, 'historical_report_redirect_detected')}"
+                    ),
+                    (
+                        "- replay_quality_webpage_stable_research_asset_detected: "
+                        f"{_metadata_value(source_intent, 'stable_research_asset_detected')}"
+                    ),
+                    (
+                        "- replay_quality_webpage_canonical_target_resolution_status: "
+                        f"{_metadata_value(source_intent, 'canonical_target_resolution_status')}"
+                    ),
+                    (
+                        "- replay_quality_webpage_canonical_source_confidence: "
+                        f"{_metadata_value(source_intent, 'canonical_source_confidence')}"
+                    ),
+                    (
                         "- replay_quality_webpage_selected_target_url: "
                         f"{_metadata_value(source_intent, 'selected_target_url')}"
                     ),

--- a/src/knowledge_adapters/public_webpage/normalize.py
+++ b/src/knowledge_adapters/public_webpage/normalize.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import re
 from collections.abc import Mapping, Sequence
+from urllib.parse import urlparse
 
 from knowledge_adapters.replay_quality import build_public_source_replay_classification
 
@@ -369,6 +370,20 @@ def _assess_source_intent(
         and substantive_paragraph_count < 4
         and retained_character_count < 5000
     )
+    url_suggests_commercial_landing = _url_suggests_commercial_landing(
+        requested_url=requested_url,
+        resolved_url=resolved_url,
+    )
+    if (
+        url_suggests_commercial_landing
+        and commercial_book_signal_count >= 1
+        and (
+            catalog_navigation_count >= 4
+            or short_selector_like_paragraph_count >= 20
+            or form_field_count >= 2
+        )
+    ):
+        commercial_landing_page_detected = True
     mutable_index_page_detected = (
         research_index_signal_count >= 2
         and short_selector_like_paragraph_count >= 6
@@ -383,6 +398,16 @@ def _assess_source_intent(
         and short_selector_like_paragraph_count >= 8
         and substantive_paragraph_count < 4
     )
+    url_suggests_mutable_research_index = _url_suggests_mutable_research_index(
+        requested_url=requested_url,
+        resolved_url=resolved_url,
+    )
+    if (
+        url_suggests_mutable_research_index
+        and short_selector_like_paragraph_count >= 40
+        and (research_index_signal_count >= 1 or catalog_navigation_count >= 4)
+    ):
+        mutable_index_page_detected = True
     historical_report_redirect_detected = _historical_report_redirect_detected(
         requested_url=requested_url,
         resolved_url=resolved_url,
@@ -475,8 +500,10 @@ def _assess_source_intent(
         "possible_download_landing_page": possible_download_landing_page,
         "possible_resource_catalog_page": possible_resource_catalog_page,
         "commercial_landing_page_detected": commercial_landing_page_detected,
+        "url_suggests_commercial_landing": url_suggests_commercial_landing,
         "mutable_index_page_detected": mutable_index_page_detected,
         "chapter_navigation_source_detected": chapter_navigation_source_detected,
+        "url_suggests_mutable_research_index": url_suggests_mutable_research_index,
         "historical_report_redirect_detected": historical_report_redirect_detected,
         "stable_research_asset_detected": stable_research_asset_detected,
         "canonical_target_resolution_status": (
@@ -658,6 +685,36 @@ def _stable_research_asset_detected(
         term in first_text for term in ("abstract", "doi", "published", "proceedings")
     ):
         return True
+    return False
+
+
+def _url_suggests_mutable_research_index(
+    *,
+    requested_url: str | None,
+    resolved_url: str | None,
+) -> bool:
+    urls = [url for url in (requested_url, resolved_url) if url]
+    for url in urls:
+        parsed = urlparse(url)
+        path = (parsed.path or "/").casefold()
+        if "research" in path:
+            return True
+        if path in {"", "/"}:
+            return True
+    return False
+
+
+def _url_suggests_commercial_landing(
+    *,
+    requested_url: str | None,
+    resolved_url: str | None,
+) -> bool:
+    urls = [url for url in (requested_url, resolved_url) if url]
+    for url in urls:
+        parsed = urlparse(url)
+        path = (parsed.path or "/").casefold()
+        if any(part in path for part in ("/book", "/books", "/product", "/shop")):
+            return True
     return False
 
 

--- a/src/knowledge_adapters/public_webpage/normalize.py
+++ b/src/knowledge_adapters/public_webpage/normalize.py
@@ -190,19 +190,31 @@ _CTA_PHRASES = {
     "book a meeting",
     "contact sales",
     "download now",
+    "download paper",
+    "download the paper",
     "download report",
     "download the report",
     "get the report",
+    "read paper",
+    "read the paper",
     "request a demo",
     "request demo",
     "submit",
+    "view paper",
+    "view the paper",
 }
 _DOWNLOAD_CTA_PHRASES = {
     "access the report",
     "download now",
+    "download paper",
+    "download the paper",
     "download report",
     "download the report",
     "get the report",
+    "read paper",
+    "read the paper",
+    "view paper",
+    "view the paper",
 }
 _LEGAL_OR_CONSENT_PHRASES = {
     "by submitting this form",
@@ -231,6 +243,53 @@ _CATALOG_NAVIGATION_TERMS = {
     "whitepapers",
 }
 _REPORT_TITLE_TERMS = {"report", "research", "state of devops", "dora"}
+_COMMERCIAL_BOOK_TERMS = {
+    "add to cart",
+    "audiobook",
+    "book",
+    "buy now",
+    "consulting",
+    "ebook",
+    "kindle",
+    "paperback",
+    "product",
+    "purchase",
+    "shop",
+    "training",
+    "workshop",
+}
+_RESEARCH_INDEX_TERMS = {
+    "all research",
+    "developer tools",
+    "latest research",
+    "octoverse",
+    "publications",
+    "research areas",
+    "research index",
+    "research portal",
+    "research projects",
+    "topics",
+}
+_CHAPTER_NAVIGATION_TERMS = {
+    "chapter",
+    "chapters",
+    "contents",
+    "part i",
+    "part ii",
+    "table of contents",
+    "toc",
+    "workbook",
+}
+_STABLE_RESEARCH_ASSET_URL_PATTERNS = (
+    ".pdf",
+    "/article/",
+    "/chapter/",
+    "/detail.cfm",
+    "/paper/",
+    "/publication/",
+    "/report/",
+    "/whitepaper/",
+)
 
 
 def _assess_source_intent(
@@ -276,6 +335,21 @@ def _assess_source_intent(
     short_selector_like_paragraph_count = sum(
         1 for paragraph in extracted_paragraphs if _is_selector_like_paragraph(paragraph)
     )
+    commercial_book_signal_count = sum(
+        1
+        for paragraph in extracted_paragraphs[:30]
+        if _contains_phrase(paragraph, _COMMERCIAL_BOOK_TERMS)
+    )
+    research_index_signal_count = sum(
+        1
+        for paragraph in extracted_paragraphs[:40]
+        if _contains_phrase(paragraph, _RESEARCH_INDEX_TERMS)
+    )
+    chapter_navigation_signal_count = sum(
+        1
+        for paragraph in extracted_paragraphs[:50]
+        if _contains_phrase(paragraph, _CHAPTER_NAVIGATION_TERMS)
+    )
 
     possible_lead_form_page = form_field_count >= 3 and (
         download_cta_count >= 1 or legal_or_consent_count >= 1
@@ -289,6 +363,35 @@ def _assess_source_intent(
         catalog_navigation_count >= 8
         and substantive_paragraph_count < 4
         and short_selector_like_paragraph_count >= 12
+    )
+    commercial_landing_page_detected = (
+        commercial_book_signal_count >= 3
+        and substantive_paragraph_count < 4
+        and retained_character_count < 5000
+    )
+    mutable_index_page_detected = (
+        research_index_signal_count >= 2
+        and short_selector_like_paragraph_count >= 6
+        and substantive_paragraph_count < 4
+    ) or (
+        possible_resource_catalog_page
+        and research_index_signal_count >= 1
+        and substantive_paragraph_count < 4
+    )
+    chapter_navigation_source_detected = (
+        chapter_navigation_signal_count >= 3
+        and short_selector_like_paragraph_count >= 8
+        and substantive_paragraph_count < 4
+    )
+    historical_report_redirect_detected = _historical_report_redirect_detected(
+        requested_url=requested_url,
+        resolved_url=resolved_url,
+    )
+    stable_research_asset_detected = _stable_research_asset_detected(
+        requested_url=requested_url,
+        resolved_url=resolved_url,
+        retained_paragraphs=retained_paragraphs,
+        substantive_paragraph_count=substantive_paragraph_count,
     )
     high_chrome_to_substance_ratio = (
         total_character_count > 0
@@ -311,13 +414,16 @@ def _assess_source_intent(
         possible_lead_form_page
         or possible_download_landing_page
         or possible_resource_catalog_page
+        or commercial_landing_page_detected
+        or mutable_index_page_detected
         or high_chrome_to_substance_ratio
+        or historical_report_redirect_detected
         or report_title_with_little_body
     )
     insufficient_substantive_body = (
         retained_character_count < 700 or substantive_paragraph_count < 2
     )
-    likely_target_mismatch = possible_wrapper_page or (
+    likely_target_mismatch = possible_wrapper_page or chapter_navigation_source_detected or (
         insufficient_substantive_body
         and retained_character_count > 0
         and (download_cta_count > 0 or catalog_navigation_count >= 4)
@@ -332,12 +438,27 @@ def _assess_source_intent(
         possible_lead_form_page=possible_lead_form_page,
         possible_download_landing_page=possible_download_landing_page,
         possible_resource_catalog_page=possible_resource_catalog_page,
+        commercial_landing_page_detected=commercial_landing_page_detected,
+        mutable_index_page_detected=mutable_index_page_detected,
+        chapter_navigation_source_detected=chapter_navigation_source_detected,
+        historical_report_redirect_detected=historical_report_redirect_detected,
+        stable_research_asset_detected=stable_research_asset_detected,
         insufficient_substantive_body=insufficient_substantive_body,
         high_chrome_to_substance_ratio=high_chrome_to_substance_ratio,
         report_title_with_little_body=report_title_with_little_body,
     )
 
-    if likely_target_mismatch:
+    if commercial_landing_page_detected:
+        target_shape_assessment = "commercial_landing_page"
+    elif mutable_index_page_detected:
+        target_shape_assessment = "mutable_index_page"
+    elif chapter_navigation_source_detected:
+        target_shape_assessment = "chapter_navigation_source"
+    elif historical_report_redirect_detected and likely_target_mismatch:
+        target_shape_assessment = "historical_report_redirect"
+    elif stable_research_asset_detected and not likely_target_mismatch:
+        target_shape_assessment = "stable_canonical_asset"
+    elif likely_target_mismatch:
         target_shape_assessment = "likely_wrong_capture_target"
     elif retained_character_count == 0:
         target_shape_assessment = "no_retained_content"
@@ -353,6 +474,26 @@ def _assess_source_intent(
         "possible_lead_form_page": possible_lead_form_page,
         "possible_download_landing_page": possible_download_landing_page,
         "possible_resource_catalog_page": possible_resource_catalog_page,
+        "commercial_landing_page_detected": commercial_landing_page_detected,
+        "mutable_index_page_detected": mutable_index_page_detected,
+        "chapter_navigation_source_detected": chapter_navigation_source_detected,
+        "historical_report_redirect_detected": historical_report_redirect_detected,
+        "stable_research_asset_detected": stable_research_asset_detected,
+        "canonical_target_resolution_status": (
+            "not_resolved_yet" if likely_target_mismatch else "not_applicable"
+        ),
+        "canonical_source_confidence": _canonical_source_confidence(
+            stable_research_asset_detected=stable_research_asset_detected,
+            mutable_index_page_detected=mutable_index_page_detected,
+            commercial_landing_page_detected=commercial_landing_page_detected,
+            chapter_navigation_source_detected=chapter_navigation_source_detected,
+            historical_report_redirect_detected=historical_report_redirect_detected,
+            likely_target_mismatch=likely_target_mismatch,
+        ),
+        "redirect_chain_summary": _redirect_chain_summary(
+            requested_url=requested_url,
+            resolved_url=resolved_url,
+        ),
         "substantive_content_confidence": substantive_content_confidence,
         "likely_target_mismatch": likely_target_mismatch,
         "reason_codes": reason_codes,
@@ -367,7 +508,10 @@ def _assess_source_intent(
             "cta_paragraphs": cta_count,
             "download_cta_paragraphs": download_cta_count,
             "form_field_paragraphs": form_field_count,
+            "commercial_book_signal_paragraphs": commercial_book_signal_count,
             "legal_or_consent_paragraphs": legal_or_consent_count,
+            "research_index_signal_paragraphs": research_index_signal_count,
+            "chapter_navigation_signal_paragraphs": chapter_navigation_signal_count,
             "report_title_mentions_near_top": report_title_mention_count,
             "short_selector_like_paragraphs": short_selector_like_paragraph_count,
             "substantive_body_paragraphs": substantive_paragraph_count,
@@ -443,6 +587,11 @@ def _source_intent_reason_codes(
     possible_lead_form_page: bool,
     possible_download_landing_page: bool,
     possible_resource_catalog_page: bool,
+    commercial_landing_page_detected: bool,
+    mutable_index_page_detected: bool,
+    chapter_navigation_source_detected: bool,
+    historical_report_redirect_detected: bool,
+    stable_research_asset_detected: bool,
     insufficient_substantive_body: bool,
     high_chrome_to_substance_ratio: bool,
     report_title_with_little_body: bool,
@@ -456,6 +605,16 @@ def _source_intent_reason_codes(
         reason_codes.append("possible_download_landing_page")
     if possible_resource_catalog_page:
         reason_codes.append("possible_resource_catalog_page")
+    if commercial_landing_page_detected:
+        reason_codes.append("commercial_landing_page_detected")
+    if mutable_index_page_detected:
+        reason_codes.append("mutable_index_page_detected")
+    if chapter_navigation_source_detected:
+        reason_codes.append("chapter_navigation_source_detected")
+    if historical_report_redirect_detected:
+        reason_codes.append("historical_report_redirect_detected")
+    if stable_research_asset_detected:
+        reason_codes.append("stable_research_asset_detected")
     if insufficient_substantive_body:
         reason_codes.append("insufficient_substantive_body")
     if high_chrome_to_substance_ratio:
@@ -463,6 +622,79 @@ def _source_intent_reason_codes(
     if report_title_with_little_body:
         reason_codes.append("report_title_mention_with_little_adjacent_substance")
     return reason_codes
+
+
+def _historical_report_redirect_detected(
+    *,
+    requested_url: str | None,
+    resolved_url: str | None,
+) -> bool:
+    if not requested_url or not resolved_url or requested_url == resolved_url:
+        return False
+    requested = requested_url.casefold()
+    resolved = resolved_url.casefold()
+    requested_years = set(re.findall(r"\b20\d{2}\b", requested))
+    if not requested_years:
+        return False
+    if not any(term in requested for term in ("report", "state-of-devops", "research")):
+        return False
+    return not requested_years <= set(re.findall(r"\b20\d{2}\b", resolved))
+
+
+def _stable_research_asset_detected(
+    *,
+    requested_url: str | None,
+    resolved_url: str | None,
+    retained_paragraphs: Sequence[str],
+    substantive_paragraph_count: int,
+) -> bool:
+    url_text = " ".join(url for url in (requested_url, resolved_url) if url).casefold()
+    if any(pattern in url_text for pattern in _STABLE_RESEARCH_ASSET_URL_PATTERNS):
+        return True
+    if "doi.org/" in url_text:
+        return True
+    first_text = _normalized_prompt_text(" ".join(retained_paragraphs[:8]))
+    if substantive_paragraph_count >= 2 and any(
+        term in first_text for term in ("abstract", "doi", "published", "proceedings")
+    ):
+        return True
+    return False
+
+
+def _canonical_source_confidence(
+    *,
+    stable_research_asset_detected: bool,
+    mutable_index_page_detected: bool,
+    commercial_landing_page_detected: bool,
+    chapter_navigation_source_detected: bool,
+    historical_report_redirect_detected: bool,
+    likely_target_mismatch: bool,
+) -> str:
+    if stable_research_asset_detected and not likely_target_mismatch:
+        return "high"
+    if historical_report_redirect_detected:
+        return "low"
+    if mutable_index_page_detected or commercial_landing_page_detected:
+        return "none"
+    if chapter_navigation_source_detected:
+        return "low"
+    return "none"
+
+
+def _redirect_chain_summary(
+    *,
+    requested_url: str | None,
+    resolved_url: str | None,
+) -> list[dict[str, object]]:
+    if not requested_url and not resolved_url:
+        return []
+    if requested_url and resolved_url and requested_url != resolved_url:
+        return [
+            {"position": 0, "role": "requested", "url": requested_url},
+            {"position": 1, "role": "final", "url": resolved_url},
+        ]
+    url = resolved_url or requested_url or ""
+    return [{"position": 0, "role": "requested_and_final", "url": url}]
 
 
 def _render_replay_quality_metadata(metadata: Mapping[str, object]) -> str:
@@ -537,12 +769,40 @@ def _render_replay_quality_metadata(metadata: Mapping[str, object]) -> str:
                 f"{_metadata_value(source_intent, 'possible_download_landing_page')}"
             ),
             (
+                "- replay_quality_webpage_commercial_landing_page_detected: "
+                f"{_metadata_value(source_intent, 'commercial_landing_page_detected')}"
+            ),
+            (
+                "- replay_quality_webpage_mutable_index_page_detected: "
+                f"{_metadata_value(source_intent, 'mutable_index_page_detected')}"
+            ),
+            (
+                "- replay_quality_webpage_chapter_navigation_source_detected: "
+                f"{_metadata_value(source_intent, 'chapter_navigation_source_detected')}"
+            ),
+            (
+                "- replay_quality_webpage_historical_report_redirect_detected: "
+                f"{_metadata_value(source_intent, 'historical_report_redirect_detected')}"
+            ),
+            (
+                "- replay_quality_webpage_stable_research_asset_detected: "
+                f"{_metadata_value(source_intent, 'stable_research_asset_detected')}"
+            ),
+            (
                 "- replay_quality_webpage_substantive_content_confidence: "
                 f"{_metadata_value(source_intent, 'substantive_content_confidence')}"
             ),
             (
                 "- replay_quality_webpage_likely_target_mismatch: "
                 f"{_metadata_value(source_intent, 'likely_target_mismatch')}"
+            ),
+            (
+                "- replay_quality_webpage_canonical_target_resolution_status: "
+                f"{_metadata_value(source_intent, 'canonical_target_resolution_status')}"
+            ),
+            (
+                "- replay_quality_webpage_canonical_source_confidence: "
+                f"{_metadata_value(source_intent, 'canonical_source_confidence')}"
             ),
             (
                 "- replay_quality_webpage_selected_target_url: "

--- a/src/knowledge_adapters/public_webpage/targets.py
+++ b/src/knowledge_adapters/public_webpage/targets.py
@@ -49,16 +49,42 @@ _REPORT_TERMS = {
     "accelerate",
     "ai",
     "assisted",
+    "article",
+    "chapter",
     "development",
     "devops",
     "dora",
     "download",
+    "paper",
     "pdf",
+    "publication",
     "report",
     "research",
     "software",
     "state",
+    "study",
+    "workbook",
     "whitepaper",
+}
+_STABLE_PUBLICATION_PATH_PARTS = {
+    "/article/",
+    "/articles/",
+    "/chapter/",
+    "/chapters/",
+    "/detail.cfm",
+    "/download/",
+    "/files/",
+    "/paper/",
+    "/papers/",
+    "/publication/",
+    "/publications/",
+    "/report/",
+    "/reports/",
+    "/resource/",
+    "/resources/",
+    "/uploads/",
+    "/whitepaper/",
+    "/whitepapers/",
 }
 _REJECT_HOST_PARTS = {
     "accounts.google.com",
@@ -91,11 +117,22 @@ def discover_target_links(
     source_intent_assessment: Mapping[str, object],
 ) -> dict[str, object]:
     """Select one high-confidence same-page report target when it is unambiguous."""
+    if _bool_value(source_intent_assessment, "commercial_landing_page_detected"):
+        return _target_selection(
+            status="no_selection_commercial_landing_page",
+            reason="commercial_landing_page_requires_operator_source_choice",
+            candidate_links=(),
+            canonical_status="no_selection",
+            canonical_confidence="none",
+        )
+
     if not _bool_value(source_intent_assessment, "likely_target_mismatch"):
         return _target_selection(
             status="not_applicable_no_target_mismatch",
             reason="source_intent_assessment_did_not_flag_target_mismatch",
             candidate_links=(),
+            canonical_status="not_applicable",
+            canonical_confidence=_source_canonical_confidence(source_intent_assessment),
         )
 
     candidates = _candidate_links(
@@ -114,12 +151,16 @@ def discover_target_links(
             status="no_high_confidence_target",
             reason="no_same_page_report_asset_met_selection_guards",
             candidate_links=candidates,
+            canonical_status="no_selection",
+            canonical_confidence="none",
         )
     if len(high_confidence_candidates) > 1:
         return _target_selection(
             status="ambiguous_multiple_high_confidence_targets",
             reason="multiple_same_page_report_assets_met_selection_guards",
             candidate_links=candidates,
+            canonical_status="ambiguous",
+            canonical_confidence="low",
         )
 
     selected = high_confidence_candidates[0]
@@ -129,6 +170,8 @@ def discover_target_links(
         candidate_links=candidates,
         selected_url=str(selected["url"]),
         selected_content_type=str(selected["content_type"]),
+        canonical_status="selected_stable_canonical_asset",
+        canonical_confidence=_candidate_confidence(selected),
     )
 
 
@@ -220,20 +263,30 @@ def _score_candidate_link(
         return None
 
     is_pdf = parsed.path.lower().endswith(".pdf")
+    stable_publication_url = _is_stable_publication_url(parsed, label)
     score = 0
     reasons: list[str] = []
     if is_pdf:
         score += 48
         reasons.append("pdf_asset")
+    elif stable_publication_url:
+        score += 34
+        reasons.append("stable_publication_url")
     elif any(term in normalized_url_text for term in ("report", "whitepaper", "download")):
         score += 28
         reasons.append("report_like_html_target")
     if link.source in {"anchor_href", "link_href", "meta_url"}:
         score += 8
         reasons.append(f"observed_in_{link.source}")
+    if any(term in label for term in ("canonical", "citation_pdf_url", "og:url")):
+        score += 10
+        reasons.append("explicit_canonical_metadata")
     if link.source == "embedded_page_url":
         score += 6
         reasons.append("observed_in_embedded_page_url")
+    if stable_publication_url:
+        score += 12
+        reasons.append("stable_research_asset")
     score += min(36, len(identity_matches) * 6)
     if "dora" in identity_matches:
         score += 8
@@ -259,6 +312,7 @@ def _score_candidate_link(
         "content_type": content_type,
         "confidence_score": score,
         "identity_matches": identity_matches,
+        "stable_research_asset": stable_publication_url or is_pdf,
         "selection_reason": ",".join(reasons),
     }
 
@@ -268,10 +322,14 @@ def _target_selection(
     status: str,
     reason: str,
     candidate_links: Sequence[Mapping[str, object]],
+    canonical_status: str,
+    canonical_confidence: str,
     selected_url: str = "",
     selected_content_type: str = "",
 ) -> dict[str, object]:
     return {
+        "canonical_target_resolution_status": canonical_status,
+        "canonical_source_confidence": canonical_confidence,
         "candidate_target_links": [dict(candidate) for candidate in candidate_links],
         "selected_target_url": selected_url,
         "selected_target_content_type": selected_content_type,
@@ -337,6 +395,23 @@ def _has_report_semantics(url_text: str, label: str) -> bool:
     return any(term in text for term in _REPORT_TERMS)
 
 
+def _is_stable_publication_url(parsed: ParseResult, label: str) -> bool:
+    path = str(parsed.path or "").lower()
+    query = str(parsed.query or "").lower()
+    if path.endswith(".pdf"):
+        return True
+    if any(path_part in path for path_part in _STABLE_PUBLICATION_PATH_PARTS):
+        return True
+    if path.endswith("/toc") or path.endswith("/table-of-contents"):
+        return True
+    if path.endswith(("/toc/", "/table-of-contents/")):
+        return True
+    if parsed.hostname == "queue.acm.org" and path.endswith("/detail.cfm") and "id=" in query:
+        return True
+    normalized_label = _normalize_text(label)
+    return "canonical" in normalized_label and _has_report_semantics(path, normalized_label)
+
+
 def _identity_tokens(text: str) -> set[str]:
     tokens = set(re.findall(r"[a-z0-9]+", _normalize_text(text)))
     return {
@@ -379,3 +454,17 @@ def _bool_value(metadata: Mapping[str, object], key: str) -> bool:
 def _int_value(metadata: Mapping[str, object], key: str) -> int:
     value = metadata.get(key, 0)
     return value if isinstance(value, int) else 0
+
+
+def _source_canonical_confidence(source_intent_assessment: Mapping[str, object]) -> str:
+    value = source_intent_assessment.get("canonical_source_confidence", "none")
+    return str(value) if value else "none"
+
+
+def _candidate_confidence(candidate: Mapping[str, object]) -> str:
+    score = _int_value(candidate, "confidence_score")
+    if score >= 75:
+        return "high"
+    if score >= 70:
+        return "medium"
+    return "low"

--- a/tests/fixtures/public_webpage/article_chrome_cases.json
+++ b/tests/fixtures/public_webpage/article_chrome_cases.json
@@ -203,6 +203,60 @@
       ]
     },
     {
+      "id": "mutable_research_portal_index",
+      "description": "A research portal or mutable index with topic links but little body is labeled as a mutable index, not a stable canonical asset.",
+      "requested_url": "https://research.example.com/research-area/developer-tools/",
+      "resolved_url": "https://research.example.com/research-area/developer-tools/",
+      "raw_content": "Developer Tools Research\n\nResearch areas\n\nLatest research\n\nPublications\n\nResearch projects\n\nTopics\n\nDeveloper productivity\n\nProgram analysis\n\nSoftware engineering\n\nAll research\n\nNews\n\nPeople\n\nLabs\n\nReports\n\nBlog\n\nExplore projects across developer tools and software engineering.",
+      "expected_content": "Developer Tools Research\n\nResearch areas\n\nLatest research\n\nPublications\n\nResearch projects\n\nTopics\n\nDeveloper productivity\n\nProgram analysis\n\nSoftware engineering\n\nAll research\n\nNews\n\nPeople\n\nLabs\n\nReports\n\nBlog\n\nExplore projects across developer tools and software engineering.",
+      "expected_metadata": {
+        "source_intent_assessment": {
+          "target_shape_assessment": "mutable_index_page",
+          "possible_wrapper_page": true,
+          "mutable_index_page_detected": true,
+          "stable_research_asset_detected": false,
+          "canonical_source_confidence": "none",
+          "likely_target_mismatch": true
+        },
+        "replay_classification": {
+          "operational_state": "likely-wrong-capture-target"
+        }
+      },
+      "expected_markdown_metadata_lines": [
+        "- replay_quality_operational_state: likely-wrong-capture-target",
+        "- replay_quality_webpage_target_shape_assessment: mutable_index_page",
+        "- replay_quality_webpage_mutable_index_page_detected: True",
+        "- replay_quality_webpage_stable_research_asset_detected: False",
+        "- replay_quality_webpage_canonical_source_confidence: none"
+      ]
+    },
+    {
+      "id": "sre_workbook_table_of_contents",
+      "description": "A book table of contents with many chapter entries is labeled as chapter navigation rather than a substantive article.",
+      "requested_url": "https://sre.example.com/workbook/table-of-contents/",
+      "resolved_url": "https://sre.example.com/workbook/table-of-contents/",
+      "raw_content": "Site Reliability Engineering Workbook\n\nTable of contents\n\nPart I\n\nChapter 1\n\nHow SRE relates to DevOps\n\nChapter 2\n\nImplementing SLOs\n\nChapter 3\n\nError budgets\n\nPart II\n\nChapter 4\n\nOn-call\n\nChapter 5\n\nIncident response\n\nChapter 6\n\nMonitoring\n\nAppendix\n\nGlossary",
+      "expected_content": "Site Reliability Engineering Workbook\n\nTable of contents\n\nPart I\n\nChapter 1\n\nHow SRE relates to DevOps\n\nChapter 2\n\nImplementing SLOs\n\nChapter 3\n\nError budgets\n\nPart II\n\nChapter 4\n\nOn-call\n\nChapter 5\n\nIncident response\n\nChapter 6\n\nMonitoring\n\nAppendix\n\nGlossary",
+      "expected_metadata": {
+        "source_intent_assessment": {
+          "target_shape_assessment": "chapter_navigation_source",
+          "chapter_navigation_source_detected": true,
+          "mutable_index_page_detected": false,
+          "canonical_source_confidence": "low",
+          "likely_target_mismatch": true
+        },
+        "replay_classification": {
+          "operational_state": "likely-wrong-capture-target"
+        }
+      },
+      "expected_markdown_metadata_lines": [
+        "- replay_quality_operational_state: likely-wrong-capture-target",
+        "- replay_quality_webpage_target_shape_assessment: chapter_navigation_source",
+        "- replay_quality_webpage_chapter_navigation_source_detected: True",
+        "- replay_quality_webpage_canonical_source_confidence: low"
+      ]
+    },
+    {
       "id": "false_positive_report_body_with_download_reference",
       "description": "A substantive report page can mention a downloadable appendix without becoming a download landing page.",
       "raw_content": "Example Resilience Report\n\nThe report body describes incident response patterns across several teams. It includes enough context to explain the research questions, the sample boundaries, and the way each measure was collected. Download the appendix is mentioned once as a supporting artifact, not as the main page structure.\n\nThe next section compares reliability outcomes across services and deployment models. It uses complete sentences, describes the interpretation limits, and gives reviewers a real body of text to inspect. Contact information is not presented as a form and there is no country selector.\n\nThe conclusion explains where the evidence is strongest and where additional review is needed. It distinguishes operational observations from recommendations. It keeps the source material in paragraph form so the adapter should not treat it as a resource catalog.",

--- a/tests/test_public_webpage_chrome_fixtures.py
+++ b/tests/test_public_webpage_chrome_fixtures.py
@@ -41,6 +41,8 @@ def test_public_webpage_article_chrome_fixture_area_is_present() -> None:
         "clean_substantive_report_page",
         "dora_style_download_landing_page",
         "google_cloud_lead_form_resources_page",
+        "mutable_research_portal_index",
+        "sre_workbook_table_of_contents",
         "false_positive_report_body_with_download_reference",
         "false_positive_article_body_with_contact_sales_phrase",
     }

--- a/tests/test_public_webpage_target_discovery.py
+++ b/tests/test_public_webpage_target_discovery.py
@@ -336,12 +336,13 @@ def test_public_webpage_commercial_book_landing_does_not_select_target(
             """
             <html><head><title>Team Topologies book</title></head>
             <body>
-              <h1>Team Topologies book</h1>
-              <p>Buy now</p>
-              <p>Paperback</p>
-              <p>ebook</p>
-              <p>Training</p>
-              <p>Workshops</p>
+              <h1>Team Topologies book by Matthew Skelton and Manuel Pais</h1>
+              <p>Enterprise Success</p>
+              <p>Assessments</p>
+              <p>Training Partners</p>
+              <p>Resources</p>
+              <p>Books</p>
+              <p>Shop</p>
               <a href="https://teamtopologies.com/resources/team-topologies-report.pdf">
                 Download sample
               </a>
@@ -354,7 +355,7 @@ def test_public_webpage_commercial_book_landing_does_not_select_target(
         lambda url: (_ for _ in ()).throw(AssertionError("unexpected PDF fetch")),
     )
 
-    document = fetch_webpage("https://teamtopologies.com/product/team-topologies-book/")
+    document = fetch_webpage("https://teamtopologies.com/book")
 
     assert isinstance(document, PublicWebpageDocument)
     source_intent = document.replay_quality_metadata["source_intent_assessment"]

--- a/tests/test_public_webpage_target_discovery.py
+++ b/tests/test_public_webpage_target_discovery.py
@@ -10,6 +10,13 @@ from knowledge_adapters.public_webpage.client import PublicWebpageDocument, fetc
 
 WRAPPER_URL = "https://cloud.example.com/devops/state-of-devops"
 PDF_URL = "https://services.example.com/fh/files/misc/2025_state_of_ai_assisted_software_development.pdf"
+PUPPET_2021_URL = "https://puppet.com/resources/report/2021-state-of-devops-report/"
+PUPPET_CURRENT_URL = "https://puppet.com/resources/report/state-of-devops-report/"
+PUPPET_2021_PDF_URL = (
+    "https://puppet.com/resources/report/2021-state-of-devops-report.pdf"
+)
+SPACE_WRAPPER_URL = "https://queue.acm.org/research/space-framework"
+SPACE_PAPER_URL = "https://queue.acm.org/detail.cfm?id=3454124"
 
 
 def test_public_webpage_wrapper_with_one_clear_pdf_target_is_fetched(
@@ -71,6 +78,135 @@ def test_public_webpage_wrapper_with_one_clear_pdf_target_is_fetched(
     assert source_intent["target_selection_status"] == "selected"
     assert source_intent["selected_target_url"] == PDF_URL
     assert source_intent["selected_target_content_type"] == "pdf"
+    assert (
+        source_intent["canonical_target_resolution_status"]
+        == "selected_stable_canonical_asset"
+    )
+    assert source_intent["canonical_source_confidence"] == "high"
+
+
+def test_public_webpage_redirected_historical_report_selects_canonical_pdf(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    def fake_fetch_public_url(url: str, **kwargs: Any) -> FetchedPublicResource:
+        calls.append(url)
+        return _html_response(
+            url,
+            f"""
+            <html>
+              <head><title>State of DevOps Report</title></head>
+              <body>
+                <h1>State of DevOps Report</h1>
+                <p>Download the report</p>
+                <p>The current report hub redirects older report URLs.</p>
+                <a href="{PUPPET_2021_PDF_URL}">2021 State of DevOps report PDF</a>
+              </body>
+            </html>
+            """,
+            final_url=PUPPET_CURRENT_URL,
+        )
+
+    def fake_fetch_pdf(url: str) -> PublicPdfDocument:
+        assert url == PUPPET_2021_PDF_URL
+        return PublicPdfDocument(
+            title="2021 State of DevOps Report",
+            canonical_id=PUPPET_2021_PDF_URL,
+            source_url=PUPPET_2021_PDF_URL,
+            fetched_at="2026-05-13T12:00:00Z",
+            content="Historical PDF report body.",
+            page_count=55,
+            replay_quality_metadata={
+                "replay_classification": {
+                    "source_type": "public_pdf",
+                    "operational_state": "review-ready",
+                    "promotion_state": "unsafe-to-promote",
+                }
+            },
+        )
+
+    monkeypatch.setattr(
+        "knowledge_adapters.public_webpage.client.fetch_public_url",
+        fake_fetch_public_url,
+    )
+    monkeypatch.setattr("knowledge_adapters.public_webpage.client.fetch_pdf", fake_fetch_pdf)
+
+    document = fetch_webpage(PUPPET_2021_URL)
+
+    assert isinstance(document, PublicPdfDocument)
+    assert calls == [PUPPET_2021_URL]
+    assert document.source_url == PUPPET_2021_PDF_URL
+    source_intent = document.replay_quality_metadata["source_intent_assessment"]
+    assert isinstance(source_intent, dict)
+    assert source_intent["target_shape_assessment"] == "historical_report_redirect"
+    assert source_intent["historical_report_redirect_detected"] is True
+    assert source_intent["selected_target_url"] == PUPPET_2021_PDF_URL
+    assert source_intent["canonical_target_resolution_status"] == (
+        "selected_stable_canonical_asset"
+    )
+    assert source_intent["redirect_chain_summary"] == [
+        {"position": 0, "role": "requested", "url": PUPPET_2021_URL},
+        {"position": 1, "role": "final", "url": PUPPET_CURRENT_URL},
+    ]
+
+
+def test_public_webpage_research_paper_wrapper_selects_stable_publication_url(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    def fake_fetch_public_url(url: str, **kwargs: Any) -> FetchedPublicResource:
+        calls.append(url)
+        if url == SPACE_PAPER_URL:
+            return _html_response(
+                url,
+                """
+                <html><head><title>The SPACE of Developer Productivity</title></head>
+                <body>
+                  <h1>The SPACE of Developer Productivity</h1>
+                  <p>Abstract. Developer productivity is about more than individual
+                  activity. The SPACE framework describes satisfaction, performance,
+                  activity, communication, and efficiency. This paragraph has enough
+                  body structure to be treated as the stable publication target.</p>
+                  <p>The paper explains how teams can combine qualitative and
+                  quantitative evidence. It warns against reducing productivity to a
+                  single metric. It provides operational guidance for engineering
+                  organizations.</p>
+                </body></html>
+                """,
+            )
+        return _html_response(
+            url,
+            f"""
+            <html><head><title>The SPACE of Developer Productivity paper</title></head>
+            <body>
+              <h1>The SPACE of Developer Productivity paper</h1>
+              <p>Read the paper</p>
+              <a href="{SPACE_PAPER_URL}">The SPACE of Developer Productivity paper</a>
+            </body></html>
+            """,
+        )
+
+    monkeypatch.setattr(
+        "knowledge_adapters.public_webpage.client.fetch_public_url",
+        fake_fetch_public_url,
+    )
+
+    document = fetch_webpage(SPACE_WRAPPER_URL)
+
+    assert isinstance(document, PublicWebpageDocument)
+    assert calls == [SPACE_WRAPPER_URL, SPACE_PAPER_URL]
+    assert document.source_url == SPACE_PAPER_URL
+    source_intent = document.replay_quality_metadata["source_intent_assessment"]
+    assert isinstance(source_intent, dict)
+    assert source_intent["selected_target_url"] == SPACE_PAPER_URL
+    assert source_intent["selected_target_content_type"] == "html"
+    assert (
+        source_intent["canonical_target_resolution_status"]
+        == "selected_stable_canonical_asset"
+    )
+    assert source_intent["canonical_source_confidence"] == "high"
 
 
 def test_public_webpage_wrapper_with_no_clear_target_reports_mismatch(
@@ -104,6 +240,7 @@ def test_public_webpage_wrapper_with_no_clear_target_reports_mismatch(
     assert source_intent["likely_target_mismatch"] is True
     assert source_intent["target_selection_status"] == "no_high_confidence_target"
     assert source_intent["selected_target_url"] == ""
+    assert source_intent["canonical_target_resolution_status"] == "no_selection"
 
 
 def test_public_webpage_wrapper_with_conflicting_targets_does_not_fetch(
@@ -184,12 +321,59 @@ def test_public_webpage_substantive_page_does_not_select_alternate_target(
     assert source_intent["likely_target_mismatch"] is False
     assert source_intent["target_selection_status"] == "not_applicable_no_target_mismatch"
     assert source_intent["selected_target_url"] == ""
+    assert source_intent["commercial_landing_page_detected"] is False
+    assert source_intent["mutable_index_page_detected"] is False
+    assert source_intent["chapter_navigation_source_detected"] is False
 
 
-def _html_response(url: str, html: str) -> FetchedPublicResource:
+def test_public_webpage_commercial_book_landing_does_not_select_target(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "knowledge_adapters.public_webpage.client.fetch_public_url",
+        lambda url, **kwargs: _html_response(
+            url,
+            """
+            <html><head><title>Team Topologies book</title></head>
+            <body>
+              <h1>Team Topologies book</h1>
+              <p>Buy now</p>
+              <p>Paperback</p>
+              <p>ebook</p>
+              <p>Training</p>
+              <p>Workshops</p>
+              <a href="https://teamtopologies.com/resources/team-topologies-report.pdf">
+                Download sample
+              </a>
+            </body></html>
+            """,
+        ),
+    )
+    monkeypatch.setattr(
+        "knowledge_adapters.public_webpage.client.fetch_pdf",
+        lambda url: (_ for _ in ()).throw(AssertionError("unexpected PDF fetch")),
+    )
+
+    document = fetch_webpage("https://teamtopologies.com/product/team-topologies-book/")
+
+    assert isinstance(document, PublicWebpageDocument)
+    source_intent = document.replay_quality_metadata["source_intent_assessment"]
+    assert isinstance(source_intent, dict)
+    assert source_intent["target_shape_assessment"] == "commercial_landing_page"
+    assert source_intent["commercial_landing_page_detected"] is True
+    assert source_intent["target_selection_status"] == "no_selection_commercial_landing_page"
+    assert source_intent["canonical_target_resolution_status"] == "no_selection"
+
+
+def _html_response(
+    url: str,
+    html: str,
+    *,
+    final_url: str | None = None,
+) -> FetchedPublicResource:
     return FetchedPublicResource(
         url=url,
-        final_url=url,
+        final_url=final_url or url,
         content=html.encode("utf-8"),
         content_type="text/html",
         content_charset="utf-8",


### PR DESCRIPTION
## Summary
- add bounded canonical-source metadata for redirected historical reports, stable research assets, mutable indexes, commercial landings, and chapter-navigation sources
- improve one-clear-winner selection for same-site PDFs and stable publication URLs while preserving no-selection for ambiguous, commercial, portal/index, and chapter-navigation shapes
- extend deterministic fixtures for Puppet-style redirects, ACM-style stable paper URLs, Team Topologies commercial landing safety, mutable research portals, Google SRE-style TOC pages, and ordinary article false positives
- add a bounded live-source proof pass for the exact knowledge-vault PR #35 operational-research URLs in `docs/public-operational-research-live-proof.md`

## Live proof result, May 13 2026
No previously failed or diagnostic operational-research source became a proven selected-target live success under this PR.

Proven live-success targets:
- none

Improved diagnostic/classification only:
- Puppet 2021 State of DevOps fetches and exposes `historical_report_redirect`, but final URL is `https://www.puppet.com/resources/state-of-devops-report`; canonical target status is `ambiguous`; no selected target was fetched.
- GitHub Research/Octoverse (`https://github.blog/news-insights/research/`) fetches and is now labeled `mutable_index_page`; canonical target status is `ambiguous`; no selected target was fetched.
- METR (`https://metr.org/`) fetches and is now labeled `mutable_index_page`; canonical target status is `no_selection`; no selected target was fetched.
- Google SRE Workbook TOC fetches and is labeled `chapter_navigation_source`; canonical target status is `no_selection`; no selected target was fetched.

Still blocked by HTTP availability:
- Accelerate (`https://itrevolution.com/product/accelerate/`) returns HTTP 403 through the adapter path.
- SPACE (`https://queue.acm.org/detail.cfm?id=3454124`) returns HTTP 403 through the adapter path; the stable URL shape is fixture-covered but not live-proven.
- Microsoft Research developer tools (`https://www.microsoft.com/en-us/research/research-area/developer-tools/`) returns HTTP 404 through the adapter path.

Intentionally no-selection:
- Team Topologies (`https://teamtopologies.com/book`) fetches, is labeled `commercial_landing_page`, and does not select or fetch another target.

## Knowledge-vault go/no-go
- Do not mark the PR #35 operational-research tranche as live replay-successful stable canonical assets based on this PR.
- PR #291 improves replay diagnostics and bounded source-shape labeling, but Accelerate, SPACE, Microsoft Research, Puppet 2021, GitHub Research/Octoverse, METR, Team Topologies, and SRE Workbook TOC should remain queued, diagnostic-only, inventory-only, or manually selected until a human reviewer supplies a stable target that the normal adapter path fetches successfully.
- knowledge-vault PR #35 was not modified.

## Validation
- `make check` passed: ruff, mypy, 530 tests
- `git diff --check` passed

## Remaining limitations
- no external search, recursive traversal, retention semantics, or auto-promotion added
- HTTP 403/404 results are not treated as successful fetches
- alternates can only be selected when redirects or fetched page metadata/links expose exactly one stable same-site target
- mutable portals remain diagnostic/no-selection unless a future page exposes exactly one high-confidence same-site canonical asset