### PR TITLE
Add github_metadata lifecycle receipts

### DIFF
--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -3838,6 +3838,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             resolve_base_urls,
         )
         from knowledge_adapters.github_metadata.config import GitHubMetadataConfig
+        from knowledge_adapters.github_metadata.incremental import (
+            classify_github_metadata_sync,
+        )
         from knowledge_adapters.github_metadata.normalize import (
             normalize_issue_to_markdown,
             normalize_pull_request_to_markdown,
@@ -4074,18 +4077,55 @@ def main(argv: Sequence[str] | None = None) -> int:
                     ).as_posix(),
                 }
             )
-        stale_artifacts = [
-            (artifact.canonical_id, artifact.output_path)
-            for artifact in find_stale_artifacts(
+        github_lifecycle_decisions = [
+            classify_github_metadata_sync(
                 github_metadata_config.output_dir,
                 previous_manifest_index,
-                current_output_paths=[
-                    str(entry["output_path"]) for entry in github_manifest_entries
-                ],
+                manifest_entry=entry,
             )
+            for entry in github_manifest_entries
         ]
+        new_count = sum(1 for decision in github_lifecycle_decisions if decision.status == "new")
+        changed_count = sum(
+            1 for decision in github_lifecycle_decisions if decision.status == "changed"
+        )
+        unchanged_count = sum(
+            1 for decision in github_lifecycle_decisions if decision.status == "unchanged"
+        )
+        write_count = new_count + changed_count
+        skip_count = unchanged_count
 
-        for record, output_path in zip(records, github_written_output_paths, strict=True):
+        stale_artifact_records = find_stale_artifacts(
+            github_metadata_config.output_dir,
+            previous_manifest_index,
+            current_output_paths=[
+                str(entry["output_path"]) for entry in github_manifest_entries
+            ],
+        )
+        stale_artifacts = [
+            (artifact.canonical_id, artifact.output_path) for artifact in stale_artifact_records
+        ]
+        stale_manifest_entries: list[dict[str, object]] = []
+        for artifact in stale_artifact_records:
+            stale_entry: dict[str, object] = {
+                "canonical_id": artifact.canonical_id,
+                "output_path": artifact.output_path,
+            }
+            prior_entry = (
+                previous_manifest_index.get(artifact.canonical_id)
+                if previous_manifest_index is not None
+                else None
+            )
+            if prior_entry is not None and prior_entry.content_hash is not None:
+                stale_entry["content_hash"] = prior_entry.content_hash
+            stale_manifest_entries.append(stale_entry)
+
+        for record, output_path, decision in zip(
+            records,
+            github_written_output_paths,
+            github_lifecycle_decisions,
+            strict=True,
+        ):
             if isinstance(record, GitHubRelease):
                 print(f"\n  {resource_label}: {record.tag_name}")
             else:
@@ -4101,11 +4141,17 @@ def main(argv: Sequence[str] | None = None) -> int:
                     f"{resource_label.replace('_', ' ')} body; output will include an "
                     "empty-body marker"
                 )
-            print(f"  action: {'would write' if github_metadata_config.dry_run else 'write'}")
+            print(f"  lifecycle_status: {decision.status}")
+            print(f"  lifecycle_reason: {decision.reason}")
+            action = "skip" if decision.status == "unchanged" else "write"
+            print(f"  action: {'would ' if github_metadata_config.dry_run else ''}{action}")
 
         manifest_output_path = output_dir / "manifest.json"
         if github_metadata_config.dry_run:
-            print(f"\nSummary: would write {len(records)}, would skip 0")
+            print(f"\nSummary: would write {write_count}, would skip {skip_count}")
+            print(f"  new_records: {new_count}")
+            print(f"  changed_records: {changed_count}")
+            print(f"  unchanged_records: {unchanged_count}")
             print(f"  stale_artifacts: {len(stale_artifacts)}")
             print_stale_artifacts(github_metadata_config.output_dir, stale_artifacts)
             print(f"Manifest path: {render_user_path(manifest_output_path)}")
@@ -4113,7 +4159,17 @@ def main(argv: Sequence[str] | None = None) -> int:
             return 0
 
         try:
-            for record in records:
+            github_rewritten_output_paths: list[Path] = []
+            github_skipped_output_paths: list[tuple[Path, str]] = []
+            for record, output_path, decision in zip(
+                records,
+                github_written_output_paths,
+                github_lifecycle_decisions,
+                strict=True,
+            ):
+                if decision.status == "unchanged":
+                    github_skipped_output_paths.append((output_path, decision.reason))
+                    continue
                 record_identifier = (
                     record.release_id if isinstance(record, GitHubRelease) else record.number
                 )
@@ -4123,9 +4179,11 @@ def main(argv: Sequence[str] | None = None) -> int:
                     record_identifier,
                     record_markdowns[record.canonical_id],
                 )
+                github_rewritten_output_paths.append(output_path)
             manifest = write_manifest(
                 github_metadata_config.output_dir,
                 github_manifest_entries,
+                stale_artifacts=stale_manifest_entries,
             )
         except OSError as exc:
             exit_with_output_error(
@@ -4134,9 +4192,14 @@ def main(argv: Sequence[str] | None = None) -> int:
                 exc=exc,
             )
 
-        for output_path in github_written_output_paths:
+        for output_path in github_rewritten_output_paths:
             print(f"\nWrote: {render_user_path(output_path)}")
-        print(f"\nSummary: wrote {len(records)}, skipped 0")
+        for output_path, reason in github_skipped_output_paths:
+            print(f"\nSkipped: {render_user_path(output_path)} ({reason})")
+        print(f"\nSummary: wrote {write_count}, skipped {skip_count}")
+        print(f"  new_records: {new_count}")
+        print(f"  changed_records: {changed_count}")
+        print(f"  unchanged_records: {unchanged_count}")
         print(f"  stale_artifacts: {len(stale_artifacts)}")
         print_stale_artifacts(github_metadata_config.output_dir, stale_artifacts)
         print(f"Manifest path: {render_user_path(manifest)}")

--- a/src/knowledge_adapters/github_metadata/incremental.py
+++ b/src/knowledge_adapters/github_metadata/incremental.py
@@ -1,0 +1,70 @@
+"""Lifecycle classification helpers for the github_metadata adapter."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from knowledge_adapters.manifest_stale import PreviousManifestEntry
+
+GitHubMetadataSyncStatus = Literal["new", "changed", "unchanged"]
+
+
+@dataclass(frozen=True)
+class GitHubMetadataSyncDecision:
+    """Lifecycle decision plus an operator-facing deterministic reason."""
+
+    status: GitHubMetadataSyncStatus
+    reason: str
+
+
+def classify_github_metadata_sync(
+    output_dir: str,
+    previous_manifest_index: dict[str, PreviousManifestEntry] | None,
+    *,
+    manifest_entry: Mapping[str, object],
+) -> GitHubMetadataSyncDecision:
+    """Classify one planned GitHub metadata artifact for lifecycle visibility."""
+    canonical_id = manifest_entry.get("canonical_id")
+    if not isinstance(canonical_id, str) or not canonical_id:
+        return GitHubMetadataSyncDecision(status="new", reason="canonical_id missing")
+
+    if previous_manifest_index is None:
+        return GitHubMetadataSyncDecision(status="new", reason="no previous manifest")
+
+    prior_entry = previous_manifest_index.get(canonical_id)
+    if prior_entry is None:
+        return GitHubMetadataSyncDecision(
+            status="new",
+            reason="prior manifest entry missing entirely",
+        )
+
+    output_path = manifest_entry.get("output_path")
+    if not isinstance(output_path, str) or not output_path:
+        return GitHubMetadataSyncDecision(status="changed", reason="output_path missing")
+
+    if prior_entry.output_path != output_path:
+        return GitHubMetadataSyncDecision(status="changed", reason="output_path changed")
+
+    if not (Path(output_dir) / prior_entry.output_path).exists():
+        return GitHubMetadataSyncDecision(
+            status="changed",
+            reason="prior artifact missing, so safe rewrite",
+        )
+
+    content_hash = manifest_entry.get("content_hash")
+    if not isinstance(content_hash, str) or not content_hash:
+        return GitHubMetadataSyncDecision(status="changed", reason="content_hash missing")
+
+    if prior_entry.content_hash is None:
+        return GitHubMetadataSyncDecision(
+            status="changed",
+            reason="prior manifest entry missing content_hash",
+        )
+
+    if prior_entry.content_hash != content_hash:
+        return GitHubMetadataSyncDecision(status="changed", reason="content_hash changed")
+
+    return GitHubMetadataSyncDecision(status="unchanged", reason="content_hash unchanged")

--- a/src/knowledge_adapters/manifest.py
+++ b/src/knowledge_adapters/manifest.py
@@ -51,9 +51,14 @@ def build_manifest_entry(
     return entry
 
 
-def write_manifest(output_dir: str, files: list[dict[str, object]]) -> Path:
+def write_manifest(
+    output_dir: str,
+    files: list[dict[str, object]],
+    *,
+    stale_artifacts: list[dict[str, object]] | None = None,
+) -> Path:
     """Write a per-run manifest describing generated files."""
-    return write_manifest_with_context(output_dir, files)
+    return write_manifest_with_context(output_dir, files, stale_artifacts=stale_artifacts)
 
 
 def write_manifest_with_context(
@@ -62,6 +67,7 @@ def write_manifest_with_context(
     *,
     root_page_id: str | None = None,
     max_depth: int | None = None,
+    stale_artifacts: list[dict[str, object]] | None = None,
 ) -> Path:
     """Write a per-run manifest describing generated files."""
     path = manifest_path(output_dir)
@@ -73,6 +79,8 @@ def write_manifest_with_context(
     if max_depth is not None:
         payload["max_depth"] = max_depth
     payload["files"] = files
+    if stale_artifacts:
+        payload["stale_artifacts"] = stale_artifacts
 
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(f"{json.dumps(payload, indent=2)}\n", encoding="utf-8")

--- a/src/knowledge_adapters/manifest_stale.py
+++ b/src/knowledge_adapters/manifest_stale.py
@@ -16,6 +16,7 @@ class PreviousManifestEntry:
     output_path: str
     page_version: str | None
     last_modified: str | None
+    content_hash: str | None
 
 
 @dataclass(frozen=True)
@@ -92,6 +93,7 @@ def _load_previous_manifest_indexes(
             output_path=output_path,
             page_version=_normalize_metadata_value(entry.get("page_version")),
             last_modified=_normalize_metadata_value(entry.get("last_modified")),
+            content_hash=_normalize_metadata_value(entry.get("content_hash")),
         )
         entries_by_output_path[output_path] = canonical_id
 

--- a/tests/test_github_metadata.py
+++ b/tests/test_github_metadata.py
@@ -30,6 +30,7 @@ from knowledge_adapters.github_metadata.normalize import (
     EMPTY_BODY_MARKER,
     EMPTY_PULL_REQUEST_BODY_MARKER,
     EMPTY_RELEASE_BODY_MARKER,
+    normalize_issue_to_markdown,
 )
 from tests.cli_output_assertions import (
     assert_dry_run_summary,
@@ -761,6 +762,216 @@ def test_github_metadata_cli_dry_run_does_not_write_files(
     assert "source_url: https://github.example.com/octo/project/issues/5" in captured.out
     assert_dry_run_summary(captured.out, would_write=1, would_skip=0)
     assert not output_dir.exists()
+
+
+def test_github_metadata_cli_skips_unchanged_issue_and_preserves_manifest_continuity(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("GH_TOKEN", "secret-token")
+    first_url = issue_list_api_url(
+        api_root="https://api.github.com",
+        owner="octo",
+        repo_name="project",
+        state="open",
+        since=None,
+    )
+    _install_fake_urlopen(
+        monkeypatch,
+        {first_url: _FakeGitHubResponse([_issue(2, title="Useful bug", body="Bug details.\n")])},
+    )
+    output_dir = tmp_path / "out"
+    issue_2_markdown = normalize_issue_to_markdown(
+        {
+            "repo": "octo/project",
+            "number": 2,
+            "title": "Useful bug",
+            "state": "open",
+            "author": "alice",
+            "created_at": "2026-04-02T00:00:00Z",
+            "updated_at": "2026-04-02T01:00:00Z",
+            "source_url": "https://github.com/octo/project/issues/2",
+            "body": "Bug details.\n",
+        }
+    )
+    issue_2_path = output_dir / "issues" / "2.md"
+    issue_2_path.parent.mkdir(parents=True, exist_ok=True)
+    issue_2_path.write_text(issue_2_markdown, encoding="utf-8")
+    stale_issue_path = output_dir / "issues" / "9.md"
+    stale_issue_path.write_text("stale issue\n", encoding="utf-8")
+    issue_2_hash = hashlib.sha256(issue_2_markdown.encode("utf-8")).hexdigest()
+    (output_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "generated_at": "2026-04-01T00:00:00Z",
+                "files": [
+                    {
+                        "canonical_id": "github_metadata:github.com:octo/project:issue:2",
+                        "source_url": "https://github.com/octo/project/issues/2",
+                        "title": "Useful bug",
+                        "content_hash": issue_2_hash,
+                        "output_path": "issues/2.md",
+                    },
+                    {
+                        "canonical_id": "github_metadata:github.com:octo/project:issue:9",
+                        "source_url": "https://github.com/octo/project/issues/9",
+                        "title": "Stale issue",
+                        "content_hash": "stale-hash",
+                        "output_path": "issues/9.md",
+                    },
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    def fail_write_markdown(*args: object, **kwargs: object) -> None:
+        raise AssertionError("unchanged artifact should not be rewritten")
+
+    monkeypatch.setattr(
+        "knowledge_adapters.github_metadata.writer.write_markdown",
+        fail_write_markdown,
+    )
+
+    exit_code = main(
+        [
+            "github_metadata",
+            "--repo",
+            "octo/project",
+            "--token-env",
+            "GH_TOKEN",
+            "--output-dir",
+            str(output_dir),
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "lifecycle_status: unchanged" in captured.out
+    assert "lifecycle_reason: content_hash unchanged" in captured.out
+    assert_write_summary(captured.out, wrote=0, skipped=1, stale_artifacts=1)
+    assert "new_records: 0" in captured.out
+    assert "changed_records: 0" in captured.out
+    assert "unchanged_records: 1" in captured.out
+    assert_stale_artifacts(captured.out, count=1, artifact_paths=[stale_issue_path])
+    manifest_payload = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest_payload["files"] == [
+        {
+            "canonical_id": "github_metadata:github.com:octo/project:issue:2",
+            "source_url": "https://github.com/octo/project/issues/2",
+            "title": "Useful bug",
+            "repo": "octo/project",
+            "resource_type": "issue",
+            "number": 2,
+            "state": "open",
+            "created_at": "2026-04-02T00:00:00Z",
+            "updated_at": "2026-04-02T01:00:00Z",
+            "author": "alice",
+            "content_hash": issue_2_hash,
+            "output_path": "issues/2.md",
+        }
+    ]
+    assert manifest_payload["stale_artifacts"] == [
+        {
+            "canonical_id": "github_metadata:github.com:octo/project:issue:9",
+            "output_path": "issues/9.md",
+            "content_hash": "stale-hash",
+        }
+    ]
+
+
+def test_github_metadata_cli_dry_run_reports_lifecycle_counts_without_writing(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("GH_TOKEN", "secret-token")
+    first_url = issue_list_api_url(
+        api_root="https://api.github.com",
+        owner="octo",
+        repo_name="project",
+        state="open",
+        since=None,
+    )
+    _install_fake_urlopen(
+        monkeypatch,
+        {
+            first_url: _FakeGitHubResponse(
+                [
+                    _issue(2, title="Useful bug", body="Bug details.\n"),
+                    _issue(7, title="Changed issue", body="New body.\n"),
+                ]
+            )
+        },
+    )
+    output_dir = tmp_path / "out"
+    issue_2_markdown = normalize_issue_to_markdown(
+        {
+            "repo": "octo/project",
+            "number": 2,
+            "title": "Useful bug",
+            "state": "open",
+            "author": "alice",
+            "created_at": "2026-04-02T00:00:00Z",
+            "updated_at": "2026-04-02T01:00:00Z",
+            "source_url": "https://github.com/octo/project/issues/2",
+            "body": "Bug details.\n",
+        }
+    )
+    issue_2_path = output_dir / "issues" / "2.md"
+    issue_7_path = output_dir / "issues" / "7.md"
+    issue_2_path.parent.mkdir(parents=True, exist_ok=True)
+    issue_2_path.write_text(issue_2_markdown, encoding="utf-8")
+    issue_7_path.write_text("old body\n", encoding="utf-8")
+    (output_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "generated_at": "2026-04-01T00:00:00Z",
+                "files": [
+                    {
+                        "canonical_id": "github_metadata:github.com:octo/project:issue:2",
+                        "content_hash": hashlib.sha256(
+                            issue_2_markdown.encode("utf-8")
+                        ).hexdigest(),
+                        "output_path": "issues/2.md",
+                    },
+                    {
+                        "canonical_id": "github_metadata:github.com:octo/project:issue:7",
+                        "content_hash": "old-hash",
+                        "output_path": "issues/7.md",
+                    },
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    exit_code = main(
+        [
+            "github_metadata",
+            "--repo",
+            "octo/project",
+            "--token-env",
+            "GH_TOKEN",
+            "--output-dir",
+            str(output_dir),
+            "--dry-run",
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert_dry_run_summary(captured.out, would_write=1, would_skip=1)
+    assert "new_records: 0" in captured.out
+    assert "changed_records: 1" in captured.out
+    assert "unchanged_records: 1" in captured.out
+    assert "lifecycle_reason: content_hash changed" in captured.out
+    assert issue_7_path.read_text(encoding="utf-8") == "old body\n"
 
 
 def test_github_metadata_cli_writes_pull_request_artifacts_and_manifest(


### PR DESCRIPTION
Summary
- Add github_metadata lifecycle classification for new, changed, and unchanged artifacts using prior manifest identity, output_path, artifact existence, and content_hash.
- Skip unchanged artifacts in write mode while preserving replacement manifest continuity for all current records.
- Preserve deterministic stale reporting and add explicit manifest stale_artifacts metadata for github_metadata stale entries when present.

Validation
- make check
- make check-gh-env
- origin/main fetched before PR; branch was based on current origin/main d93c58b, so no rebase was needed.

Non-goals
- No semantic interpretation, repo-health scoring, summarization behavior, or cross-resource reasoning.
- No provider lifecycle inference beyond deterministic manifest-backed acquisition receipts.
- No docs lane edits; this stays scoped to github_metadata lifecycle and manifest/reporting surfaces.

Sequencing notes
- Merges after Lane A.
- Lane C should inspect/rebase after this if it changes shared manifest/schema or CLI reporting surfaces.