### PR TITLE
Add github_metadata PR conversation receipts

### DIFF
--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -926,8 +926,9 @@ def build_parser() -> argparse.ArgumentParser:
             "artifact per record under issues/, pull_requests/, or releases/. Issue "
             "mode filters out pull requests returned by the issues endpoint. Issue "
             "comments can be included optionally in issue mode. Pull request "
-            "comments, release assets, changelog generation, timelines, reactions, "
-            "reviews, checks, GraphQL, attachments, and live sync are not included. "
+            "comments and review comments can be included optionally in pull_request "
+            "mode. Release assets, changelog generation, timelines, reactions, "
+            "checks, GraphQL, attachments, and live sync are not included. "
             "The token is read only from --token-env, and token values are never "
             "printed."
         ),
@@ -998,6 +999,22 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "Fetch issue comments and append them to issue artifacts. Ignored for "
             "pull_request and release resource types."
+        ),
+    )
+    github_metadata_parser.add_argument(
+        "--include-pr-comments",
+        action="store_true",
+        help=(
+            "Fetch whole-pull-request comments and append them to pull request "
+            "artifacts. Ignored for issue and release resource types."
+        ),
+    )
+    github_metadata_parser.add_argument(
+        "--include-pr-review-comments",
+        action="store_true",
+        help=(
+            "Fetch pull request review comments and append them to pull request "
+            "artifacts. Ignored for issue and release resource types."
         ),
     )
     github_metadata_parser.add_argument(
@@ -3868,6 +3885,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             since=args.since,
             max_items=args.max_items,
             include_issue_comments=args.include_issue_comments,
+            include_pr_comments=args.include_pr_comments,
+            include_pr_review_comments=args.include_pr_review_comments,
             dry_run=args.dry_run,
         )
 
@@ -3903,6 +3922,10 @@ def main(argv: Sequence[str] | None = None) -> int:
                     state=github_metadata_config.state,
                     since=github_metadata_config.since,
                     max_items=github_metadata_config.max_items,
+                    include_pr_comments=github_metadata_config.include_pr_comments,
+                    include_pr_review_comments=(
+                        github_metadata_config.include_pr_review_comments
+                    ),
                 )
             else:
                 records = list_repository_releases(
@@ -3938,6 +3961,16 @@ def main(argv: Sequence[str] | None = None) -> int:
             and github_metadata_config.include_issue_comments
         ):
             print("  include_issue_comments: true")
+        if (
+            github_metadata_config.resource_type == "pull_request"
+            and github_metadata_config.include_pr_comments
+        ):
+            print("  include_pr_comments: true")
+        if (
+            github_metadata_config.resource_type == "pull_request"
+            and github_metadata_config.include_pr_review_comments
+        ):
+            print("  include_pr_review_comments: true")
         print(f"  run_mode: {'dry-run' if github_metadata_config.dry_run else 'write'}")
 
         try:
@@ -4016,6 +4049,39 @@ def main(argv: Sequence[str] | None = None) -> int:
                     "source_url": record.source_url,
                     "body": record.body,
                 }
+                if record.comments:
+                    normalized_record["comments"] = [
+                        {
+                            "comment_id": comment.comment_id,
+                            "source_url": comment.source_url,
+                            "author": comment.author,
+                            "created_at": comment.created_at,
+                            "updated_at": comment.updated_at,
+                            "body": comment.body,
+                        }
+                        for comment in record.comments
+                    ]
+                if record.review_comments:
+                    normalized_record["review_comments"] = [
+                        {
+                            "comment_id": comment.comment_id,
+                            "source_url": comment.source_url,
+                            "author": comment.author,
+                            "created_at": comment.created_at,
+                            "updated_at": comment.updated_at,
+                            "path": comment.path,
+                            "line": comment.line,
+                            "original_line": comment.original_line,
+                            "start_line": comment.start_line,
+                            "original_start_line": comment.original_start_line,
+                            "position": comment.position,
+                            "original_position": comment.original_position,
+                            "side": comment.side,
+                            "start_side": comment.start_side,
+                            "body": comment.body,
+                        }
+                        for comment in record.review_comments
+                    ]
                 markdown = normalize_pull_request_to_markdown(normalized_record)
                 manifest_entry = {
                     "canonical_id": record.canonical_id,
@@ -4030,6 +4096,12 @@ def main(argv: Sequence[str] | None = None) -> int:
                     "author": record.author,
                     "content_hash": hashlib.sha256(markdown.encode("utf-8")).hexdigest(),
                 }
+                if github_metadata_config.include_pr_comments:
+                    manifest_entry["pr_comments_count"] = len(record.comments)
+                if github_metadata_config.include_pr_review_comments:
+                    manifest_entry["pr_review_comments_count"] = len(
+                        record.review_comments
+                    )
             else:
                 assert isinstance(record, GitHubRelease)
                 record_identifier = record.release_id

--- a/src/knowledge_adapters/github_metadata/client.py
+++ b/src/knowledge_adapters/github_metadata/client.py
@@ -78,11 +78,46 @@ class GitHubPullRequest:
     updated_at: str
     source_url: str
     body: str
+    comments: tuple[GitHubPullRequestComment, ...] = ()
+    review_comments: tuple[GitHubPullRequestReviewComment, ...] = ()
 
     @property
     def canonical_id(self) -> str:
         """Return the pull request canonical ID."""
         return f"github_metadata:{self.host}:{self.repo}:pull_request:{self.number}"
+
+
+@dataclass(frozen=True)
+class GitHubPullRequestComment:
+    """One normalized whole-pull-request comment record."""
+
+    comment_id: int | None
+    source_url: str | None
+    author: str | None
+    created_at: str
+    updated_at: str
+    body: str
+
+
+@dataclass(frozen=True)
+class GitHubPullRequestReviewComment:
+    """One normalized pull request review comment record."""
+
+    comment_id: int | None
+    source_url: str | None
+    author: str | None
+    created_at: str
+    updated_at: str
+    path: str | None
+    line: int | None
+    original_line: int | None
+    start_line: int | None
+    original_start_line: int | None
+    position: int | None
+    original_position: int | None
+    side: str | None
+    start_side: str | None
+    body: str
 
 
 @dataclass(frozen=True)
@@ -344,6 +379,8 @@ def list_repository_pull_requests(
     state: str = "open",
     since: str | None = None,
     max_items: int | None = None,
+    include_pr_comments: bool = False,
+    include_pr_review_comments: bool = False,
 ) -> tuple[GitHubPullRequest, ...]:
     """List normalized pull requests for one repository through the REST API."""
     owner, repo_name, normalized_repo = validate_repo(repo)
@@ -394,9 +431,48 @@ def list_repository_pull_requests(
             for pull_request in ordered_pull_requests
             if _parse_timestamp(pull_request.updated_at) >= since_cutoff
         )
-    if normalized_max_items is None:
-        return ordered_pull_requests
-    return ordered_pull_requests[:normalized_max_items]
+    selected_pull_requests = (
+        ordered_pull_requests
+        if normalized_max_items is None
+        else ordered_pull_requests[:normalized_max_items]
+    )
+    if not include_pr_comments and not include_pr_review_comments:
+        return selected_pull_requests
+
+    hydrated_pull_requests: list[GitHubPullRequest] = []
+    for pull_request in selected_pull_requests:
+        comments = (
+            _list_pull_request_comments(
+                pull_number=pull_request.number,
+                owner=owner,
+                repo_name=repo_name,
+                repo=normalized_repo,
+                api_root=base_urls.api_root,
+                request_auth=request_auth,
+            )
+            if include_pr_comments
+            else pull_request.comments
+        )
+        review_comments = (
+            _list_pull_request_review_comments(
+                pull_number=pull_request.number,
+                owner=owner,
+                repo_name=repo_name,
+                repo=normalized_repo,
+                api_root=base_urls.api_root,
+                request_auth=request_auth,
+            )
+            if include_pr_review_comments
+            else pull_request.review_comments
+        )
+        hydrated_pull_requests.append(
+            replace(
+                pull_request,
+                comments=comments,
+                review_comments=review_comments,
+            )
+        )
+    return tuple(hydrated_pull_requests)
 
 
 def list_repository_releases(
@@ -633,6 +709,39 @@ def issue_comments_api_url(
     )
 
 
+def pull_request_comments_api_url(
+    *,
+    api_root: str,
+    owner: str,
+    repo_name: str,
+    pull_number: int,
+) -> str:
+    """Build the first whole-pull-request comments API URL."""
+    return issue_comments_api_url(
+        api_root=api_root,
+        owner=owner,
+        repo_name=repo_name,
+        issue_number=pull_number,
+    )
+
+
+def pull_request_review_comments_api_url(
+    *,
+    api_root: str,
+    owner: str,
+    repo_name: str,
+    pull_number: int,
+) -> str:
+    """Build the first pull request review comments API URL."""
+    encoded_owner = parse.quote(owner, safe="")
+    encoded_repo = parse.quote(repo_name, safe="")
+    query = parse.urlencode({"per_page": _PAGE_SIZE})
+    return (
+        f"{api_root.rstrip('/')}/repos/{encoded_owner}/{encoded_repo}/pulls/"
+        f"{pull_number}/comments?{query}"
+    )
+
+
 def _list_issue_comments(
     *,
     issue_number: int,
@@ -704,6 +813,169 @@ def _map_issue_comment(payload: dict[str, object]) -> GitHubIssueComment:
     )
 
 
+def _list_pull_request_comments(
+    *,
+    pull_number: int,
+    owner: str,
+    repo_name: str,
+    repo: str,
+    api_root: str,
+    request_auth: RequestAuth,
+) -> tuple[GitHubPullRequestComment, ...]:
+    next_url: str | None = pull_request_comments_api_url(
+        api_root=api_root,
+        owner=owner,
+        repo_name=repo_name,
+        pull_number=pull_number,
+    )
+    seen_urls: set[str] = set()
+    comments: list[GitHubPullRequestComment] = []
+    while next_url is not None:
+        if next_url in seen_urls:
+            raise ValueError(
+                "Response error: repeated GitHub pull request comments pagination URL."
+            )
+        seen_urls.add(next_url)
+
+        payload, link_header = _request_json_list(
+            next_url,
+            request_auth=request_auth,
+            repo=repo,
+            api_root=api_root,
+        )
+        for item in payload:
+            comments.append(_map_pull_request_comment(item))
+        next_url = _next_link_url(link_header)
+
+    return tuple(
+        sorted(
+            comments,
+            key=lambda comment: (
+                comment.created_at,
+                comment.updated_at,
+                -1 if comment.comment_id is None else comment.comment_id,
+                "" if comment.source_url is None else comment.source_url,
+                "" if comment.author is None else comment.author,
+                comment.body,
+            ),
+        )
+    )
+
+
+def _list_pull_request_review_comments(
+    *,
+    pull_number: int,
+    owner: str,
+    repo_name: str,
+    repo: str,
+    api_root: str,
+    request_auth: RequestAuth,
+) -> tuple[GitHubPullRequestReviewComment, ...]:
+    next_url: str | None = pull_request_review_comments_api_url(
+        api_root=api_root,
+        owner=owner,
+        repo_name=repo_name,
+        pull_number=pull_number,
+    )
+    seen_urls: set[str] = set()
+    comments: list[GitHubPullRequestReviewComment] = []
+    while next_url is not None:
+        if next_url in seen_urls:
+            raise ValueError(
+                "Response error: repeated GitHub pull request review comments pagination URL."
+            )
+        seen_urls.add(next_url)
+
+        payload, link_header = _request_json_list(
+            next_url,
+            request_auth=request_auth,
+            repo=repo,
+            api_root=api_root,
+        )
+        for item in payload:
+            comments.append(_map_pull_request_review_comment(item))
+        next_url = _next_link_url(link_header)
+
+    return tuple(
+        sorted(
+            comments,
+            key=lambda comment: (
+                comment.created_at,
+                comment.updated_at,
+                -1 if comment.comment_id is None else comment.comment_id,
+                "" if comment.source_url is None else comment.source_url,
+                "" if comment.path is None else comment.path,
+                -1 if comment.line is None else comment.line,
+                -1 if comment.original_line is None else comment.original_line,
+                "" if comment.author is None else comment.author,
+                comment.body,
+            ),
+        )
+    )
+
+
+def _map_pull_request_comment(payload: dict[str, object]) -> GitHubPullRequestComment:
+    created_at = _require_string(payload, "created_at")
+    updated_at = _require_string(payload, "updated_at")
+    body = _optional_body(payload, "pull request comment")
+    user = payload.get("user")
+    author: str | None = None
+    if isinstance(user, dict):
+        login = user.get("login")
+        if isinstance(login, str) and login:
+            author = login
+
+    return GitHubPullRequestComment(
+        comment_id=_optional_int(payload, "id"),
+        source_url=_optional_string(payload, "html_url") or _optional_string(payload, "url"),
+        author=author,
+        created_at=created_at,
+        updated_at=updated_at,
+        body=body,
+    )
+
+
+def _map_pull_request_review_comment(
+    payload: dict[str, object],
+) -> GitHubPullRequestReviewComment:
+    created_at = _require_string(payload, "created_at")
+    updated_at = _require_string(payload, "updated_at")
+    body = _optional_body(payload, "pull request review comment")
+    user = payload.get("user")
+    author: str | None = None
+    if isinstance(user, dict):
+        login = user.get("login")
+        if isinstance(login, str) and login:
+            author = login
+
+    return GitHubPullRequestReviewComment(
+        comment_id=_optional_int(payload, "id"),
+        source_url=_optional_string(payload, "html_url") or _optional_string(payload, "url"),
+        author=author,
+        created_at=created_at,
+        updated_at=updated_at,
+        path=_optional_string(payload, "path"),
+        line=_optional_int(payload, "line"),
+        original_line=_optional_int(payload, "original_line"),
+        start_line=_optional_int(payload, "start_line"),
+        original_start_line=_optional_int(payload, "original_start_line"),
+        position=_optional_int(payload, "position"),
+        original_position=_optional_int(payload, "original_position"),
+        side=_optional_string(payload, "side"),
+        start_side=_optional_string(payload, "start_side"),
+        body=body,
+    )
+
+
+def _optional_body(payload: dict[str, object], label: str) -> str:
+    body_value = payload.get("body")
+    if body_value is None:
+        return ""
+    if isinstance(body_value, str):
+        return body_value
+    raise ValueError(f"Response error: invalid {label} body.")
+
+
 def _require_string(payload: dict[str, object], key: str) -> str:
     value = payload.get(key)
     if not isinstance(value, str):
@@ -716,6 +988,15 @@ def _optional_string(payload: dict[str, object], key: str) -> str | None:
     if value is None:
         return None
     if not isinstance(value, str):
+        raise ValueError(f"Response error: missing or invalid {key}.")
+    return value
+
+
+def _optional_int(payload: dict[str, object], key: str) -> int | None:
+    value = payload.get(key)
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
         raise ValueError(f"Response error: missing or invalid {key}.")
     return value
 

--- a/src/knowledge_adapters/github_metadata/config.py
+++ b/src/knowledge_adapters/github_metadata/config.py
@@ -20,4 +20,6 @@ class GitHubMetadataConfig:
     since: str | None = None
     max_items: int | None = None
     include_issue_comments: bool = False
+    include_pr_comments: bool = False
+    include_pr_review_comments: bool = False
     dry_run: bool = False

--- a/src/knowledge_adapters/github_metadata/normalize.py
+++ b/src/knowledge_adapters/github_metadata/normalize.py
@@ -8,6 +8,8 @@ EMPTY_BODY_MARKER = "(empty issue body)"
 EMPTY_PULL_REQUEST_BODY_MARKER = "(empty pull request body)"
 EMPTY_RELEASE_BODY_MARKER = "(empty release body)"
 EMPTY_COMMENT_BODY_MARKER = "(empty issue comment body)"
+EMPTY_PR_COMMENT_BODY_MARKER = "(empty pull request comment body)"
+EMPTY_PR_REVIEW_COMMENT_BODY_MARKER = "(empty pull request review comment body)"
 
 
 def normalize_issue_to_markdown(issue: Mapping[str, object]) -> str:
@@ -29,6 +31,7 @@ def normalize_pull_request_to_markdown(pull_request: Mapping[str, object]) -> st
         resource_type="pull_request",
         empty_body_marker=EMPTY_PULL_REQUEST_BODY_MARKER,
         include_comments=False,
+        comments_section=_normalize_pull_request_sections(pull_request),
     )
 
 
@@ -93,6 +96,7 @@ def _normalize_record_to_markdown(
     resource_type: str,
     empty_body_marker: str,
     include_comments: bool,
+    comments_section: str = "",
 ) -> str:
     number_value = record.get("number")
     if not isinstance(number_value, int) or isinstance(number_value, bool):
@@ -108,8 +112,10 @@ def _normalize_record_to_markdown(
     repo = str(record.get("repo", ""))
     body = str(record.get("body") or "").rstrip("\n")
     body_text = body if body else empty_body_marker
-    comments_section = (
-        _normalize_comments_section(record.get("comments")) if include_comments else ""
+    rendered_comments_section = (
+        _normalize_comments_section(record.get("comments"))
+        if include_comments
+        else comments_section
     )
 
     return f"""# {heading_prefix} #{number}: {title}
@@ -126,7 +132,7 @@ def _normalize_record_to_markdown(
 
 ## Body
 
-{body_text}{comments_section}
+{body_text}{rendered_comments_section}
 """
 
 
@@ -159,3 +165,82 @@ def _normalize_comments_section(comments_value: object) -> str:
 """
         )
     return "\n\n## Comments\n\n" + "\n".join(rendered_comments).rstrip("\n")
+
+
+def _normalize_pull_request_sections(record: Mapping[str, object]) -> str:
+    sections = [
+        _normalize_pull_request_comments_section(record.get("comments")),
+        _normalize_pull_request_review_comments_section(record.get("review_comments")),
+    ]
+    return "".join(section for section in sections if section)
+
+
+def _normalize_pull_request_comments_section(comments_value: object) -> str:
+    if comments_value is None:
+        return ""
+    if not isinstance(comments_value, (list, tuple)):
+        raise ValueError("pull request comments must be a list or tuple when provided.")
+    if not comments_value:
+        return ""
+
+    rendered_comments: list[str] = []
+    for index, comment_value in enumerate(comments_value, start=1):
+        if not isinstance(comment_value, Mapping):
+            raise ValueError("pull request comments must contain mapping entries.")
+        author = comment_value.get("author")
+        body = str(comment_value.get("body") or "").rstrip("\n")
+        rendered_comments.append(
+            f"""### Comment {index}
+
+- id: {_format_optional_value(comment_value.get("comment_id"))}
+- source_url: {_format_optional_value(comment_value.get("source_url"))}
+- author: {'' if author is None else str(author)}
+- created_at: {str(comment_value.get("created_at", ""))}
+- updated_at: {str(comment_value.get("updated_at", ""))}
+
+{body if body else EMPTY_PR_COMMENT_BODY_MARKER}
+"""
+        )
+    return "\n\n## Comments\n\n" + "\n".join(rendered_comments).rstrip("\n")
+
+
+def _normalize_pull_request_review_comments_section(comments_value: object) -> str:
+    if comments_value is None:
+        return ""
+    if not isinstance(comments_value, (list, tuple)):
+        raise ValueError("pull request review comments must be a list or tuple when provided.")
+    if not comments_value:
+        return ""
+
+    rendered_comments: list[str] = []
+    for index, comment_value in enumerate(comments_value, start=1):
+        if not isinstance(comment_value, Mapping):
+            raise ValueError("pull request review comments must contain mapping entries.")
+        author = comment_value.get("author")
+        body = str(comment_value.get("body") or "").rstrip("\n")
+        rendered_comments.append(
+            f"""### Review Comment {index}
+
+- id: {_format_optional_value(comment_value.get("comment_id"))}
+- source_url: {_format_optional_value(comment_value.get("source_url"))}
+- author: {'' if author is None else str(author)}
+- created_at: {str(comment_value.get("created_at", ""))}
+- updated_at: {str(comment_value.get("updated_at", ""))}
+- path: {_format_optional_value(comment_value.get("path"))}
+- line: {_format_optional_value(comment_value.get("line"))}
+- original_line: {_format_optional_value(comment_value.get("original_line"))}
+- start_line: {_format_optional_value(comment_value.get("start_line"))}
+- original_start_line: {_format_optional_value(comment_value.get("original_start_line"))}
+- position: {_format_optional_value(comment_value.get("position"))}
+- original_position: {_format_optional_value(comment_value.get("original_position"))}
+- side: {_format_optional_value(comment_value.get("side"))}
+- start_side: {_format_optional_value(comment_value.get("start_side"))}
+
+{body if body else EMPTY_PR_REVIEW_COMMENT_BODY_MARKER}
+"""
+        )
+    return "\n\n## Review Comments\n\n" + "\n".join(rendered_comments).rstrip("\n")
+
+
+def _format_optional_value(value: object) -> str:
+    return "" if value is None else str(value)

--- a/src/knowledge_adapters/run_config.py
+++ b/src/knowledge_adapters/run_config.py
@@ -104,6 +104,8 @@ _GITHUB_METADATA_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
         "dry_run",
         "enabled",
         "include_issue_comments",
+        "include_pr_comments",
+        "include_pr_review_comments",
         "max_items",
         "output_dir",
         "repo",
@@ -1178,6 +1180,22 @@ def _build_github_metadata_argv(
         default=False,
     ):
         argv.append("--include-issue-comments")
+    if _optional_bool(
+        run_config,
+        "include_pr_comments",
+        index=index,
+        config_path=config_path,
+        default=False,
+    ):
+        argv.append("--include-pr-comments")
+    if _optional_bool(
+        run_config,
+        "include_pr_review_comments",
+        index=index,
+        config_path=config_path,
+        default=False,
+    ):
+        argv.append("--include-pr-review-comments")
 
     if _optional_bool(run_config, "dry_run", index=index, config_path=config_path, default=False):
         argv.append("--dry-run")

--- a/tests/test_cli_help.py
+++ b/tests/test_cli_help.py
@@ -97,7 +97,8 @@ def test_github_metadata_cli_help_includes_resource_type_guidance(tmp_path: Path
     assert "Issue mode filters out pull requests returned by the issues endpoint." in stdout
     assert "under issues/, pull_requests/, or releases/." in stdout
     assert "Issue comments can be included optionally in issue mode." in stdout
-    assert "Pull request comments, release assets, changelog generation, timelines" in stdout
+    assert "Pull request comments and review comments can be included optionally" in stdout
+    assert "Release assets, changelog generation, timelines" in stdout
     assert "--repo OWNER/NAME" in stdout
     assert "--base-url BASE_URL" in stdout
     assert "--token-env ENV_VAR" in stdout
@@ -107,6 +108,8 @@ def test_github_metadata_cli_help_includes_resource_type_guidance(tmp_path: Path
     assert "--since SINCE" in stdout
     assert "--max-items N" in stdout
     assert "--include-issue-comments" in stdout
+    assert "--include-pr-comments" in stdout
+    assert "--include-pr-review-comments" in stdout
     assert "--dry-run" in stdout
     assert "token value is read from the environment only and is never printed" in stdout
     assert "knowledge-adapters github_metadata" in stdout

--- a/tests/test_github_metadata.py
+++ b/tests/test_github_metadata.py
@@ -22,12 +22,16 @@ from knowledge_adapters.github_metadata.client import (
     list_repository_issues,
     list_repository_pull_requests,
     list_repository_releases,
+    pull_request_comments_api_url,
     pull_request_list_api_url,
+    pull_request_review_comments_api_url,
     release_list_api_url,
     resolve_base_urls,
 )
 from knowledge_adapters.github_metadata.normalize import (
     EMPTY_BODY_MARKER,
+    EMPTY_PR_COMMENT_BODY_MARKER,
+    EMPTY_PR_REVIEW_COMMENT_BODY_MARKER,
     EMPTY_PULL_REQUEST_BODY_MARKER,
     EMPTY_RELEASE_BODY_MARKER,
     normalize_issue_to_markdown,
@@ -135,6 +139,57 @@ def _issue_comment(
     return payload
 
 
+def _pr_comment(
+    comment_id: int,
+    *,
+    body: str | None = "PR comment",
+    author: str | None = "alice",
+    created_at: str | None = None,
+    updated_at: str | None = None,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "id": comment_id,
+        "html_url": f"https://github.com/octo/project/pull/4#issuecomment-{comment_id}",
+        "created_at": created_at or f"2026-04-{comment_id:02d}T02:00:00Z",
+        "updated_at": updated_at or f"2026-04-{comment_id:02d}T03:00:00Z",
+        "body": body,
+    }
+    if author is not None:
+        payload["user"] = {"login": author}
+    return payload
+
+
+def _pr_review_comment(
+    comment_id: int,
+    *,
+    body: str | None = "Review comment",
+    author: str | None = "alice",
+    path: str | None = "src/app.py",
+    line: int | None = 12,
+    created_at: str | None = None,
+    updated_at: str | None = None,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "id": comment_id,
+        "html_url": f"https://github.com/octo/project/pull/4#discussion-diff-{comment_id}",
+        "created_at": created_at or f"2026-04-{comment_id:02d}T02:00:00Z",
+        "updated_at": updated_at or f"2026-04-{comment_id:02d}T03:00:00Z",
+        "path": path,
+        "line": line,
+        "original_line": line,
+        "start_line": None,
+        "original_start_line": None,
+        "position": 5,
+        "original_position": 4,
+        "side": "RIGHT",
+        "start_side": None,
+        "body": body,
+    }
+    if author is not None:
+        payload["user"] = {"login": author}
+    return payload
+
+
 def _release(
     release_id: int,
     *,
@@ -207,6 +262,24 @@ def test_github_metadata_resolves_github_and_ghe_base_urls() -> None:
             state="open",
         )
         == "https://api.github.com/repos/octo/project/pulls?state=open&per_page=100"
+    )
+    assert (
+        pull_request_comments_api_url(
+            api_root=github_urls.api_root,
+            owner="octo",
+            repo_name="project",
+            pull_number=4,
+        )
+        == "https://api.github.com/repos/octo/project/issues/4/comments?per_page=100"
+    )
+    assert (
+        pull_request_review_comments_api_url(
+            api_root=github_urls.api_root,
+            owner="octo",
+            repo_name="project",
+            pull_number=4,
+        )
+        == "https://api.github.com/repos/octo/project/pulls/4/comments?per_page=100"
     )
     assert (
         release_list_api_url(
@@ -394,6 +467,105 @@ def test_github_metadata_pull_requests_paginate_filter_since_and_limit(
         "github_metadata:github.com:octo/project:pull_request:2",
         "github_metadata:github.com:octo/project:pull_request:4",
     ]
+
+
+def test_github_metadata_pr_comments_paginate_and_sort_deterministically(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GH_TOKEN", "secret-token")
+    pull_requests_url = pull_request_list_api_url(
+        api_root="https://api.github.com",
+        owner="octo",
+        repo_name="project",
+        state="open",
+    )
+    pr_comments_url = pull_request_comments_api_url(
+        api_root="https://api.github.com",
+        owner="octo",
+        repo_name="project",
+        pull_number=4,
+    )
+    pr_comments_page_2_url = (
+        "https://api.github.com/repos/octo/project/issues/4/comments?per_page=100&page=2"
+    )
+    pr_review_comments_url = pull_request_review_comments_api_url(
+        api_root="https://api.github.com",
+        owner="octo",
+        repo_name="project",
+        pull_number=4,
+    )
+    fake_urlopen = _install_fake_urlopen(
+        monkeypatch,
+        {
+            pull_requests_url: _FakeGitHubResponse([_pull_request(4)]),
+            pr_comments_url: _FakeGitHubResponse(
+                [
+                    _pr_comment(
+                        30,
+                        body="Later whole-PR comment",
+                        created_at="2026-04-04T05:00:00Z",
+                    )
+                ],
+                headers={"Link": f'<{pr_comments_page_2_url}>; rel="next"'},
+            ),
+            pr_comments_page_2_url: _FakeGitHubResponse(
+                [
+                    _pr_comment(
+                        20,
+                        body="Earlier whole-PR comment",
+                        author="bob",
+                        created_at="2026-04-04T04:00:00Z",
+                    )
+                ]
+            ),
+            pr_review_comments_url: _FakeGitHubResponse(
+                [
+                    _pr_review_comment(
+                        44,
+                        body="Later line comment",
+                        path="src/late.py",
+                        line=20,
+                        created_at="2026-04-04T07:00:00Z",
+                    ),
+                    _pr_review_comment(
+                        43,
+                        body="Earlier line comment",
+                        author=None,
+                        path="src/early.py",
+                        line=None,
+                        created_at="2026-04-04T06:00:00Z",
+                    ),
+                ]
+            ),
+        },
+    )
+
+    pull_requests = list_repository_pull_requests(
+        repo="octo/project",
+        token_env="GH_TOKEN",
+        include_pr_comments=True,
+        include_pr_review_comments=True,
+    )
+
+    assert fake_urlopen.calls == [
+        pull_requests_url,
+        pr_comments_url,
+        pr_comments_page_2_url,
+        pr_review_comments_url,
+    ]
+    assert len(pull_requests) == 1
+    assert [comment.body for comment in pull_requests[0].comments] == [
+        "Earlier whole-PR comment",
+        "Later whole-PR comment",
+    ]
+    assert pull_requests[0].comments[0].comment_id == 20
+    assert [comment.body for comment in pull_requests[0].review_comments] == [
+        "Earlier line comment",
+        "Later line comment",
+    ]
+    assert pull_requests[0].review_comments[0].author is None
+    assert pull_requests[0].review_comments[0].path == "src/early.py"
+    assert pull_requests[0].review_comments[0].line is None
 
 
 def test_github_metadata_releases_paginate_filter_since_order_and_limit(
@@ -1027,6 +1199,8 @@ def test_github_metadata_cli_writes_pull_request_artifacts_and_manifest(
     pr_8_markdown = pr_8_path.read_text(encoding="utf-8")
     assert "# Pull Request #4: Add API docs" in pr_4_markdown
     assert "Implements docs." in pr_4_markdown
+    assert "## Comments" not in pr_4_markdown
+    assert "## Review Comments" not in pr_4_markdown
     assert EMPTY_PULL_REQUEST_BODY_MARKER in pr_8_markdown
 
     manifest_payload = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
@@ -1060,6 +1234,119 @@ def test_github_metadata_cli_writes_pull_request_artifacts_and_manifest(
             "content_hash": hashlib.sha256(pr_8_markdown.encode("utf-8")).hexdigest(),
             "output_path": "pull_requests/8.md",
         },
+    ]
+
+
+def test_github_metadata_cli_writes_pr_comments_when_enabled(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("GH_TOKEN", "secret-token")
+    pull_requests_url = pull_request_list_api_url(
+        api_root="https://api.github.com",
+        owner="octo",
+        repo_name="project",
+        state="open",
+    )
+    pr_4_comments_url = pull_request_comments_api_url(
+        api_root="https://api.github.com",
+        owner="octo",
+        repo_name="project",
+        pull_number=4,
+    )
+    pr_4_review_comments_url = pull_request_review_comments_api_url(
+        api_root="https://api.github.com",
+        owner="octo",
+        repo_name="project",
+        pull_number=4,
+    )
+    fake_urlopen = _install_fake_urlopen(
+        monkeypatch,
+        {
+            pull_requests_url: _FakeGitHubResponse(
+                [_pull_request(4, title="Add API docs", body="Implements docs.\n")]
+            ),
+            pr_4_comments_url: _FakeGitHubResponse(
+                [
+                    _pr_comment(20, body="Whole PR note"),
+                    _pr_comment(21, body=None, author=None),
+                ]
+            ),
+            pr_4_review_comments_url: _FakeGitHubResponse(
+                [
+                    _pr_review_comment(
+                        43,
+                        body="Line note",
+                        path="src/knowledge.py",
+                        line=17,
+                    ),
+                    _pr_review_comment(44, body=None, path=None, line=None),
+                ]
+            ),
+        },
+    )
+    output_dir = tmp_path / "out"
+
+    exit_code = main(
+        [
+            "github_metadata",
+            "--repo",
+            "octo/project",
+            "--token-env",
+            "GH_TOKEN",
+            "--resource-type",
+            "pull_request",
+            "--output-dir",
+            str(output_dir),
+            "--include-pr-comments",
+            "--include-pr-review-comments",
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "include_pr_comments: true" in captured.out
+    assert "include_pr_review_comments: true" in captured.out
+    assert_write_summary(captured.out, wrote=1, skipped=0)
+    assert fake_urlopen.calls == [
+        pull_requests_url,
+        pr_4_comments_url,
+        pr_4_review_comments_url,
+    ]
+
+    pr_4_markdown = (output_dir / "pull_requests" / "4.md").read_text(encoding="utf-8")
+    assert "## Comments" in pr_4_markdown
+    assert "### Comment 1" in pr_4_markdown
+    assert "- id: 20" in pr_4_markdown
+    assert "- source_url: https://github.com/octo/project/pull/4#issuecomment-20" in pr_4_markdown
+    assert "Whole PR note" in pr_4_markdown
+    assert EMPTY_PR_COMMENT_BODY_MARKER in pr_4_markdown
+    assert "## Review Comments" in pr_4_markdown
+    assert "### Review Comment 1" in pr_4_markdown
+    assert "- path: src/knowledge.py" in pr_4_markdown
+    assert "- line: 17" in pr_4_markdown
+    assert "Line note" in pr_4_markdown
+    assert EMPTY_PR_REVIEW_COMMENT_BODY_MARKER in pr_4_markdown
+
+    manifest_payload = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest_payload["files"] == [
+        {
+            "canonical_id": "github_metadata:github.com:octo/project:pull_request:4",
+            "source_url": "https://github.com/octo/project/pull/4",
+            "title": "Add API docs",
+            "repo": "octo/project",
+            "resource_type": "pull_request",
+            "number": 4,
+            "state": "open",
+            "created_at": "2026-04-04T00:00:00Z",
+            "updated_at": "2026-04-04T01:00:00Z",
+            "author": "alice",
+            "content_hash": hashlib.sha256(pr_4_markdown.encode("utf-8")).hexdigest(),
+            "pr_comments_count": 2,
+            "pr_review_comments_count": 2,
+            "output_path": "pull_requests/4.md",
+        }
     ]
 
 

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -488,6 +488,8 @@ runs:
     since: 2026-01-01T00:00:00Z
     max_items: 25
     include_issue_comments: true
+    include_pr_comments: true
+    include_pr_review_comments: true
     output_dir: ./artifacts/github/repo-issues
     dry_run: true
 """.strip()
@@ -520,6 +522,8 @@ runs:
                 "--max-items",
                 "25",
                 "--include-issue-comments",
+                "--include-pr-comments",
+                "--include-pr-review-comments",
                 "--dry-run",
             ),
             dry_run=True,


### PR DESCRIPTION
## Summary

- Adds opt-in PR conversation receipt acquisition to `github_metadata`.
- Supports whole-PR comments via the Issues comments endpoint and PR review comments via the Pull request review comments endpoint.
- Extends PR markdown with deterministic `## Comments` and `## Review Comments` sections only when requested.
- Adds PR-local manifest count fields when those surfaces are requested.
- Adds runs.yaml support for the new CLI flags.

## Validation

- `make check`

## Non-goals

- No timeline/event expansion, checks, reactions, commits, status, branch analysis, semantic reports, summarization, scoring, or cross-resource reasoning.
- No changes to Lane B lifecycle schema or top-level manifest lifecycle model.
- No broad docs reconciliation; Lane A owns docs sequencing.

## Sequencing notes

- Depends on #294 for final readiness.
- Rebase after #294 merges.
- Expected merge order is #293, then #294, then this PR.
- This branch was intentionally implemented from current `main` and is expected to overlap with #294 in `src/knowledge_adapters/cli.py` and `tests/test_github_metadata.py`.

