### PR TITLE
[codex] Add safe stale artifact pruning

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ Every adapter follows the same high-level shape:
 Recommended first run: use `--dry-run` to confirm the planned source,
 artifact path, and manifest path, then rerun without it.
 
+Manifest-backed adapter commands that write artifacts also support opt-in stale
+artifact pruning with `--prune-stale-artifacts`: `local_files`,
+`public_webpage`, `public_pdf`, `confluence`, `github_metadata`, and
+`git_repo`. Pruning is manifest-owned only. It deletes only stale regular files
+that were listed in the prior `manifest.json` and are absent from the current
+run plan under the selected `--output-dir`. It does not delete unmanifested
+files, and it does not delete directories. In `--dry-run`, pruning deletes
+nothing and reports `would_prune_stale_artifacts` with the candidate paths.
+
 Minimal local file first run:
 
 ```bash
@@ -328,6 +337,20 @@ The config uses a top-level `runs:` list. Each run includes a `name`, a `type`,
 adapter-specific inputs such as `base_url`/`target` or `file_path`, and its own
 `output_dir`. `runs.example.yaml` is committed for reference, while `runs.yaml`
 is gitignored for local use.
+
+To enable stale artifact pruning in config-driven refreshes, set
+`prune_stale_artifacts: true` on each adapter run that should prune. There is no
+top-level global prune setting for `knowledge-adapters run`; pruning remains
+opt-in per manifest-backed adapter run.
+
+```yaml
+runs:
+  - name: repo-docs
+    type: git_repo
+    repo_url: https://github.com/example/project.git
+    output_dir: ./artifacts/git/repo-docs
+    prune_stale_artifacts: true
+```
 
 To keep a lightweight human-readable record of a config-driven execution, pass
 `--report-output`:

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -525,6 +525,17 @@ def build_parser() -> argparse.ArgumentParser:
             help=_VERBOSE_HELP,
         )
 
+    def add_prune_stale_artifacts_argument(subparser: argparse.ArgumentParser) -> None:
+        subparser.add_argument(
+            "--prune-stale-artifacts",
+            action="store_true",
+            help=(
+                "Opt in to deleting stale manifest-owned regular files under --output-dir "
+                "after a successful write. In --dry-run, validate and report candidates "
+                "without deleting files."
+            ),
+        )
+
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     confluence_parser = subparsers.add_parser(
@@ -551,6 +562,7 @@ def build_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     add_verbose_argument(confluence_parser)
+    add_prune_stale_artifacts_argument(confluence_parser)
     confluence_parser.add_argument(
         "--base-url",
         required=True,
@@ -726,6 +738,7 @@ def build_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     add_verbose_argument(local_files_parser)
+    add_prune_stale_artifacts_argument(local_files_parser)
     local_files_parser.add_argument(
         "--file-path",
         required=True,
@@ -769,6 +782,7 @@ def build_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     add_verbose_argument(public_webpage_parser)
+    add_prune_stale_artifacts_argument(public_webpage_parser)
     public_webpage_parser.add_argument(
         "--url",
         required=True,
@@ -807,6 +821,7 @@ def build_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     add_verbose_argument(public_pdf_parser)
+    add_prune_stale_artifacts_argument(public_pdf_parser)
     public_pdf_parser.add_argument(
         "--url",
         required=True,
@@ -863,6 +878,7 @@ def build_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     add_verbose_argument(git_repo_parser)
+    add_prune_stale_artifacts_argument(git_repo_parser)
     git_repo_parser.add_argument(
         "--repo-url",
         required=True,
@@ -936,6 +952,7 @@ def build_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     add_verbose_argument(github_metadata_parser)
+    add_prune_stale_artifacts_argument(github_metadata_parser)
     github_metadata_parser.add_argument(
         "--repo",
         required=True,
@@ -1271,6 +1288,24 @@ def print_stale_artifacts(
     remaining_count = len(stale_artifacts) - stale_preview_limit
     if remaining_count > 0:
         print(f"    ... and {remaining_count} more")
+
+
+def print_pruned_stale_artifacts(
+    output_dir: str | Path,
+    pruned_artifacts: Sequence[tuple[str, str]],
+) -> None:
+    """Print stale artifacts removed from disk."""
+    if not pruned_artifacts:
+        return
+
+    output_dir_path = Path(output_dir)
+    print("  Pruned stale artifacts:")
+    for canonical_id, relative_output_path in pruned_artifacts:
+        print(
+            "    "
+            f"{render_user_path(output_dir_path / relative_output_path)} "
+            f"(canonical_id: {canonical_id})"
+        )
 
 
 def _print_public_pdf_replay_quality_metadata(metadata: Mapping[str, object]) -> None:
@@ -1934,8 +1969,12 @@ def main(argv: Sequence[str] | None = None) -> int:
             write_manifest_with_context,
         )
         from knowledge_adapters.manifest_stale import (
+            PrunedArtifact,
+            StaleArtifact,
             find_stale_artifacts,
             load_previous_manifest_index,
+            plan_stale_artifact_prune,
+            prune_stale_artifacts,
         )
 
         confluence_config = ConfluenceConfig(
@@ -2588,6 +2627,59 @@ def main(argv: Sequence[str] | None = None) -> int:
             _print_confluence_run_metrics(indent="  ")
             _print_confluence_request_summary(indent="  ")
 
+        def _plan_confluence_stale_prune(
+            stale_artifact_records: Sequence[StaleArtifact],
+        ) -> list[PrunedArtifact]:
+            if not args.prune_stale_artifacts:
+                return []
+            try:
+                return plan_stale_artifact_prune(
+                    confluence_config.output_dir,
+                    stale_artifact_records,
+                )
+            except RuntimeError as exc:
+                exit_with_cli_error(str(exc), command="confluence")
+            raise AssertionError("unreachable")
+
+        def _print_confluence_dry_run_prune_summary(
+            prune_stale_artifact_plan: Sequence[PrunedArtifact],
+        ) -> None:
+            if args.prune_stale_artifacts:
+                _print(
+                    "  would_prune_stale_artifacts: "
+                    f"{len(prune_stale_artifact_plan)}"
+                )
+
+        def _prune_confluence_stale_after_write(
+            stale_artifact_records: Sequence[StaleArtifact],
+        ) -> list[PrunedArtifact]:
+            if not args.prune_stale_artifacts:
+                return []
+            try:
+                return prune_stale_artifacts(
+                    confluence_config.output_dir,
+                    stale_artifact_records,
+                )
+            except RuntimeError as exc:
+                exit_with_cli_error(str(exc), command="confluence")
+            raise AssertionError("unreachable")
+
+        def _print_confluence_write_prune_summary(
+            stale_artifacts: Sequence[tuple[str, str]],
+            pruned_stale_artifacts: Sequence[PrunedArtifact],
+        ) -> None:
+            if args.prune_stale_artifacts:
+                _print(f"  pruned_stale_artifacts: {len(pruned_stale_artifacts)}")
+                print_pruned_stale_artifacts(
+                    confluence_config.output_dir,
+                    [
+                        (artifact.canonical_id, artifact.output_path)
+                        for artifact in pruned_stale_artifacts
+                    ],
+                )
+            else:
+                print_stale_artifacts(confluence_config.output_dir, stale_artifacts)
+
         def _print_stub_tree_mode_note() -> None:
             if not (confluence_config.tree and confluence_config.client_mode == "stub"):
                 return
@@ -2696,17 +2788,21 @@ def main(argv: Sequence[str] | None = None) -> int:
                 )
                 action = "skip" if page_decision.status == "unchanged" else "write"
                 space_page_records.append((page, output_path, page_decision, action))
+            stale_artifact_records = find_stale_artifacts(
+                confluence_config.output_dir,
+                previous_manifest_index,
+                current_output_paths=[
+                    output_path.relative_to(Path(confluence_config.output_dir)).as_posix()
+                    for _page, output_path, _page_decision, _action in space_page_records
+                ],
+            )
             stale_artifacts = [
                 (artifact.canonical_id, artifact.output_path)
-                for artifact in find_stale_artifacts(
-                    confluence_config.output_dir,
-                    previous_manifest_index,
-                    current_output_paths=[
-                        output_path.relative_to(Path(confluence_config.output_dir)).as_posix()
-                        for _page, output_path, _page_decision, _action in space_page_records
-                    ],
-                )
+                for artifact in stale_artifact_records
             ]
+            prune_stale_artifact_plan = _plan_confluence_stale_prune(
+                stale_artifact_records
+            )
 
             write_count = sum(
                 1
@@ -2746,6 +2842,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     space_key=resolved_space_key,
                     discovered_count=len(discovered_page_ids),
                 )
+                _print_confluence_dry_run_prune_summary(prune_stale_artifact_plan)
                 print_stale_artifacts(confluence_config.output_dir, stale_artifacts)
                 if verbose:
                     for _page, output_path, page_decision, action in space_page_records:
@@ -2844,6 +2941,9 @@ def main(argv: Sequence[str] | None = None) -> int:
                     command="confluence",
                     exc=exc,
                 )
+            pruned_stale_artifacts = _prune_confluence_stale_after_write(
+                stale_artifact_records
+            )
             _print_confluence_write_summary(
                 new_count=new_count,
                 changed_count=changed_count,
@@ -2852,7 +2952,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 skip_count=skip_count,
                 stale_count=len(stale_artifacts),
             )
-            print_stale_artifacts(confluence_config.output_dir, stale_artifacts)
+            _print_confluence_write_prune_summary(stale_artifacts, pruned_stale_artifacts)
             _print(f"Manifest: {_display_output_path(manifest)}")
             print_write_complete(output_dir)
             return 0
@@ -2910,17 +3010,21 @@ def main(argv: Sequence[str] | None = None) -> int:
                 )
                 action = "skip" if page_decision.status == "unchanged" else "write"
                 page_records.append((page, output_path, page_decision, action))
+            stale_artifact_records = find_stale_artifacts(
+                confluence_config.output_dir,
+                previous_manifest_index,
+                current_output_paths=[
+                    output_path.relative_to(Path(confluence_config.output_dir)).as_posix()
+                    for _page, output_path, _page_decision, _action in page_records
+                ],
+            )
             stale_artifacts = [
                 (artifact.canonical_id, artifact.output_path)
-                for artifact in find_stale_artifacts(
-                    confluence_config.output_dir,
-                    previous_manifest_index,
-                    current_output_paths=[
-                        output_path.relative_to(Path(confluence_config.output_dir)).as_posix()
-                        for _page, output_path, _page_decision, _action in page_records
-                    ],
-                )
+                for artifact in stale_artifact_records
             ]
+            prune_stale_artifact_plan = _plan_confluence_stale_prune(
+                stale_artifact_records
+            )
 
             write_count = sum(
                 1
@@ -2959,6 +3063,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     skip_count=skip_count,
                     stale_count=len(stale_artifacts),
                 )
+                _print_confluence_dry_run_prune_summary(prune_stale_artifact_plan)
                 print_stale_artifacts(confluence_config.output_dir, stale_artifacts)
                 if verbose:
                     for _page, output_path, page_decision, action in page_records:
@@ -3062,6 +3167,9 @@ def main(argv: Sequence[str] | None = None) -> int:
                     command="confluence",
                     exc=exc,
                 )
+            pruned_stale_artifacts = _prune_confluence_stale_after_write(
+                stale_artifact_records
+            )
             _print_confluence_write_summary(
                 new_count=new_count,
                 changed_count=changed_count,
@@ -3070,7 +3178,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 skip_count=skip_count,
                 stale_count=len(stale_artifacts),
             )
-            print_stale_artifacts(confluence_config.output_dir, stale_artifacts)
+            _print_confluence_write_prune_summary(stale_artifacts, pruned_stale_artifacts)
             _print(f"Manifest: {_display_output_path(manifest)}")
             print_write_complete(output_dir)
             return 0
@@ -3107,16 +3215,18 @@ def main(argv: Sequence[str] | None = None) -> int:
             page=page,
             output_path=output_path,
         )
+        stale_artifact_records = find_stale_artifacts(
+            confluence_config.output_dir,
+            previous_manifest_index,
+            current_output_paths=[
+                output_path.relative_to(Path(confluence_config.output_dir)).as_posix()
+            ],
+        )
         stale_artifacts = [
             (artifact.canonical_id, artifact.output_path)
-            for artifact in find_stale_artifacts(
-                confluence_config.output_dir,
-                previous_manifest_index,
-                current_output_paths=[
-                    output_path.relative_to(Path(confluence_config.output_dir)).as_posix()
-                ],
-            )
+            for artifact in stale_artifact_records
         ]
+        prune_stale_artifact_plan = _plan_confluence_stale_prune(stale_artifact_records)
         action = "skip" if page_decision.status == "unchanged" else "write"
 
         if confluence_config.dry_run:
@@ -3142,6 +3252,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 stale_count=len(stale_artifacts),
                 markdown=planned_markdown,
             )
+            _print_confluence_dry_run_prune_summary(prune_stale_artifact_plan)
             print_stale_artifacts(confluence_config.output_dir, stale_artifacts)
             print_dry_run_complete()
             return 0
@@ -3200,6 +3311,9 @@ def main(argv: Sequence[str] | None = None) -> int:
                 command="confluence",
                 exc=exc,
             )
+        pruned_stale_artifacts = _prune_confluence_stale_after_write(
+            stale_artifact_records
+        )
         write_count = 1 if action == "write" else 0
         skip_count = 1 if action == "skip" else 0
         _print_confluence_write_summary(
@@ -3210,7 +3324,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             skip_count=skip_count,
             stale_count=len(stale_artifacts),
         )
-        print_stale_artifacts(confluence_config.output_dir, stale_artifacts)
+        _print_confluence_write_prune_summary(stale_artifacts, pruned_stale_artifacts)
         print(f"Manifest: {_display_output_path(manifest)}")
         print_write_complete(output_dir)
         return 0
@@ -3464,6 +3578,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             find_stale_artifacts,
             load_previous_manifest_index,
             load_previous_manifest_output_index,
+            plan_stale_artifact_prune,
+            prune_stale_artifacts,
         )
 
         local_files_config = LocalFilesConfig(
@@ -3521,14 +3637,23 @@ def main(argv: Sequence[str] | None = None) -> int:
                 prior_source_path=prior_source_path,
                 current_source_path=current_source_path,
             )
+        stale_artifact_records = find_stale_artifacts(
+            local_files_config.output_dir,
+            previous_manifest_index,
+            current_output_paths=[planned_output_path],
+        )
         stale_artifacts = [
-            (artifact.canonical_id, artifact.output_path)
-            for artifact in find_stale_artifacts(
-                local_files_config.output_dir,
-                previous_manifest_index,
-                current_output_paths=[planned_output_path],
-            )
+            (artifact.canonical_id, artifact.output_path) for artifact in stale_artifact_records
         ]
+        prune_stale_artifact_plan = []
+        if args.prune_stale_artifacts:
+            try:
+                prune_stale_artifact_plan = plan_stale_artifact_prune(
+                    local_files_config.output_dir,
+                    stale_artifact_records,
+                )
+            except RuntimeError as exc:
+                exit_with_cli_error(str(exc), command="local_files")
 
         print("\nPlan: Local files run")
         print(f"  resolved_file_path: {resolved_input_path}")
@@ -3547,6 +3672,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         if local_files_config.dry_run:
             print("  Summary: would write 1, would skip 0")
             print(f"  stale_artifacts: {len(stale_artifacts)}")
+            if args.prune_stale_artifacts:
+                print(
+                    "  would_prune_stale_artifacts: "
+                    f"{len(prune_stale_artifact_plan)}"
+                )
             print_stale_artifacts(local_files_config.output_dir, stale_artifacts)
             print()
             print(markdown)
@@ -3577,10 +3707,29 @@ def main(argv: Sequence[str] | None = None) -> int:
                 command="local_files",
                 exc=exc,
             )
+        pruned_stale_artifacts = []
+        if args.prune_stale_artifacts:
+            try:
+                pruned_stale_artifacts = prune_stale_artifacts(
+                    local_files_config.output_dir,
+                    stale_artifact_records,
+                )
+            except RuntimeError as exc:
+                exit_with_cli_error(str(exc), command="local_files")
         print(f"\nWrote: {render_user_path(output_path)}")
         print("\nSummary: wrote 1, skipped 0")
         print(f"  stale_artifacts: {len(stale_artifacts)}")
-        print_stale_artifacts(local_files_config.output_dir, stale_artifacts)
+        if args.prune_stale_artifacts:
+            print(f"  pruned_stale_artifacts: {len(pruned_stale_artifacts)}")
+            print_pruned_stale_artifacts(
+                local_files_config.output_dir,
+                [
+                    (artifact.canonical_id, artifact.output_path)
+                    for artifact in pruned_stale_artifacts
+                ],
+            )
+        else:
+            print_stale_artifacts(local_files_config.output_dir, stale_artifacts)
         print(f"Artifact path: {render_user_path(output_path)}")
         print(f"Manifest path: {render_user_path(manifest)}")
         print_write_complete(output_dir)
@@ -3629,6 +3778,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         from knowledge_adapters.manifest_stale import (
             find_stale_artifacts,
             load_previous_manifest_index,
+            plan_stale_artifact_prune,
+            prune_stale_artifacts,
         )
 
         command = str(args.command)
@@ -3777,14 +3928,23 @@ def main(argv: Sequence[str] | None = None) -> int:
             manifest_entry["fetched_at"] = fetched_at
             if replay_quality_metadata:
                 manifest_entry["replay_quality_metadata"] = dict(replay_quality_metadata)
+        stale_artifact_records = find_stale_artifacts(
+            output_dir_arg,
+            previous_manifest_index,
+            current_output_paths=[str(manifest_entry["output_path"])],
+        )
         stale_artifacts = [
-            (artifact.canonical_id, artifact.output_path)
-            for artifact in find_stale_artifacts(
-                output_dir_arg,
-                previous_manifest_index,
-                current_output_paths=[str(manifest_entry["output_path"])],
-            )
+            (artifact.canonical_id, artifact.output_path) for artifact in stale_artifact_records
         ]
+        prune_stale_artifact_plan = []
+        if args.prune_stale_artifacts:
+            try:
+                prune_stale_artifact_plan = plan_stale_artifact_prune(
+                    output_dir_arg,
+                    stale_artifact_records,
+                )
+            except RuntimeError as exc:
+                exit_with_cli_error(str(exc), command=command)
 
         print(f"\nPlan: {plan_title}")
         print(f"  source_url: {source_url}")
@@ -3812,6 +3972,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         if dry_run:
             print("  Summary: would write 1, would skip 0")
             print(f"  stale_artifacts: {len(stale_artifacts)}")
+            if args.prune_stale_artifacts:
+                print(
+                    "  would_prune_stale_artifacts: "
+                    f"{len(prune_stale_artifact_plan)}"
+                )
             print_stale_artifacts(output_dir_arg, stale_artifacts)
             print()
             print(markdown)
@@ -3831,11 +3996,30 @@ def main(argv: Sequence[str] | None = None) -> int:
                 command=command,
                 exc=exc,
             )
+        pruned_stale_artifacts = []
+        if args.prune_stale_artifacts:
+            try:
+                pruned_stale_artifacts = prune_stale_artifacts(
+                    output_dir_arg,
+                    stale_artifact_records,
+                )
+            except RuntimeError as exc:
+                exit_with_cli_error(str(exc), command=command)
 
         print(f"\nWrote: {render_user_path(output_path)}")
         print("\nSummary: wrote 1, skipped 0")
         print(f"  stale_artifacts: {len(stale_artifacts)}")
-        print_stale_artifacts(output_dir_arg, stale_artifacts)
+        if args.prune_stale_artifacts:
+            print(f"  pruned_stale_artifacts: {len(pruned_stale_artifacts)}")
+            print_pruned_stale_artifacts(
+                output_dir_arg,
+                [
+                    (artifact.canonical_id, artifact.output_path)
+                    for artifact in pruned_stale_artifacts
+                ],
+            )
+        else:
+            print_stale_artifacts(output_dir_arg, stale_artifacts)
         print(f"Artifact path: {render_user_path(output_path)}")
         print(f"Manifest path: {render_user_path(manifest)}")
         print_write_complete(output_dir)
@@ -3873,6 +4057,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         from knowledge_adapters.manifest_stale import (
             find_stale_artifacts,
             load_previous_manifest_index,
+            plan_stale_artifact_prune,
+            prune_stale_artifacts,
         )
 
         github_metadata_config = GitHubMetadataConfig(
@@ -4191,6 +4377,15 @@ def main(argv: Sequence[str] | None = None) -> int:
             if prior_entry is not None and prior_entry.content_hash is not None:
                 stale_entry["content_hash"] = prior_entry.content_hash
             stale_manifest_entries.append(stale_entry)
+        prune_stale_artifact_plan = []
+        if args.prune_stale_artifacts:
+            try:
+                prune_stale_artifact_plan = plan_stale_artifact_prune(
+                    github_metadata_config.output_dir,
+                    stale_artifact_records,
+                )
+            except RuntimeError as exc:
+                exit_with_cli_error(str(exc), command="github_metadata")
 
         for record, output_path, decision in zip(
             records,
@@ -4225,6 +4420,11 @@ def main(argv: Sequence[str] | None = None) -> int:
             print(f"  changed_records: {changed_count}")
             print(f"  unchanged_records: {unchanged_count}")
             print(f"  stale_artifacts: {len(stale_artifacts)}")
+            if args.prune_stale_artifacts:
+                print(
+                    "  would_prune_stale_artifacts: "
+                    f"{len(prune_stale_artifact_plan)}"
+                )
             print_stale_artifacts(github_metadata_config.output_dir, stale_artifacts)
             print(f"Manifest path: {render_user_path(manifest_output_path)}")
             print_dry_run_complete()
@@ -4263,6 +4463,15 @@ def main(argv: Sequence[str] | None = None) -> int:
                 command="github_metadata",
                 exc=exc,
             )
+        pruned_stale_artifacts = []
+        if args.prune_stale_artifacts:
+            try:
+                pruned_stale_artifacts = prune_stale_artifacts(
+                    github_metadata_config.output_dir,
+                    stale_artifact_records,
+                )
+            except RuntimeError as exc:
+                exit_with_cli_error(str(exc), command="github_metadata")
 
         for output_path in github_rewritten_output_paths:
             print(f"\nWrote: {render_user_path(output_path)}")
@@ -4273,7 +4482,17 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"  changed_records: {changed_count}")
         print(f"  unchanged_records: {unchanged_count}")
         print(f"  stale_artifacts: {len(stale_artifacts)}")
-        print_stale_artifacts(github_metadata_config.output_dir, stale_artifacts)
+        if args.prune_stale_artifacts:
+            print(f"  pruned_stale_artifacts: {len(pruned_stale_artifacts)}")
+            print_pruned_stale_artifacts(
+                github_metadata_config.output_dir,
+                [
+                    (artifact.canonical_id, artifact.output_path)
+                    for artifact in pruned_stale_artifacts
+                ],
+            )
+        else:
+            print_stale_artifacts(github_metadata_config.output_dir, stale_artifacts)
         print(f"Manifest path: {render_user_path(manifest)}")
         print_write_complete(output_dir)
         return 0
@@ -4297,6 +4516,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         from knowledge_adapters.manifest_stale import (
             find_stale_artifacts,
             load_previous_manifest_index,
+            plan_stale_artifact_prune,
+            prune_stale_artifacts,
         )
 
         git_repo_config = GitRepoConfig(
@@ -4388,14 +4609,23 @@ def main(argv: Sequence[str] | None = None) -> int:
                 )
             )
             written_output_paths.append(output_path)
+        stale_artifact_records = find_stale_artifacts(
+            git_repo_config.output_dir,
+            previous_manifest_index,
+            current_output_paths=[str(entry["output_path"]) for entry in manifest_entries],
+        )
         stale_artifacts = [
-            (artifact.canonical_id, artifact.output_path)
-            for artifact in find_stale_artifacts(
-                git_repo_config.output_dir,
-                previous_manifest_index,
-                current_output_paths=[str(entry["output_path"]) for entry in manifest_entries],
-            )
+            (artifact.canonical_id, artifact.output_path) for artifact in stale_artifact_records
         ]
+        prune_stale_artifact_plan = []
+        if args.prune_stale_artifacts:
+            try:
+                prune_stale_artifact_plan = plan_stale_artifact_prune(
+                    git_repo_config.output_dir,
+                    stale_artifact_records,
+                )
+            except RuntimeError as exc:
+                exit_with_cli_error(str(exc), command="git_repo")
 
         for repo_file, output_path in zip(snapshot.files, written_output_paths, strict=True):
             print(f"\n  path: {repo_file.repo_path}")
@@ -4427,6 +4657,11 @@ def main(argv: Sequence[str] | None = None) -> int:
                 f"{len(snapshot.files)}, would skip {len(snapshot.skipped_files)}"
             )
             print(f"  stale_artifacts: {len(stale_artifacts)}")
+            if args.prune_stale_artifacts:
+                print(
+                    "  would_prune_stale_artifacts: "
+                    f"{len(prune_stale_artifact_plan)}"
+                )
             print_stale_artifacts(git_repo_config.output_dir, stale_artifacts)
             print(f"Manifest path: {render_user_path(manifest_output_path)}")
             print_dry_run_complete()
@@ -4459,6 +4694,15 @@ def main(argv: Sequence[str] | None = None) -> int:
                 command="git_repo",
                 exc=exc,
             )
+        pruned_stale_artifacts = []
+        if args.prune_stale_artifacts:
+            try:
+                pruned_stale_artifacts = prune_stale_artifacts(
+                    git_repo_config.output_dir,
+                    stale_artifact_records,
+                )
+            except RuntimeError as exc:
+                exit_with_cli_error(str(exc), command="git_repo")
 
         for output_path in written_output_paths:
             print(f"\nWrote: {render_user_path(output_path)}")
@@ -4466,7 +4710,17 @@ def main(argv: Sequence[str] | None = None) -> int:
             print(f"\nSkipped: {skipped_file.repo_path} ({skipped_file.reason})")
         print(f"\nSummary: wrote {len(snapshot.files)}, skipped {len(snapshot.skipped_files)}")
         print(f"  stale_artifacts: {len(stale_artifacts)}")
-        print_stale_artifacts(git_repo_config.output_dir, stale_artifacts)
+        if args.prune_stale_artifacts:
+            print(f"  pruned_stale_artifacts: {len(pruned_stale_artifacts)}")
+            print_pruned_stale_artifacts(
+                git_repo_config.output_dir,
+                [
+                    (artifact.canonical_id, artifact.output_path)
+                    for artifact in pruned_stale_artifacts
+                ],
+            )
+        else:
+            print_stale_artifacts(git_repo_config.output_dir, stale_artifacts)
         print(f"Manifest path: {render_user_path(manifest)}")
         print_write_complete(output_dir)
         return 0

--- a/src/knowledge_adapters/manifest_stale.py
+++ b/src/knowledge_adapters/manifest_stale.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import stat
 from collections.abc import Collection
 from dataclasses import dataclass
 from pathlib import Path
@@ -25,6 +26,15 @@ class StaleArtifact:
 
     canonical_id: str
     output_path: str
+
+
+@dataclass(frozen=True)
+class PrunedArtifact:
+    """Stale manifest-owned artifact removed from disk."""
+
+    canonical_id: str
+    output_path: str
+    path: Path
 
 
 def _normalize_metadata_value(value: object) -> str | None:
@@ -151,3 +161,76 @@ def find_stale_artifacts(
         )
 
     return stale_artifacts
+
+
+def plan_stale_artifact_prune(
+    output_dir: str | Path,
+    stale_artifacts: Collection[StaleArtifact],
+) -> list[PrunedArtifact]:
+    """Validate stale-artifact prune candidates without deleting anything."""
+    output_dir_path = Path(output_dir).expanduser().resolve()
+    pruned_artifacts: list[PrunedArtifact] = []
+    validation_errors: list[str] = []
+
+    for artifact in sorted(stale_artifacts, key=lambda item: (item.output_path, item.canonical_id)):
+        artifact_path = output_dir_path / artifact.output_path
+        try:
+            resolved_artifact_path = artifact_path.resolve(strict=True)
+        except OSError as exc:
+            validation_errors.append(
+                f"{artifact.output_path!r} ({artifact.canonical_id}) could not be resolved: {exc}"
+            )
+            continue
+
+        try:
+            resolved_artifact_path.relative_to(output_dir_path)
+        except ValueError:
+            validation_errors.append(
+                f"{artifact.output_path!r} ({artifact.canonical_id}) resolves outside "
+                f"output_dir {output_dir_path}: {resolved_artifact_path}"
+            )
+            continue
+
+        try:
+            artifact_stat = artifact_path.stat(follow_symlinks=False)
+        except OSError as exc:
+            validation_errors.append(
+                f"{artifact.output_path!r} ({artifact.canonical_id}) could not be inspected: {exc}"
+            )
+            continue
+
+        if not stat.S_ISREG(artifact_stat.st_mode):
+            validation_errors.append(
+                f"{artifact.output_path!r} ({artifact.canonical_id}) is not a regular file"
+            )
+            continue
+
+        pruned_artifacts.append(
+            PrunedArtifact(
+                canonical_id=artifact.canonical_id,
+                output_path=artifact.output_path,
+                path=resolved_artifact_path,
+            )
+        )
+
+    if validation_errors:
+        details = "\n  ".join(validation_errors)
+        raise RuntimeError(f"Could not safely prune stale artifacts:\n  {details}")
+
+    return pruned_artifacts
+
+
+def prune_stale_artifacts(
+    output_dir: str | Path,
+    stale_artifacts: Collection[StaleArtifact],
+) -> list[PrunedArtifact]:
+    """Delete validated stale manifest-owned regular files under output_dir."""
+    pruned_artifacts = plan_stale_artifact_prune(output_dir, stale_artifacts)
+    for artifact in pruned_artifacts:
+        try:
+            artifact.path.unlink()
+        except OSError as exc:
+            raise RuntimeError(
+                f"Could not prune stale artifact {artifact.path}: {exc}"
+            ) from exc
+    return pruned_artifacts

--- a/src/knowledge_adapters/run_config.py
+++ b/src/knowledge_adapters/run_config.py
@@ -47,6 +47,7 @@ _SUPPORTED_GITHUB_METADATA_STATES = frozenset({"open", "closed", "all"})
 _SUPPORTED_GITHUB_METADATA_RESOURCE_TYPES = SUPPORTED_RESOURCE_TYPES
 
 _COMMON_REQUIRED_KEYS = frozenset({"name", "type"})
+_PRUNE_STALE_ARTIFACTS_KEY = "prune_stale_artifacts"
 _BUNDLE_OPTION_KEYS = frozenset(
     {
         "baseline_manifest",
@@ -77,6 +78,7 @@ _CONFLUENCE_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
         "max_depth",
         "max_requests_per_second",
         "output_dir",
+        _PRUNE_STALE_ARTIFACTS_KEY,
         "request_delay_ms",
         "space_key",
         "space_url",
@@ -90,13 +92,23 @@ _BUNDLE_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | _BUNDLE_OPTION_KEYS | frozenset(
 )
 _NAMED_BUNDLE_ALLOWED_KEYS = _BUNDLE_OPTION_KEYS | frozenset({"name", "runs"})
 _LOCAL_FILES_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
-    {"dry_run", "enabled", "file_path", "output_dir"}
+    {"dry_run", "enabled", "file_path", "output_dir", _PRUNE_STALE_ARTIFACTS_KEY}
 )
 _PUBLIC_URL_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
-    {"dry_run", "enabled", "output_dir", "url"}
+    {"dry_run", "enabled", "output_dir", "url", _PRUNE_STALE_ARTIFACTS_KEY}
 )
 _GIT_REPO_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
-    {"dry_run", "enabled", "exclude", "include", "output_dir", "ref", "repo_url", "subdir"}
+    {
+        "dry_run",
+        "enabled",
+        "exclude",
+        "include",
+        "output_dir",
+        "ref",
+        "repo_url",
+        "subdir",
+        _PRUNE_STALE_ARTIFACTS_KEY,
+    }
 )
 _GITHUB_METADATA_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
     {
@@ -108,6 +120,7 @@ _GITHUB_METADATA_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
         "include_pr_review_comments",
         "max_items",
         "output_dir",
+        _PRUNE_STALE_ARTIFACTS_KEY,
         "repo",
         "resource_type",
         "since",
@@ -631,6 +644,12 @@ def _build_confluence_argv(
         argv.append("--debug")
     if _optional_bool(run_config, "dry_run", index=index, config_path=config_path, default=False):
         argv.append("--dry-run")
+    _append_prune_stale_artifacts_argv(
+        argv,
+        run_config,
+        index=index,
+        config_path=config_path,
+    )
     if tree:
         argv.append("--tree")
 
@@ -980,6 +999,23 @@ def _resolve_configured_ca_bundle(
     return _resolve_path_string(ca_bundle, config_path=config_path)
 
 
+def _append_prune_stale_artifacts_argv(
+    argv: list[str],
+    run_config: dict[str, object],
+    *,
+    index: int | str,
+    config_path: Path,
+) -> None:
+    if _optional_bool(
+        run_config,
+        _PRUNE_STALE_ARTIFACTS_KEY,
+        index=index,
+        config_path=config_path,
+        default=False,
+    ):
+        argv.append("--prune-stale-artifacts")
+
+
 def _build_local_files_argv(
     run_config: dict[str, object],
     *,
@@ -1010,6 +1046,12 @@ def _build_local_files_argv(
     ]
     if _optional_bool(run_config, "dry_run", index=index, config_path=config_path, default=False):
         argv.append("--dry-run")
+    _append_prune_stale_artifacts_argv(
+        argv,
+        run_config,
+        index=index,
+        config_path=config_path,
+    )
     return tuple(argv)
 
 
@@ -1064,6 +1106,12 @@ def _build_git_repo_argv(
 
     if _optional_bool(run_config, "dry_run", index=index, config_path=config_path, default=False):
         argv.append("--dry-run")
+    _append_prune_stale_artifacts_argv(
+        argv,
+        run_config,
+        index=index,
+        config_path=config_path,
+    )
     return tuple(argv)
 
 
@@ -1095,6 +1143,12 @@ def _build_public_url_argv(
     ]
     if _optional_bool(run_config, "dry_run", index=index, config_path=config_path, default=False):
         argv.append("--dry-run")
+    _append_prune_stale_artifacts_argv(
+        argv,
+        run_config,
+        index=index,
+        config_path=config_path,
+    )
     return tuple(argv)
 
 
@@ -1199,6 +1253,12 @@ def _build_github_metadata_argv(
 
     if _optional_bool(run_config, "dry_run", index=index, config_path=config_path, default=False):
         argv.append("--dry-run")
+    _append_prune_stale_artifacts_argv(
+        argv,
+        run_config,
+        index=index,
+        config_path=config_path,
+    )
     return tuple(argv)
 
 

--- a/tests/test_git_repo.py
+++ b/tests/test_git_repo.py
@@ -301,6 +301,58 @@ def test_git_repo_cli_reports_stale_artifacts_when_output_paths_change(
     assert (output_dir / "pages" / "README.md").exists()
 
 
+def test_git_repo_cli_prunes_stale_manifest_artifacts_only_with_flag(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    repo_dir = tmp_path / "repo"
+    _init_repo(repo_dir)
+    _write_text(repo_dir / "README.md", "# Repo\n")
+    _write_text(repo_dir / "docs" / "guide.txt", "Guide text.\n")
+    _commit_all(repo_dir, "initial import")
+    output_dir = tmp_path / "out"
+
+    first_exit_code = main(
+        [
+            "git_repo",
+            "--repo-url",
+            str(repo_dir),
+            "--output-dir",
+            str(output_dir),
+        ]
+    )
+
+    assert first_exit_code == 0
+    capsys.readouterr()
+    stale_output = output_dir / "pages" / "docs" / "guide.txt.md"
+    unmanifested_output = output_dir / "pages" / "unmanifested.md"
+    unmanifested_output.write_text("keep me\n", encoding="utf-8")
+
+    (repo_dir / "docs" / "guide.txt").unlink()
+    _commit_all(repo_dir, "remove guide")
+
+    exit_code = main(
+        [
+            "git_repo",
+            "--repo-url",
+            str(repo_dir),
+            "--output-dir",
+            str(output_dir),
+            "--prune-stale-artifacts",
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert_write_summary(captured.out, wrote=1, skipped=0, stale_artifacts=1)
+    assert "pruned_stale_artifacts: 1" in captured.out
+    assert "Pruned stale artifacts:" in captured.out
+    assert str(stale_output) in captured.out
+    assert not stale_output.exists()
+    assert unmanifested_output.read_text(encoding="utf-8") == "keep me\n"
+    assert (output_dir / "pages" / "README.md").exists()
+
+
 def test_git_repo_cli_dry_run_reports_stale_artifacts_when_files_disappear(
     tmp_path: Path,
     capsys: CaptureFixture[str],
@@ -357,3 +409,53 @@ def test_git_repo_cli_dry_run_reports_stale_artifacts_when_files_disappear(
         "README.md",
         "docs/guide.txt",
     ]
+
+
+def test_git_repo_cli_dry_run_with_prune_flag_reports_candidates_without_deleting(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    repo_dir = tmp_path / "repo"
+    _init_repo(repo_dir)
+    _write_text(repo_dir / "README.md", "# Repo\n")
+    _write_text(repo_dir / "docs" / "guide.txt", "Guide text.\n")
+    _commit_all(repo_dir, "initial import")
+    output_dir = tmp_path / "out"
+
+    assert (
+        main(
+            [
+                "git_repo",
+                "--repo-url",
+                str(repo_dir),
+                "--output-dir",
+                str(output_dir),
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    stale_output = output_dir / "pages" / "docs" / "guide.txt.md"
+    stale_contents = stale_output.read_text(encoding="utf-8")
+    (repo_dir / "docs" / "guide.txt").unlink()
+    _commit_all(repo_dir, "remove guide")
+
+    exit_code = main(
+        [
+            "git_repo",
+            "--repo-url",
+            str(repo_dir),
+            "--output-dir",
+            str(output_dir),
+            "--dry-run",
+            "--prune-stale-artifacts",
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert_dry_run_summary(captured.out, would_write=1, would_skip=0)
+    assert_stale_artifacts(captured.out, count=1, artifact_paths=[stale_output])
+    assert "would_prune_stale_artifacts: 1" in captured.out
+    assert stale_output.read_text(encoding="utf-8") == stale_contents

--- a/tests/test_local_files.py
+++ b/tests/test_local_files.py
@@ -286,6 +286,168 @@ def test_local_files_cli_fails_fast_for_same_name_different_directory_collision(
     assert manifest_payload["files"][0]["canonical_id"] == str(first_source.resolve())
 
 
+def test_local_files_cli_prune_flag_reports_and_deletes_stale_manifest_file(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    first_source = tmp_path / "first.txt"
+    first_source.write_text("First file.\n", encoding="utf-8")
+    second_source = tmp_path / "second.txt"
+    second_source.write_text("Second file.\n", encoding="utf-8")
+    output_dir = tmp_path / "out"
+
+    assert (
+        main(
+            [
+                "local_files",
+                "--file-path",
+                str(first_source),
+                "--output-dir",
+                str(output_dir),
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+    stale_output = output_dir / "pages" / "first.md"
+    unmanifested_output = output_dir / "pages" / "unmanifested.md"
+    unmanifested_output.write_text("keep\n", encoding="utf-8")
+
+    exit_code = main(
+        [
+            "local_files",
+            "--file-path",
+            str(second_source),
+            "--output-dir",
+            str(output_dir),
+            "--prune-stale-artifacts",
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "Summary: wrote 1, skipped 0" in captured.out
+    assert "stale_artifacts: 1" in captured.out
+    assert "pruned_stale_artifacts: 1" in captured.out
+    assert str(stale_output) in captured.out
+    assert not stale_output.exists()
+    assert unmanifested_output.read_text(encoding="utf-8") == "keep\n"
+    assert (output_dir / "pages" / "second.md").exists()
+
+
+def test_local_files_cli_prune_dry_run_reports_candidates_without_deleting(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    first_source = tmp_path / "first.txt"
+    first_source.write_text("First file.\n", encoding="utf-8")
+    second_source = tmp_path / "second.txt"
+    second_source.write_text("Second file.\n", encoding="utf-8")
+    output_dir = tmp_path / "out"
+
+    assert (
+        main(
+            [
+                "local_files",
+                "--file-path",
+                str(first_source),
+                "--output-dir",
+                str(output_dir),
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+    stale_output = output_dir / "pages" / "first.md"
+    stale_contents = stale_output.read_text(encoding="utf-8")
+
+    exit_code = main(
+        [
+            "local_files",
+            "--file-path",
+            str(second_source),
+            "--output-dir",
+            str(output_dir),
+            "--dry-run",
+            "--prune-stale-artifacts",
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "Summary: would write 1, would skip 0" in captured.out
+    assert "stale_artifacts: 1" in captured.out
+    assert "would_prune_stale_artifacts: 1" in captured.out
+    assert str(stale_output) in captured.out
+    assert stale_output.read_text(encoding="utf-8") == stale_contents
+
+
+def test_local_files_cli_prune_rejects_outside_manifest_path_before_delete(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    source_file = tmp_path / "current.txt"
+    source_file.write_text("Current file.\n", encoding="utf-8")
+    output_dir = tmp_path / "out"
+    current_output = output_dir / "pages" / "current.md"
+    safe_stale_output = output_dir / "pages" / "safe-stale.md"
+    outside_output = tmp_path / "outside.md"
+    safe_stale_output.parent.mkdir(parents=True)
+    current_output.write_text("old current\n", encoding="utf-8")
+    safe_stale_output.write_text("safe stale\n", encoding="utf-8")
+    outside_output.write_text("outside\n", encoding="utf-8")
+    (output_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "generated_at": "2026-04-20T00:00:00Z",
+                "files": [
+                    {
+                        "canonical_id": str(source_file.resolve()),
+                        "source_url": source_file.resolve().as_uri(),
+                        "output_path": "pages/current.md",
+                        "title": "current.txt",
+                    },
+                    {
+                        "canonical_id": "safe-stale",
+                        "source_url": "file:///safe-stale",
+                        "output_path": "pages/safe-stale.md",
+                        "title": "safe-stale",
+                    },
+                    {
+                        "canonical_id": "outside",
+                        "source_url": "file:///outside",
+                        "output_path": str(outside_output),
+                        "title": "outside",
+                    },
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(
+            [
+                "local_files",
+                "--file-path",
+                str(source_file),
+                "--output-dir",
+                str(output_dir),
+                "--prune-stale-artifacts",
+            ]
+        )
+
+    assert exc_info.value.code == 2
+    captured = capsys.readouterr()
+    assert "knowledge-adapters local_files: error:" in captured.err
+    assert "outside output_dir" in captured.err
+    assert current_output.read_text(encoding="utf-8") == "old current\n"
+    assert safe_stale_output.read_text(encoding="utf-8") == "safe stale\n"
+    assert outside_output.read_text(encoding="utf-8") == "outside\n"
+
+
 def test_fetch_file_reports_permission_errors(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_manifest_stale.py
+++ b/tests/test_manifest_stale.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from knowledge_adapters.manifest_stale import (
+    StaleArtifact,
+    plan_stale_artifact_prune,
+    prune_stale_artifacts,
+)
+
+
+def test_prune_stale_artifacts_deletes_regular_files_in_deterministic_order(
+    tmp_path: Path,
+) -> None:
+    output_dir = tmp_path / "out"
+    first = output_dir / "pages" / "a.md"
+    second = output_dir / "pages" / "b.md"
+    unmanifested = output_dir / "pages" / "keep.md"
+    for path in (first, second, unmanifested):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(path.name, encoding="utf-8")
+
+    pruned = prune_stale_artifacts(
+        output_dir,
+        (
+            StaleArtifact(canonical_id="second", output_path="pages/b.md"),
+            StaleArtifact(canonical_id="first", output_path="pages/a.md"),
+        ),
+    )
+
+    assert [(artifact.canonical_id, artifact.output_path) for artifact in pruned] == [
+        ("first", "pages/a.md"),
+        ("second", "pages/b.md"),
+    ]
+    assert not first.exists()
+    assert not second.exists()
+    assert unmanifested.read_text(encoding="utf-8") == "keep.md"
+
+
+def test_plan_stale_artifact_prune_does_not_delete_files(tmp_path: Path) -> None:
+    output_dir = tmp_path / "out"
+    stale_file = output_dir / "pages" / "stale.md"
+    stale_file.parent.mkdir(parents=True)
+    stale_file.write_text("stale\n", encoding="utf-8")
+
+    planned = plan_stale_artifact_prune(
+        output_dir,
+        (StaleArtifact(canonical_id="stale", output_path="pages/stale.md"),),
+    )
+
+    assert [(artifact.canonical_id, artifact.output_path) for artifact in planned] == [
+        ("stale", "pages/stale.md")
+    ]
+    assert stale_file.read_text(encoding="utf-8") == "stale\n"
+
+
+def test_prune_stale_artifacts_rejects_outside_paths_before_deleting_anything(
+    tmp_path: Path,
+) -> None:
+    output_dir = tmp_path / "out"
+    safe_file = output_dir / "pages" / "safe.md"
+    outside_file = tmp_path / "outside.md"
+    safe_file.parent.mkdir(parents=True)
+    safe_file.write_text("safe\n", encoding="utf-8")
+    outside_file.write_text("outside\n", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="outside output_dir"):
+        prune_stale_artifacts(
+            output_dir,
+            (
+                StaleArtifact(canonical_id="safe", output_path="pages/safe.md"),
+                StaleArtifact(canonical_id="outside", output_path=str(outside_file)),
+            ),
+        )
+
+    assert safe_file.read_text(encoding="utf-8") == "safe\n"
+    assert outside_file.read_text(encoding="utf-8") == "outside\n"
+
+
+def test_prune_stale_artifacts_rejects_directories_without_deleting_them(
+    tmp_path: Path,
+) -> None:
+    output_dir = tmp_path / "out"
+    stale_dir = output_dir / "pages" / "stale-dir"
+    stale_dir.mkdir(parents=True)
+
+    with pytest.raises(RuntimeError, match="not a regular file"):
+        prune_stale_artifacts(
+            output_dir,
+            (StaleArtifact(canonical_id="stale-dir", output_path="pages/stale-dir"),),
+        )
+
+    assert stale_dir.is_dir()

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -1079,6 +1079,60 @@ runs:
     ]
 
 
+def test_run_command_parses_summary_when_configured_run_prunes_stale_artifacts(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    first_source = tmp_path / "inputs" / "first.txt"
+    second_source = tmp_path / "inputs" / "second.txt"
+    first_source.parent.mkdir(parents=True)
+    first_source.write_text("First.\n", encoding="utf-8")
+    second_source.write_text("Second.\n", encoding="utf-8")
+    output_dir = tmp_path / "artifacts" / "local" / "team-notes"
+
+    assert (
+        main(
+            [
+                "local_files",
+                "--file-path",
+                str(first_source),
+                "--output-dir",
+                str(output_dir),
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: team-notes
+    type: local_files
+    file_path: ./inputs/second.txt
+    output_dir: ./artifacts/local/team-notes
+    prune_stale_artifacts: true
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    exit_code = main(["run", str(config_path)])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "--prune-stale-artifacts" in captured.out
+    assert "Summary: wrote 1, skipped 0" in captured.out
+    assert "pruned_stale_artifacts: 1" in captured.out
+    assert "Run summary: wrote 1, skipped 0" in captured.out
+    assert "Aggregate summary:" in captured.out
+    assert "wrote: 1" in captured.out
+    assert "skipped: 0" in captured.out
+    assert not (output_dir / "pages" / "first.md").exists()
+    assert (output_dir / "pages" / "second.md").exists()
+
+
 def test_run_command_preserves_nested_confluence_inline_progress_on_tty(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,


### PR DESCRIPTION
## Summary

Adds an opt-in `--prune-stale-artifacts` flag to manifest-backed adapter commands that write artifacts: `local_files`, `public_webpage`, `public_pdf`, `confluence`, `github_metadata`, and `git_repo`.

The pruning path reuses existing stale artifact detection, validates every candidate before deleting anything, and only removes prior-manifest regular files that remain under the selected `--output-dir`. Dry-run mode reports `would_prune_stale_artifacts` and never deletes files. Write mode prunes only after successful artifact writes and manifest updates, while keeping the existing `Summary: wrote X, skipped Y` shape intact for config-driven runs.

## Testing

- `make test` passed: 544 passed
- `make check` passed:
  - Ruff: All checks passed
  - mypy: Success, no issues found in 104 source files
  - pytest: 544 passed