### PR TITLE
[codex] Add config run dry-run override

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,17 @@ adapter-specific inputs such as `base_url`/`target` or `file_path`, and its own
 `output_dir`. `runs.example.yaml` is committed for reference, while `runs.yaml`
 is gitignored for local use.
 
+To test an entire config-driven run without editing `runs.yaml`, pass
+`--dry-run` to the top-level `run` command:
+
+```bash
+knowledge-adapters run runs.yaml --dry-run
+```
+
+This temporarily appends `--dry-run` to every configured adapter run that
+supports dry-run mode. It does not modify or persist `runs.yaml`, and it
+overrides per-run `dry_run:` settings only for that invocation.
+
 To enable stale artifact pruning in config-driven refreshes, set
 `prune_stale_artifacts: true` on each adapter run that should prune. There is no
 top-level global prune setting for `knowledge-adapters run`; pruning remains

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -184,6 +184,7 @@ GITHUB_METADATA_HELP_EXAMPLES = """Examples:
 RUN_HELP_EXAMPLES = """Examples:
   knowledge-adapters run runs.yaml
   knowledge-adapters run ./configs/runs.yaml
+  knowledge-adapters run runs.yaml --dry-run
   knowledge-adapters run runs.yaml --only team-notes,docs-home
   knowledge-adapters run runs.yaml --continue-on-error
   knowledge-adapters run runs.yaml --report-output ./artifacts/run-report.md
@@ -222,6 +223,16 @@ _CONFLUENCE_REAL_ONLY_INPUT_FLAGS = (
     "--tree-cache-dir",
     "--request-delay-ms",
     "--max-requests-per-second",
+)
+_DRY_RUN_CONFIGURED_RUN_TYPES = frozenset(
+    {
+        "confluence",
+        "git_repo",
+        "github_metadata",
+        "local_files",
+        "public_pdf",
+        "public_webpage",
+    }
 )
 _VERBOSE_HELP = "Show per-item write/skip details that are hidden by default."
 
@@ -1212,6 +1223,14 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     run_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Append --dry-run to every configured adapter run that supports it "
+            "for this invocation only, without editing runs.yaml."
+        ),
+    )
+    run_parser.add_argument(
         "--report-output",
         metavar="PATH",
         help=(
@@ -1584,12 +1603,19 @@ def _effective_configured_run_argv(
     run_type: str,
     argv: Sequence[str],
     debug: bool,
+    dry_run: bool,
     verbose: bool,
 ) -> tuple[str, ...]:
     """Apply safe top-level run overrides before invoking a configured run."""
     effective_argv = tuple(argv)
     if debug and run_type == "confluence" and "--debug" not in effective_argv:
         effective_argv = (*effective_argv, "--debug")
+    if (
+        dry_run
+        and run_type in _DRY_RUN_CONFIGURED_RUN_TYPES
+        and "--dry-run" not in effective_argv
+    ):
+        effective_argv = (*effective_argv, "--dry-run")
     if verbose and "--verbose" not in effective_argv:
         effective_argv = (*effective_argv, "--verbose")
     return effective_argv
@@ -1710,6 +1736,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 run_type=configured_run.run_type,
                 argv=configured_run.argv,
                 debug=args.debug,
+                dry_run=args.dry_run,
                 verbose=verbose,
             )
             display_command = shlex.join(("knowledge-adapters", *effective_argv))

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -1351,6 +1351,183 @@ runs:
     assert not (tmp_path / "artifacts").exists()
 
 
+def test_effective_configured_run_argv_appends_global_dry_run_without_duplicates() -> None:
+    assert cli._effective_configured_run_argv(
+        run_type="local_files",
+        argv=("local_files", "--file-path", "notes.txt", "--output-dir", "out"),
+        debug=False,
+        dry_run=True,
+        verbose=False,
+    ) == ("local_files", "--file-path", "notes.txt", "--output-dir", "out", "--dry-run")
+
+    effective_argv = cli._effective_configured_run_argv(
+        run_type="local_files",
+        argv=("local_files", "--file-path", "notes.txt", "--output-dir", "out", "--dry-run"),
+        debug=False,
+        dry_run=True,
+        verbose=False,
+    )
+
+    assert effective_argv.count("--dry-run") == 1
+
+
+def test_run_command_global_dry_run_forces_false_runs_and_preserves_aggregate_summary(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    source_file = tmp_path / "inputs" / "team-notes.txt"
+    source_file.parent.mkdir(parents=True)
+    source_file.write_text("Ship it.\n", encoding="utf-8")
+    config_path = tmp_path / "runs.yaml"
+    config_text = """
+runs:
+  - name: team-notes
+    type: local_files
+    file_path: ./inputs/team-notes.txt
+    output_dir: ./artifacts/local/team-notes
+    dry_run: false
+  - name: docs-home
+    type: confluence
+    base_url: https://example.com/wiki
+    target: "12345"
+    output_dir: ./artifacts/confluence/docs-home
+    dry_run: false
+""".strip() + "\n"
+    config_path.write_text(config_text, encoding="utf-8")
+
+    exit_code = main(["run", str(config_path), "--dry-run"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "Run 1/2 completed: team-notes (local_files)" in captured.out
+    assert "Run 2/2 completed: docs-home (confluence)" in captured.out
+    assert "Run summary: would write 1, would skip 0" in captured.out
+    assert "Aggregate summary:" in captured.out
+    assert "write_runs: 0" in captured.out
+    assert "dry_run_runs: 2" in captured.out
+    assert "wrote: 0" in captured.out
+    assert "skipped: 0" in captured.out
+    assert "would_write: 2" in captured.out
+    assert "would_skip: 0" in captured.out
+    assert not (tmp_path / "artifacts").exists()
+    assert config_path.read_text(encoding="utf-8") == config_text
+
+
+def test_run_command_global_dry_run_works_when_config_omits_dry_run(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    source_file = tmp_path / "inputs" / "team-notes.txt"
+    source_file.parent.mkdir(parents=True)
+    source_file.write_text("Ship it.\n", encoding="utf-8")
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: team-notes
+    type: local_files
+    file_path: ./inputs/team-notes.txt
+    output_dir: ./artifacts/local/team-notes
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    exit_code = main(["run", str(config_path), "--dry-run"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "Run summary: would write 1, would skip 0" in captured.out
+    assert "dry_run_runs: 1" in captured.out
+    assert "would_write: 1" in captured.out
+    assert not (tmp_path / "artifacts").exists()
+
+
+def test_run_command_preserves_per_run_dry_run_true_without_global_override(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    source_file = tmp_path / "inputs" / "team-notes.txt"
+    source_file.parent.mkdir(parents=True)
+    source_file.write_text("Ship it.\n", encoding="utf-8")
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: team-notes
+    type: local_files
+    file_path: ./inputs/team-notes.txt
+    output_dir: ./artifacts/local/team-notes
+    dry_run: true
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    exit_code = main(["run", str(config_path)])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "Run summary: would write 1, would skip 0" in captured.out
+    assert "write_runs: 0" in captured.out
+    assert "dry_run_runs: 1" in captured.out
+    assert "would_write: 1" in captured.out
+    assert not (tmp_path / "artifacts").exists()
+
+
+def test_run_command_global_dry_run_prune_reports_without_deleting(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    first_source = tmp_path / "inputs" / "first.txt"
+    second_source = tmp_path / "inputs" / "second.txt"
+    first_source.parent.mkdir(parents=True)
+    first_source.write_text("First file.\n", encoding="utf-8")
+    second_source.write_text("Second file.\n", encoding="utf-8")
+    output_dir = tmp_path / "artifacts" / "local" / "team-notes"
+
+    assert (
+        main(
+            [
+                "local_files",
+                "--file-path",
+                str(first_source),
+                "--output-dir",
+                str(output_dir),
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+    stale_output = output_dir / "pages" / "first.md"
+    stale_contents = stale_output.read_text(encoding="utf-8")
+
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: team-notes
+    type: local_files
+    file_path: ./inputs/second.txt
+    output_dir: ./artifacts/local/team-notes
+    prune_stale_artifacts: true
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    exit_code = main(["run", str(config_path), "--dry-run"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "Summary: would write 1, would skip 0" in captured.out
+    assert "stale_artifacts: 1" in captured.out
+    assert "would_prune_stale_artifacts: 1" in captured.out
+    assert "Run summary: would write 1, would skip 0" in captured.out
+    assert "dry_run_runs: 1" in captured.out
+    assert stale_output.read_text(encoding="utf-8") == stale_contents
+
+
 def test_run_command_verbose_preserves_nested_confluence_per_item_output(
     tmp_path: Path,
     capsys: CaptureFixture[str],


### PR DESCRIPTION
## Summary
- add a top-level knowledge-adapters run --dry-run override that appends --dry-run to dry-run-capable configured adapter runs at runtime
- preserve existing per-run dry_run behavior, duplicate guards, verbose propagation, and Confluence debug propagation
- document the invocation-only override and add regression tests for aggregate summaries and stale prune dry-run safety

## Validation
- make test
- make check

Note: PR #297 is already merged, so this change is published as a follow-up PR.