### PR TITLE
Add orphaned artifact cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,14 +57,24 @@ Every adapter follows the same high-level shape:
 Recommended first run: use `--dry-run` to confirm the planned source,
 artifact path, and manifest path, then rerun without it.
 
-Manifest-backed adapter commands that write artifacts also support opt-in stale
-artifact pruning with `--prune-stale-artifacts`: `local_files`,
-`public_webpage`, `public_pdf`, `confluence`, `github_metadata`, and
-`git_repo`. Pruning is manifest-owned only. It deletes only stale regular files
-that were listed in the prior `manifest.json` and are absent from the current
-run plan under the selected `--output-dir`. It does not delete unmanifested
-files, and it does not delete directories. In `--dry-run`, pruning deletes
-nothing and reports `would_prune_stale_artifacts` with the candidate paths.
+Manifest-backed adapter commands that write artifacts also support opt-in
+artifact cleanup: `local_files`, `public_webpage`, `public_pdf`, `confluence`,
+`github_metadata`, and `git_repo`.
+
+- A stale artifact was listed in the prior `manifest.json` but is absent from
+  the current run plan. `--prune-stale-artifacts` deletes only those stale
+  regular files under the selected `--output-dir`.
+- An orphaned artifact is a regular generated markdown file under
+  `--output-dir/pages/**/*.md` that is not referenced by the current run plan.
+  `--report-orphaned-artifacts` reports these candidates without deleting
+  files. `--prune-orphaned-artifacts` implies reporting and deletes only
+  validated orphan candidates.
+
+In `--dry-run`, stale pruning reports `would_prune_stale_artifacts`, orphan
+pruning reports `would_prune_orphaned_artifacts`, and nothing is deleted.
+Orphan cleanup is intentionally limited to generated markdown artifacts under
+`pages/**/*.md`; it never deletes `manifest.json`, directories, non-markdown
+files, or files outside `pages/`.
 
 Minimal local file first run:
 
@@ -349,10 +359,10 @@ This temporarily appends `--dry-run` to every configured adapter run that
 supports dry-run mode. It does not modify or persist `runs.yaml`, and it
 overrides per-run `dry_run:` settings only for that invocation.
 
-To enable stale artifact pruning in config-driven refreshes, set
-`prune_stale_artifacts: true` on each adapter run that should prune. There is no
-top-level global prune setting for `knowledge-adapters run`; pruning remains
-opt-in per manifest-backed adapter run.
+To enable artifact cleanup in config-driven refreshes, set per-run cleanup keys
+on each manifest-backed adapter run that should report or prune. There are no
+top-level global cleanup settings for `knowledge-adapters run`; cleanup remains
+opt-in per run.
 
 ```yaml
 runs:
@@ -361,7 +371,14 @@ runs:
     repo_url: https://github.com/example/project.git
     output_dir: ./artifacts/git/repo-docs
     prune_stale_artifacts: true
+    report_orphaned_artifacts: true
+    prune_orphaned_artifacts: true
 ```
+
+Use `report_orphaned_artifacts: true` to list orphaned `pages/**/*.md`
+candidates without deleting them. Use `prune_orphaned_artifacts: true` to delete
+validated orphan candidates; top-level `knowledge-adapters run --dry-run` turns
+that into `would_prune_orphaned_artifacts` reporting and deletes nothing.
 
 To keep a lightweight human-readable record of a config-driven execution, pass
 `--report-output`:

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -547,6 +547,26 @@ def build_parser() -> argparse.ArgumentParser:
             ),
         )
 
+    def add_orphaned_artifacts_arguments(subparser: argparse.ArgumentParser) -> None:
+        subparser.add_argument(
+            "--report-orphaned-artifacts",
+            action="store_true",
+            help=(
+                "Report unreferenced generated markdown files under --output-dir/pages "
+                "without deleting files."
+            ),
+        )
+        subparser.add_argument(
+            "--prune-orphaned-artifacts",
+            action="store_true",
+            help=(
+                "Opt in to deleting unreferenced generated markdown files under "
+                "--output-dir/pages after a successful write. Implies "
+                "--report-orphaned-artifacts. In --dry-run, validate and report "
+                "candidates without deleting files."
+            ),
+        )
+
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     confluence_parser = subparsers.add_parser(
@@ -574,6 +594,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     add_verbose_argument(confluence_parser)
     add_prune_stale_artifacts_argument(confluence_parser)
+    add_orphaned_artifacts_arguments(confluence_parser)
     confluence_parser.add_argument(
         "--base-url",
         required=True,
@@ -750,6 +771,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     add_verbose_argument(local_files_parser)
     add_prune_stale_artifacts_argument(local_files_parser)
+    add_orphaned_artifacts_arguments(local_files_parser)
     local_files_parser.add_argument(
         "--file-path",
         required=True,
@@ -794,6 +816,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     add_verbose_argument(public_webpage_parser)
     add_prune_stale_artifacts_argument(public_webpage_parser)
+    add_orphaned_artifacts_arguments(public_webpage_parser)
     public_webpage_parser.add_argument(
         "--url",
         required=True,
@@ -833,6 +856,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     add_verbose_argument(public_pdf_parser)
     add_prune_stale_artifacts_argument(public_pdf_parser)
+    add_orphaned_artifacts_arguments(public_pdf_parser)
     public_pdf_parser.add_argument(
         "--url",
         required=True,
@@ -890,6 +914,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     add_verbose_argument(git_repo_parser)
     add_prune_stale_artifacts_argument(git_repo_parser)
+    add_orphaned_artifacts_arguments(git_repo_parser)
     git_repo_parser.add_argument(
         "--repo-url",
         required=True,
@@ -964,6 +989,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     add_verbose_argument(github_metadata_parser)
     add_prune_stale_artifacts_argument(github_metadata_parser)
+    add_orphaned_artifacts_arguments(github_metadata_parser)
     github_metadata_parser.add_argument(
         "--repo",
         required=True,
@@ -1325,6 +1351,38 @@ def print_pruned_stale_artifacts(
             f"{render_user_path(output_dir_path / relative_output_path)} "
             f"(canonical_id: {canonical_id})"
         )
+
+
+def print_orphaned_artifacts(
+    output_dir: str | Path,
+    orphaned_artifacts: Sequence[str],
+) -> None:
+    """Print a preview of orphaned generated markdown artifacts."""
+    if not orphaned_artifacts:
+        return
+
+    orphaned_preview_limit = 5
+    output_dir_path = Path(output_dir)
+    print("  Orphaned artifacts:")
+    for relative_output_path in orphaned_artifacts[:orphaned_preview_limit]:
+        print(f"    {render_user_path(output_dir_path / relative_output_path)}")
+    remaining_count = len(orphaned_artifacts) - orphaned_preview_limit
+    if remaining_count > 0:
+        print(f"    ... and {remaining_count} more")
+
+
+def print_pruned_orphaned_artifacts(
+    output_dir: str | Path,
+    pruned_artifacts: Sequence[str],
+) -> None:
+    """Print orphaned generated markdown artifacts removed from disk."""
+    if not pruned_artifacts:
+        return
+
+    output_dir_path = Path(output_dir)
+    print("  Pruned orphaned artifacts:")
+    for relative_output_path in pruned_artifacts:
+        print(f"    {render_user_path(output_dir_path / relative_output_path)}")
 
 
 def _print_public_pdf_replay_quality_metadata(metadata: Mapping[str, object]) -> None:
@@ -1996,11 +2054,16 @@ def main(argv: Sequence[str] | None = None) -> int:
             write_manifest_with_context,
         )
         from knowledge_adapters.manifest_stale import (
+            OrphanedArtifact,
             PrunedArtifact,
+            PrunedOrphanedArtifact,
             StaleArtifact,
+            find_orphaned_artifacts,
             find_stale_artifacts,
             load_previous_manifest_index,
+            plan_orphaned_artifact_prune,
             plan_stale_artifact_prune,
+            prune_orphaned_artifacts,
             prune_stale_artifacts,
         )
 
@@ -2677,6 +2740,37 @@ def main(argv: Sequence[str] | None = None) -> int:
                     f"{len(prune_stale_artifact_plan)}"
                 )
 
+        def _plan_confluence_orphaned_prune(
+            orphaned_artifact_records: Sequence[OrphanedArtifact],
+            *,
+            current_output_paths: Sequence[str],
+        ) -> list[PrunedOrphanedArtifact]:
+            if not args.prune_orphaned_artifacts:
+                return []
+            try:
+                return plan_orphaned_artifact_prune(
+                    confluence_config.output_dir,
+                    orphaned_artifact_records,
+                    current_output_paths=current_output_paths,
+                )
+            except RuntimeError as exc:
+                exit_with_cli_error(str(exc), command="confluence")
+            raise AssertionError("unreachable")
+
+        def _print_confluence_dry_run_orphaned_summary(
+            orphaned_artifacts: Sequence[str],
+            prune_orphaned_artifact_plan: Sequence[PrunedOrphanedArtifact],
+        ) -> None:
+            if not (args.report_orphaned_artifacts or args.prune_orphaned_artifacts):
+                return
+            _print(f"  orphaned_artifacts: {len(orphaned_artifacts)}")
+            if args.prune_orphaned_artifacts:
+                _print(
+                    "  would_prune_orphaned_artifacts: "
+                    f"{len(prune_orphaned_artifact_plan)}"
+                )
+            print_orphaned_artifacts(confluence_config.output_dir, orphaned_artifacts)
+
         def _prune_confluence_stale_after_write(
             stale_artifact_records: Sequence[StaleArtifact],
         ) -> list[PrunedArtifact]:
@@ -2691,9 +2785,28 @@ def main(argv: Sequence[str] | None = None) -> int:
                 exit_with_cli_error(str(exc), command="confluence")
             raise AssertionError("unreachable")
 
+        def _prune_confluence_orphaned_after_write(
+            orphaned_artifact_records: Sequence[OrphanedArtifact],
+            *,
+            current_output_paths: Sequence[str],
+        ) -> list[PrunedOrphanedArtifact]:
+            if not args.prune_orphaned_artifacts:
+                return []
+            try:
+                return prune_orphaned_artifacts(
+                    confluence_config.output_dir,
+                    orphaned_artifact_records,
+                    current_output_paths=current_output_paths,
+                )
+            except RuntimeError as exc:
+                exit_with_cli_error(str(exc), command="confluence")
+            raise AssertionError("unreachable")
+
         def _print_confluence_write_prune_summary(
             stale_artifacts: Sequence[tuple[str, str]],
             pruned_stale_artifacts: Sequence[PrunedArtifact],
+            orphaned_artifacts: Sequence[str],
+            pruned_orphaned_artifacts: Sequence[PrunedOrphanedArtifact],
         ) -> None:
             if args.prune_stale_artifacts:
                 _print(f"  pruned_stale_artifacts: {len(pruned_stale_artifacts)}")
@@ -2706,6 +2819,19 @@ def main(argv: Sequence[str] | None = None) -> int:
                 )
             else:
                 print_stale_artifacts(confluence_config.output_dir, stale_artifacts)
+            if args.report_orphaned_artifacts or args.prune_orphaned_artifacts:
+                _print(f"  orphaned_artifacts: {len(orphaned_artifacts)}")
+                if args.prune_orphaned_artifacts:
+                    _print(
+                        "  pruned_orphaned_artifacts: "
+                        f"{len(pruned_orphaned_artifacts)}"
+                    )
+                    print_pruned_orphaned_artifacts(
+                        confluence_config.output_dir,
+                        [artifact.output_path for artifact in pruned_orphaned_artifacts],
+                    )
+                else:
+                    print_orphaned_artifacts(confluence_config.output_dir, orphaned_artifacts)
 
         def _print_stub_tree_mode_note() -> None:
             if not (confluence_config.tree and confluence_config.client_mode == "stub"):
@@ -2815,13 +2941,14 @@ def main(argv: Sequence[str] | None = None) -> int:
                 )
                 action = "skip" if page_decision.status == "unchanged" else "write"
                 space_page_records.append((page, output_path, page_decision, action))
+            current_output_paths = [
+                output_path.relative_to(Path(confluence_config.output_dir)).as_posix()
+                for _page, output_path, _page_decision, _action in space_page_records
+            ]
             stale_artifact_records = find_stale_artifacts(
                 confluence_config.output_dir,
                 previous_manifest_index,
-                current_output_paths=[
-                    output_path.relative_to(Path(confluence_config.output_dir)).as_posix()
-                    for _page, output_path, _page_decision, _action in space_page_records
-                ],
+                current_output_paths=current_output_paths,
             )
             stale_artifacts = [
                 (artifact.canonical_id, artifact.output_path)
@@ -2829,6 +2956,19 @@ def main(argv: Sequence[str] | None = None) -> int:
             ]
             prune_stale_artifact_plan = _plan_confluence_stale_prune(
                 stale_artifact_records
+            )
+            orphan_reference_paths = [
+                *current_output_paths,
+                *(artifact.output_path for artifact in stale_artifact_records),
+            ]
+            orphaned_artifact_records = find_orphaned_artifacts(
+                confluence_config.output_dir,
+                current_output_paths=orphan_reference_paths,
+            )
+            orphaned_artifacts = [artifact.output_path for artifact in orphaned_artifact_records]
+            prune_orphaned_artifact_plan = _plan_confluence_orphaned_prune(
+                orphaned_artifact_records,
+                current_output_paths=orphan_reference_paths,
             )
 
             write_count = sum(
@@ -2871,6 +3011,10 @@ def main(argv: Sequence[str] | None = None) -> int:
                 )
                 _print_confluence_dry_run_prune_summary(prune_stale_artifact_plan)
                 print_stale_artifacts(confluence_config.output_dir, stale_artifacts)
+                _print_confluence_dry_run_orphaned_summary(
+                    orphaned_artifacts,
+                    prune_orphaned_artifact_plan,
+                )
                 if verbose:
                     for _page, output_path, page_decision, action in space_page_records:
                         _print(
@@ -2971,6 +3115,10 @@ def main(argv: Sequence[str] | None = None) -> int:
             pruned_stale_artifacts = _prune_confluence_stale_after_write(
                 stale_artifact_records
             )
+            pruned_orphaned_artifacts = _prune_confluence_orphaned_after_write(
+                orphaned_artifact_records,
+                current_output_paths=orphan_reference_paths,
+            )
             _print_confluence_write_summary(
                 new_count=new_count,
                 changed_count=changed_count,
@@ -2979,7 +3127,12 @@ def main(argv: Sequence[str] | None = None) -> int:
                 skip_count=skip_count,
                 stale_count=len(stale_artifacts),
             )
-            _print_confluence_write_prune_summary(stale_artifacts, pruned_stale_artifacts)
+            _print_confluence_write_prune_summary(
+                stale_artifacts,
+                pruned_stale_artifacts,
+                orphaned_artifacts,
+                pruned_orphaned_artifacts,
+            )
             _print(f"Manifest: {_display_output_path(manifest)}")
             print_write_complete(output_dir)
             return 0
@@ -3037,13 +3190,14 @@ def main(argv: Sequence[str] | None = None) -> int:
                 )
                 action = "skip" if page_decision.status == "unchanged" else "write"
                 page_records.append((page, output_path, page_decision, action))
+            current_output_paths = [
+                output_path.relative_to(Path(confluence_config.output_dir)).as_posix()
+                for _page, output_path, _page_decision, _action in page_records
+            ]
             stale_artifact_records = find_stale_artifacts(
                 confluence_config.output_dir,
                 previous_manifest_index,
-                current_output_paths=[
-                    output_path.relative_to(Path(confluence_config.output_dir)).as_posix()
-                    for _page, output_path, _page_decision, _action in page_records
-                ],
+                current_output_paths=current_output_paths,
             )
             stale_artifacts = [
                 (artifact.canonical_id, artifact.output_path)
@@ -3051,6 +3205,19 @@ def main(argv: Sequence[str] | None = None) -> int:
             ]
             prune_stale_artifact_plan = _plan_confluence_stale_prune(
                 stale_artifact_records
+            )
+            orphan_reference_paths = [
+                *current_output_paths,
+                *(artifact.output_path for artifact in stale_artifact_records),
+            ]
+            orphaned_artifact_records = find_orphaned_artifacts(
+                confluence_config.output_dir,
+                current_output_paths=orphan_reference_paths,
+            )
+            orphaned_artifacts = [artifact.output_path for artifact in orphaned_artifact_records]
+            prune_orphaned_artifact_plan = _plan_confluence_orphaned_prune(
+                orphaned_artifact_records,
+                current_output_paths=orphan_reference_paths,
             )
 
             write_count = sum(
@@ -3092,6 +3259,10 @@ def main(argv: Sequence[str] | None = None) -> int:
                 )
                 _print_confluence_dry_run_prune_summary(prune_stale_artifact_plan)
                 print_stale_artifacts(confluence_config.output_dir, stale_artifacts)
+                _print_confluence_dry_run_orphaned_summary(
+                    orphaned_artifacts,
+                    prune_orphaned_artifact_plan,
+                )
                 if verbose:
                     for _page, output_path, page_decision, action in page_records:
                         _print(
@@ -3197,6 +3368,10 @@ def main(argv: Sequence[str] | None = None) -> int:
             pruned_stale_artifacts = _prune_confluence_stale_after_write(
                 stale_artifact_records
             )
+            pruned_orphaned_artifacts = _prune_confluence_orphaned_after_write(
+                orphaned_artifact_records,
+                current_output_paths=orphan_reference_paths,
+            )
             _print_confluence_write_summary(
                 new_count=new_count,
                 changed_count=changed_count,
@@ -3205,7 +3380,12 @@ def main(argv: Sequence[str] | None = None) -> int:
                 skip_count=skip_count,
                 stale_count=len(stale_artifacts),
             )
-            _print_confluence_write_prune_summary(stale_artifacts, pruned_stale_artifacts)
+            _print_confluence_write_prune_summary(
+                stale_artifacts,
+                pruned_stale_artifacts,
+                orphaned_artifacts,
+                pruned_orphaned_artifacts,
+            )
             _print(f"Manifest: {_display_output_path(manifest)}")
             print_write_complete(output_dir)
             return 0
@@ -3242,18 +3422,32 @@ def main(argv: Sequence[str] | None = None) -> int:
             page=page,
             output_path=output_path,
         )
+        current_output_paths = [
+            output_path.relative_to(Path(confluence_config.output_dir)).as_posix()
+        ]
         stale_artifact_records = find_stale_artifacts(
             confluence_config.output_dir,
             previous_manifest_index,
-            current_output_paths=[
-                output_path.relative_to(Path(confluence_config.output_dir)).as_posix()
-            ],
+            current_output_paths=current_output_paths,
         )
         stale_artifacts = [
             (artifact.canonical_id, artifact.output_path)
             for artifact in stale_artifact_records
         ]
         prune_stale_artifact_plan = _plan_confluence_stale_prune(stale_artifact_records)
+        orphan_reference_paths = [
+            *current_output_paths,
+            *(artifact.output_path for artifact in stale_artifact_records),
+        ]
+        orphaned_artifact_records = find_orphaned_artifacts(
+            confluence_config.output_dir,
+            current_output_paths=orphan_reference_paths,
+        )
+        orphaned_artifacts = [artifact.output_path for artifact in orphaned_artifact_records]
+        prune_orphaned_artifact_plan = _plan_confluence_orphaned_prune(
+            orphaned_artifact_records,
+            current_output_paths=orphan_reference_paths,
+        )
         action = "skip" if page_decision.status == "unchanged" else "write"
 
         if confluence_config.dry_run:
@@ -3281,6 +3475,10 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
             _print_confluence_dry_run_prune_summary(prune_stale_artifact_plan)
             print_stale_artifacts(confluence_config.output_dir, stale_artifacts)
+            _print_confluence_dry_run_orphaned_summary(
+                orphaned_artifacts,
+                prune_orphaned_artifact_plan,
+            )
             print_dry_run_complete()
             return 0
 
@@ -3341,6 +3539,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         pruned_stale_artifacts = _prune_confluence_stale_after_write(
             stale_artifact_records
         )
+        pruned_orphaned_artifacts = _prune_confluence_orphaned_after_write(
+            orphaned_artifact_records,
+            current_output_paths=orphan_reference_paths,
+        )
         write_count = 1 if action == "write" else 0
         skip_count = 1 if action == "skip" else 0
         _print_confluence_write_summary(
@@ -3351,7 +3553,12 @@ def main(argv: Sequence[str] | None = None) -> int:
             skip_count=skip_count,
             stale_count=len(stale_artifacts),
         )
-        _print_confluence_write_prune_summary(stale_artifacts, pruned_stale_artifacts)
+        _print_confluence_write_prune_summary(
+            stale_artifacts,
+            pruned_stale_artifacts,
+            orphaned_artifacts,
+            pruned_orphaned_artifacts,
+        )
         print(f"Manifest: {_display_output_path(manifest)}")
         print_write_complete(output_dir)
         return 0
@@ -3602,10 +3809,13 @@ def main(argv: Sequence[str] | None = None) -> int:
             write_manifest,
         )
         from knowledge_adapters.manifest_stale import (
+            find_orphaned_artifacts,
             find_stale_artifacts,
             load_previous_manifest_index,
             load_previous_manifest_output_index,
+            plan_orphaned_artifact_prune,
             plan_stale_artifact_prune,
+            prune_orphaned_artifacts,
             prune_stale_artifacts,
         )
 
@@ -3672,12 +3882,32 @@ def main(argv: Sequence[str] | None = None) -> int:
         stale_artifacts = [
             (artifact.canonical_id, artifact.output_path) for artifact in stale_artifact_records
         ]
+        current_output_paths = [planned_output_path]
+        orphan_reference_paths = [
+            *current_output_paths,
+            *(artifact.output_path for artifact in stale_artifact_records),
+        ]
+        orphaned_artifact_records = find_orphaned_artifacts(
+            local_files_config.output_dir,
+            current_output_paths=orphan_reference_paths,
+        )
+        orphaned_artifacts = [artifact.output_path for artifact in orphaned_artifact_records]
         prune_stale_artifact_plan = []
         if args.prune_stale_artifacts:
             try:
                 prune_stale_artifact_plan = plan_stale_artifact_prune(
                     local_files_config.output_dir,
                     stale_artifact_records,
+                )
+            except RuntimeError as exc:
+                exit_with_cli_error(str(exc), command="local_files")
+        prune_orphaned_artifact_plan = []
+        if args.prune_orphaned_artifacts:
+            try:
+                prune_orphaned_artifact_plan = plan_orphaned_artifact_prune(
+                    local_files_config.output_dir,
+                    orphaned_artifact_records,
+                    current_output_paths=orphan_reference_paths,
                 )
             except RuntimeError as exc:
                 exit_with_cli_error(str(exc), command="local_files")
@@ -3705,6 +3935,14 @@ def main(argv: Sequence[str] | None = None) -> int:
                     f"{len(prune_stale_artifact_plan)}"
                 )
             print_stale_artifacts(local_files_config.output_dir, stale_artifacts)
+            if args.report_orphaned_artifacts or args.prune_orphaned_artifacts:
+                print(f"  orphaned_artifacts: {len(orphaned_artifacts)}")
+                if args.prune_orphaned_artifacts:
+                    print(
+                        "  would_prune_orphaned_artifacts: "
+                        f"{len(prune_orphaned_artifact_plan)}"
+                    )
+                print_orphaned_artifacts(local_files_config.output_dir, orphaned_artifacts)
             print()
             print(markdown)
             print_dry_run_complete()
@@ -3743,6 +3981,16 @@ def main(argv: Sequence[str] | None = None) -> int:
                 )
             except RuntimeError as exc:
                 exit_with_cli_error(str(exc), command="local_files")
+        pruned_orphaned_artifacts = []
+        if args.prune_orphaned_artifacts:
+            try:
+                pruned_orphaned_artifacts = prune_orphaned_artifacts(
+                    local_files_config.output_dir,
+                    orphaned_artifact_records,
+                    current_output_paths=orphan_reference_paths,
+                )
+            except RuntimeError as exc:
+                exit_with_cli_error(str(exc), command="local_files")
         print(f"\nWrote: {render_user_path(output_path)}")
         print("\nSummary: wrote 1, skipped 0")
         print(f"  stale_artifacts: {len(stale_artifacts)}")
@@ -3757,6 +4005,16 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
         else:
             print_stale_artifacts(local_files_config.output_dir, stale_artifacts)
+        if args.report_orphaned_artifacts or args.prune_orphaned_artifacts:
+            print(f"  orphaned_artifacts: {len(orphaned_artifacts)}")
+            if args.prune_orphaned_artifacts:
+                print(f"  pruned_orphaned_artifacts: {len(pruned_orphaned_artifacts)}")
+                print_pruned_orphaned_artifacts(
+                    local_files_config.output_dir,
+                    [artifact.output_path for artifact in pruned_orphaned_artifacts],
+                )
+            else:
+                print_orphaned_artifacts(local_files_config.output_dir, orphaned_artifacts)
         print(f"Artifact path: {render_user_path(output_path)}")
         print(f"Manifest path: {render_user_path(manifest)}")
         print_write_complete(output_dir)
@@ -3803,9 +4061,12 @@ def main(argv: Sequence[str] | None = None) -> int:
             write_manifest,
         )
         from knowledge_adapters.manifest_stale import (
+            find_orphaned_artifacts,
             find_stale_artifacts,
             load_previous_manifest_index,
+            plan_orphaned_artifact_prune,
             plan_stale_artifact_prune,
+            prune_orphaned_artifacts,
             prune_stale_artifacts,
         )
 
@@ -3963,12 +4224,32 @@ def main(argv: Sequence[str] | None = None) -> int:
         stale_artifacts = [
             (artifact.canonical_id, artifact.output_path) for artifact in stale_artifact_records
         ]
+        current_output_paths = [str(manifest_entry["output_path"])]
+        orphan_reference_paths = [
+            *current_output_paths,
+            *(artifact.output_path for artifact in stale_artifact_records),
+        ]
+        orphaned_artifact_records = find_orphaned_artifacts(
+            output_dir_arg,
+            current_output_paths=orphan_reference_paths,
+        )
+        orphaned_artifacts = [artifact.output_path for artifact in orphaned_artifact_records]
         prune_stale_artifact_plan = []
         if args.prune_stale_artifacts:
             try:
                 prune_stale_artifact_plan = plan_stale_artifact_prune(
                     output_dir_arg,
                     stale_artifact_records,
+                )
+            except RuntimeError as exc:
+                exit_with_cli_error(str(exc), command=command)
+        prune_orphaned_artifact_plan = []
+        if args.prune_orphaned_artifacts:
+            try:
+                prune_orphaned_artifact_plan = plan_orphaned_artifact_prune(
+                    output_dir_arg,
+                    orphaned_artifact_records,
+                    current_output_paths=orphan_reference_paths,
                 )
             except RuntimeError as exc:
                 exit_with_cli_error(str(exc), command=command)
@@ -4005,6 +4286,14 @@ def main(argv: Sequence[str] | None = None) -> int:
                     f"{len(prune_stale_artifact_plan)}"
                 )
             print_stale_artifacts(output_dir_arg, stale_artifacts)
+            if args.report_orphaned_artifacts or args.prune_orphaned_artifacts:
+                print(f"  orphaned_artifacts: {len(orphaned_artifacts)}")
+                if args.prune_orphaned_artifacts:
+                    print(
+                        "  would_prune_orphaned_artifacts: "
+                        f"{len(prune_orphaned_artifact_plan)}"
+                    )
+                print_orphaned_artifacts(output_dir_arg, orphaned_artifacts)
             print()
             print(markdown)
             print_dry_run_complete()
@@ -4032,6 +4321,16 @@ def main(argv: Sequence[str] | None = None) -> int:
                 )
             except RuntimeError as exc:
                 exit_with_cli_error(str(exc), command=command)
+        pruned_orphaned_artifacts = []
+        if args.prune_orphaned_artifacts:
+            try:
+                pruned_orphaned_artifacts = prune_orphaned_artifacts(
+                    output_dir_arg,
+                    orphaned_artifact_records,
+                    current_output_paths=orphan_reference_paths,
+                )
+            except RuntimeError as exc:
+                exit_with_cli_error(str(exc), command=command)
 
         print(f"\nWrote: {render_user_path(output_path)}")
         print("\nSummary: wrote 1, skipped 0")
@@ -4047,6 +4346,16 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
         else:
             print_stale_artifacts(output_dir_arg, stale_artifacts)
+        if args.report_orphaned_artifacts or args.prune_orphaned_artifacts:
+            print(f"  orphaned_artifacts: {len(orphaned_artifacts)}")
+            if args.prune_orphaned_artifacts:
+                print(f"  pruned_orphaned_artifacts: {len(pruned_orphaned_artifacts)}")
+                print_pruned_orphaned_artifacts(
+                    output_dir_arg,
+                    [artifact.output_path for artifact in pruned_orphaned_artifacts],
+                )
+            else:
+                print_orphaned_artifacts(output_dir_arg, orphaned_artifacts)
         print(f"Artifact path: {render_user_path(output_path)}")
         print(f"Manifest path: {render_user_path(manifest)}")
         print_write_complete(output_dir)
@@ -4082,9 +4391,12 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         from knowledge_adapters.manifest import write_manifest
         from knowledge_adapters.manifest_stale import (
+            find_orphaned_artifacts,
             find_stale_artifacts,
             load_previous_manifest_index,
+            plan_orphaned_artifact_prune,
             plan_stale_artifact_prune,
+            prune_orphaned_artifacts,
             prune_stale_artifacts,
         )
 
@@ -4390,6 +4702,16 @@ def main(argv: Sequence[str] | None = None) -> int:
         stale_artifacts = [
             (artifact.canonical_id, artifact.output_path) for artifact in stale_artifact_records
         ]
+        current_output_paths = [str(entry["output_path"]) for entry in github_manifest_entries]
+        orphan_reference_paths = [
+            *current_output_paths,
+            *(artifact.output_path for artifact in stale_artifact_records),
+        ]
+        orphaned_artifact_records = find_orphaned_artifacts(
+            github_metadata_config.output_dir,
+            current_output_paths=orphan_reference_paths,
+        )
+        orphaned_artifacts = [artifact.output_path for artifact in orphaned_artifact_records]
         stale_manifest_entries: list[dict[str, object]] = []
         for artifact in stale_artifact_records:
             stale_entry: dict[str, object] = {
@@ -4410,6 +4732,16 @@ def main(argv: Sequence[str] | None = None) -> int:
                 prune_stale_artifact_plan = plan_stale_artifact_prune(
                     github_metadata_config.output_dir,
                     stale_artifact_records,
+                )
+            except RuntimeError as exc:
+                exit_with_cli_error(str(exc), command="github_metadata")
+        prune_orphaned_artifact_plan = []
+        if args.prune_orphaned_artifacts:
+            try:
+                prune_orphaned_artifact_plan = plan_orphaned_artifact_prune(
+                    github_metadata_config.output_dir,
+                    orphaned_artifact_records,
+                    current_output_paths=orphan_reference_paths,
                 )
             except RuntimeError as exc:
                 exit_with_cli_error(str(exc), command="github_metadata")
@@ -4453,6 +4785,14 @@ def main(argv: Sequence[str] | None = None) -> int:
                     f"{len(prune_stale_artifact_plan)}"
                 )
             print_stale_artifacts(github_metadata_config.output_dir, stale_artifacts)
+            if args.report_orphaned_artifacts or args.prune_orphaned_artifacts:
+                print(f"  orphaned_artifacts: {len(orphaned_artifacts)}")
+                if args.prune_orphaned_artifacts:
+                    print(
+                        "  would_prune_orphaned_artifacts: "
+                        f"{len(prune_orphaned_artifact_plan)}"
+                    )
+                print_orphaned_artifacts(github_metadata_config.output_dir, orphaned_artifacts)
             print(f"Manifest path: {render_user_path(manifest_output_path)}")
             print_dry_run_complete()
             return 0
@@ -4499,6 +4839,16 @@ def main(argv: Sequence[str] | None = None) -> int:
                 )
             except RuntimeError as exc:
                 exit_with_cli_error(str(exc), command="github_metadata")
+        pruned_orphaned_artifacts = []
+        if args.prune_orphaned_artifacts:
+            try:
+                pruned_orphaned_artifacts = prune_orphaned_artifacts(
+                    github_metadata_config.output_dir,
+                    orphaned_artifact_records,
+                    current_output_paths=orphan_reference_paths,
+                )
+            except RuntimeError as exc:
+                exit_with_cli_error(str(exc), command="github_metadata")
 
         for output_path in github_rewritten_output_paths:
             print(f"\nWrote: {render_user_path(output_path)}")
@@ -4520,6 +4870,19 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
         else:
             print_stale_artifacts(github_metadata_config.output_dir, stale_artifacts)
+        if args.report_orphaned_artifacts or args.prune_orphaned_artifacts:
+            print(f"  orphaned_artifacts: {len(orphaned_artifacts)}")
+            if args.prune_orphaned_artifacts:
+                print(f"  pruned_orphaned_artifacts: {len(pruned_orphaned_artifacts)}")
+                print_pruned_orphaned_artifacts(
+                    github_metadata_config.output_dir,
+                    [artifact.output_path for artifact in pruned_orphaned_artifacts],
+                )
+            else:
+                print_orphaned_artifacts(
+                    github_metadata_config.output_dir,
+                    orphaned_artifacts,
+                )
         print(f"Manifest path: {render_user_path(manifest)}")
         print_write_complete(output_dir)
         return 0
@@ -4541,9 +4904,12 @@ def main(argv: Sequence[str] | None = None) -> int:
             write_manifest,
         )
         from knowledge_adapters.manifest_stale import (
+            find_orphaned_artifacts,
             find_stale_artifacts,
             load_previous_manifest_index,
+            plan_orphaned_artifact_prune,
             plan_stale_artifact_prune,
+            prune_orphaned_artifacts,
             prune_stale_artifacts,
         )
 
@@ -4644,12 +5010,32 @@ def main(argv: Sequence[str] | None = None) -> int:
         stale_artifacts = [
             (artifact.canonical_id, artifact.output_path) for artifact in stale_artifact_records
         ]
+        current_output_paths = [str(entry["output_path"]) for entry in manifest_entries]
+        orphan_reference_paths = [
+            *current_output_paths,
+            *(artifact.output_path for artifact in stale_artifact_records),
+        ]
+        orphaned_artifact_records = find_orphaned_artifacts(
+            git_repo_config.output_dir,
+            current_output_paths=orphan_reference_paths,
+        )
+        orphaned_artifacts = [artifact.output_path for artifact in orphaned_artifact_records]
         prune_stale_artifact_plan = []
         if args.prune_stale_artifacts:
             try:
                 prune_stale_artifact_plan = plan_stale_artifact_prune(
                     git_repo_config.output_dir,
                     stale_artifact_records,
+                )
+            except RuntimeError as exc:
+                exit_with_cli_error(str(exc), command="git_repo")
+        prune_orphaned_artifact_plan = []
+        if args.prune_orphaned_artifacts:
+            try:
+                prune_orphaned_artifact_plan = plan_orphaned_artifact_prune(
+                    git_repo_config.output_dir,
+                    orphaned_artifact_records,
+                    current_output_paths=orphan_reference_paths,
                 )
             except RuntimeError as exc:
                 exit_with_cli_error(str(exc), command="git_repo")
@@ -4690,6 +5076,14 @@ def main(argv: Sequence[str] | None = None) -> int:
                     f"{len(prune_stale_artifact_plan)}"
                 )
             print_stale_artifacts(git_repo_config.output_dir, stale_artifacts)
+            if args.report_orphaned_artifacts or args.prune_orphaned_artifacts:
+                print(f"  orphaned_artifacts: {len(orphaned_artifacts)}")
+                if args.prune_orphaned_artifacts:
+                    print(
+                        "  would_prune_orphaned_artifacts: "
+                        f"{len(prune_orphaned_artifact_plan)}"
+                    )
+                print_orphaned_artifacts(git_repo_config.output_dir, orphaned_artifacts)
             print(f"Manifest path: {render_user_path(manifest_output_path)}")
             print_dry_run_complete()
             return 0
@@ -4730,6 +5124,16 @@ def main(argv: Sequence[str] | None = None) -> int:
                 )
             except RuntimeError as exc:
                 exit_with_cli_error(str(exc), command="git_repo")
+        pruned_orphaned_artifacts = []
+        if args.prune_orphaned_artifacts:
+            try:
+                pruned_orphaned_artifacts = prune_orphaned_artifacts(
+                    git_repo_config.output_dir,
+                    orphaned_artifact_records,
+                    current_output_paths=orphan_reference_paths,
+                )
+            except RuntimeError as exc:
+                exit_with_cli_error(str(exc), command="git_repo")
 
         for output_path in written_output_paths:
             print(f"\nWrote: {render_user_path(output_path)}")
@@ -4748,6 +5152,16 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
         else:
             print_stale_artifacts(git_repo_config.output_dir, stale_artifacts)
+        if args.report_orphaned_artifacts or args.prune_orphaned_artifacts:
+            print(f"  orphaned_artifacts: {len(orphaned_artifacts)}")
+            if args.prune_orphaned_artifacts:
+                print(f"  pruned_orphaned_artifacts: {len(pruned_orphaned_artifacts)}")
+                print_pruned_orphaned_artifacts(
+                    git_repo_config.output_dir,
+                    [artifact.output_path for artifact in pruned_orphaned_artifacts],
+                )
+            else:
+                print_orphaned_artifacts(git_repo_config.output_dir, orphaned_artifacts)
         print(f"Manifest path: {render_user_path(manifest)}")
         print_write_complete(output_dir)
         return 0

--- a/src/knowledge_adapters/manifest_stale.py
+++ b/src/knowledge_adapters/manifest_stale.py
@@ -275,9 +275,8 @@ def find_orphaned_artifacts(
         try:
             artifact_stat = artifact_path.lstat()
         except OSError:
-            orphaned_artifacts.append(OrphanedArtifact(output_path=relative_output_path))
             continue
-        if stat.S_ISREG(artifact_stat.st_mode) or stat.S_ISLNK(artifact_stat.st_mode):
+        if stat.S_ISREG(artifact_stat.st_mode):
             orphaned_artifacts.append(OrphanedArtifact(output_path=relative_output_path))
 
     return sorted(orphaned_artifacts, key=lambda artifact: artifact.output_path)

--- a/src/knowledge_adapters/manifest_stale.py
+++ b/src/knowledge_adapters/manifest_stale.py
@@ -1,4 +1,4 @@
-"""Shared helpers for stale-artifact reporting across manifest-backed adapters."""
+"""Shared helpers for manifest-backed artifact cleanup."""
 
 from __future__ import annotations
 
@@ -33,6 +33,21 @@ class PrunedArtifact:
     """Stale manifest-owned artifact removed from disk."""
 
     canonical_id: str
+    output_path: str
+    path: Path
+
+
+@dataclass(frozen=True)
+class OrphanedArtifact:
+    """Generated markdown artifact not referenced by the current run output."""
+
+    output_path: str
+
+
+@dataclass(frozen=True)
+class PrunedOrphanedArtifact:
+    """Orphaned generated markdown artifact removed from disk."""
+
     output_path: str
     path: Path
 
@@ -234,3 +249,141 @@ def prune_stale_artifacts(
                 f"Could not prune stale artifact {artifact.path}: {exc}"
             ) from exc
     return pruned_artifacts
+
+
+def find_orphaned_artifacts(
+    output_dir: str | Path,
+    *,
+    current_output_paths: Collection[str],
+) -> list[OrphanedArtifact]:
+    """Return unreferenced generated markdown artifacts under output_dir/pages."""
+    output_dir_path = Path(output_dir).expanduser()
+    pages_dir = output_dir_path / "pages"
+    if not pages_dir.exists():
+        return []
+
+    current_paths = frozenset(_normalize_output_path(path) for path in current_output_paths)
+    orphaned_artifacts: list[OrphanedArtifact] = []
+
+    for artifact_path in pages_dir.rglob("*.md"):
+        try:
+            relative_output_path = artifact_path.relative_to(output_dir_path).as_posix()
+        except ValueError:
+            continue
+        if _normalize_output_path(relative_output_path) in current_paths:
+            continue
+        try:
+            artifact_stat = artifact_path.lstat()
+        except OSError:
+            orphaned_artifacts.append(OrphanedArtifact(output_path=relative_output_path))
+            continue
+        if stat.S_ISREG(artifact_stat.st_mode) or stat.S_ISLNK(artifact_stat.st_mode):
+            orphaned_artifacts.append(OrphanedArtifact(output_path=relative_output_path))
+
+    return sorted(orphaned_artifacts, key=lambda artifact: artifact.output_path)
+
+
+def plan_orphaned_artifact_prune(
+    output_dir: str | Path,
+    orphaned_artifacts: Collection[OrphanedArtifact],
+    *,
+    current_output_paths: Collection[str] = (),
+) -> list[PrunedOrphanedArtifact]:
+    """Validate orphaned-artifact prune candidates without deleting anything."""
+    output_dir_path = Path(output_dir).expanduser().resolve()
+    pages_dir = output_dir_path / "pages"
+    current_paths = frozenset(_normalize_output_path(path) for path in current_output_paths)
+    pruned_artifacts: list[PrunedOrphanedArtifact] = []
+    validation_errors: list[str] = []
+
+    for artifact in sorted(orphaned_artifacts, key=lambda item: item.output_path):
+        normalized_output_path = _normalize_output_path(artifact.output_path)
+        artifact_path = output_dir_path / normalized_output_path
+
+        if normalized_output_path in current_paths:
+            validation_errors.append(
+                f"{artifact.output_path!r} is referenced by the current run plan"
+            )
+            continue
+        if Path(normalized_output_path).is_absolute():
+            validation_errors.append(f"{artifact.output_path!r} is not a relative path")
+            continue
+        if Path(normalized_output_path).parts[:1] != ("pages",):
+            validation_errors.append(f"{artifact.output_path!r} is outside pages/")
+            continue
+        if artifact_path.suffix != ".md":
+            validation_errors.append(f"{artifact.output_path!r} is not a markdown artifact")
+            continue
+
+        try:
+            resolved_artifact_path = artifact_path.resolve(strict=True)
+        except OSError as exc:
+            validation_errors.append(f"{artifact.output_path!r} could not be resolved: {exc}")
+            continue
+
+        try:
+            resolved_artifact_path.relative_to(output_dir_path)
+        except ValueError:
+            validation_errors.append(
+                f"{artifact.output_path!r} resolves outside output_dir "
+                f"{output_dir_path}: {resolved_artifact_path}"
+            )
+            continue
+
+        try:
+            resolved_artifact_path.relative_to(pages_dir)
+        except ValueError:
+            validation_errors.append(
+                f"{artifact.output_path!r} resolves outside pages/ "
+                f"{pages_dir}: {resolved_artifact_path}"
+            )
+            continue
+
+        try:
+            artifact_stat = artifact_path.stat(follow_symlinks=False)
+        except OSError as exc:
+            validation_errors.append(f"{artifact.output_path!r} could not be inspected: {exc}")
+            continue
+
+        if not stat.S_ISREG(artifact_stat.st_mode):
+            validation_errors.append(f"{artifact.output_path!r} is not a regular file")
+            continue
+
+        pruned_artifacts.append(
+            PrunedOrphanedArtifact(
+                output_path=normalized_output_path,
+                path=resolved_artifact_path,
+            )
+        )
+
+    if validation_errors:
+        details = "\n  ".join(validation_errors)
+        raise RuntimeError(f"Could not safely prune orphaned artifacts:\n  {details}")
+
+    return pruned_artifacts
+
+
+def prune_orphaned_artifacts(
+    output_dir: str | Path,
+    orphaned_artifacts: Collection[OrphanedArtifact],
+    *,
+    current_output_paths: Collection[str] = (),
+) -> list[PrunedOrphanedArtifact]:
+    """Delete validated orphaned markdown artifacts under output_dir/pages."""
+    pruned_artifacts = plan_orphaned_artifact_prune(
+        output_dir,
+        orphaned_artifacts,
+        current_output_paths=current_output_paths,
+    )
+    for artifact in pruned_artifacts:
+        try:
+            artifact.path.unlink()
+        except OSError as exc:
+            raise RuntimeError(
+                f"Could not prune orphaned artifact {artifact.path}: {exc}"
+            ) from exc
+    return pruned_artifacts
+
+
+def _normalize_output_path(output_path: str) -> str:
+    return Path(output_path).as_posix().removeprefix("./")

--- a/src/knowledge_adapters/run_config.py
+++ b/src/knowledge_adapters/run_config.py
@@ -47,6 +47,8 @@ _SUPPORTED_GITHUB_METADATA_STATES = frozenset({"open", "closed", "all"})
 _SUPPORTED_GITHUB_METADATA_RESOURCE_TYPES = SUPPORTED_RESOURCE_TYPES
 
 _COMMON_REQUIRED_KEYS = frozenset({"name", "type"})
+_REPORT_ORPHANED_ARTIFACTS_KEY = "report_orphaned_artifacts"
+_PRUNE_ORPHANED_ARTIFACTS_KEY = "prune_orphaned_artifacts"
 _PRUNE_STALE_ARTIFACTS_KEY = "prune_stale_artifacts"
 _BUNDLE_OPTION_KEYS = frozenset(
     {
@@ -79,6 +81,8 @@ _CONFLUENCE_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
         "max_requests_per_second",
         "output_dir",
         _PRUNE_STALE_ARTIFACTS_KEY,
+        _PRUNE_ORPHANED_ARTIFACTS_KEY,
+        _REPORT_ORPHANED_ARTIFACTS_KEY,
         "request_delay_ms",
         "space_key",
         "space_url",
@@ -92,10 +96,26 @@ _BUNDLE_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | _BUNDLE_OPTION_KEYS | frozenset(
 )
 _NAMED_BUNDLE_ALLOWED_KEYS = _BUNDLE_OPTION_KEYS | frozenset({"name", "runs"})
 _LOCAL_FILES_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
-    {"dry_run", "enabled", "file_path", "output_dir", _PRUNE_STALE_ARTIFACTS_KEY}
+    {
+        "dry_run",
+        "enabled",
+        "file_path",
+        "output_dir",
+        _PRUNE_STALE_ARTIFACTS_KEY,
+        _PRUNE_ORPHANED_ARTIFACTS_KEY,
+        _REPORT_ORPHANED_ARTIFACTS_KEY,
+    }
 )
 _PUBLIC_URL_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
-    {"dry_run", "enabled", "output_dir", "url", _PRUNE_STALE_ARTIFACTS_KEY}
+    {
+        "dry_run",
+        "enabled",
+        "output_dir",
+        "url",
+        _PRUNE_STALE_ARTIFACTS_KEY,
+        _PRUNE_ORPHANED_ARTIFACTS_KEY,
+        _REPORT_ORPHANED_ARTIFACTS_KEY,
+    }
 )
 _GIT_REPO_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
     {
@@ -108,6 +128,8 @@ _GIT_REPO_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
         "repo_url",
         "subdir",
         _PRUNE_STALE_ARTIFACTS_KEY,
+        _PRUNE_ORPHANED_ARTIFACTS_KEY,
+        _REPORT_ORPHANED_ARTIFACTS_KEY,
     }
 )
 _GITHUB_METADATA_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
@@ -121,6 +143,8 @@ _GITHUB_METADATA_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
         "max_items",
         "output_dir",
         _PRUNE_STALE_ARTIFACTS_KEY,
+        _PRUNE_ORPHANED_ARTIFACTS_KEY,
+        _REPORT_ORPHANED_ARTIFACTS_KEY,
         "repo",
         "resource_type",
         "since",
@@ -650,6 +674,12 @@ def _build_confluence_argv(
         index=index,
         config_path=config_path,
     )
+    _append_orphaned_artifacts_argv(
+        argv,
+        run_config,
+        index=index,
+        config_path=config_path,
+    )
     if tree:
         argv.append("--tree")
 
@@ -1016,6 +1046,31 @@ def _append_prune_stale_artifacts_argv(
         argv.append("--prune-stale-artifacts")
 
 
+def _append_orphaned_artifacts_argv(
+    argv: list[str],
+    run_config: dict[str, object],
+    *,
+    index: int | str,
+    config_path: Path,
+) -> None:
+    if _optional_bool(
+        run_config,
+        _REPORT_ORPHANED_ARTIFACTS_KEY,
+        index=index,
+        config_path=config_path,
+        default=False,
+    ):
+        argv.append("--report-orphaned-artifacts")
+    if _optional_bool(
+        run_config,
+        _PRUNE_ORPHANED_ARTIFACTS_KEY,
+        index=index,
+        config_path=config_path,
+        default=False,
+    ):
+        argv.append("--prune-orphaned-artifacts")
+
+
 def _build_local_files_argv(
     run_config: dict[str, object],
     *,
@@ -1047,6 +1102,12 @@ def _build_local_files_argv(
     if _optional_bool(run_config, "dry_run", index=index, config_path=config_path, default=False):
         argv.append("--dry-run")
     _append_prune_stale_artifacts_argv(
+        argv,
+        run_config,
+        index=index,
+        config_path=config_path,
+    )
+    _append_orphaned_artifacts_argv(
         argv,
         run_config,
         index=index,
@@ -1112,6 +1173,12 @@ def _build_git_repo_argv(
         index=index,
         config_path=config_path,
     )
+    _append_orphaned_artifacts_argv(
+        argv,
+        run_config,
+        index=index,
+        config_path=config_path,
+    )
     return tuple(argv)
 
 
@@ -1144,6 +1211,12 @@ def _build_public_url_argv(
     if _optional_bool(run_config, "dry_run", index=index, config_path=config_path, default=False):
         argv.append("--dry-run")
     _append_prune_stale_artifacts_argv(
+        argv,
+        run_config,
+        index=index,
+        config_path=config_path,
+    )
+    _append_orphaned_artifacts_argv(
         argv,
         run_config,
         index=index,
@@ -1254,6 +1327,12 @@ def _build_github_metadata_argv(
     if _optional_bool(run_config, "dry_run", index=index, config_path=config_path, default=False):
         argv.append("--dry-run")
     _append_prune_stale_artifacts_argv(
+        argv,
+        run_config,
+        index=index,
+        config_path=config_path,
+    )
+    _append_orphaned_artifacts_argv(
         argv,
         run_config,
         index=index,

--- a/tests/cli_output_assertions.py
+++ b/tests/cli_output_assertions.py
@@ -28,6 +28,22 @@ def assert_stale_artifacts(
         assert_contains_normalized(output, str(path))
 
 
+def assert_orphaned_artifacts(
+    output: str,
+    *,
+    count: int,
+    artifact_paths: Iterable[Path] = (),
+) -> None:
+    assert f"orphaned_artifacts: {count}" in output
+    if count == 0:
+        assert "Orphaned artifacts:" not in output
+        return
+
+    assert "Orphaned artifacts:" in output
+    for path in artifact_paths:
+        assert_contains_normalized(output, str(path))
+
+
 def assert_dry_run_summary(
     output: str,
     *,

--- a/tests/test_git_repo.py
+++ b/tests/test_git_repo.py
@@ -353,6 +353,44 @@ def test_git_repo_cli_prunes_stale_manifest_artifacts_only_with_flag(
     assert (output_dir / "pages" / "README.md").exists()
 
 
+def test_git_repo_cli_prunes_orphaned_artifacts_without_deleting_current_plan(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    repo_dir = tmp_path / "repo"
+    _init_repo(repo_dir)
+    _write_text(repo_dir / "README.md", "# Repo\n")
+    _commit_all(repo_dir, "initial import")
+    output_dir = tmp_path / "out"
+    current_output = output_dir / "pages" / "README.md"
+    current_output.parent.mkdir(parents=True)
+    current_output.write_text("old current\n", encoding="utf-8")
+    orphaned_output = output_dir / "pages" / "old.md"
+    orphaned_output.write_text("old artifact\n", encoding="utf-8")
+
+    exit_code = main(
+        [
+            "git_repo",
+            "--repo-url",
+            str(repo_dir),
+            "--output-dir",
+            str(output_dir),
+            "--prune-orphaned-artifacts",
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert_write_summary(captured.out, wrote=1, skipped=0)
+    assert "orphaned_artifacts: 1" in captured.out
+    assert "pruned_orphaned_artifacts: 1" in captured.out
+    assert "Pruned orphaned artifacts:" in captured.out
+    assert str(orphaned_output) in captured.out
+    assert not orphaned_output.exists()
+    assert current_output.exists()
+    assert "# Repo" in current_output.read_text(encoding="utf-8")
+
+
 def test_git_repo_cli_dry_run_reports_stale_artifacts_when_files_disappear(
     tmp_path: Path,
     capsys: CaptureFixture[str],

--- a/tests/test_local_files.py
+++ b/tests/test_local_files.py
@@ -12,6 +12,7 @@ from tests.artifact_assertions import (
     assert_markdown_document,
     manifest_file,
 )
+from tests.cli_output_assertions import assert_orphaned_artifacts
 
 
 def test_fetch_file_reads_local_path_into_adapter_payload(tmp_path: Path) -> None:
@@ -335,6 +336,129 @@ def test_local_files_cli_prune_flag_reports_and_deletes_stale_manifest_file(
     assert (output_dir / "pages" / "second.md").exists()
 
 
+def test_local_files_cli_reports_orphaned_artifacts_without_deleting(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    source_file = tmp_path / "current.txt"
+    source_file.write_text("Current file.\n", encoding="utf-8")
+    output_dir = tmp_path / "out"
+    orphaned_output = output_dir / "pages" / "orphaned.md"
+    orphaned_output.parent.mkdir(parents=True)
+    orphaned_output.write_text("orphaned\n", encoding="utf-8")
+    ignored_non_markdown = output_dir / "pages" / "ignored.txt"
+    ignored_non_markdown.write_text("ignored\n", encoding="utf-8")
+    outside_pages = output_dir / "other" / "orphaned.md"
+    outside_pages.parent.mkdir(parents=True)
+    outside_pages.write_text("outside\n", encoding="utf-8")
+
+    exit_code = main(
+        [
+            "local_files",
+            "--file-path",
+            str(source_file),
+            "--output-dir",
+            str(output_dir),
+            "--report-orphaned-artifacts",
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert_orphaned_artifacts(captured.out, count=1, artifact_paths=[orphaned_output])
+    assert "pruned_orphaned_artifacts" not in captured.out
+    assert orphaned_output.read_text(encoding="utf-8") == "orphaned\n"
+    assert ignored_non_markdown.read_text(encoding="utf-8") == "ignored\n"
+    assert outside_pages.read_text(encoding="utf-8") == "outside\n"
+
+
+def test_local_files_cli_prunes_orphaned_artifacts_only_under_pages_markdown(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    source_file = tmp_path / "current.txt"
+    source_file.write_text("Current file.\n", encoding="utf-8")
+    output_dir = tmp_path / "out"
+    orphaned_output = output_dir / "pages" / "orphaned.md"
+    orphaned_output.parent.mkdir(parents=True)
+    orphaned_output.write_text("orphaned\n", encoding="utf-8")
+    ignored_non_markdown = output_dir / "pages" / "ignored.txt"
+    ignored_non_markdown.write_text("ignored\n", encoding="utf-8")
+
+    exit_code = main(
+        [
+            "local_files",
+            "--file-path",
+            str(source_file),
+            "--output-dir",
+            str(output_dir),
+            "--prune-orphaned-artifacts",
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "orphaned_artifacts: 1" in captured.out
+    assert "pruned_orphaned_artifacts: 1" in captured.out
+    assert "Pruned orphaned artifacts:" in captured.out
+    assert str(orphaned_output) in captured.out
+    assert not orphaned_output.exists()
+    assert ignored_non_markdown.read_text(encoding="utf-8") == "ignored\n"
+    assert (output_dir / "pages" / "current.md").exists()
+
+
+def test_local_files_cli_prunes_stale_and_orphaned_artifacts_separately(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    first_source = tmp_path / "first.txt"
+    first_source.write_text("First file.\n", encoding="utf-8")
+    second_source = tmp_path / "second.txt"
+    second_source.write_text("Second file.\n", encoding="utf-8")
+    output_dir = tmp_path / "out"
+
+    assert (
+        main(
+            [
+                "local_files",
+                "--file-path",
+                str(first_source),
+                "--output-dir",
+                str(output_dir),
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+    stale_output = output_dir / "pages" / "first.md"
+    orphaned_output = output_dir / "pages" / "orphaned.md"
+    orphaned_output.write_text("orphaned\n", encoding="utf-8")
+
+    exit_code = main(
+        [
+            "local_files",
+            "--file-path",
+            str(second_source),
+            "--output-dir",
+            str(output_dir),
+            "--prune-stale-artifacts",
+            "--prune-orphaned-artifacts",
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "stale_artifacts: 1" in captured.out
+    assert "pruned_stale_artifacts: 1" in captured.out
+    assert "orphaned_artifacts: 1" in captured.out
+    assert "pruned_orphaned_artifacts: 1" in captured.out
+    assert str(stale_output) in captured.out
+    assert str(orphaned_output) in captured.out
+    assert not stale_output.exists()
+    assert not orphaned_output.exists()
+    assert (output_dir / "pages" / "second.md").exists()
+
+
 def test_local_files_cli_prune_dry_run_reports_candidates_without_deleting(
     tmp_path: Path,
     capsys: CaptureFixture[str],
@@ -380,6 +504,37 @@ def test_local_files_cli_prune_dry_run_reports_candidates_without_deleting(
     assert "would_prune_stale_artifacts: 1" in captured.out
     assert str(stale_output) in captured.out
     assert stale_output.read_text(encoding="utf-8") == stale_contents
+
+
+def test_local_files_cli_dry_run_prune_orphaned_reports_without_deleting(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    source_file = tmp_path / "current.txt"
+    source_file.write_text("Current file.\n", encoding="utf-8")
+    output_dir = tmp_path / "out"
+    orphaned_output = output_dir / "pages" / "orphaned.md"
+    orphaned_output.parent.mkdir(parents=True)
+    orphaned_output.write_text("orphaned\n", encoding="utf-8")
+
+    exit_code = main(
+        [
+            "local_files",
+            "--file-path",
+            str(source_file),
+            "--output-dir",
+            str(output_dir),
+            "--dry-run",
+            "--prune-orphaned-artifacts",
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "Summary: would write 1, would skip 0" in captured.out
+    assert_orphaned_artifacts(captured.out, count=1, artifact_paths=[orphaned_output])
+    assert "would_prune_orphaned_artifacts: 1" in captured.out
+    assert orphaned_output.read_text(encoding="utf-8") == "orphaned\n"
 
 
 def test_local_files_cli_prune_rejects_outside_manifest_path_before_delete(

--- a/tests/test_manifest_stale.py
+++ b/tests/test_manifest_stale.py
@@ -123,6 +123,57 @@ def test_find_orphaned_artifacts_reports_unreferenced_markdown_under_pages(
     ]
 
 
+def test_find_orphaned_artifacts_does_not_report_markdown_symlinks(
+    tmp_path: Path,
+) -> None:
+    output_dir = tmp_path / "out"
+    real_orphaned = output_dir / "pages" / "real.md"
+    symlink_orphaned = output_dir / "pages" / "linked.md"
+    outside_target = tmp_path / "outside.md"
+    real_orphaned.parent.mkdir(parents=True)
+    real_orphaned.write_text("real\n", encoding="utf-8")
+    outside_target.write_text("outside\n", encoding="utf-8")
+    try:
+        symlink_orphaned.symlink_to(outside_target)
+    except OSError as exc:
+        pytest.skip(f"symlinks unavailable: {exc}")
+
+    orphaned_artifacts = find_orphaned_artifacts(
+        output_dir,
+        current_output_paths=[],
+    )
+
+    assert [artifact.output_path for artifact in orphaned_artifacts] == ["pages/real.md"]
+
+
+def test_find_orphaned_artifacts_does_not_report_uninspectable_candidates(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    output_dir = tmp_path / "out"
+    visible = output_dir / "pages" / "visible.md"
+    uninspectable = output_dir / "pages" / "uninspectable.md"
+    for path in (visible, uninspectable):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(path.name, encoding="utf-8")
+
+    original_lstat = Path.lstat
+
+    def fake_lstat(self: Path) -> object:
+        if self == uninspectable:
+            raise OSError("cannot inspect")
+        return original_lstat(self)
+
+    monkeypatch.setattr(Path, "lstat", fake_lstat)
+
+    orphaned_artifacts = find_orphaned_artifacts(
+        output_dir,
+        current_output_paths=[],
+    )
+
+    assert [artifact.output_path for artifact in orphaned_artifacts] == ["pages/visible.md"]
+
+
 def test_prune_orphaned_artifacts_deletes_only_unreferenced_markdown_under_pages(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_manifest_stale.py
+++ b/tests/test_manifest_stale.py
@@ -5,8 +5,12 @@ from pathlib import Path
 import pytest
 
 from knowledge_adapters.manifest_stale import (
+    OrphanedArtifact,
     StaleArtifact,
+    find_orphaned_artifacts,
+    plan_orphaned_artifact_prune,
     plan_stale_artifact_prune,
+    prune_orphaned_artifacts,
     prune_stale_artifacts,
 )
 
@@ -93,3 +97,124 @@ def test_prune_stale_artifacts_rejects_directories_without_deleting_them(
         )
 
     assert stale_dir.is_dir()
+
+
+def test_find_orphaned_artifacts_reports_unreferenced_markdown_under_pages(
+    tmp_path: Path,
+) -> None:
+    output_dir = tmp_path / "out"
+    kept = output_dir / "pages" / "kept.md"
+    orphaned = output_dir / "pages" / "nested" / "orphaned.md"
+    non_markdown = output_dir / "pages" / "nested" / "ignored.txt"
+    outside_pages = output_dir / "other" / "orphaned.md"
+    directory = output_dir / "pages" / "dir.md"
+    for path in (kept, orphaned, non_markdown, outside_pages):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(path.name, encoding="utf-8")
+    directory.mkdir()
+
+    orphaned_artifacts = find_orphaned_artifacts(
+        output_dir,
+        current_output_paths=["pages/kept.md"],
+    )
+
+    assert [artifact.output_path for artifact in orphaned_artifacts] == [
+        "pages/nested/orphaned.md"
+    ]
+
+
+def test_prune_orphaned_artifacts_deletes_only_unreferenced_markdown_under_pages(
+    tmp_path: Path,
+) -> None:
+    output_dir = tmp_path / "out"
+    kept = output_dir / "pages" / "kept.md"
+    orphaned = output_dir / "pages" / "orphaned.md"
+    non_markdown = output_dir / "pages" / "ignored.txt"
+    outside_pages = output_dir / "other" / "orphaned.md"
+    for path in (kept, orphaned, non_markdown, outside_pages):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(path.name, encoding="utf-8")
+
+    orphaned_artifacts = find_orphaned_artifacts(
+        output_dir,
+        current_output_paths=["pages/kept.md"],
+    )
+    pruned = prune_orphaned_artifacts(
+        output_dir,
+        orphaned_artifacts,
+        current_output_paths=["pages/kept.md"],
+    )
+
+    assert [artifact.output_path for artifact in pruned] == ["pages/orphaned.md"]
+    assert kept.read_text(encoding="utf-8") == "kept.md"
+    assert not orphaned.exists()
+    assert non_markdown.read_text(encoding="utf-8") == "ignored.txt"
+    assert outside_pages.read_text(encoding="utf-8") == "orphaned.md"
+
+
+def test_plan_orphaned_artifact_prune_does_not_delete_files(tmp_path: Path) -> None:
+    output_dir = tmp_path / "out"
+    orphaned = output_dir / "pages" / "orphaned.md"
+    orphaned.parent.mkdir(parents=True)
+    orphaned.write_text("orphaned\n", encoding="utf-8")
+
+    planned = plan_orphaned_artifact_prune(
+        output_dir,
+        (OrphanedArtifact(output_path="pages/orphaned.md"),),
+    )
+
+    assert [artifact.output_path for artifact in planned] == ["pages/orphaned.md"]
+    assert orphaned.read_text(encoding="utf-8") == "orphaned\n"
+
+
+def test_prune_orphaned_artifacts_rejects_unsafe_candidates_before_deleting(
+    tmp_path: Path,
+) -> None:
+    output_dir = tmp_path / "out"
+    safe_orphaned = output_dir / "pages" / "safe.md"
+    outside_target = tmp_path / "outside.md"
+    unsafe_link = output_dir / "pages" / "unsafe.md"
+    safe_orphaned.parent.mkdir(parents=True)
+    safe_orphaned.write_text("safe\n", encoding="utf-8")
+    outside_target.write_text("outside\n", encoding="utf-8")
+    try:
+        unsafe_link.symlink_to(outside_target)
+    except OSError as exc:
+        pytest.skip(f"symlinks unavailable: {exc}")
+
+    with pytest.raises(RuntimeError, match="outside output_dir"):
+        prune_orphaned_artifacts(
+            output_dir,
+            (
+                OrphanedArtifact(output_path="pages/safe.md"),
+                OrphanedArtifact(output_path="pages/unsafe.md"),
+            ),
+        )
+
+    assert safe_orphaned.read_text(encoding="utf-8") == "safe\n"
+    assert outside_target.read_text(encoding="utf-8") == "outside\n"
+    assert unsafe_link.is_symlink()
+
+
+def test_prune_orphaned_artifacts_rejects_referenced_candidates_before_deleting(
+    tmp_path: Path,
+) -> None:
+    output_dir = tmp_path / "out"
+    referenced = output_dir / "pages" / "referenced.md"
+    other = output_dir / "pages" / "other.md"
+    for path in (referenced, other):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(path.name, encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="referenced by the current run plan"):
+        prune_orphaned_artifacts(
+            output_dir,
+            (
+                OrphanedArtifact(output_path="pages/referenced.md"),
+                OrphanedArtifact(output_path="pages/other.md"),
+            ),
+            current_output_paths=["pages/referenced.md"],
+        )
+
+    assert referenced.read_text(encoding="utf-8") == "referenced.md"
+    assert other.read_text(encoding="utf-8") == "other.md"

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -1133,6 +1133,118 @@ runs:
     assert (output_dir / "pages" / "second.md").exists()
 
 
+def test_run_command_passes_report_orphaned_artifacts(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    source_file = tmp_path / "inputs" / "current.txt"
+    source_file.parent.mkdir(parents=True)
+    source_file.write_text("Current.\n", encoding="utf-8")
+    output_dir = tmp_path / "artifacts" / "local" / "team-notes"
+    orphaned_output = output_dir / "pages" / "orphaned.md"
+    orphaned_output.parent.mkdir(parents=True)
+    orphaned_output.write_text("orphaned\n", encoding="utf-8")
+
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: team-notes
+    type: local_files
+    file_path: ./inputs/current.txt
+    output_dir: ./artifacts/local/team-notes
+    report_orphaned_artifacts: true
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    exit_code = main(["run", str(config_path)])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "--report-orphaned-artifacts" in captured.out
+    assert "orphaned_artifacts: 1" in captured.out
+    assert str(orphaned_output) in captured.out
+    assert "Run summary: wrote 1, skipped 0" in captured.out
+    assert orphaned_output.read_text(encoding="utf-8") == "orphaned\n"
+
+
+def test_run_command_passes_prune_orphaned_artifacts(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    source_file = tmp_path / "inputs" / "current.txt"
+    source_file.parent.mkdir(parents=True)
+    source_file.write_text("Current.\n", encoding="utf-8")
+    output_dir = tmp_path / "artifacts" / "local" / "team-notes"
+    orphaned_output = output_dir / "pages" / "orphaned.md"
+    orphaned_output.parent.mkdir(parents=True)
+    orphaned_output.write_text("orphaned\n", encoding="utf-8")
+
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: team-notes
+    type: local_files
+    file_path: ./inputs/current.txt
+    output_dir: ./artifacts/local/team-notes
+    prune_orphaned_artifacts: true
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    exit_code = main(["run", str(config_path)])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "--prune-orphaned-artifacts" in captured.out
+    assert "orphaned_artifacts: 1" in captured.out
+    assert "pruned_orphaned_artifacts: 1" in captured.out
+    assert "Run summary: wrote 1, skipped 0" in captured.out
+    assert not orphaned_output.exists()
+
+
+def test_run_command_global_dry_run_with_prune_orphaned_reports_without_deleting(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    source_file = tmp_path / "inputs" / "current.txt"
+    source_file.parent.mkdir(parents=True)
+    source_file.write_text("Current.\n", encoding="utf-8")
+    output_dir = tmp_path / "artifacts" / "local" / "team-notes"
+    orphaned_output = output_dir / "pages" / "orphaned.md"
+    orphaned_output.parent.mkdir(parents=True)
+    orphaned_output.write_text("orphaned\n", encoding="utf-8")
+
+    config_path = tmp_path / "runs.yaml"
+    config_path.write_text(
+        """
+runs:
+  - name: team-notes
+    type: local_files
+    file_path: ./inputs/current.txt
+    output_dir: ./artifacts/local/team-notes
+    prune_orphaned_artifacts: true
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    exit_code = main(["run", str(config_path), "--dry-run"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "Summary: would write 1, would skip 0" in captured.out
+    assert "orphaned_artifacts: 1" in captured.out
+    assert "would_prune_orphaned_artifacts: 1" in captured.out
+    assert "Run summary: would write 1, would skip 0" in captured.out
+    assert "dry_run_runs: 1" in captured.out
+    assert orphaned_output.read_text(encoding="utf-8") == "orphaned\n"
+
+
 def test_run_command_preserves_nested_confluence_inline_progress_on_tty(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,


### PR DESCRIPTION
Summary:
- Added --report-orphaned-artifacts and --prune-orphaned-artifacts to manifest-backed writer commands.
- Added shared orphan discovery/validation/pruning limited to pages/**/*.md and protected current/stale-owned paths from orphan deletion.
- Wired per-run config keys and documented stale versus orphan cleanup behavior.

Validation:
- make test: 562 passed
- make check: ruff passed, mypy passed, 562 tests passed