### PR TITLE
Simplify orphan artifact cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,12 @@ artifact cleanup: `local_files`, `public_webpage`, `public_pdf`, `confluence`,
   regular files under the selected `--output-dir`.
 - An orphaned artifact is a regular generated markdown file under
   `--output-dir/pages/**/*.md` that is not referenced by the current run plan.
-  `--report-orphaned-artifacts` reports these candidates without deleting
-  files. `--prune-orphaned-artifacts` implies reporting and deletes only
-  validated orphan candidates.
+  `--prune-orphaned-artifacts` reports these candidates and deletes only
+  validated orphan candidates during write mode.
 
 In `--dry-run`, stale pruning reports `would_prune_stale_artifacts`, orphan
-pruning reports `would_prune_orphaned_artifacts`, and nothing is deleted.
+pruning reports `orphaned_artifacts` and `would_prune_orphaned_artifacts`, and
+nothing is deleted.
 Orphan cleanup is intentionally limited to generated markdown artifacts under
 `pages/**/*.md`; it never deletes `manifest.json`, directories, non-markdown
 files, or files outside `pages/`.
@@ -371,14 +371,13 @@ runs:
     repo_url: https://github.com/example/project.git
     output_dir: ./artifacts/git/repo-docs
     prune_stale_artifacts: true
-    report_orphaned_artifacts: true
     prune_orphaned_artifacts: true
 ```
 
-Use `report_orphaned_artifacts: true` to list orphaned `pages/**/*.md`
-candidates without deleting them. Use `prune_orphaned_artifacts: true` to delete
-validated orphan candidates; top-level `knowledge-adapters run --dry-run` turns
-that into `would_prune_orphaned_artifacts` reporting and deletes nothing.
+Use `prune_orphaned_artifacts: true` to report orphaned `pages/**/*.md`
+candidates and delete validated orphan candidates during write mode. Top-level
+`knowledge-adapters run --dry-run` previews that cleanup as
+`would_prune_orphaned_artifacts` reporting and deletes nothing.
 
 To keep a lightweight human-readable record of a config-driven execution, pass
 `--report-output`:

--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -547,23 +547,14 @@ def build_parser() -> argparse.ArgumentParser:
             ),
         )
 
-    def add_orphaned_artifacts_arguments(subparser: argparse.ArgumentParser) -> None:
-        subparser.add_argument(
-            "--report-orphaned-artifacts",
-            action="store_true",
-            help=(
-                "Report unreferenced generated markdown files under --output-dir/pages "
-                "without deleting files."
-            ),
-        )
+    def add_orphaned_artifacts_argument(subparser: argparse.ArgumentParser) -> None:
         subparser.add_argument(
             "--prune-orphaned-artifacts",
             action="store_true",
             help=(
                 "Opt in to deleting unreferenced generated markdown files under "
-                "--output-dir/pages after a successful write. Implies "
-                "--report-orphaned-artifacts. In --dry-run, validate and report "
-                "candidates without deleting files."
+                "--output-dir/pages after a successful write. Always reports candidates; "
+                "in --dry-run, validate and report candidates without deleting files."
             ),
         )
 
@@ -594,7 +585,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     add_verbose_argument(confluence_parser)
     add_prune_stale_artifacts_argument(confluence_parser)
-    add_orphaned_artifacts_arguments(confluence_parser)
+    add_orphaned_artifacts_argument(confluence_parser)
     confluence_parser.add_argument(
         "--base-url",
         required=True,
@@ -771,7 +762,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     add_verbose_argument(local_files_parser)
     add_prune_stale_artifacts_argument(local_files_parser)
-    add_orphaned_artifacts_arguments(local_files_parser)
+    add_orphaned_artifacts_argument(local_files_parser)
     local_files_parser.add_argument(
         "--file-path",
         required=True,
@@ -816,7 +807,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     add_verbose_argument(public_webpage_parser)
     add_prune_stale_artifacts_argument(public_webpage_parser)
-    add_orphaned_artifacts_arguments(public_webpage_parser)
+    add_orphaned_artifacts_argument(public_webpage_parser)
     public_webpage_parser.add_argument(
         "--url",
         required=True,
@@ -856,7 +847,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     add_verbose_argument(public_pdf_parser)
     add_prune_stale_artifacts_argument(public_pdf_parser)
-    add_orphaned_artifacts_arguments(public_pdf_parser)
+    add_orphaned_artifacts_argument(public_pdf_parser)
     public_pdf_parser.add_argument(
         "--url",
         required=True,
@@ -914,7 +905,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     add_verbose_argument(git_repo_parser)
     add_prune_stale_artifacts_argument(git_repo_parser)
-    add_orphaned_artifacts_arguments(git_repo_parser)
+    add_orphaned_artifacts_argument(git_repo_parser)
     git_repo_parser.add_argument(
         "--repo-url",
         required=True,
@@ -989,7 +980,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     add_verbose_argument(github_metadata_parser)
     add_prune_stale_artifacts_argument(github_metadata_parser)
-    add_orphaned_artifacts_arguments(github_metadata_parser)
+    add_orphaned_artifacts_argument(github_metadata_parser)
     github_metadata_parser.add_argument(
         "--repo",
         required=True,
@@ -2761,14 +2752,13 @@ def main(argv: Sequence[str] | None = None) -> int:
             orphaned_artifacts: Sequence[str],
             prune_orphaned_artifact_plan: Sequence[PrunedOrphanedArtifact],
         ) -> None:
-            if not (args.report_orphaned_artifacts or args.prune_orphaned_artifacts):
+            if not args.prune_orphaned_artifacts:
                 return
             _print(f"  orphaned_artifacts: {len(orphaned_artifacts)}")
-            if args.prune_orphaned_artifacts:
-                _print(
-                    "  would_prune_orphaned_artifacts: "
-                    f"{len(prune_orphaned_artifact_plan)}"
-                )
+            _print(
+                "  would_prune_orphaned_artifacts: "
+                f"{len(prune_orphaned_artifact_plan)}"
+            )
             print_orphaned_artifacts(confluence_config.output_dir, orphaned_artifacts)
 
         def _prune_confluence_stale_after_write(
@@ -2819,19 +2809,16 @@ def main(argv: Sequence[str] | None = None) -> int:
                 )
             else:
                 print_stale_artifacts(confluence_config.output_dir, stale_artifacts)
-            if args.report_orphaned_artifacts or args.prune_orphaned_artifacts:
+            if args.prune_orphaned_artifacts:
                 _print(f"  orphaned_artifacts: {len(orphaned_artifacts)}")
-                if args.prune_orphaned_artifacts:
-                    _print(
-                        "  pruned_orphaned_artifacts: "
-                        f"{len(pruned_orphaned_artifacts)}"
-                    )
-                    print_pruned_orphaned_artifacts(
-                        confluence_config.output_dir,
-                        [artifact.output_path for artifact in pruned_orphaned_artifacts],
-                    )
-                else:
-                    print_orphaned_artifacts(confluence_config.output_dir, orphaned_artifacts)
+                _print(
+                    "  pruned_orphaned_artifacts: "
+                    f"{len(pruned_orphaned_artifacts)}"
+                )
+                print_pruned_orphaned_artifacts(
+                    confluence_config.output_dir,
+                    [artifact.output_path for artifact in pruned_orphaned_artifacts],
+                )
 
         def _print_stub_tree_mode_note() -> None:
             if not (confluence_config.tree and confluence_config.client_mode == "stub"):
@@ -3935,13 +3922,12 @@ def main(argv: Sequence[str] | None = None) -> int:
                     f"{len(prune_stale_artifact_plan)}"
                 )
             print_stale_artifacts(local_files_config.output_dir, stale_artifacts)
-            if args.report_orphaned_artifacts or args.prune_orphaned_artifacts:
+            if args.prune_orphaned_artifacts:
                 print(f"  orphaned_artifacts: {len(orphaned_artifacts)}")
-                if args.prune_orphaned_artifacts:
-                    print(
-                        "  would_prune_orphaned_artifacts: "
-                        f"{len(prune_orphaned_artifact_plan)}"
-                    )
+                print(
+                    "  would_prune_orphaned_artifacts: "
+                    f"{len(prune_orphaned_artifact_plan)}"
+                )
                 print_orphaned_artifacts(local_files_config.output_dir, orphaned_artifacts)
             print()
             print(markdown)
@@ -4005,16 +3991,13 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
         else:
             print_stale_artifacts(local_files_config.output_dir, stale_artifacts)
-        if args.report_orphaned_artifacts or args.prune_orphaned_artifacts:
+        if args.prune_orphaned_artifacts:
             print(f"  orphaned_artifacts: {len(orphaned_artifacts)}")
-            if args.prune_orphaned_artifacts:
-                print(f"  pruned_orphaned_artifacts: {len(pruned_orphaned_artifacts)}")
-                print_pruned_orphaned_artifacts(
-                    local_files_config.output_dir,
-                    [artifact.output_path for artifact in pruned_orphaned_artifacts],
-                )
-            else:
-                print_orphaned_artifacts(local_files_config.output_dir, orphaned_artifacts)
+            print(f"  pruned_orphaned_artifacts: {len(pruned_orphaned_artifacts)}")
+            print_pruned_orphaned_artifacts(
+                local_files_config.output_dir,
+                [artifact.output_path for artifact in pruned_orphaned_artifacts],
+            )
         print(f"Artifact path: {render_user_path(output_path)}")
         print(f"Manifest path: {render_user_path(manifest)}")
         print_write_complete(output_dir)
@@ -4286,13 +4269,12 @@ def main(argv: Sequence[str] | None = None) -> int:
                     f"{len(prune_stale_artifact_plan)}"
                 )
             print_stale_artifacts(output_dir_arg, stale_artifacts)
-            if args.report_orphaned_artifacts or args.prune_orphaned_artifacts:
+            if args.prune_orphaned_artifacts:
                 print(f"  orphaned_artifacts: {len(orphaned_artifacts)}")
-                if args.prune_orphaned_artifacts:
-                    print(
-                        "  would_prune_orphaned_artifacts: "
-                        f"{len(prune_orphaned_artifact_plan)}"
-                    )
+                print(
+                    "  would_prune_orphaned_artifacts: "
+                    f"{len(prune_orphaned_artifact_plan)}"
+                )
                 print_orphaned_artifacts(output_dir_arg, orphaned_artifacts)
             print()
             print(markdown)
@@ -4346,16 +4328,13 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
         else:
             print_stale_artifacts(output_dir_arg, stale_artifacts)
-        if args.report_orphaned_artifacts or args.prune_orphaned_artifacts:
+        if args.prune_orphaned_artifacts:
             print(f"  orphaned_artifacts: {len(orphaned_artifacts)}")
-            if args.prune_orphaned_artifacts:
-                print(f"  pruned_orphaned_artifacts: {len(pruned_orphaned_artifacts)}")
-                print_pruned_orphaned_artifacts(
-                    output_dir_arg,
-                    [artifact.output_path for artifact in pruned_orphaned_artifacts],
-                )
-            else:
-                print_orphaned_artifacts(output_dir_arg, orphaned_artifacts)
+            print(f"  pruned_orphaned_artifacts: {len(pruned_orphaned_artifacts)}")
+            print_pruned_orphaned_artifacts(
+                output_dir_arg,
+                [artifact.output_path for artifact in pruned_orphaned_artifacts],
+            )
         print(f"Artifact path: {render_user_path(output_path)}")
         print(f"Manifest path: {render_user_path(manifest)}")
         print_write_complete(output_dir)
@@ -4785,13 +4764,12 @@ def main(argv: Sequence[str] | None = None) -> int:
                     f"{len(prune_stale_artifact_plan)}"
                 )
             print_stale_artifacts(github_metadata_config.output_dir, stale_artifacts)
-            if args.report_orphaned_artifacts or args.prune_orphaned_artifacts:
+            if args.prune_orphaned_artifacts:
                 print(f"  orphaned_artifacts: {len(orphaned_artifacts)}")
-                if args.prune_orphaned_artifacts:
-                    print(
-                        "  would_prune_orphaned_artifacts: "
-                        f"{len(prune_orphaned_artifact_plan)}"
-                    )
+                print(
+                    "  would_prune_orphaned_artifacts: "
+                    f"{len(prune_orphaned_artifact_plan)}"
+                )
                 print_orphaned_artifacts(github_metadata_config.output_dir, orphaned_artifacts)
             print(f"Manifest path: {render_user_path(manifest_output_path)}")
             print_dry_run_complete()
@@ -4870,19 +4848,13 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
         else:
             print_stale_artifacts(github_metadata_config.output_dir, stale_artifacts)
-        if args.report_orphaned_artifacts or args.prune_orphaned_artifacts:
+        if args.prune_orphaned_artifacts:
             print(f"  orphaned_artifacts: {len(orphaned_artifacts)}")
-            if args.prune_orphaned_artifacts:
-                print(f"  pruned_orphaned_artifacts: {len(pruned_orphaned_artifacts)}")
-                print_pruned_orphaned_artifacts(
-                    github_metadata_config.output_dir,
-                    [artifact.output_path for artifact in pruned_orphaned_artifacts],
-                )
-            else:
-                print_orphaned_artifacts(
-                    github_metadata_config.output_dir,
-                    orphaned_artifacts,
-                )
+            print(f"  pruned_orphaned_artifacts: {len(pruned_orphaned_artifacts)}")
+            print_pruned_orphaned_artifacts(
+                github_metadata_config.output_dir,
+                [artifact.output_path for artifact in pruned_orphaned_artifacts],
+            )
         print(f"Manifest path: {render_user_path(manifest)}")
         print_write_complete(output_dir)
         return 0
@@ -5076,13 +5048,12 @@ def main(argv: Sequence[str] | None = None) -> int:
                     f"{len(prune_stale_artifact_plan)}"
                 )
             print_stale_artifacts(git_repo_config.output_dir, stale_artifacts)
-            if args.report_orphaned_artifacts or args.prune_orphaned_artifacts:
+            if args.prune_orphaned_artifacts:
                 print(f"  orphaned_artifacts: {len(orphaned_artifacts)}")
-                if args.prune_orphaned_artifacts:
-                    print(
-                        "  would_prune_orphaned_artifacts: "
-                        f"{len(prune_orphaned_artifact_plan)}"
-                    )
+                print(
+                    "  would_prune_orphaned_artifacts: "
+                    f"{len(prune_orphaned_artifact_plan)}"
+                )
                 print_orphaned_artifacts(git_repo_config.output_dir, orphaned_artifacts)
             print(f"Manifest path: {render_user_path(manifest_output_path)}")
             print_dry_run_complete()
@@ -5152,16 +5123,13 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
         else:
             print_stale_artifacts(git_repo_config.output_dir, stale_artifacts)
-        if args.report_orphaned_artifacts or args.prune_orphaned_artifacts:
+        if args.prune_orphaned_artifacts:
             print(f"  orphaned_artifacts: {len(orphaned_artifacts)}")
-            if args.prune_orphaned_artifacts:
-                print(f"  pruned_orphaned_artifacts: {len(pruned_orphaned_artifacts)}")
-                print_pruned_orphaned_artifacts(
-                    git_repo_config.output_dir,
-                    [artifact.output_path for artifact in pruned_orphaned_artifacts],
-                )
-            else:
-                print_orphaned_artifacts(git_repo_config.output_dir, orphaned_artifacts)
+            print(f"  pruned_orphaned_artifacts: {len(pruned_orphaned_artifacts)}")
+            print_pruned_orphaned_artifacts(
+                git_repo_config.output_dir,
+                [artifact.output_path for artifact in pruned_orphaned_artifacts],
+            )
         print(f"Manifest path: {render_user_path(manifest)}")
         print_write_complete(output_dir)
         return 0

--- a/src/knowledge_adapters/run_config.py
+++ b/src/knowledge_adapters/run_config.py
@@ -47,7 +47,6 @@ _SUPPORTED_GITHUB_METADATA_STATES = frozenset({"open", "closed", "all"})
 _SUPPORTED_GITHUB_METADATA_RESOURCE_TYPES = SUPPORTED_RESOURCE_TYPES
 
 _COMMON_REQUIRED_KEYS = frozenset({"name", "type"})
-_REPORT_ORPHANED_ARTIFACTS_KEY = "report_orphaned_artifacts"
 _PRUNE_ORPHANED_ARTIFACTS_KEY = "prune_orphaned_artifacts"
 _PRUNE_STALE_ARTIFACTS_KEY = "prune_stale_artifacts"
 _BUNDLE_OPTION_KEYS = frozenset(
@@ -82,7 +81,6 @@ _CONFLUENCE_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
         "output_dir",
         _PRUNE_STALE_ARTIFACTS_KEY,
         _PRUNE_ORPHANED_ARTIFACTS_KEY,
-        _REPORT_ORPHANED_ARTIFACTS_KEY,
         "request_delay_ms",
         "space_key",
         "space_url",
@@ -103,7 +101,6 @@ _LOCAL_FILES_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
         "output_dir",
         _PRUNE_STALE_ARTIFACTS_KEY,
         _PRUNE_ORPHANED_ARTIFACTS_KEY,
-        _REPORT_ORPHANED_ARTIFACTS_KEY,
     }
 )
 _PUBLIC_URL_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
@@ -114,7 +111,6 @@ _PUBLIC_URL_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
         "url",
         _PRUNE_STALE_ARTIFACTS_KEY,
         _PRUNE_ORPHANED_ARTIFACTS_KEY,
-        _REPORT_ORPHANED_ARTIFACTS_KEY,
     }
 )
 _GIT_REPO_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
@@ -129,7 +125,6 @@ _GIT_REPO_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
         "subdir",
         _PRUNE_STALE_ARTIFACTS_KEY,
         _PRUNE_ORPHANED_ARTIFACTS_KEY,
-        _REPORT_ORPHANED_ARTIFACTS_KEY,
     }
 )
 _GITHUB_METADATA_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
@@ -144,7 +139,6 @@ _GITHUB_METADATA_ALLOWED_KEYS = _COMMON_REQUIRED_KEYS | frozenset(
         "output_dir",
         _PRUNE_STALE_ARTIFACTS_KEY,
         _PRUNE_ORPHANED_ARTIFACTS_KEY,
-        _REPORT_ORPHANED_ARTIFACTS_KEY,
         "repo",
         "resource_type",
         "since",
@@ -1053,14 +1047,6 @@ def _append_orphaned_artifacts_argv(
     index: int | str,
     config_path: Path,
 ) -> None:
-    if _optional_bool(
-        run_config,
-        _REPORT_ORPHANED_ARTIFACTS_KEY,
-        index=index,
-        config_path=config_path,
-        default=False,
-    ):
-        argv.append("--report-orphaned-artifacts")
     if _optional_bool(
         run_config,
         _PRUNE_ORPHANED_ARTIFACTS_KEY,

--- a/tests/test_local_files.py
+++ b/tests/test_local_files.py
@@ -336,42 +336,6 @@ def test_local_files_cli_prune_flag_reports_and_deletes_stale_manifest_file(
     assert (output_dir / "pages" / "second.md").exists()
 
 
-def test_local_files_cli_reports_orphaned_artifacts_without_deleting(
-    tmp_path: Path,
-    capsys: CaptureFixture[str],
-) -> None:
-    source_file = tmp_path / "current.txt"
-    source_file.write_text("Current file.\n", encoding="utf-8")
-    output_dir = tmp_path / "out"
-    orphaned_output = output_dir / "pages" / "orphaned.md"
-    orphaned_output.parent.mkdir(parents=True)
-    orphaned_output.write_text("orphaned\n", encoding="utf-8")
-    ignored_non_markdown = output_dir / "pages" / "ignored.txt"
-    ignored_non_markdown.write_text("ignored\n", encoding="utf-8")
-    outside_pages = output_dir / "other" / "orphaned.md"
-    outside_pages.parent.mkdir(parents=True)
-    outside_pages.write_text("outside\n", encoding="utf-8")
-
-    exit_code = main(
-        [
-            "local_files",
-            "--file-path",
-            str(source_file),
-            "--output-dir",
-            str(output_dir),
-            "--report-orphaned-artifacts",
-        ]
-    )
-
-    assert exit_code == 0
-    captured = capsys.readouterr()
-    assert_orphaned_artifacts(captured.out, count=1, artifact_paths=[orphaned_output])
-    assert "pruned_orphaned_artifacts" not in captured.out
-    assert orphaned_output.read_text(encoding="utf-8") == "orphaned\n"
-    assert ignored_non_markdown.read_text(encoding="utf-8") == "ignored\n"
-    assert outside_pages.read_text(encoding="utf-8") == "outside\n"
-
-
 def test_local_files_cli_prunes_orphaned_artifacts_only_under_pages_markdown(
     tmp_path: Path,
     capsys: CaptureFixture[str],

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -1133,18 +1133,9 @@ runs:
     assert (output_dir / "pages" / "second.md").exists()
 
 
-def test_run_command_passes_report_orphaned_artifacts(
+def test_run_config_rejects_removed_report_orphaned_artifacts_key(
     tmp_path: Path,
-    capsys: CaptureFixture[str],
 ) -> None:
-    source_file = tmp_path / "inputs" / "current.txt"
-    source_file.parent.mkdir(parents=True)
-    source_file.write_text("Current.\n", encoding="utf-8")
-    output_dir = tmp_path / "artifacts" / "local" / "team-notes"
-    orphaned_output = output_dir / "pages" / "orphaned.md"
-    orphaned_output.parent.mkdir(parents=True)
-    orphaned_output.write_text("orphaned\n", encoding="utf-8")
-
     config_path = tmp_path / "runs.yaml"
     config_path.write_text(
         """
@@ -1159,15 +1150,8 @@ runs:
         encoding="utf-8",
     )
 
-    exit_code = main(["run", str(config_path)])
-
-    assert exit_code == 0
-    captured = capsys.readouterr()
-    assert "--report-orphaned-artifacts" in captured.out
-    assert "orphaned_artifacts: 1" in captured.out
-    assert str(orphaned_output) in captured.out
-    assert "Run summary: wrote 1, skipped 0" in captured.out
-    assert orphaned_output.read_text(encoding="utf-8") == "orphaned\n"
+    with pytest.raises(ValueError, match="report_orphaned_artifacts"):
+        load_run_config(config_path)
 
 
 def test_run_command_passes_prune_orphaned_artifacts(


### PR DESCRIPTION
## Summary
- Remove the report-only orphan artifact CLI flag and config key.
- Make --prune-orphaned-artifacts report orphan candidates in both dry-run and write mode, with dry-run previewing would-prune counts.
- Update run config pass-through, README guidance, and tests for the single prune flag model.

## Validation
- make test: 563 passed
- make check: ruff passed, mypy passed, 563 tests passed
- make check-gh-env: passed