### PR TITLE
Refactor auth strategy selection helper

### DIFF
--- a/src/knowledge_adapters/confluence/auth.py
+++ b/src/knowledge_adapters/confluence/auth.py
@@ -7,6 +7,8 @@ import ssl
 from dataclasses import dataclass
 from typing import Protocol
 
+from knowledge_adapters.strategy_registry import select_strategy
+
 CONFLUENCE_CA_BUNDLE_ENV = "KNOWLEDGE_ADAPTERS_CONFLUENCE_CA_BUNDLE"
 
 
@@ -106,13 +108,7 @@ SUPPORTED_AUTH_METHODS = tuple(_AUTH_STRATEGIES)
 
 def select_auth_strategy(auth_method: str) -> ConfluenceAuthStrategy:
     """Select a supported Confluence auth strategy by its stable config name."""
-    try:
-        return _AUTH_STRATEGIES[auth_method]
-    except KeyError as exc:
-        supported_values = " or ".join(repr(method) for method in SUPPORTED_AUTH_METHODS)
-        raise ValueError(
-            f"Unsupported Confluence auth method {auth_method!r}. Use {supported_values}."
-        ) from exc
+    return select_strategy(_AUTH_STRATEGIES, auth_method, label="Confluence auth method")
 
 
 def build_request_auth(

--- a/src/knowledge_adapters/github_metadata/auth.py
+++ b/src/knowledge_adapters/github_metadata/auth.py
@@ -6,6 +6,8 @@ import os
 from dataclasses import dataclass
 from typing import Protocol
 
+from knowledge_adapters.strategy_registry import select_strategy
+
 GITHUB_API_VERSION = "2022-11-28"
 DEFAULT_AUTH_STRATEGY = "token-env"
 
@@ -56,13 +58,11 @@ SUPPORTED_AUTH_STRATEGIES = tuple(_AUTH_STRATEGIES)
 
 def select_auth_strategy(auth_strategy: str) -> GitHubMetadataAuthStrategy:
     """Select a supported GitHub metadata auth strategy by stable config name."""
-    try:
-        return _AUTH_STRATEGIES[auth_strategy]
-    except KeyError as exc:
-        supported_values = " or ".join(repr(strategy) for strategy in SUPPORTED_AUTH_STRATEGIES)
-        raise ValueError(
-            f"Unsupported GitHub metadata auth strategy {auth_strategy!r}. Use {supported_values}."
-        ) from exc
+    return select_strategy(
+        _AUTH_STRATEGIES,
+        auth_strategy,
+        label="GitHub metadata auth strategy",
+    )
 
 
 def build_request_auth(

--- a/src/knowledge_adapters/strategy_registry.py
+++ b/src/knowledge_adapters/strategy_registry.py
@@ -1,0 +1,14 @@
+"""Named strategy registry helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+
+def select_strategy[T](strategies: Mapping[str, T], name: str, *, label: str) -> T:
+    """Select a named strategy or raise a stable unsupported-strategy error."""
+    try:
+        return strategies[name]
+    except KeyError as exc:
+        supported_values = " or ".join(repr(strategy_name) for strategy_name in strategies)
+        raise ValueError(f"Unsupported {label} {name!r}. Use {supported_values}.") from exc


### PR DESCRIPTION
## Summary
- Add a shared named-strategy registry helper for lookup and unsupported-strategy error formatting.
- Route Confluence and github_metadata auth strategy selection through the helper while keeping adapter-specific auth Protocols and request auth shapes separate.

Closes #307

## Testing
- make check
- make check-gh-env