### PR TITLE
Extract shared incremental sync classifier

### DIFF
--- a/src/knowledge_adapters/confluence/incremental.py
+++ b/src/knowledge_adapters/confluence/incremental.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
+from knowledge_adapters.incremental_sync import SyncChangeKey, classify_incremental_sync
 from knowledge_adapters.manifest_stale import PreviousManifestEntry
 
 PageSyncStatus = Literal["new", "changed", "unchanged"]
@@ -39,39 +40,19 @@ def classify_page_sync(
 ) -> PageSyncDecision:
     """Classify a page as new, changed, or unchanged for incremental sync."""
     canonical_id = str(page.get("canonical_id") or "")
-    if previous_manifest_index is None:
-        return PageSyncDecision(status="new", rewrite_reason="new page")
-
-    prior_entry = previous_manifest_index.get(canonical_id)
-    if prior_entry is None:
-        return PageSyncDecision(
-            status="new",
-            rewrite_reason="prior manifest entry missing entirely",
-        )
-
     expected_output_path = output_path.relative_to(Path(output_dir)).as_posix()
-    if prior_entry.output_path != expected_output_path:
-        return PageSyncDecision(status="changed", rewrite_reason="output_path changed")
-
-    if not (Path(output_dir) / prior_entry.output_path).exists():
-        return PageSyncDecision(
-            status="changed",
-            rewrite_reason="prior artifact missing, so safe rewrite",
-        )
-
     current_page_version = _normalize_metadata_value(page.get("page_version"))
-    if current_page_version is not None and prior_entry.page_version is not None:
-        if current_page_version == prior_entry.page_version:
-            return PageSyncDecision(status="unchanged")
-        return PageSyncDecision(status="changed", rewrite_reason="page_version changed")
-
     current_last_modified = _normalize_metadata_value(page.get("last_modified"))
-    if current_last_modified is not None and prior_entry.last_modified is not None:
-        if current_last_modified == prior_entry.last_modified:
-            return PageSyncDecision(status="unchanged")
-        return PageSyncDecision(status="changed", rewrite_reason="last_modified changed")
-
-    return PageSyncDecision(
-        status="changed",
-        rewrite_reason="prior manifest entry missing metadata, so safe rewrite",
+    decision = classify_incremental_sync(
+        output_dir,
+        previous_manifest_index,
+        canonical_id=canonical_id,
+        output_path=expected_output_path,
+        change_keys=(
+            SyncChangeKey(name="page_version", current_value=current_page_version),
+            SyncChangeKey(name="last_modified", current_value=current_last_modified),
+        ),
+        no_previous_manifest_reason="new page",
+        missing_metadata_reason="prior manifest entry missing metadata, so safe rewrite",
     )
+    return PageSyncDecision(status=decision.status, rewrite_reason=decision.reason)

--- a/src/knowledge_adapters/github_metadata/incremental.py
+++ b/src/knowledge_adapters/github_metadata/incremental.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Literal
 
+from knowledge_adapters.incremental_sync import SyncChangeKey, classify_incremental_sync
 from knowledge_adapters.manifest_stale import PreviousManifestEntry
 
 GitHubMetadataSyncStatus = Literal["new", "changed", "unchanged"]
@@ -31,40 +31,29 @@ def classify_github_metadata_sync(
     if not isinstance(canonical_id, str) or not canonical_id:
         return GitHubMetadataSyncDecision(status="new", reason="canonical_id missing")
 
-    if previous_manifest_index is None:
-        return GitHubMetadataSyncDecision(status="new", reason="no previous manifest")
-
-    prior_entry = previous_manifest_index.get(canonical_id)
-    if prior_entry is None:
-        return GitHubMetadataSyncDecision(
-            status="new",
-            reason="prior manifest entry missing entirely",
-        )
-
     output_path = manifest_entry.get("output_path")
-    if not isinstance(output_path, str) or not output_path:
-        return GitHubMetadataSyncDecision(status="changed", reason="output_path missing")
-
-    if prior_entry.output_path != output_path:
-        return GitHubMetadataSyncDecision(status="changed", reason="output_path changed")
-
-    if not (Path(output_dir) / prior_entry.output_path).exists():
-        return GitHubMetadataSyncDecision(
-            status="changed",
-            reason="prior artifact missing, so safe rewrite",
-        )
+    normalized_output_path = output_path if isinstance(output_path, str) else ""
 
     content_hash = manifest_entry.get("content_hash")
-    if not isinstance(content_hash, str) or not content_hash:
-        return GitHubMetadataSyncDecision(status="changed", reason="content_hash missing")
-
-    if prior_entry.content_hash is None:
-        return GitHubMetadataSyncDecision(
-            status="changed",
-            reason="prior manifest entry missing content_hash",
-        )
-
-    if prior_entry.content_hash != content_hash:
-        return GitHubMetadataSyncDecision(status="changed", reason="content_hash changed")
-
-    return GitHubMetadataSyncDecision(status="unchanged", reason="content_hash unchanged")
+    normalized_content_hash = (
+        content_hash if isinstance(content_hash, str) and content_hash else None
+    )
+    decision = classify_incremental_sync(
+        output_dir,
+        previous_manifest_index,
+        canonical_id=canonical_id,
+        output_path=normalized_output_path,
+        change_keys=(
+            SyncChangeKey(
+                name="content_hash",
+                current_value=normalized_content_hash,
+                unchanged_reason="content_hash unchanged",
+            ),
+        ),
+        no_previous_manifest_reason="no previous manifest",
+        missing_metadata_reason="prior manifest entry missing content_hash",
+        missing_output_path_reason="output_path missing",
+        missing_current_change_key_reason="content_hash missing",
+        missing_previous_change_key_reason="prior manifest entry missing content_hash",
+    )
+    return GitHubMetadataSyncDecision(status=decision.status, reason=decision.reason or "")

--- a/src/knowledge_adapters/incremental_sync.py
+++ b/src/knowledge_adapters/incremental_sync.py
@@ -1,0 +1,93 @@
+"""Shared incremental sync classification primitives."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from knowledge_adapters.manifest_stale import PreviousManifestEntry
+
+SyncStatus = Literal["new", "changed", "unchanged"]
+
+
+@dataclass(frozen=True)
+class SyncChangeKey:
+    """One adapter-specific field used to detect source changes."""
+
+    name: str
+    current_value: str | None
+    changed_reason: str | None = None
+    unchanged_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class SyncDecision:
+    """Generic incremental sync decision plus an optional operator-facing reason."""
+
+    status: SyncStatus
+    reason: str | None = None
+
+
+def classify_incremental_sync(
+    output_dir: str,
+    previous_manifest_index: Mapping[str, PreviousManifestEntry] | None,
+    *,
+    canonical_id: str,
+    output_path: str,
+    change_keys: Sequence[SyncChangeKey],
+    no_previous_manifest_reason: str,
+    missing_metadata_reason: str,
+    missing_prior_entry_reason: str = "prior manifest entry missing entirely",
+    missing_output_path_reason: str | None = None,
+    artifact_missing_reason: str = "prior artifact missing, so safe rewrite",
+    output_path_changed_reason: str = "output_path changed",
+    missing_current_change_key_reason: str | None = None,
+    missing_previous_change_key_reason: str | None = None,
+) -> SyncDecision:
+    """Classify whether a manifest-backed artifact should be written or skipped."""
+    if previous_manifest_index is None:
+        return SyncDecision(status="new", reason=no_previous_manifest_reason)
+
+    prior_entry = previous_manifest_index.get(canonical_id)
+    if prior_entry is None:
+        return SyncDecision(status="new", reason=missing_prior_entry_reason)
+
+    if not output_path:
+        reason = missing_output_path_reason or output_path_changed_reason
+        return SyncDecision(status="changed", reason=reason)
+
+    if prior_entry.output_path != output_path:
+        return SyncDecision(status="changed", reason=output_path_changed_reason)
+
+    if not (Path(output_dir) / prior_entry.output_path).exists():
+        return SyncDecision(status="changed", reason=artifact_missing_reason)
+
+    all_current_values_missing = True
+    any_current_value_without_prior = False
+    for change_key in change_keys:
+        if change_key.current_value is None:
+            continue
+
+        all_current_values_missing = False
+        prior_value = getattr(prior_entry, change_key.name, None)
+        if prior_value is None:
+            any_current_value_without_prior = True
+            continue
+
+        if change_key.current_value == prior_value:
+            return SyncDecision(status="unchanged", reason=change_key.unchanged_reason)
+
+        return SyncDecision(
+            status="changed",
+            reason=change_key.changed_reason or f"{change_key.name} changed",
+        )
+
+    if all_current_values_missing and missing_current_change_key_reason is not None:
+        return SyncDecision(status="changed", reason=missing_current_change_key_reason)
+
+    if any_current_value_without_prior and missing_previous_change_key_reason is not None:
+        return SyncDecision(status="changed", reason=missing_previous_change_key_reason)
+
+    return SyncDecision(status="changed", reason=missing_metadata_reason)

--- a/tests/test_incremental_sync.py
+++ b/tests/test_incremental_sync.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from knowledge_adapters.incremental_sync import SyncChangeKey, classify_incremental_sync
+from knowledge_adapters.manifest_stale import PreviousManifestEntry
+
+
+def _previous_entry(
+    *,
+    output_path: str = "records/1.md",
+    page_version: str | None = None,
+    last_modified: str | None = None,
+    content_hash: str | None = None,
+) -> PreviousManifestEntry:
+    return PreviousManifestEntry(
+        canonical_id="record:1",
+        output_path=output_path,
+        page_version=page_version,
+        last_modified=last_modified,
+        content_hash=content_hash,
+    )
+
+
+def test_classify_incremental_sync_uses_ordered_change_keys(tmp_path: Path) -> None:
+    artifact_path = tmp_path / "records" / "1.md"
+    artifact_path.parent.mkdir(parents=True)
+    artifact_path.write_text("already written\n", encoding="utf-8")
+    previous_manifest_index = {
+        "record:1": _previous_entry(last_modified="2026-04-20T00:00:00Z")
+    }
+
+    decision = classify_incremental_sync(
+        str(tmp_path),
+        previous_manifest_index,
+        canonical_id="record:1",
+        output_path="records/1.md",
+        change_keys=(
+            SyncChangeKey(name="page_version", current_value="7"),
+            SyncChangeKey(name="last_modified", current_value="2026-04-20T00:00:00Z"),
+        ),
+        no_previous_manifest_reason="new page",
+        missing_metadata_reason="prior manifest entry missing metadata, so safe rewrite",
+    )
+
+    assert decision.status == "unchanged"
+    assert decision.reason is None
+
+
+def test_classify_incremental_sync_reports_single_change_key_missing_reasons(
+    tmp_path: Path,
+) -> None:
+    artifact_path = tmp_path / "records" / "1.md"
+    artifact_path.parent.mkdir(parents=True)
+    artifact_path.write_text("already written\n", encoding="utf-8")
+    previous_manifest_index = {"record:1": _previous_entry()}
+
+    missing_current = classify_incremental_sync(
+        str(tmp_path),
+        previous_manifest_index,
+        canonical_id="record:1",
+        output_path="records/1.md",
+        change_keys=(SyncChangeKey(name="content_hash", current_value=None),),
+        no_previous_manifest_reason="no previous manifest",
+        missing_metadata_reason="prior manifest entry missing content_hash",
+        missing_current_change_key_reason="content_hash missing",
+        missing_previous_change_key_reason="prior manifest entry missing content_hash",
+    )
+    missing_previous = classify_incremental_sync(
+        str(tmp_path),
+        previous_manifest_index,
+        canonical_id="record:1",
+        output_path="records/1.md",
+        change_keys=(SyncChangeKey(name="content_hash", current_value="new-hash"),),
+        no_previous_manifest_reason="no previous manifest",
+        missing_metadata_reason="prior manifest entry missing content_hash",
+        missing_current_change_key_reason="content_hash missing",
+        missing_previous_change_key_reason="prior manifest entry missing content_hash",
+    )
+
+    assert missing_current.status == "changed"
+    assert missing_current.reason == "content_hash missing"
+    assert missing_previous.status == "changed"
+    assert missing_previous.reason == "prior manifest entry missing content_hash"


### PR DESCRIPTION
Summary
- Added a shared incremental sync classifier and change-key primitive.
- Refactored Confluence and GitHub metadata classifiers to delegate to it while preserving public wrappers and reasons.
- Added focused unit coverage for ordered fallback and missing-key cases.

Testing
- make check
- make check-gh-env

Closes #306