### PR TITLE
Fix github_metadata orphan cleanup layout

### DIFF
--- a/src/knowledge_adapters/cli.py
+++ b/src/knowledge_adapters/cli.py
@@ -4363,6 +4363,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             normalize_release_to_markdown,
         )
         from knowledge_adapters.github_metadata.writer import (
+            OUTPUT_SUBDIRECTORIES as GITHUB_METADATA_OUTPUT_SUBDIRECTORIES,
+        )
+        from knowledge_adapters.github_metadata.writer import (
             markdown_path as github_metadata_markdown_path,
         )
         from knowledge_adapters.github_metadata.writer import (
@@ -4689,6 +4692,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         orphaned_artifact_records = find_orphaned_artifacts(
             github_metadata_config.output_dir,
             current_output_paths=orphan_reference_paths,
+            output_subdirectories=GITHUB_METADATA_OUTPUT_SUBDIRECTORIES,
         )
         orphaned_artifacts = [artifact.output_path for artifact in orphaned_artifact_records]
         stale_manifest_entries: list[dict[str, object]] = []
@@ -4721,6 +4725,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     github_metadata_config.output_dir,
                     orphaned_artifact_records,
                     current_output_paths=orphan_reference_paths,
+                    output_subdirectories=GITHUB_METADATA_OUTPUT_SUBDIRECTORIES,
                 )
             except RuntimeError as exc:
                 exit_with_cli_error(str(exc), command="github_metadata")
@@ -4824,6 +4829,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     github_metadata_config.output_dir,
                     orphaned_artifact_records,
                     current_output_paths=orphan_reference_paths,
+                    output_subdirectories=GITHUB_METADATA_OUTPUT_SUBDIRECTORIES,
                 )
             except RuntimeError as exc:
                 exit_with_cli_error(str(exc), command="github_metadata")

--- a/src/knowledge_adapters/github_metadata/writer.py
+++ b/src/knowledge_adapters/github_metadata/writer.py
@@ -9,6 +9,7 @@ _RESOURCE_DIRECTORIES = {
     "pull_request": "pull_requests",
     "release": "releases",
 }
+OUTPUT_SUBDIRECTORIES = tuple(_RESOURCE_DIRECTORIES.values())
 
 
 def markdown_path(output_dir: str, resource_type: str, identifier: int | str) -> Path:

--- a/src/knowledge_adapters/manifest_stale.py
+++ b/src/knowledge_adapters/manifest_stale.py
@@ -245,9 +245,7 @@ def prune_stale_artifacts(
         try:
             artifact.path.unlink()
         except OSError as exc:
-            raise RuntimeError(
-                f"Could not prune stale artifact {artifact.path}: {exc}"
-            ) from exc
+            raise RuntimeError(f"Could not prune stale artifact {artifact.path}: {exc}") from exc
     return pruned_artifacts
 
 
@@ -255,29 +253,37 @@ def find_orphaned_artifacts(
     output_dir: str | Path,
     *,
     current_output_paths: Collection[str],
+    output_subdirectories: Collection[str] = ("pages",),
 ) -> list[OrphanedArtifact]:
-    """Return unreferenced generated markdown artifacts under output_dir/pages."""
+    """Return unreferenced generated markdown artifacts under configured output roots."""
     output_dir_path = Path(output_dir).expanduser()
-    pages_dir = output_dir_path / "pages"
-    if not pages_dir.exists():
-        return []
+    artifact_subdirectories = _normalize_output_subdirectories(output_subdirectories)
 
     current_paths = frozenset(_normalize_output_path(path) for path in current_output_paths)
     orphaned_artifacts: list[OrphanedArtifact] = []
+    orphaned_output_paths: set[str] = set()
 
-    for artifact_path in pages_dir.rglob("*.md"):
-        try:
-            relative_output_path = artifact_path.relative_to(output_dir_path).as_posix()
-        except ValueError:
+    for output_subdirectory in artifact_subdirectories:
+        artifact_root = output_dir_path / output_subdirectory
+        if not artifact_root.exists():
             continue
-        if _normalize_output_path(relative_output_path) in current_paths:
-            continue
-        try:
-            artifact_stat = artifact_path.lstat()
-        except OSError:
-            continue
-        if stat.S_ISREG(artifact_stat.st_mode):
-            orphaned_artifacts.append(OrphanedArtifact(output_path=relative_output_path))
+
+        for artifact_path in artifact_root.rglob("*.md"):
+            try:
+                relative_output_path = artifact_path.relative_to(output_dir_path).as_posix()
+            except ValueError:
+                continue
+            if _normalize_output_path(relative_output_path) in current_paths:
+                continue
+            if relative_output_path in orphaned_output_paths:
+                continue
+            try:
+                artifact_stat = artifact_path.lstat()
+            except OSError:
+                continue
+            if stat.S_ISREG(artifact_stat.st_mode):
+                orphaned_output_paths.add(relative_output_path)
+                orphaned_artifacts.append(OrphanedArtifact(output_path=relative_output_path))
 
     return sorted(orphaned_artifacts, key=lambda artifact: artifact.output_path)
 
@@ -287,10 +293,12 @@ def plan_orphaned_artifact_prune(
     orphaned_artifacts: Collection[OrphanedArtifact],
     *,
     current_output_paths: Collection[str] = (),
+    output_subdirectories: Collection[str] = ("pages",),
 ) -> list[PrunedOrphanedArtifact]:
     """Validate orphaned-artifact prune candidates without deleting anything."""
     output_dir_path = Path(output_dir).expanduser().resolve()
-    pages_dir = output_dir_path / "pages"
+    artifact_subdirectories = _normalize_output_subdirectories(output_subdirectories)
+    artifact_roots = tuple(output_dir_path / subdir for subdir in artifact_subdirectories)
     current_paths = frozenset(_normalize_output_path(path) for path in current_output_paths)
     pruned_artifacts: list[PrunedOrphanedArtifact] = []
     validation_errors: list[str] = []
@@ -307,8 +315,13 @@ def plan_orphaned_artifact_prune(
         if Path(normalized_output_path).is_absolute():
             validation_errors.append(f"{artifact.output_path!r} is not a relative path")
             continue
-        if Path(normalized_output_path).parts[:1] != ("pages",):
-            validation_errors.append(f"{artifact.output_path!r} is outside pages/")
+        if not _is_under_any_output_subdirectory(
+            normalized_output_path,
+            artifact_subdirectories,
+        ):
+            validation_errors.append(
+                f"{artifact.output_path!r} is outside configured output subdirectories"
+            )
             continue
         if artifact_path.suffix != ".md":
             validation_errors.append(f"{artifact.output_path!r} is not a markdown artifact")
@@ -329,12 +342,13 @@ def plan_orphaned_artifact_prune(
             )
             continue
 
-        try:
-            resolved_artifact_path.relative_to(pages_dir)
-        except ValueError:
+        if not any(
+            _is_relative_to(resolved_artifact_path, artifact_root)
+            for artifact_root in artifact_roots
+        ):
             validation_errors.append(
-                f"{artifact.output_path!r} resolves outside pages/ "
-                f"{pages_dir}: {resolved_artifact_path}"
+                f"{artifact.output_path!r} resolves outside configured output "
+                f"subdirectories: {resolved_artifact_path}"
             )
             continue
 
@@ -367,22 +381,61 @@ def prune_orphaned_artifacts(
     orphaned_artifacts: Collection[OrphanedArtifact],
     *,
     current_output_paths: Collection[str] = (),
+    output_subdirectories: Collection[str] = ("pages",),
 ) -> list[PrunedOrphanedArtifact]:
-    """Delete validated orphaned markdown artifacts under output_dir/pages."""
+    """Delete validated orphaned markdown artifacts under configured output roots."""
     pruned_artifacts = plan_orphaned_artifact_prune(
         output_dir,
         orphaned_artifacts,
         current_output_paths=current_output_paths,
+        output_subdirectories=output_subdirectories,
     )
     for artifact in pruned_artifacts:
         try:
             artifact.path.unlink()
         except OSError as exc:
-            raise RuntimeError(
-                f"Could not prune orphaned artifact {artifact.path}: {exc}"
-            ) from exc
+            raise RuntimeError(f"Could not prune orphaned artifact {artifact.path}: {exc}") from exc
     return pruned_artifacts
 
 
 def _normalize_output_path(output_path: str) -> str:
     return Path(output_path).as_posix().removeprefix("./")
+
+
+def _normalize_output_subdirectories(output_subdirectories: Collection[str]) -> tuple[str, ...]:
+    normalized_subdirectories: list[str] = []
+    seen: set[str] = set()
+
+    for output_subdirectory in output_subdirectories:
+        normalized = _normalize_output_path(output_subdirectory).removesuffix("/")
+        path = Path(normalized)
+        if not normalized or path.is_absolute() or ".." in path.parts:
+            raise ValueError(
+                "orphan artifact output_subdirectories must be relative "
+                "subdirectories under output_dir"
+            )
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        normalized_subdirectories.append(normalized)
+
+    return tuple(normalized_subdirectories)
+
+
+def _is_under_any_output_subdirectory(
+    output_path: str,
+    output_subdirectories: Collection[str],
+) -> bool:
+    output_path_parts = Path(output_path).parts
+    return any(
+        output_path_parts[: len(Path(output_subdirectory).parts)] == Path(output_subdirectory).parts
+        for output_subdirectory in output_subdirectories
+    )
+
+
+def _is_relative_to(path: Path, other: Path) -> bool:
+    try:
+        path.relative_to(other)
+    except ValueError:
+        return False
+    return True

--- a/tests/test_github_metadata.py
+++ b/tests/test_github_metadata.py
@@ -37,6 +37,7 @@ from knowledge_adapters.github_metadata.normalize import (
     normalize_issue_to_markdown,
 )
 from tests.cli_output_assertions import (
+    assert_contains_normalized,
     assert_dry_run_summary,
     assert_stale_artifacts,
     assert_write_summary,
@@ -802,6 +803,55 @@ def test_github_metadata_cli_writes_issue_artifacts_and_manifest(
             "output_path": "issues/7.md",
         },
     ]
+
+
+def test_github_metadata_cli_prunes_orphaned_artifacts_under_resource_directories(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("GH_TOKEN", "secret-token")
+    first_url = issue_list_api_url(
+        api_root="https://api.github.com",
+        owner="octo",
+        repo_name="project",
+        state="open",
+        since=None,
+    )
+    _install_fake_urlopen(
+        monkeypatch,
+        {first_url: _FakeGitHubResponse([_issue(2, title="Current issue")])},
+    )
+    output_dir = tmp_path / "out"
+    orphaned_issue = output_dir / "issues" / "99.md"
+    pages_artifact = output_dir / "pages" / "old.md"
+    for path in (orphaned_issue, pages_artifact):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(path.name, encoding="utf-8")
+
+    exit_code = main(
+        [
+            "github_metadata",
+            "--repo",
+            "octo/project",
+            "--token-env",
+            "GH_TOKEN",
+            "--output-dir",
+            str(output_dir),
+            "--prune-orphaned-artifacts",
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert_write_summary(captured.out, wrote=1, skipped=0)
+    assert "orphaned_artifacts: 1" in captured.out
+    assert "pruned_orphaned_artifacts: 1" in captured.out
+    assert "Pruned orphaned artifacts:" in captured.out
+    assert_contains_normalized(captured.out, str(orphaned_issue))
+    assert not orphaned_issue.exists()
+    assert (output_dir / "issues" / "2.md").exists()
+    assert pages_artifact.read_text(encoding="utf-8") == "old.md"
 
 
 def test_github_metadata_cli_writes_issue_comments_when_enabled(

--- a/tests/test_manifest_stale.py
+++ b/tests/test_manifest_stale.py
@@ -118,8 +118,30 @@ def test_find_orphaned_artifacts_reports_unreferenced_markdown_under_pages(
         current_output_paths=["pages/kept.md"],
     )
 
+    assert [artifact.output_path for artifact in orphaned_artifacts] == ["pages/nested/orphaned.md"]
+
+
+def test_find_orphaned_artifacts_scans_configured_output_subdirectories(
+    tmp_path: Path,
+) -> None:
+    output_dir = tmp_path / "out"
+    kept = output_dir / "issues" / "2.md"
+    orphaned_issue = output_dir / "issues" / "7.md"
+    orphaned_release = output_dir / "releases" / "9.md"
+    ignored_page = output_dir / "pages" / "old.md"
+    for path in (kept, orphaned_issue, orphaned_release, ignored_page):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(path.name, encoding="utf-8")
+
+    orphaned_artifacts = find_orphaned_artifacts(
+        output_dir,
+        current_output_paths=["issues/2.md"],
+        output_subdirectories=("issues", "pull_requests", "releases"),
+    )
+
     assert [artifact.output_path for artifact in orphaned_artifacts] == [
-        "pages/nested/orphaned.md"
+        "issues/7.md",
+        "releases/9.md",
     ]
 
 
@@ -201,6 +223,35 @@ def test_prune_orphaned_artifacts_deletes_only_unreferenced_markdown_under_pages
     assert not orphaned.exists()
     assert non_markdown.read_text(encoding="utf-8") == "ignored.txt"
     assert outside_pages.read_text(encoding="utf-8") == "orphaned.md"
+
+
+def test_prune_orphaned_artifacts_deletes_configured_output_subdirectory_orphans(
+    tmp_path: Path,
+) -> None:
+    output_dir = tmp_path / "out"
+    kept = output_dir / "issues" / "2.md"
+    orphaned = output_dir / "pull_requests" / "4.md"
+    outside_layout = output_dir / "pages" / "old.md"
+    for path in (kept, orphaned, outside_layout):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(path.name, encoding="utf-8")
+
+    orphaned_artifacts = find_orphaned_artifacts(
+        output_dir,
+        current_output_paths=["issues/2.md"],
+        output_subdirectories=("issues", "pull_requests", "releases"),
+    )
+    pruned = prune_orphaned_artifacts(
+        output_dir,
+        orphaned_artifacts,
+        current_output_paths=["issues/2.md"],
+        output_subdirectories=("issues", "pull_requests", "releases"),
+    )
+
+    assert [artifact.output_path for artifact in pruned] == ["pull_requests/4.md"]
+    assert kept.read_text(encoding="utf-8") == "2.md"
+    assert not orphaned.exists()
+    assert outside_layout.read_text(encoding="utf-8") == "old.md"
 
 
 def test_plan_orphaned_artifact_prune_does_not_delete_files(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Parameterize orphan artifact scanning/pruning by output subdirectory layout while preserving the default pages-only behavior.
- Expose github_metadata writer output subdirectories and wire orphan cleanup to issues/, pull_requests/, and releases/.
- Add helper and github_metadata CLI coverage for detecting and pruning resource-directory orphans.

## Testing
- make check

Closes #305