### PR TITLE
feat: add Source Package core

### DIFF
--- a/docs/source-package-contract.md
+++ b/docs/source-package-contract.md
@@ -1,6 +1,6 @@
 # Source Package Contract
 
-Status: design draft for contract approval. This document defines an
+Status: experimental v1 contract. This document defines an
 interchange boundary; it does not define adapter implementation, a CLI, or a
 vault ingestion pipeline.
 

--- a/src/knowledge_adapters/source_package/__init__.py
+++ b/src/knowledge_adapters/source_package/__init__.py
@@ -1,0 +1,31 @@
+"""Provider-neutral Source Package construction and verification."""
+
+from .core import (
+    PackageBuilder,
+    SealResult,
+    VerificationIssue,
+    VerificationResult,
+    canonical_json_bytes,
+    verify_package,
+)
+from .models import (
+    AdapterIdentity,
+    Artifact,
+    ArtifactInventoryEntry,
+    ItemOutcome,
+    PackageItem,
+)
+
+__all__ = [
+    "AdapterIdentity",
+    "Artifact",
+    "ArtifactInventoryEntry",
+    "ItemOutcome",
+    "PackageBuilder",
+    "PackageItem",
+    "SealResult",
+    "VerificationIssue",
+    "VerificationResult",
+    "canonical_json_bytes",
+    "verify_package",
+]

--- a/src/knowledge_adapters/source_package/__init__.py
+++ b/src/knowledge_adapters/source_package/__init__.py
@@ -1,14 +1,18 @@
 """Provider-neutral Source Package construction and verification."""
 
 from .core import (
+    FindingSeverity,
     PackageBuilder,
     SealResult,
     VerificationIssue,
     VerificationResult,
+    VerificationStage,
+    VerificationState,
     canonical_json_bytes,
     verify_package,
 )
 from .models import (
+    AcquisitionRequest,
     AdapterIdentity,
     Artifact,
     ArtifactInventoryEntry,
@@ -17,15 +21,19 @@ from .models import (
 )
 
 __all__ = [
+    "AcquisitionRequest",
     "AdapterIdentity",
     "Artifact",
     "ArtifactInventoryEntry",
+    "FindingSeverity",
     "ItemOutcome",
     "PackageBuilder",
     "PackageItem",
     "SealResult",
     "VerificationIssue",
     "VerificationResult",
+    "VerificationStage",
+    "VerificationState",
     "canonical_json_bytes",
     "verify_package",
 ]

--- a/src/knowledge_adapters/source_package/__init__.py
+++ b/src/knowledge_adapters/source_package/__init__.py
@@ -8,6 +8,8 @@ from .core import (
     VerificationResult,
     VerificationStage,
     VerificationState,
+    VerifiedAdapterClaims,
+    VerifiedManifestClaims,
     canonical_json_bytes,
     verify_package,
 )
@@ -31,6 +33,8 @@ __all__ = [
     "PackageItem",
     "SealResult",
     "VerificationIssue",
+    "VerifiedAdapterClaims",
+    "VerifiedManifestClaims",
     "VerificationResult",
     "VerificationStage",
     "VerificationState",

--- a/src/knowledge_adapters/source_package/core.py
+++ b/src/knowledge_adapters/source_package/core.py
@@ -108,6 +108,9 @@ class VerificationStage(StrEnum):
     COMPLETE = "complete"
 
 
+STAGE_ORDER = tuple(VerificationStage)
+
+
 class FindingSeverity(StrEnum):
     ERROR = "error"
     WARNING = "warning"
@@ -194,11 +197,15 @@ def _result(
     content_address: str | None = None,
     manifest: Mapping[str, Any] | None = None,
 ) -> VerificationResult:
+    completed_stage = stage
+    if state is not VerificationState.VERIFIED:
+        stage_index = STAGE_ORDER.index(stage)
+        completed_stage = STAGE_ORDER[max(0, stage_index - 1)]
     return VerificationResult(
         RESULT_SCHEMA_VERSION,
         _library_version(),
         state,
-        stage,
+        completed_stage,
         tuple(findings),
         content_address,
         manifest,

--- a/src/knowledge_adapters/source_package/core.py
+++ b/src/knowledge_adapters/source_package/core.py
@@ -24,7 +24,7 @@ from .models import (
 )
 
 CONTRACT_NAME = "knowledge-source-package"
-RESULT_SCHEMA_VERSION = "1.0.0"
+RESULT_SCHEMA_VERSION = "2.0.0"
 SIDECAR_RE = re.compile(rb"[0-9a-f]{64}\n\Z")
 SHA256_RE = re.compile(r"[0-9a-f]{64}\Z")
 RESERVED_MANIFEST_FIELDS = frozenset(
@@ -101,10 +101,10 @@ class VerificationStage(StrEnum):
     COMPATIBILITY = "compatibility"
     PATH_SAFETY = "path-safety"
     INVENTORY_COVERAGE = "inventory-coverage"
-    ARTIFACT_INTEGRITY = "artifact-integrity"
     TERMINAL_ACCOUNTING = "terminal-accounting"
     ITEM_SEMANTICS = "item-semantics"
     LINEAGE = "lineage"
+    ARTIFACT_INTEGRITY = "artifact-integrity"
     COMPLETE = "complete"
 
 
@@ -144,6 +144,36 @@ VerificationIssue = VerificationFinding
 
 
 @dataclass(frozen=True)
+class VerifiedAdapterClaims:
+    name: str | None = None
+    version: str | None = None
+    revision: str | None = None
+
+
+@dataclass(frozen=True)
+class VerifiedManifestClaims:
+    """Bounded, curated claims from verification stages that completed."""
+
+    schema_version: str = "1.0.0"
+    contract_name: str | None = None
+    contract_version: str | None = None
+    package_id: str | None = None
+    request_id: str | None = None
+    run_id: str | None = None
+    created_at: str | None = None
+    adapter: VerifiedAdapterClaims | None = None
+    status: str | None = None
+    counts: Mapping[str, int] | None = None
+    required_capabilities: tuple[str, ...] = ()
+    item_references: tuple[str, ...] = ()
+    request_reference: str | None = None
+    resumes_run_id: str | None = None
+    prior_run_ids: tuple[str, ...] = ()
+    prior_package_ids: tuple[str, ...] = ()
+    content_address: str | None = None
+
+
+@dataclass(frozen=True)
 class VerificationResult:
     schema_version: str
     verifier_version: str | None
@@ -151,7 +181,7 @@ class VerificationResult:
     last_completed_stage: VerificationStage
     findings: tuple[VerificationFinding, ...]
     content_address: str | None = None
-    manifest_claims: Mapping[str, Any] | None = None
+    verified_claims: VerifiedManifestClaims | None = None
 
     @property
     def ok(self) -> bool:
@@ -160,11 +190,6 @@ class VerificationResult:
     @property
     def issues(self) -> tuple[VerificationFinding, ...]:
         return self.findings
-
-    @property
-    def manifest(self) -> Mapping[str, Any] | None:
-        return self.manifest_claims
-
 
 def _bounded(value: object, limit: int = 200) -> str:
     text = str(value).replace("\n", "\\n").replace("\r", "\\r")
@@ -195,7 +220,7 @@ def _result(
     stage: VerificationStage,
     findings: Sequence[VerificationFinding] = (),
     content_address: str | None = None,
-    manifest: Mapping[str, Any] | None = None,
+    claims: VerifiedManifestClaims | None = None,
 ) -> VerificationResult:
     completed_stage = stage
     if state is not VerificationState.VERIFIED:
@@ -208,7 +233,70 @@ def _result(
         completed_stage,
         tuple(findings),
         content_address,
-        manifest,
+        claims,
+    )
+
+
+def _bounded_claim(value: object, limit: int = 200) -> str | None:
+    return value if isinstance(value, str) and len(value) <= limit else None
+
+
+def _bounded_string_tuple(value: object, *, limit: int = 256) -> tuple[str, ...]:
+    if not isinstance(value, list) or len(value) > limit:
+        return ()
+    if any(not isinstance(item, str) or len(item) > 200 for item in value):
+        return ()
+    return tuple(value)
+
+
+def _curated_claims(
+    manifest: Mapping[str, Any],
+    content_address: str,
+    *,
+    accounting: bool = False,
+    lineage: bool = False,
+) -> VerifiedManifestClaims:
+    adapter_value = manifest.get("adapter")
+    adapter = None
+    if isinstance(adapter_value, dict):
+        adapter = VerifiedAdapterClaims(
+            _bounded_claim(adapter_value.get("name")),
+            _bounded_claim(adapter_value.get("version")),
+            _bounded_claim(adapter_value.get("revision")),
+        )
+    counts_value = manifest.get("counts")
+    counts = None
+    if accounting and isinstance(counts_value, dict):
+        counts = {
+            key: value
+            for key, value in counts_value.items()
+            if isinstance(key, str) and type(value) is int
+        }
+    return VerifiedManifestClaims(
+        contract_name=_bounded_claim(manifest.get("contract_name")),
+        contract_version=_bounded_claim(manifest.get("contract_version")),
+        package_id=_bounded_claim(manifest.get("package_id")),
+        request_id=_bounded_claim(manifest.get("request_id")),
+        run_id=_bounded_claim(manifest.get("run_id")),
+        created_at=_bounded_claim(manifest.get("created_at")),
+        adapter=adapter,
+        status=_bounded_claim(manifest.get("status")) if accounting else None,
+        counts=counts,
+        required_capabilities=_bounded_string_tuple(manifest.get("required_capabilities")),
+        item_references=(
+            _bounded_string_tuple(manifest.get("items"), limit=10_000) if accounting else ()
+        ),
+        request_reference=_bounded_claim(manifest.get("request_path")),
+        resumes_run_id=(
+            _bounded_claim(manifest.get("resumes_run_id")) if lineage else None
+        ),
+        prior_run_ids=(
+            _bounded_string_tuple(manifest.get("prior_run_ids")) if lineage else ()
+        ),
+        prior_package_ids=(
+            _bounded_string_tuple(manifest.get("prior_package_ids")) if lineage else ()
+        ),
+        content_address=content_address,
     )
 
 
@@ -553,8 +641,9 @@ def verify_package(
             )
     if issues:
         return _result(
-            VerificationState.REJECTED, VerificationStage.COMPATIBILITY, issues, actual, manifest
+            VerificationState.REJECTED, VerificationStage.COMPATIBILITY, issues, actual
         )
+    compatibility_claims = _curated_claims(manifest, actual)
 
     inventory = manifest.get("artifacts")
     if not isinstance(inventory, list):
@@ -570,7 +659,7 @@ def verify_package(
                 ),
             ),
             actual,
-            manifest,
+            compatibility_claims,
         )
     expected_paths: set[str] = set()
     entries: dict[str, Mapping[str, Any]] = {}
@@ -604,7 +693,11 @@ def verify_package(
         entries[relative] = entry
     if issues:
         return _result(
-            VerificationState.REJECTED, VerificationStage.PATH_SAFETY, issues, actual, manifest
+            VerificationState.REJECTED,
+            VerificationStage.PATH_SAFETY,
+            issues,
+            actual,
+            compatibility_claims,
         )
 
     actual_paths: set[str] = set()
@@ -634,7 +727,7 @@ def verify_package(
                 ),
             ),
             actual,
-            manifest,
+            compatibility_claims,
         )
     if actual_paths - {"package.json", "package.sha256"} != expected_paths:
         issues.append(
@@ -650,62 +743,7 @@ def verify_package(
             VerificationStage.INVENTORY_COVERAGE,
             issues,
             actual,
-            manifest,
-        )
-
-    artifact_data: dict[str, bytes] = {}
-    for relative in sorted(expected_paths):
-        try:
-            data = package.joinpath(*PurePosixPath(relative).parts).read_bytes()
-        except OSError:
-            return _result(
-                VerificationState.INDETERMINATE_IO,
-                VerificationStage.INVENTORY_COVERAGE,
-                (
-                    _finding(
-                        "io-artifact-read-failure",
-                        VerificationStage.ARTIFACT_INTEGRITY,
-                        "could not read inventoried artifact",
-                        relative,
-                    ),
-                ),
-                actual,
-                manifest,
-            )
-        artifact_data[relative] = data
-        entry = entries[relative]
-        if type(entry.get("bytes")) is not int or entry["bytes"] != len(data):
-            issues.append(
-                _finding(
-                    "artifact-size-mismatch",
-                    VerificationStage.ARTIFACT_INTEGRITY,
-                    "artifact byte size mismatch",
-                    relative,
-                    len(data),
-                    entry.get("bytes"),
-                )
-            )
-        digest = entry.get("sha256")
-        if (
-            not isinstance(digest, str)
-            or not SHA256_RE.fullmatch(digest)
-            or digest != _digest(data)
-        ):
-            issues.append(
-                _finding(
-                    "artifact-digest-mismatch",
-                    VerificationStage.ARTIFACT_INTEGRITY,
-                    "artifact SHA-256 mismatch",
-                    relative,
-                )
-            )
-    if issues:
-        return _result(
-            VerificationState.REJECTED,
-            VerificationStage.ARTIFACT_INTEGRITY,
-            issues,
-            actual,
-            manifest,
+            compatibility_claims,
         )
 
     counts = manifest.get("counts")
@@ -741,15 +779,19 @@ def verify_package(
             VerificationStage.TERMINAL_ACCOUNTING,
             issues,
             actual,
-            manifest,
+            compatibility_claims,
         )
 
+    structural_data: dict[str, bytes] = {}
     observed = {value.value: 0 for value in ItemOutcome}
     parsed_items: list[tuple[str, Mapping[str, Any]]] = []
     assert isinstance(item_paths, list)
     for relative in item_paths:
         try:
-            item = json.loads(artifact_data[relative], object_pairs_hook=_unique_object)
+            structural_data[relative] = package.joinpath(
+                *PurePosixPath(relative).parts
+            ).read_bytes()
+            item = json.loads(structural_data[relative], object_pairs_hook=_unique_object)
             if not isinstance(item, dict):
                 raise ValueError
         except (
@@ -808,8 +850,10 @@ def verify_package(
             VerificationStage.TERMINAL_ACCOUNTING,
             issues,
             actual,
-            manifest,
+            compatibility_claims,
         )
+
+    accounting_claims = _curated_claims(manifest, actual, accounting=True)
 
     for relative, item in parsed_items:
         outcome = ItemOutcome(item["outcome"])
@@ -843,12 +887,16 @@ def verify_package(
             )
     if issues:
         return _result(
-            VerificationState.REJECTED, VerificationStage.ITEM_SEMANTICS, issues, actual, manifest
+            VerificationState.REJECTED,
+            VerificationStage.ITEM_SEMANTICS,
+            issues,
+            actual,
+            accounting_claims,
         )
 
     receipt_path = manifest.get("run_receipt")
     if receipt_path is not None:
-        if not isinstance(receipt_path, str) or receipt_path not in artifact_data:
+        if not isinstance(receipt_path, str) or receipt_path not in expected_paths:
             issues.append(
                 _finding(
                     "invalid-run-receipt-reference",
@@ -859,8 +907,13 @@ def verify_package(
             )
         else:
             try:
-                receipt = json.loads(artifact_data[receipt_path], object_pairs_hook=_unique_object)
-            except (UnicodeDecodeError, json.JSONDecodeError, _DuplicateKey):
+                structural_data[receipt_path] = package.joinpath(
+                    *PurePosixPath(receipt_path).parts
+                ).read_bytes()
+                receipt = json.loads(
+                    structural_data[receipt_path], object_pairs_hook=_unique_object
+                )
+            except (OSError, UnicodeDecodeError, json.JSONDecodeError, _DuplicateKey):
                 receipt = None
                 issues.append(
                     _finding(
@@ -891,6 +944,72 @@ def verify_package(
                         )
     if issues:
         return _result(
-            VerificationState.REJECTED, VerificationStage.LINEAGE, issues, actual, manifest
+            VerificationState.REJECTED,
+            VerificationStage.LINEAGE,
+            issues,
+            actual,
+            accounting_claims,
         )
-    return _result(VerificationState.VERIFIED, VerificationStage.COMPLETE, (), actual, manifest)
+
+    lineage_claims = _curated_claims(manifest, actual, accounting=True, lineage=True)
+    for relative in sorted(expected_paths):
+        try:
+            data = structural_data.get(relative)
+            if data is None:
+                data = package.joinpath(*PurePosixPath(relative).parts).read_bytes()
+        except OSError:
+            return _result(
+                VerificationState.INDETERMINATE_IO,
+                VerificationStage.LINEAGE,
+                (
+                    _finding(
+                        "io-artifact-read-failure",
+                        VerificationStage.ARTIFACT_INTEGRITY,
+                        "could not read inventoried artifact",
+                        relative,
+                    ),
+                ),
+                actual,
+                lineage_claims,
+            )
+        entry = entries[relative]
+        if type(entry.get("bytes")) is not int or entry["bytes"] != len(data):
+            issues.append(
+                _finding(
+                    "artifact-size-mismatch",
+                    VerificationStage.ARTIFACT_INTEGRITY,
+                    "artifact byte size mismatch",
+                    relative,
+                    len(data),
+                    entry.get("bytes"),
+                )
+            )
+        digest = entry.get("sha256")
+        if (
+            not isinstance(digest, str)
+            or not SHA256_RE.fullmatch(digest)
+            or digest != _digest(data)
+        ):
+            issues.append(
+                _finding(
+                    "artifact-digest-mismatch",
+                    VerificationStage.ARTIFACT_INTEGRITY,
+                    "artifact SHA-256 mismatch",
+                    relative,
+                )
+            )
+    if issues:
+        return _result(
+            VerificationState.REJECTED,
+            VerificationStage.ARTIFACT_INTEGRITY,
+            issues,
+            actual,
+            lineage_claims,
+        )
+    return _result(
+        VerificationState.VERIFIED,
+        VerificationStage.COMPLETE,
+        (),
+        actual,
+        lineage_claims,
+    )

--- a/src/knowledge_adapters/source_package/core.py
+++ b/src/knowledge_adapters/source_package/core.py
@@ -4,18 +4,63 @@ from __future__ import annotations
 
 import hashlib
 import json
-import os
 import re
+import shutil
+import uuid
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from enum import StrEnum
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path, PurePosixPath
 from typing import Any
 
-from .models import AdapterIdentity, Artifact, ArtifactInventoryEntry, ItemOutcome, PackageItem
+from .models import (
+    AcquisitionRequest,
+    AdapterIdentity,
+    Artifact,
+    ArtifactInventoryEntry,
+    ItemOutcome,
+    PackageItem,
+)
 
 CONTRACT_NAME = "knowledge-source-package"
+RESULT_SCHEMA_VERSION = "1.0.0"
 SIDECAR_RE = re.compile(rb"[0-9a-f]{64}\n\Z")
 SHA256_RE = re.compile(r"[0-9a-f]{64}\Z")
+RESERVED_MANIFEST_FIELDS = frozenset(
+    {
+        "contract_name",
+        "contract_version",
+        "package_id",
+        "request_id",
+        "run_id",
+        "created_at",
+        "adapter",
+        "boundary",
+        "required_capabilities",
+        "status",
+        "counts",
+        "items",
+        "artifacts",
+        "request_path",
+        "run_receipt",
+        "resumes_run_id",
+        "prior_package_ids",
+        "prior_run_ids",
+        "reconciliation_summary",
+        "final_attempt_counts",
+        "lineage",
+        "integrity",
+        "content_address",
+    }
+)
+
+
+def _library_version() -> str | None:
+    try:
+        return version("knowledge-adapters")
+    except PackageNotFoundError:
+        return None
 
 
 def canonical_json_bytes(value: object) -> bytes:
@@ -27,11 +72,45 @@ def canonical_json_bytes(value: object) -> bytes:
 
 def _safe_path(value: str) -> bool:
     path = PurePosixPath(value)
-    return bool(value) and "\\" not in value and not path.is_absolute() and ".." not in path.parts
+    return (
+        bool(value)
+        and "\\" not in value
+        and not path.is_absolute()
+        and ".." not in path.parts
+        and path.as_posix() == value
+        and not value.startswith("./")
+        and "//" not in value
+    )
 
 
 def _digest(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
+
+
+class VerificationState(StrEnum):
+    VERIFIED = "verified"
+    REJECTED = "rejected"
+    INDETERMINATE_IO = "indeterminate_io"
+
+
+class VerificationStage(StrEnum):
+    ENVELOPE = "envelope"
+    SIDECAR_FORMAT = "sidecar-format"
+    MANIFEST_DIGEST = "manifest-digest"
+    MANIFEST_PARSE = "manifest-parse"
+    COMPATIBILITY = "compatibility"
+    PATH_SAFETY = "path-safety"
+    INVENTORY_COVERAGE = "inventory-coverage"
+    ARTIFACT_INTEGRITY = "artifact-integrity"
+    TERMINAL_ACCOUNTING = "terminal-accounting"
+    ITEM_SEMANTICS = "item-semantics"
+    LINEAGE = "lineage"
+    COMPLETE = "complete"
+
+
+class FindingSeverity(StrEnum):
+    ERROR = "error"
+    WARNING = "warning"
 
 
 @dataclass(frozen=True)
@@ -43,18 +122,108 @@ class SealResult:
 
 
 @dataclass(frozen=True)
-class VerificationIssue:
+class VerificationFinding:
     code: str
+    severity: FindingSeverity
+    stage: VerificationStage
     message: str
-    path: str | None = None
+    reference: str | None = None
+    observed: str | int | None = None
+    expected: str | int | None = None
+
+    @property
+    def path(self) -> str | None:
+        """Backward-compatible alias for portable path/field references."""
+        return self.reference
+
+
+VerificationIssue = VerificationFinding
 
 
 @dataclass(frozen=True)
 class VerificationResult:
-    ok: bool
-    issues: tuple[VerificationIssue, ...]
+    schema_version: str
+    verifier_version: str | None
+    state: VerificationState
+    last_completed_stage: VerificationStage
+    findings: tuple[VerificationFinding, ...]
     content_address: str | None = None
-    manifest: Mapping[str, Any] | None = None
+    manifest_claims: Mapping[str, Any] | None = None
+
+    @property
+    def ok(self) -> bool:
+        return self.state is VerificationState.VERIFIED
+
+    @property
+    def issues(self) -> tuple[VerificationFinding, ...]:
+        return self.findings
+
+    @property
+    def manifest(self) -> Mapping[str, Any] | None:
+        return self.manifest_claims
+
+
+def _bounded(value: object, limit: int = 200) -> str:
+    text = str(value).replace("\n", "\\n").replace("\r", "\\r")
+    return text if len(text) <= limit else f"{text[:limit]}…"
+
+
+def _finding(
+    code: str,
+    stage: VerificationStage,
+    message: str,
+    reference: str | None = None,
+    observed: object | None = None,
+    expected: object | None = None,
+) -> VerificationFinding:
+    return VerificationFinding(
+        code,
+        FindingSeverity.ERROR,
+        stage,
+        _bounded(message),
+        reference,
+        None if observed is None else _bounded(observed),
+        None if expected is None else _bounded(expected),
+    )
+
+
+def _result(
+    state: VerificationState,
+    stage: VerificationStage,
+    findings: Sequence[VerificationFinding] = (),
+    content_address: str | None = None,
+    manifest: Mapping[str, Any] | None = None,
+) -> VerificationResult:
+    return VerificationResult(
+        RESULT_SCHEMA_VERSION,
+        _library_version(),
+        state,
+        stage,
+        tuple(findings),
+        content_address,
+        manifest,
+    )
+
+
+class _DuplicateKey(ValueError):
+    pass
+
+
+def _unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    value: dict[str, Any] = {}
+    for key, item in pairs:
+        if key in value:
+            raise _DuplicateKey(key)
+        value[key] = item
+    return value
+
+
+def _json_depth(value: Any, depth: int = 1) -> int:
+    if isinstance(value, dict):
+        return max((_json_depth(item, depth + 1) for item in value.values()), default=depth)
+    if isinstance(value, list):
+        return max((_json_depth(item, depth + 1) for item in value), default=depth)
+    return depth
 
 
 class PackageBuilder:
@@ -64,27 +233,41 @@ class PackageBuilder:
         self,
         *,
         package_id: str,
-        request_id: str,
+        request: AcquisitionRequest,
         run_id: str,
         created_at: str,
         adapter: AdapterIdentity,
         contract_version: str = "1.0.0",
         required_capabilities: Sequence[str] = (),
         boundary: Mapping[str, str],
+        extensions: Mapping[str, Any] | None = None,
         manifest_fields: Mapping[str, Any] | None = None,
     ) -> None:
+        if manifest_fields:
+            reserved = RESERVED_MANIFEST_FIELDS & manifest_fields.keys()
+            if reserved:
+                raise ValueError(
+                    f"manifest_fields contain reserved keys: {', '.join(sorted(reserved))}"
+                )
+            raise ValueError("manifest_fields is unsupported; use namespaced extensions")
+        if not request.request_id:
+            raise ValueError("request_id must not be empty")
+        if extensions and any("." not in key for key in extensions):
+            raise ValueError("extension keys must be namespaced")
+        self._request = request
         self._identity = {
             "contract_name": CONTRACT_NAME,
             "contract_version": contract_version,
             "package_id": package_id,
-            "request_id": request_id,
+            "request_id": request.request_id,
             "run_id": run_id,
             "created_at": created_at,
             "adapter": adapter.as_dict(),
             "boundary": dict(boundary),
             "required_capabilities": sorted(set(required_capabilities)),
+            "request_path": "request.json",
         }
-        self._extra = dict(manifest_fields or {})
+        self._extensions = dict(extensions or {})
         self._items: dict[str, PackageItem] = {}
         self._artifacts: dict[str, Artifact] = {}
         self._sealed = False
@@ -96,12 +279,17 @@ class PackageBuilder:
             raise ValueError("item_id must be a non-empty path segment")
         if item.item_id in self._items:
             raise ValueError(f"duplicate item_id: {item.item_id}")
+        item.as_dict()
         self._items[item.item_id] = item
 
     def add_artifact(self, artifact: Artifact) -> None:
         if self._sealed:
             raise RuntimeError("package builder is sealed")
-        if not _safe_path(artifact.path) or artifact.path in {"package.json", "package.sha256"}:
+        if not _safe_path(artifact.path) or artifact.path in {
+            "package.json",
+            "package.sha256",
+            "request.json",
+        }:
             raise ValueError(f"unsafe or reserved artifact path: {artifact.path}")
         if artifact.path in self._artifacts:
             raise ValueError(f"duplicate artifact path: {artifact.path}")
@@ -114,21 +302,28 @@ class PackageBuilder:
             return SealResult(False, error="destination already exists")
 
         artifacts = dict(self._artifacts)
+        artifacts["request.json"] = Artifact(
+            "request.json",
+            canonical_json_bytes(self._request.as_dict()),
+            "acquisition-request",
+            "application/json",
+        )
         item_paths: list[str] = []
-        for item_id, item in sorted(self._items.items()):
-            path = f"items/{item_id}.json"
-            item_paths.append(path)
-            artifacts[path] = Artifact(
-                path, canonical_json_bytes(item.as_dict()), "item-record", "application/json"
-            )
+        try:
+            for item_id, item in sorted(self._items.items()):
+                path = f"items/{item_id}.json"
+                item_paths.append(path)
+                artifacts[path] = Artifact(
+                    path, canonical_json_bytes(item.as_dict()), "item-record", "application/json"
+                )
+        except (TypeError, ValueError) as exc:
+            return SealResult(False, error=f"failed to build package: {_bounded(exc)}")
 
         outcomes = {outcome.value: 0 for outcome in ItemOutcome}
         for item in self._items.values():
             outcomes[item.outcome.value] += 1
         status = (
-            "completed_with_errors"
-            if outcomes[ItemOutcome.FAILED.value] or outcomes[ItemOutcome.CANCELLED.value]
-            else "completed"
+            "completed_with_errors" if outcomes["failed"] or outcomes["cancelled"] else "completed"
         )
         inventory = [
             ArtifactInventoryEntry(
@@ -136,17 +331,18 @@ class PackageBuilder:
             )
             for path, value in sorted(artifacts.items())
         ]
-        manifest = {
+        manifest: dict[str, Any] = {
             **self._identity,
-            **self._extra,
             "status": status,
             "counts": outcomes,
             "items": item_paths,
             "artifacts": [entry.as_dict() for entry in inventory],
         }
+        if self._extensions:
+            manifest["extensions"] = self._extensions
         manifest_bytes = canonical_json_bytes(manifest)
         content_address = _digest(manifest_bytes)
-        temporary = destination.with_name(f".{destination.name}.tmp-{os.getpid()}")
+        temporary = destination.with_name(f".{destination.name}.tmp-{uuid.uuid4().hex}")
         try:
             temporary.mkdir(parents=True)
             for path, artifact in sorted(artifacts.items()):
@@ -157,7 +353,8 @@ class PackageBuilder:
             (temporary / "package.sha256").write_bytes(f"{content_address}\n".encode())
             temporary.rename(destination)
         except OSError as exc:
-            return SealResult(False, error=f"failed to seal package: {exc}")
+            shutil.rmtree(temporary, ignore_errors=True)
+            return SealResult(False, error=f"failed to seal package: {_bounded(exc)}")
         self._sealed = True
         return SealResult(True, destination, content_address)
 
@@ -169,86 +366,217 @@ def verify_package(
     supported_capabilities: Sequence[str] = (),
     max_manifest_bytes: int = 4 * 1024 * 1024,
     max_sidecar_bytes: int = 65,
+    max_json_depth: int | None = None,
 ) -> VerificationResult:
-    """Verify a sealed package in the contract-mandated order without raising."""
+    """Verify a sealed package in contract order without exposing untrusted content."""
     manifest_path, sidecar_path = package / "package.json", package / "package.sha256"
     for path in (manifest_path, sidecar_path):
         if not path.is_file() or path.is_symlink():
-            return VerificationResult(
-                False, (VerificationIssue("missing", "required regular file missing", path.name),)
+            return _result(
+                VerificationState.REJECTED,
+                VerificationStage.ENVELOPE,
+                (
+                    _finding(
+                        "missing-required-file",
+                        VerificationStage.ENVELOPE,
+                        "required regular file missing",
+                        path.name,
+                    ),
+                ),
             )
     try:
-        if (
-            manifest_path.stat().st_size > max_manifest_bytes
-            or sidecar_path.stat().st_size > max_sidecar_bytes
-        ):
-            return VerificationResult(
-                False, (VerificationIssue("size-limit", "manifest or sidecar exceeds size limit"),)
+        manifest_size, sidecar_size = manifest_path.stat().st_size, sidecar_path.stat().st_size
+        if manifest_size > max_manifest_bytes or sidecar_size > max_sidecar_bytes:
+            return _result(
+                VerificationState.REJECTED,
+                VerificationStage.ENVELOPE,
+                (
+                    _finding(
+                        "consumer-size-limit",
+                        VerificationStage.ENVELOPE,
+                        "manifest or sidecar exceeds consumer limit",
+                        observed=max(manifest_size, sidecar_size),
+                    ),
+                ),
             )
         sidecar = sidecar_path.read_bytes()
         if not SIDECAR_RE.fullmatch(sidecar):
-            return VerificationResult(
-                False,
+            return _result(
+                VerificationState.REJECTED,
+                VerificationStage.SIDECAR_FORMAT,
                 (
-                    VerificationIssue(
-                        "sidecar-format", "invalid package.sha256 format", "package.sha256"
+                    _finding(
+                        "invalid-sidecar-format",
+                        VerificationStage.SIDECAR_FORMAT,
+                        "package.sha256 must be lowercase hexadecimal plus one newline",
+                        "package.sha256",
                     ),
                 ),
             )
         manifest_bytes = manifest_path.read_bytes()
-    except OSError as exc:
-        return VerificationResult(False, (VerificationIssue("read-error", str(exc)),))
+    except OSError:
+        return _result(
+            VerificationState.INDETERMINATE_IO,
+            VerificationStage.ENVELOPE,
+            (
+                _finding(
+                    "io-read-failure", VerificationStage.ENVELOPE, "could not read package envelope"
+                ),
+            ),
+        )
     actual = _digest(manifest_bytes)
     expected = sidecar[:-1].decode()
     if actual != expected:
-        return VerificationResult(
-            False,
-            (VerificationIssue("manifest-digest", "package.json digest mismatch", "package.json"),),
+        return _result(
+            VerificationState.REJECTED,
+            VerificationStage.MANIFEST_DIGEST,
+            (
+                _finding(
+                    "manifest-digest-mismatch",
+                    VerificationStage.MANIFEST_DIGEST,
+                    "package.json digest mismatch",
+                    "package.json",
+                ),
+            ),
         )
     try:
-        manifest = json.loads(manifest_bytes)
-    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-        return VerificationResult(
-            False, (VerificationIssue("manifest-json", str(exc), "package.json"),), actual
+        manifest = json.loads(manifest_bytes, object_pairs_hook=_unique_object)
+    except _DuplicateKey:
+        return _result(
+            VerificationState.REJECTED,
+            VerificationStage.MANIFEST_PARSE,
+            (
+                _finding(
+                    "duplicate-json-key",
+                    VerificationStage.MANIFEST_PARSE,
+                    "manifest contains a duplicate object key",
+                    "package.json",
+                ),
+            ),
+            actual,
         )
-    issues: list[VerificationIssue] = []
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return _result(
+            VerificationState.REJECTED,
+            VerificationStage.MANIFEST_PARSE,
+            (
+                _finding(
+                    "invalid-manifest-json",
+                    VerificationStage.MANIFEST_PARSE,
+                    "manifest is not valid UTF-8 JSON",
+                    "package.json",
+                ),
+            ),
+            actual,
+        )
+    if max_json_depth is not None and _json_depth(manifest) > max_json_depth:
+        return _result(
+            VerificationState.REJECTED,
+            VerificationStage.MANIFEST_PARSE,
+            (
+                _finding(
+                    "consumer-depth-limit",
+                    VerificationStage.MANIFEST_PARSE,
+                    "manifest exceeds consumer nesting limit",
+                    observed=_json_depth(manifest),
+                    expected=max_json_depth,
+                ),
+            ),
+            actual,
+        )
     if not isinstance(manifest, dict):
-        return VerificationResult(
-            False, (VerificationIssue("manifest-shape", "manifest must be an object"),), actual
+        return _result(
+            VerificationState.REJECTED,
+            VerificationStage.MANIFEST_PARSE,
+            (
+                _finding(
+                    "invalid-manifest-shape",
+                    VerificationStage.MANIFEST_PARSE,
+                    "manifest must be an object",
+                    "package.json",
+                ),
+            ),
+            actual,
         )
+
+    issues: list[VerificationFinding] = []
     if manifest.get("contract_name") != CONTRACT_NAME:
-        issues.append(VerificationIssue("contract-name", "unsupported contract name"))
-    version = manifest.get("contract_version")
+        issues.append(
+            _finding(
+                "unsupported-contract-name",
+                VerificationStage.COMPATIBILITY,
+                "unsupported contract name",
+                "contract_name",
+            )
+        )
+    version_value = manifest.get("contract_version")
     try:
-        major = int(version.split(".", 1)[0]) if isinstance(version, str) else -1
+        major = int(version_value.split(".", 1)[0]) if isinstance(version_value, str) else -1
     except ValueError:
         major = -1
     if major not in supported_major_versions:
-        issues.append(VerificationIssue("contract-version", "unsupported contract major version"))
+        issues.append(
+            _finding(
+                "unsupported-contract-major",
+                VerificationStage.COMPATIBILITY,
+                "unsupported contract major version",
+                "contract_version",
+            )
+        )
     required = manifest.get("required_capabilities", [])
     if not isinstance(required, list) or any(not isinstance(value, str) for value in required):
         issues.append(
-            VerificationIssue("capabilities-shape", "required_capabilities must be strings")
+            _finding(
+                "invalid-required-capabilities",
+                VerificationStage.COMPATIBILITY,
+                "required_capabilities must be strings",
+                "required_capabilities",
+            )
         )
     else:
         unsupported = sorted(set(required) - set(supported_capabilities))
         if unsupported:
             issues.append(
-                VerificationIssue("required-capability", f"unsupported: {', '.join(unsupported)}")
+                _finding(
+                    "unknown-required-capability",
+                    VerificationStage.COMPATIBILITY,
+                    "unsupported required capability",
+                    "required_capabilities",
+                )
             )
+    if issues:
+        return _result(
+            VerificationState.REJECTED, VerificationStage.COMPATIBILITY, issues, actual, manifest
+        )
+
     inventory = manifest.get("artifacts")
     if not isinstance(inventory, list):
-        issues.append(VerificationIssue("inventory-shape", "artifacts must be a list"))
-        inventory = []
-    counts = manifest.get("counts")
-    if not isinstance(counts, dict) or set(counts) != {value.value for value in ItemOutcome}:
-        issues.append(
-            VerificationIssue("accounting", "counts must contain exactly all terminal outcomes")
+        return _result(
+            VerificationState.REJECTED,
+            VerificationStage.PATH_SAFETY,
+            (
+                _finding(
+                    "invalid-inventory-shape",
+                    VerificationStage.PATH_SAFETY,
+                    "artifacts must be a list",
+                    "artifacts",
+                ),
+            ),
+            actual,
+            manifest,
         )
     expected_paths: set[str] = set()
+    entries: dict[str, Mapping[str, Any]] = {}
     for entry in inventory:
         if not isinstance(entry, dict) or not isinstance(entry.get("path"), str):
-            issues.append(VerificationIssue("inventory-entry", "invalid inventory entry"))
+            issues.append(
+                _finding(
+                    "invalid-inventory-entry",
+                    VerificationStage.PATH_SAFETY,
+                    "inventory entry requires a string path",
+                    "artifacts",
+                )
+            )
             continue
         relative = entry["path"]
         if (
@@ -257,77 +585,294 @@ def verify_package(
             or relative in {"package.json", "package.sha256"}
         ):
             issues.append(
-                VerificationIssue("path-safety", "unsafe, duplicate, or reserved path", relative)
+                _finding(
+                    "unsafe-artifact-path",
+                    VerificationStage.PATH_SAFETY,
+                    "unsafe, duplicate, aliased, or reserved path",
+                    _bounded(relative),
+                )
             )
             continue
         expected_paths.add(relative)
+        entries[relative] = entry
     if issues:
-        return VerificationResult(False, tuple(issues), actual, manifest)
+        return _result(
+            VerificationState.REJECTED, VerificationStage.PATH_SAFETY, issues, actual, manifest
+        )
+
     actual_paths: set[str] = set()
     try:
         for path in package.rglob("*"):
+            relative = path.relative_to(package).as_posix()
             if path.is_symlink():
                 issues.append(
-                    VerificationIssue(
-                        "path-safety",
+                    _finding(
+                        "symbolic-link-forbidden",
+                        VerificationStage.INVENTORY_COVERAGE,
                         "symbolic links are forbidden",
-                        path.relative_to(package).as_posix(),
+                        relative,
                     )
                 )
             elif path.is_file():
-                actual_paths.add(path.relative_to(package).as_posix())
-    except OSError as exc:
-        issues.append(VerificationIssue("read-error", str(exc)))
+                actual_paths.add(relative)
+    except OSError:
+        return _result(
+            VerificationState.INDETERMINATE_IO,
+            VerificationStage.PATH_SAFETY,
+            (
+                _finding(
+                    "io-scan-failure",
+                    VerificationStage.INVENTORY_COVERAGE,
+                    "could not enumerate package files",
+                ),
+            ),
+            actual,
+            manifest,
+        )
     if actual_paths - {"package.json", "package.sha256"} != expected_paths:
         issues.append(
-            VerificationIssue(
-                "inventory-coverage", "inventory does not exactly cover handoff artifacts"
+            _finding(
+                "inventory-coverage-mismatch",
+                VerificationStage.INVENTORY_COVERAGE,
+                "inventory does not exactly cover handoff artifacts",
             )
         )
-    entries = {entry["path"]: entry for entry in inventory}
+    if issues:
+        return _result(
+            VerificationState.REJECTED,
+            VerificationStage.INVENTORY_COVERAGE,
+            issues,
+            actual,
+            manifest,
+        )
+
+    artifact_data: dict[str, bytes] = {}
     for relative in sorted(expected_paths):
         try:
             data = package.joinpath(*PurePosixPath(relative).parts).read_bytes()
-        except OSError as exc:
-            issues.append(VerificationIssue("artifact-read", str(exc), relative))
-            continue
+        except OSError:
+            return _result(
+                VerificationState.INDETERMINATE_IO,
+                VerificationStage.INVENTORY_COVERAGE,
+                (
+                    _finding(
+                        "io-artifact-read-failure",
+                        VerificationStage.ARTIFACT_INTEGRITY,
+                        "could not read inventoried artifact",
+                        relative,
+                    ),
+                ),
+                actual,
+                manifest,
+            )
+        artifact_data[relative] = data
         entry = entries[relative]
         if type(entry.get("bytes")) is not int or entry["bytes"] != len(data):
-            issues.append(VerificationIssue("artifact-size", "byte size mismatch", relative))
+            issues.append(
+                _finding(
+                    "artifact-size-mismatch",
+                    VerificationStage.ARTIFACT_INTEGRITY,
+                    "artifact byte size mismatch",
+                    relative,
+                    len(data),
+                    entry.get("bytes"),
+                )
+            )
         digest = entry.get("sha256")
         if (
             not isinstance(digest, str)
             or not SHA256_RE.fullmatch(digest)
             or digest != _digest(data)
         ):
-            issues.append(VerificationIssue("artifact-digest", "SHA-256 mismatch", relative))
-    item_paths = manifest.get("items")
-    if not isinstance(item_paths, list) or any(path not in expected_paths for path in item_paths):
-        issues.append(VerificationIssue("items", "item references must be inventoried paths"))
-    else:
-        observed = {value.value: 0 for value in ItemOutcome}
-        for relative in item_paths:
-            try:
-                item = json.loads(package.joinpath(*PurePosixPath(relative).parts).read_bytes())
-                observed[ItemOutcome(item["outcome"]).value] += 1
-            except (
-                OSError,
-                UnicodeDecodeError,
-                json.JSONDecodeError,
-                KeyError,
-                ValueError,
-                TypeError,
-            ):
-                issues.append(VerificationIssue("item-record", "invalid item record", relative))
-        if counts != observed:
             issues.append(
-                VerificationIssue("accounting", "manifest counts do not match item outcomes")
+                _finding(
+                    "artifact-digest-mismatch",
+                    VerificationStage.ARTIFACT_INTEGRITY,
+                    "artifact SHA-256 mismatch",
+                    relative,
+                )
             )
-        wanted = (
-            "completed_with_errors" if observed["failed"] or observed["cancelled"] else "completed"
+    if issues:
+        return _result(
+            VerificationState.REJECTED,
+            VerificationStage.ARTIFACT_INTEGRITY,
+            issues,
+            actual,
+            manifest,
         )
-        if manifest.get("status") != wanted:
-            issues.append(
-                VerificationIssue("accounting", "package status does not match item outcomes")
+
+    counts = manifest.get("counts")
+    item_paths = manifest.get("items")
+    terminal_names = {value.value for value in ItemOutcome}
+    if (
+        not isinstance(counts, dict)
+        or set(counts) != terminal_names
+        or any(type(v) is not int or v < 0 for v in counts.values())
+    ):
+        issues.append(
+            _finding(
+                "invalid-terminal-counts",
+                VerificationStage.TERMINAL_ACCOUNTING,
+                "counts must contain nonnegative integers for every terminal outcome",
+                "counts",
             )
-    return VerificationResult(not issues, tuple(issues), actual, manifest)
+        )
+    if not isinstance(item_paths, list) or any(
+        not isinstance(path, str) or path not in expected_paths for path in item_paths
+    ):
+        issues.append(
+            _finding(
+                "invalid-item-references",
+                VerificationStage.TERMINAL_ACCOUNTING,
+                "item references must be inventoried paths",
+                "items",
+            )
+        )
+    if issues:
+        return _result(
+            VerificationState.REJECTED,
+            VerificationStage.TERMINAL_ACCOUNTING,
+            issues,
+            actual,
+            manifest,
+        )
+
+    observed = {value.value: 0 for value in ItemOutcome}
+    parsed_items: list[tuple[str, Mapping[str, Any]]] = []
+    assert isinstance(item_paths, list)
+    for relative in item_paths:
+        try:
+            item = json.loads(artifact_data[relative], object_pairs_hook=_unique_object)
+            outcome = ItemOutcome(item["outcome"])
+            if not isinstance(item, dict):
+                raise ValueError
+        except (
+            UnicodeDecodeError,
+            json.JSONDecodeError,
+            _DuplicateKey,
+            KeyError,
+            ValueError,
+            TypeError,
+        ):
+            issues.append(
+                _finding(
+                    "invalid-item-record",
+                    VerificationStage.ITEM_SEMANTICS,
+                    "invalid item record",
+                    relative,
+                )
+            )
+            continue
+        observed[outcome.value] += 1
+        parsed_items.append((relative, item))
+    if counts != observed:
+        issues.append(
+            _finding(
+                "terminal-count-mismatch",
+                VerificationStage.TERMINAL_ACCOUNTING,
+                "manifest counts do not match item outcomes",
+                "counts",
+            )
+        )
+    wanted = "completed_with_errors" if observed["failed"] or observed["cancelled"] else "completed"
+    if manifest.get("status") != wanted:
+        issues.append(
+            _finding(
+                "status-outcome-mismatch",
+                VerificationStage.TERMINAL_ACCOUNTING,
+                "package status does not match terminal outcomes",
+                "status",
+            )
+        )
+    if issues:
+        return _result(
+            VerificationState.REJECTED,
+            VerificationStage.TERMINAL_ACCOUNTING,
+            issues,
+            actual,
+            manifest,
+        )
+
+    for relative, item in parsed_items:
+        outcome = ItemOutcome(item["outcome"])
+        error = item.get("error")
+        if outcome in {ItemOutcome.COMPLETED, ItemOutcome.UNCHANGED} and error is not None:
+            issues.append(
+                _finding(
+                    "contradictory-item-error",
+                    VerificationStage.ITEM_SEMANTICS,
+                    "successful item outcome cannot carry an error",
+                    relative,
+                )
+            )
+        if outcome in {ItemOutcome.FAILED, ItemOutcome.CANCELLED} and not isinstance(error, dict):
+            issues.append(
+                _finding(
+                    "missing-item-error",
+                    VerificationStage.ITEM_SEMANTICS,
+                    "failed or cancelled item requires a structured error",
+                    relative,
+                )
+            )
+        if outcome is ItemOutcome.SKIPPED and not isinstance(item.get("skip_reason"), (str, dict)):
+            issues.append(
+                _finding(
+                    "missing-skip-reason",
+                    VerificationStage.ITEM_SEMANTICS,
+                    "skipped item requires a skip_reason",
+                    relative,
+                )
+            )
+    if issues:
+        return _result(
+            VerificationState.REJECTED, VerificationStage.ITEM_SEMANTICS, issues, actual, manifest
+        )
+
+    receipt_path = manifest.get("run_receipt")
+    if receipt_path is not None:
+        if not isinstance(receipt_path, str) or receipt_path not in artifact_data:
+            issues.append(
+                _finding(
+                    "invalid-run-receipt-reference",
+                    VerificationStage.LINEAGE,
+                    "run receipt must reference an inventoried artifact",
+                    "run_receipt",
+                )
+            )
+        else:
+            try:
+                receipt = json.loads(artifact_data[receipt_path], object_pairs_hook=_unique_object)
+            except (UnicodeDecodeError, json.JSONDecodeError, _DuplicateKey):
+                receipt = None
+                issues.append(
+                    _finding(
+                        "invalid-run-receipt",
+                        VerificationStage.LINEAGE,
+                        "run receipt is not valid UTF-8 JSON",
+                        receipt_path,
+                    )
+                )
+            if isinstance(receipt, dict):
+                lineage_keys = {
+                    "run_id",
+                    "resumes_run_id",
+                    "prior_run_ids",
+                    "prior_package_ids",
+                    "reconciliation_summary",
+                    "final_attempt_counts",
+                }
+                for key in lineage_keys & receipt.keys():
+                    if key in manifest and receipt[key] != manifest[key]:
+                        issues.append(
+                            _finding(
+                                "receipt-lineage-conflict",
+                                VerificationStage.LINEAGE,
+                                "run receipt conflicts with authoritative manifest lineage",
+                                key,
+                            )
+                        )
+    if issues:
+        return _result(
+            VerificationState.REJECTED, VerificationStage.LINEAGE, issues, actual, manifest
+        )
+    return _result(VerificationState.VERIFIED, VerificationStage.COMPLETE, (), actual, manifest)

--- a/src/knowledge_adapters/source_package/core.py
+++ b/src/knowledge_adapters/source_package/core.py
@@ -750,7 +750,6 @@ def verify_package(
     for relative in item_paths:
         try:
             item = json.loads(artifact_data[relative], object_pairs_hook=_unique_object)
-            outcome = ItemOutcome(item["outcome"])
             if not isinstance(item, dict):
                 raise ValueError
         except (
@@ -766,6 +765,18 @@ def verify_package(
                     "invalid-item-record",
                     VerificationStage.ITEM_SEMANTICS,
                     "invalid item record",
+                    relative,
+                )
+            )
+            continue
+        try:
+            outcome = ItemOutcome(item["outcome"])
+        except (KeyError, ValueError, TypeError):
+            issues.append(
+                _finding(
+                    "nonterminal-item-outcome",
+                    VerificationStage.TERMINAL_ACCOUNTING,
+                    "sealed item must use a terminal outcome",
                     relative,
                 )
             )

--- a/src/knowledge_adapters/source_package/core.py
+++ b/src/knowledge_adapters/source_package/core.py
@@ -1,0 +1,333 @@
+"""Deterministic Source Package assembly, sealing, and verification."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from .models import AdapterIdentity, Artifact, ArtifactInventoryEntry, ItemOutcome, PackageItem
+
+CONTRACT_NAME = "knowledge-source-package"
+SIDECAR_RE = re.compile(rb"[0-9a-f]{64}\n\Z")
+SHA256_RE = re.compile(r"[0-9a-f]{64}\Z")
+
+
+def canonical_json_bytes(value: object) -> bytes:
+    """Serialize JSON deterministically as UTF-8, with one trailing newline."""
+    return (
+        json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n"
+    ).encode()
+
+
+def _safe_path(value: str) -> bool:
+    path = PurePosixPath(value)
+    return bool(value) and "\\" not in value and not path.is_absolute() and ".." not in path.parts
+
+
+def _digest(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+@dataclass(frozen=True)
+class SealResult:
+    ok: bool
+    package_path: Path | None = None
+    content_address: str | None = None
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class VerificationIssue:
+    code: str
+    message: str
+    path: str | None = None
+
+
+@dataclass(frozen=True)
+class VerificationResult:
+    ok: bool
+    issues: tuple[VerificationIssue, ...]
+    content_address: str | None = None
+    manifest: Mapping[str, Any] | None = None
+
+
+class PackageBuilder:
+    """Collect a complete package in memory and atomically seal it once."""
+
+    def __init__(
+        self,
+        *,
+        package_id: str,
+        request_id: str,
+        run_id: str,
+        created_at: str,
+        adapter: AdapterIdentity,
+        contract_version: str = "1.0.0",
+        required_capabilities: Sequence[str] = (),
+        boundary: Mapping[str, str],
+        manifest_fields: Mapping[str, Any] | None = None,
+    ) -> None:
+        self._identity = {
+            "contract_name": CONTRACT_NAME,
+            "contract_version": contract_version,
+            "package_id": package_id,
+            "request_id": request_id,
+            "run_id": run_id,
+            "created_at": created_at,
+            "adapter": adapter.as_dict(),
+            "boundary": dict(boundary),
+            "required_capabilities": sorted(set(required_capabilities)),
+        }
+        self._extra = dict(manifest_fields or {})
+        self._items: dict[str, PackageItem] = {}
+        self._artifacts: dict[str, Artifact] = {}
+        self._sealed = False
+
+    def add_item(self, item: PackageItem) -> None:
+        if self._sealed:
+            raise RuntimeError("package builder is sealed")
+        if not item.item_id or "/" in item.item_id or "\\" in item.item_id:
+            raise ValueError("item_id must be a non-empty path segment")
+        if item.item_id in self._items:
+            raise ValueError(f"duplicate item_id: {item.item_id}")
+        self._items[item.item_id] = item
+
+    def add_artifact(self, artifact: Artifact) -> None:
+        if self._sealed:
+            raise RuntimeError("package builder is sealed")
+        if not _safe_path(artifact.path) or artifact.path in {"package.json", "package.sha256"}:
+            raise ValueError(f"unsafe or reserved artifact path: {artifact.path}")
+        if artifact.path in self._artifacts:
+            raise ValueError(f"duplicate artifact path: {artifact.path}")
+        self._artifacts[artifact.path] = artifact
+
+    def seal(self, destination: Path) -> SealResult:
+        if self._sealed:
+            return SealResult(False, error="package builder is already sealed")
+        if destination.exists():
+            return SealResult(False, error="destination already exists")
+
+        artifacts = dict(self._artifacts)
+        item_paths: list[str] = []
+        for item_id, item in sorted(self._items.items()):
+            path = f"items/{item_id}.json"
+            item_paths.append(path)
+            artifacts[path] = Artifact(
+                path, canonical_json_bytes(item.as_dict()), "item-record", "application/json"
+            )
+
+        outcomes = {outcome.value: 0 for outcome in ItemOutcome}
+        for item in self._items.values():
+            outcomes[item.outcome.value] += 1
+        status = (
+            "completed_with_errors"
+            if outcomes[ItemOutcome.FAILED.value] or outcomes[ItemOutcome.CANCELLED.value]
+            else "completed"
+        )
+        inventory = [
+            ArtifactInventoryEntry(
+                path, value.role, value.media_type, len(value.data), _digest(value.data)
+            )
+            for path, value in sorted(artifacts.items())
+        ]
+        manifest = {
+            **self._identity,
+            **self._extra,
+            "status": status,
+            "counts": outcomes,
+            "items": item_paths,
+            "artifacts": [entry.as_dict() for entry in inventory],
+        }
+        manifest_bytes = canonical_json_bytes(manifest)
+        content_address = _digest(manifest_bytes)
+        temporary = destination.with_name(f".{destination.name}.tmp-{os.getpid()}")
+        try:
+            temporary.mkdir(parents=True)
+            for path, artifact in sorted(artifacts.items()):
+                output = temporary.joinpath(*PurePosixPath(path).parts)
+                output.parent.mkdir(parents=True, exist_ok=True)
+                output.write_bytes(artifact.data)
+            (temporary / "package.json").write_bytes(manifest_bytes)
+            (temporary / "package.sha256").write_bytes(f"{content_address}\n".encode())
+            temporary.rename(destination)
+        except OSError as exc:
+            return SealResult(False, error=f"failed to seal package: {exc}")
+        self._sealed = True
+        return SealResult(True, destination, content_address)
+
+
+def verify_package(
+    package: Path,
+    *,
+    supported_major_versions: Sequence[int] = (1,),
+    supported_capabilities: Sequence[str] = (),
+    max_manifest_bytes: int = 4 * 1024 * 1024,
+    max_sidecar_bytes: int = 65,
+) -> VerificationResult:
+    """Verify a sealed package in the contract-mandated order without raising."""
+    manifest_path, sidecar_path = package / "package.json", package / "package.sha256"
+    for path in (manifest_path, sidecar_path):
+        if not path.is_file() or path.is_symlink():
+            return VerificationResult(
+                False, (VerificationIssue("missing", "required regular file missing", path.name),)
+            )
+    try:
+        if (
+            manifest_path.stat().st_size > max_manifest_bytes
+            or sidecar_path.stat().st_size > max_sidecar_bytes
+        ):
+            return VerificationResult(
+                False, (VerificationIssue("size-limit", "manifest or sidecar exceeds size limit"),)
+            )
+        sidecar = sidecar_path.read_bytes()
+        if not SIDECAR_RE.fullmatch(sidecar):
+            return VerificationResult(
+                False,
+                (
+                    VerificationIssue(
+                        "sidecar-format", "invalid package.sha256 format", "package.sha256"
+                    ),
+                ),
+            )
+        manifest_bytes = manifest_path.read_bytes()
+    except OSError as exc:
+        return VerificationResult(False, (VerificationIssue("read-error", str(exc)),))
+    actual = _digest(manifest_bytes)
+    expected = sidecar[:-1].decode()
+    if actual != expected:
+        return VerificationResult(
+            False,
+            (VerificationIssue("manifest-digest", "package.json digest mismatch", "package.json"),),
+        )
+    try:
+        manifest = json.loads(manifest_bytes)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        return VerificationResult(
+            False, (VerificationIssue("manifest-json", str(exc), "package.json"),), actual
+        )
+    issues: list[VerificationIssue] = []
+    if not isinstance(manifest, dict):
+        return VerificationResult(
+            False, (VerificationIssue("manifest-shape", "manifest must be an object"),), actual
+        )
+    if manifest.get("contract_name") != CONTRACT_NAME:
+        issues.append(VerificationIssue("contract-name", "unsupported contract name"))
+    version = manifest.get("contract_version")
+    try:
+        major = int(version.split(".", 1)[0]) if isinstance(version, str) else -1
+    except ValueError:
+        major = -1
+    if major not in supported_major_versions:
+        issues.append(VerificationIssue("contract-version", "unsupported contract major version"))
+    required = manifest.get("required_capabilities", [])
+    if not isinstance(required, list) or any(not isinstance(value, str) for value in required):
+        issues.append(
+            VerificationIssue("capabilities-shape", "required_capabilities must be strings")
+        )
+    else:
+        unsupported = sorted(set(required) - set(supported_capabilities))
+        if unsupported:
+            issues.append(
+                VerificationIssue("required-capability", f"unsupported: {', '.join(unsupported)}")
+            )
+    inventory = manifest.get("artifacts")
+    if not isinstance(inventory, list):
+        issues.append(VerificationIssue("inventory-shape", "artifacts must be a list"))
+        inventory = []
+    counts = manifest.get("counts")
+    if not isinstance(counts, dict) or set(counts) != {value.value for value in ItemOutcome}:
+        issues.append(
+            VerificationIssue("accounting", "counts must contain exactly all terminal outcomes")
+        )
+    expected_paths: set[str] = set()
+    for entry in inventory:
+        if not isinstance(entry, dict) or not isinstance(entry.get("path"), str):
+            issues.append(VerificationIssue("inventory-entry", "invalid inventory entry"))
+            continue
+        relative = entry["path"]
+        if (
+            not _safe_path(relative)
+            or relative in expected_paths
+            or relative in {"package.json", "package.sha256"}
+        ):
+            issues.append(
+                VerificationIssue("path-safety", "unsafe, duplicate, or reserved path", relative)
+            )
+            continue
+        expected_paths.add(relative)
+    if issues:
+        return VerificationResult(False, tuple(issues), actual, manifest)
+    actual_paths: set[str] = set()
+    try:
+        for path in package.rglob("*"):
+            if path.is_symlink():
+                issues.append(
+                    VerificationIssue(
+                        "path-safety",
+                        "symbolic links are forbidden",
+                        path.relative_to(package).as_posix(),
+                    )
+                )
+            elif path.is_file():
+                actual_paths.add(path.relative_to(package).as_posix())
+    except OSError as exc:
+        issues.append(VerificationIssue("read-error", str(exc)))
+    if actual_paths - {"package.json", "package.sha256"} != expected_paths:
+        issues.append(
+            VerificationIssue(
+                "inventory-coverage", "inventory does not exactly cover handoff artifacts"
+            )
+        )
+    entries = {entry["path"]: entry for entry in inventory}
+    for relative in sorted(expected_paths):
+        try:
+            data = package.joinpath(*PurePosixPath(relative).parts).read_bytes()
+        except OSError as exc:
+            issues.append(VerificationIssue("artifact-read", str(exc), relative))
+            continue
+        entry = entries[relative]
+        if type(entry.get("bytes")) is not int or entry["bytes"] != len(data):
+            issues.append(VerificationIssue("artifact-size", "byte size mismatch", relative))
+        digest = entry.get("sha256")
+        if (
+            not isinstance(digest, str)
+            or not SHA256_RE.fullmatch(digest)
+            or digest != _digest(data)
+        ):
+            issues.append(VerificationIssue("artifact-digest", "SHA-256 mismatch", relative))
+    item_paths = manifest.get("items")
+    if not isinstance(item_paths, list) or any(path not in expected_paths for path in item_paths):
+        issues.append(VerificationIssue("items", "item references must be inventoried paths"))
+    else:
+        observed = {value.value: 0 for value in ItemOutcome}
+        for relative in item_paths:
+            try:
+                item = json.loads(package.joinpath(*PurePosixPath(relative).parts).read_bytes())
+                observed[ItemOutcome(item["outcome"]).value] += 1
+            except (
+                OSError,
+                UnicodeDecodeError,
+                json.JSONDecodeError,
+                KeyError,
+                ValueError,
+                TypeError,
+            ):
+                issues.append(VerificationIssue("item-record", "invalid item record", relative))
+        if counts != observed:
+            issues.append(
+                VerificationIssue("accounting", "manifest counts do not match item outcomes")
+            )
+        wanted = (
+            "completed_with_errors" if observed["failed"] or observed["cancelled"] else "completed"
+        )
+        if manifest.get("status") != wanted:
+            issues.append(
+                VerificationIssue("accounting", "package status does not match item outcomes")
+            )
+    return VerificationResult(not issues, tuple(issues), actual, manifest)

--- a/src/knowledge_adapters/source_package/core.py
+++ b/src/knowledge_adapters/source_package/core.py
@@ -791,6 +791,22 @@ def verify_package(
             structural_data[relative] = package.joinpath(
                 *PurePosixPath(relative).parts
             ).read_bytes()
+        except OSError:
+            return _result(
+                VerificationState.INDETERMINATE_IO,
+                VerificationStage.TERMINAL_ACCOUNTING,
+                (
+                    _finding(
+                        "io-item-read-failure",
+                        VerificationStage.TERMINAL_ACCOUNTING,
+                        "could not read inventoried item record",
+                        relative,
+                    ),
+                ),
+                actual,
+                compatibility_claims,
+            )
+        try:
             item = json.loads(structural_data[relative], object_pairs_hook=_unique_object)
             if not isinstance(item, dict):
                 raise ValueError
@@ -910,10 +926,26 @@ def verify_package(
                 structural_data[receipt_path] = package.joinpath(
                     *PurePosixPath(receipt_path).parts
                 ).read_bytes()
+            except OSError:
+                return _result(
+                    VerificationState.INDETERMINATE_IO,
+                    VerificationStage.LINEAGE,
+                    (
+                        _finding(
+                            "io-run-receipt-read-failure",
+                            VerificationStage.LINEAGE,
+                            "could not read inventoried run receipt",
+                            receipt_path,
+                        ),
+                    ),
+                    actual,
+                    accounting_claims,
+                )
+            try:
                 receipt = json.loads(
                     structural_data[receipt_path], object_pairs_hook=_unique_object
                 )
-            except (OSError, UnicodeDecodeError, json.JSONDecodeError, _DuplicateKey):
+            except (UnicodeDecodeError, json.JSONDecodeError, _DuplicateKey):
                 receipt = None
                 issues.append(
                     _finding(
@@ -954,13 +986,11 @@ def verify_package(
     lineage_claims = _curated_claims(manifest, actual, accounting=True, lineage=True)
     for relative in sorted(expected_paths):
         try:
-            data = structural_data.get(relative)
-            if data is None:
-                data = package.joinpath(*PurePosixPath(relative).parts).read_bytes()
+            data = package.joinpath(*PurePosixPath(relative).parts).read_bytes()
         except OSError:
             return _result(
                 VerificationState.INDETERMINATE_IO,
-                VerificationStage.LINEAGE,
+                VerificationStage.ARTIFACT_INTEGRITY,
                 (
                     _finding(
                         "io-artifact-read-failure",

--- a/src/knowledge_adapters/source_package/models.py
+++ b/src/knowledge_adapters/source_package/models.py
@@ -16,6 +16,43 @@ class ItemOutcome(StrEnum):
 
 
 @dataclass(frozen=True)
+class AcquisitionRequest:
+    request_id: str
+    adapter_type: str
+    targets: tuple[str, ...]
+    scope: dict[str, Any]
+    output_location: str
+    credential_reference: str | None = None
+    selection: dict[str, Any] | None = None
+    checkpoint_reference: str | None = None
+    retry_policy: dict[str, Any] | None = None
+    expected_contract: str | None = None
+    extensions: dict[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, Any]:
+        value: dict[str, Any] = {
+            "request_id": self.request_id,
+            "adapter_type": self.adapter_type,
+            "targets": list(self.targets),
+            "scope": self.scope,
+            "output_location": self.output_location,
+        }
+        for key in (
+            "credential_reference",
+            "selection",
+            "checkpoint_reference",
+            "retry_policy",
+            "expected_contract",
+        ):
+            item = getattr(self, key)
+            if item is not None:
+                value[key] = item
+        if self.extensions:
+            value["extensions"] = self.extensions
+        return value
+
+
+@dataclass(frozen=True)
 class AdapterIdentity:
     name: str
     version: str
@@ -62,6 +99,9 @@ class PackageItem:
     fields: dict[str, Any] = field(default_factory=dict)
 
     def as_dict(self) -> dict[str, Any]:
+        reserved = {"item_id", "resource_kind", "outcome"} & self.fields.keys()
+        if reserved:
+            raise ValueError(f"item fields contain reserved keys: {', '.join(sorted(reserved))}")
         return {
             "item_id": self.item_id,
             "resource_kind": self.resource_kind,

--- a/src/knowledge_adapters/source_package/models.py
+++ b/src/knowledge_adapters/source_package/models.py
@@ -1,0 +1,70 @@
+"""Reusable models for the Source Package contract."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any
+
+
+class ItemOutcome(StrEnum):
+    COMPLETED = "completed"
+    UNCHANGED = "unchanged"
+    SKIPPED = "skipped"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+@dataclass(frozen=True)
+class AdapterIdentity:
+    name: str
+    version: str
+    revision: str | None = None
+
+    def as_dict(self) -> dict[str, str]:
+        value = {"name": self.name, "version": self.version}
+        if self.revision is not None:
+            value["revision"] = self.revision
+        return value
+
+
+@dataclass(frozen=True)
+class Artifact:
+    path: str
+    data: bytes
+    role: str
+    media_type: str
+
+
+@dataclass(frozen=True)
+class ArtifactInventoryEntry:
+    path: str
+    role: str
+    media_type: str
+    bytes: int
+    sha256: str
+
+    def as_dict(self) -> dict[str, str | int]:
+        return {
+            "path": self.path,
+            "role": self.role,
+            "media_type": self.media_type,
+            "bytes": self.bytes,
+            "sha256": self.sha256,
+        }
+
+
+@dataclass(frozen=True)
+class PackageItem:
+    item_id: str
+    resource_kind: str
+    outcome: ItemOutcome
+    fields: dict[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "item_id": self.item_id,
+            "resource_kind": self.resource_kind,
+            "outcome": self.outcome.value,
+            **self.fields,
+        }

--- a/tests/test_source_package.py
+++ b/tests/test_source_package.py
@@ -1,5 +1,8 @@
+import hashlib
 import json
+from collections.abc import Callable
 from pathlib import Path
+from typing import Any, cast
 from unittest.mock import patch
 
 from knowledge_adapters.source_package import (
@@ -38,6 +41,21 @@ def builder() -> PackageBuilder:
     return value
 
 
+def rewrite_manifest(
+    destination: Path, mutate: Callable[[dict[str, Any]], None]
+) -> dict[str, Any]:
+    manifest = cast(dict[str, Any], json.loads((destination / "package.json").read_bytes()))
+    mutate(manifest)
+    manifest_bytes = (
+        json.dumps(manifest, ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n"
+    ).encode()
+    (destination / "package.json").write_bytes(manifest_bytes)
+    (destination / "package.sha256").write_text(
+        hashlib.sha256(manifest_bytes).hexdigest() + "\n"
+    )
+    return manifest
+
+
 def test_seal_is_deterministic_and_verifiable(tmp_path: Path) -> None:
     first, second = tmp_path / "first", tmp_path / "second"
     one, two = builder().seal(first), builder().seal(second)
@@ -64,7 +82,7 @@ def test_verifier_rejects_manifest_before_parsing(tmp_path: Path) -> None:
     assert result.issues[0].code == "manifest-digest-mismatch"
     assert result.last_completed_stage == "sidecar-format"
     assert result.findings[0].stage == "manifest-digest"
-    assert result.manifest_claims is None
+    assert result.verified_claims is None
 
 
 def test_builder_rejects_unsafe_paths() -> None:
@@ -117,8 +135,6 @@ def test_verifier_rejects_duplicate_manifest_keys_after_digest(tmp_path: Path) -
     assert builder().seal(destination).ok
     manifest = (destination / "package.json").read_bytes()
     duplicate = manifest.replace(b'{"adapter":', b'{"run_id":"other","adapter":', 1)
-    import hashlib
-
     (destination / "package.json").write_bytes(duplicate)
     (destination / "package.sha256").write_text(hashlib.sha256(duplicate).hexdigest() + "\n")
     result = verify_package(destination)
@@ -134,3 +150,91 @@ def test_verifier_applies_consumer_json_depth_limit(tmp_path: Path) -> None:
     result = verify_package(destination, max_json_depth=2)
     assert result.state == "rejected"
     assert result.findings[0].code == "consumer-depth-limit"
+
+
+def test_accounting_precedes_candidate_artifact_integrity(tmp_path: Path) -> None:
+    destination = tmp_path / "package"
+    value = builder()
+    value.add_artifact(
+        Artifact("artifacts/one.md", b"original\n", "normalized-content", "text/markdown")
+    )
+    assert value.seal(destination).ok
+    rewrite_manifest(destination, lambda manifest: manifest["counts"].update(completed=2))
+    (destination / "artifacts/one.md").write_bytes(b"corrupt\n")
+    result = verify_package(destination)
+    assert result.findings[0].stage == "terminal-accounting"
+    assert result.last_completed_stage == "inventory-coverage"
+
+
+def test_item_semantics_precedes_candidate_artifact_integrity(tmp_path: Path) -> None:
+    destination = tmp_path / "package"
+    value = builder()
+    value.add_artifact(
+        Artifact("artifacts/one.md", b"original\n", "normalized-content", "text/markdown")
+    )
+    assert value.seal(destination).ok
+    item_path = destination / "items/one.json"
+    item = json.loads(item_path.read_bytes())
+    item["error"] = {"category": "contradiction"}
+    item_path.write_bytes((json.dumps(item, sort_keys=True, separators=(",", ":")) + "\n").encode())
+    (destination / "artifacts/one.md").write_bytes(b"corrupt\n")
+    result = verify_package(destination)
+    assert result.findings[0].stage == "item-semantics"
+    assert result.last_completed_stage == "terminal-accounting"
+
+
+def test_lineage_precedes_candidate_artifact_integrity(tmp_path: Path) -> None:
+    destination = tmp_path / "package"
+    value = builder()
+    value.add_artifact(
+        Artifact("artifacts/one.md", b"original\n", "normalized-content", "text/markdown")
+    )
+    value.add_artifact(
+        Artifact(
+            "run-receipt.json",
+            b'{"run_id":"other"}\n',
+            "run-receipt",
+            "application/json",
+        )
+    )
+    assert value.seal(destination).ok
+    rewrite_manifest(destination, lambda manifest: manifest.update(run_receipt="run-receipt.json"))
+    (destination / "artifacts/one.md").write_bytes(b"corrupt\n")
+    result = verify_package(destination)
+    assert result.findings[0].stage == "lineage"
+    assert result.last_completed_stage == "item-semantics"
+
+
+def test_verified_claims_are_curated_bounded_and_not_raw_manifest(tmp_path: Path) -> None:
+    destination = tmp_path / "package"
+    value = PackageBuilder(
+        package_id="x" * 201,
+        request=request(),
+        run_id="run-1",
+        created_at="2026-07-10T00:00:00Z",
+        adapter=AdapterIdentity("fixture", "1.0.0"),
+        boundary={"live": "fixture", "deterministic": "assembly"},
+        extensions={"org.example.provider": {"secretish": "not-a-claim"}},
+    )
+    value.add_item(PackageItem("one", "document", ItemOutcome.COMPLETED))
+    assert value.seal(destination).ok
+    rewrite_manifest(destination, lambda manifest: manifest.update(arbitrary="not-a-claim"))
+    result = verify_package(destination)
+    assert result.ok and result.schema_version == "2.0.0"
+    assert result.verified_claims is not None
+    assert result.verified_claims.package_id is None
+    assert not hasattr(result.verified_claims, "extensions")
+    assert not hasattr(result.verified_claims, "arbitrary")
+    assert not hasattr(result, "manifest")
+    assert not hasattr(result, "manifest_claims")
+
+
+def test_rejected_result_only_exposes_claims_from_completed_stages(tmp_path: Path) -> None:
+    destination = tmp_path / "package"
+    assert builder().seal(destination).ok
+    rewrite_manifest(destination, lambda manifest: manifest["counts"].update(completed=2))
+    result = verify_package(destination)
+    assert result.verified_claims is not None
+    assert result.verified_claims.package_id == "pkg-1"
+    assert result.verified_claims.status is None
+    assert result.verified_claims.counts is None

--- a/tests/test_source_package.py
+++ b/tests/test_source_package.py
@@ -62,7 +62,8 @@ def test_verifier_rejects_manifest_before_parsing(tmp_path: Path) -> None:
     result = verify_package(destination)
     assert not result.ok
     assert result.issues[0].code == "manifest-digest-mismatch"
-    assert result.last_completed_stage == "manifest-digest"
+    assert result.last_completed_stage == "sidecar-format"
+    assert result.findings[0].stage == "manifest-digest"
     assert result.manifest_claims is None
 
 
@@ -122,7 +123,8 @@ def test_verifier_rejects_duplicate_manifest_keys_after_digest(tmp_path: Path) -
     (destination / "package.sha256").write_text(hashlib.sha256(duplicate).hexdigest() + "\n")
     result = verify_package(destination)
     assert result.state == "rejected"
-    assert result.last_completed_stage == "manifest-parse"
+    assert result.last_completed_stage == "manifest-digest"
+    assert result.findings[0].stage == "manifest-parse"
     assert result.findings[0].code == "duplicate-json-key"
 
 

--- a/tests/test_source_package.py
+++ b/tests/test_source_package.py
@@ -1,6 +1,9 @@
+import json
 from pathlib import Path
+from unittest.mock import patch
 
 from knowledge_adapters.source_package import (
+    AcquisitionRequest,
     AdapterIdentity,
     Artifact,
     ItemOutcome,
@@ -10,16 +13,27 @@ from knowledge_adapters.source_package import (
 )
 
 
+def request() -> AcquisitionRequest:
+    return AcquisitionRequest(
+        request_id="req-1",
+        adapter_type="fixture",
+        targets=("fixture:one",),
+        scope={"kind": "resource"},
+        output_location="package",
+        selection={"language": "en"},
+        extensions={"org.example.fixture": {"mode": "test"}},
+    )
+
+
 def builder() -> PackageBuilder:
     value = PackageBuilder(
         package_id="pkg-1",
-        request_id="req-1",
+        request=request(),
         run_id="run-1",
         created_at="2026-07-10T00:00:00Z",
         adapter=AdapterIdentity("fixture", "1.0.0"),
         boundary={"live": "fixture", "deterministic": "assembly"},
     )
-    value.add_artifact(Artifact("request.json", b"{}\n", "request", "application/json"))
     value.add_item(PackageItem("one", "document", ItemOutcome.COMPLETED))
     return value
 
@@ -32,6 +46,13 @@ def test_seal_is_deterministic_and_verifiable(tmp_path: Path) -> None:
     result = verify_package(first)
     assert result.ok
     assert result.content_address == one.content_address
+    assert result.state == "verified"
+    assert result.last_completed_stage == "complete"
+    assert (first / "request.json").read_bytes() == (second / "request.json").read_bytes()
+    manifest = json.loads((first / "package.json").read_bytes())
+    assert manifest["request_path"] == "request.json"
+    request_entry = next(item for item in manifest["artifacts"] if item["path"] == "request.json")
+    assert request_entry["role"] == "acquisition-request"
 
 
 def test_verifier_rejects_manifest_before_parsing(tmp_path: Path) -> None:
@@ -40,7 +61,9 @@ def test_verifier_rejects_manifest_before_parsing(tmp_path: Path) -> None:
     (destination / "package.json").write_bytes(b"not json")
     result = verify_package(destination)
     assert not result.ok
-    assert result.issues[0].code == "manifest-digest"
+    assert result.issues[0].code == "manifest-digest-mismatch"
+    assert result.last_completed_stage == "manifest-digest"
+    assert result.manifest_claims is None
 
 
 def test_builder_rejects_unsafe_paths() -> None:
@@ -51,3 +74,61 @@ def test_builder_rejects_unsafe_paths() -> None:
         assert "unsafe" in str(exc)
     else:
         raise AssertionError("unsafe path accepted")
+
+
+def test_builder_rejects_reserved_manifest_fields_and_request_artifact() -> None:
+    try:
+        PackageBuilder(
+            package_id="pkg-1",
+            request=request(),
+            run_id="run-1",
+            created_at="2026-07-10T00:00:00Z",
+            adapter=AdapterIdentity("fixture", "1.0.0"),
+            boundary={"live": "fixture", "deterministic": "assembly"},
+            manifest_fields={"status": "completed"},
+        )
+    except ValueError as exc:
+        assert "reserved" in str(exc)
+    else:
+        raise AssertionError("reserved manifest field accepted")
+    value = builder()
+    try:
+        value.add_artifact(Artifact("request.json", b"{}", "request", "application/json"))
+    except ValueError as exc:
+        assert "reserved" in str(exc)
+    else:
+        raise AssertionError("caller-provided request artifact accepted")
+
+
+def test_seal_failure_cleans_temporary_output_and_retry_succeeds(tmp_path: Path) -> None:
+    destination = tmp_path / "package"
+    value = builder()
+    with patch.object(Path, "rename", side_effect=OSError("simulated rename failure")):
+        failed = value.seal(destination)
+    assert not failed.ok
+    assert not destination.exists()
+    assert not list(tmp_path.glob(".package.tmp-*"))
+    assert value.seal(destination).ok
+
+
+def test_verifier_rejects_duplicate_manifest_keys_after_digest(tmp_path: Path) -> None:
+    destination = tmp_path / "package"
+    assert builder().seal(destination).ok
+    manifest = (destination / "package.json").read_bytes()
+    duplicate = manifest.replace(b'{"adapter":', b'{"run_id":"other","adapter":', 1)
+    import hashlib
+
+    (destination / "package.json").write_bytes(duplicate)
+    (destination / "package.sha256").write_text(hashlib.sha256(duplicate).hexdigest() + "\n")
+    result = verify_package(destination)
+    assert result.state == "rejected"
+    assert result.last_completed_stage == "manifest-parse"
+    assert result.findings[0].code == "duplicate-json-key"
+
+
+def test_verifier_applies_consumer_json_depth_limit(tmp_path: Path) -> None:
+    destination = tmp_path / "package"
+    assert builder().seal(destination).ok
+    result = verify_package(destination, max_json_depth=2)
+    assert result.state == "rejected"
+    assert result.findings[0].code == "consumer-depth-limit"

--- a/tests/test_source_package.py
+++ b/tests/test_source_package.py
@@ -15,6 +15,8 @@ from knowledge_adapters.source_package import (
     verify_package,
 )
 
+ORIGINAL_READ_BYTES = Path.read_bytes
+
 
 def request() -> AcquisitionRequest:
     return AcquisitionRequest(
@@ -238,3 +240,118 @@ def test_rejected_result_only_exposes_claims_from_completed_stages(tmp_path: Pat
     assert result.verified_claims.package_id == "pkg-1"
     assert result.verified_claims.status is None
     assert result.verified_claims.counts is None
+
+
+def test_item_read_failure_is_structured_indeterminate_io(tmp_path: Path) -> None:
+    destination = tmp_path / "package"
+    assert builder().seal(destination).ok
+    item_path = destination / "items/one.json"
+
+    def read_bytes(path: Path) -> bytes:
+        if path == item_path:
+            raise OSError("simulated disappearing item")
+        return ORIGINAL_READ_BYTES(path)
+
+    with patch.object(Path, "read_bytes", autospec=True, side_effect=read_bytes):
+        result = verify_package(destination)
+    assert result.state == "indeterminate_io"
+    assert result.findings[0].code == "io-item-read-failure"
+    assert result.findings[0].stage == "terminal-accounting"
+    assert result.findings[0].reference == "items/one.json"
+    assert result.last_completed_stage == "inventory-coverage"
+
+
+def test_run_receipt_read_failure_is_structured_indeterminate_io(tmp_path: Path) -> None:
+    destination = tmp_path / "package"
+    value = builder()
+    value.add_artifact(
+        Artifact("run-receipt.json", b'{"run_id":"run-1"}\n', "run-receipt", "application/json")
+    )
+    assert value.seal(destination).ok
+    rewrite_manifest(destination, lambda manifest: manifest.update(run_receipt="run-receipt.json"))
+    receipt_path = destination / "run-receipt.json"
+
+    def read_bytes(path: Path) -> bytes:
+        if path == receipt_path:
+            raise OSError("simulated disappearing receipt")
+        return ORIGINAL_READ_BYTES(path)
+
+    with patch.object(Path, "read_bytes", autospec=True, side_effect=read_bytes):
+        result = verify_package(destination)
+    assert result.state == "indeterminate_io"
+    assert result.findings[0].code == "io-run-receipt-read-failure"
+    assert result.findings[0].reference == "run-receipt.json"
+    assert result.last_completed_stage == "item-semantics"
+
+
+def test_changed_item_is_freshly_read_for_final_integrity(tmp_path: Path) -> None:
+    destination = tmp_path / "package"
+    assert builder().seal(destination).ok
+    item_path = destination / "items/one.json"
+    calls = 0
+
+    def read_bytes(path: Path) -> bytes:
+        nonlocal calls
+        if path == item_path:
+            calls += 1
+            if calls == 2:
+                return ORIGINAL_READ_BYTES(path) + b" "
+        return ORIGINAL_READ_BYTES(path)
+
+    with patch.object(Path, "read_bytes", autospec=True, side_effect=read_bytes):
+        result = verify_package(destination)
+    assert calls == 2
+    assert result.state == "rejected"
+    assert result.findings[0].stage == "artifact-integrity"
+    assert result.findings[0].code == "artifact-size-mismatch"
+
+
+def test_changed_receipt_is_freshly_read_for_final_integrity(tmp_path: Path) -> None:
+    destination = tmp_path / "package"
+    value = builder()
+    value.add_artifact(
+        Artifact("run-receipt.json", b'{"run_id":"run-1"}\n', "run-receipt", "application/json")
+    )
+    assert value.seal(destination).ok
+    rewrite_manifest(destination, lambda manifest: manifest.update(run_receipt="run-receipt.json"))
+    receipt_path = destination / "run-receipt.json"
+    calls = 0
+
+    def read_bytes(path: Path) -> bytes:
+        nonlocal calls
+        if path == receipt_path:
+            calls += 1
+            if calls == 2:
+                return ORIGINAL_READ_BYTES(path) + b" "
+        return ORIGINAL_READ_BYTES(path)
+
+    with patch.object(Path, "read_bytes", autospec=True, side_effect=read_bytes):
+        result = verify_package(destination)
+    assert calls == 2
+    assert result.state == "rejected"
+    assert result.findings[0].stage == "artifact-integrity"
+    assert result.findings[0].code == "artifact-size-mismatch"
+
+
+def test_file_disappearing_before_final_integrity_is_indeterminate(tmp_path: Path) -> None:
+    destination = tmp_path / "package"
+    value = builder()
+    value.add_artifact(
+        Artifact("artifacts/one.md", b"candidate\n", "normalized-content", "text/markdown")
+    )
+    assert value.seal(destination).ok
+    candidate_path = destination / "artifacts/one.md"
+
+    def read_bytes(path: Path) -> bytes:
+        if path == candidate_path:
+            raise OSError("simulated disappearing artifact")
+        return ORIGINAL_READ_BYTES(path)
+
+    with patch.object(Path, "read_bytes", autospec=True, side_effect=read_bytes):
+        result = verify_package(destination)
+    assert result.state == "indeterminate_io"
+    assert result.findings[0].code == "io-artifact-read-failure"
+    assert result.findings[0].stage == "artifact-integrity"
+    assert result.last_completed_stage == "lineage"
+    assert result.verified_claims is not None
+    assert result.verified_claims.status == "completed"

--- a/tests/test_source_package.py
+++ b/tests/test_source_package.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+
+from knowledge_adapters.source_package import (
+    AdapterIdentity,
+    Artifact,
+    ItemOutcome,
+    PackageBuilder,
+    PackageItem,
+    verify_package,
+)
+
+
+def builder() -> PackageBuilder:
+    value = PackageBuilder(
+        package_id="pkg-1",
+        request_id="req-1",
+        run_id="run-1",
+        created_at="2026-07-10T00:00:00Z",
+        adapter=AdapterIdentity("fixture", "1.0.0"),
+        boundary={"live": "fixture", "deterministic": "assembly"},
+    )
+    value.add_artifact(Artifact("request.json", b"{}\n", "request", "application/json"))
+    value.add_item(PackageItem("one", "document", ItemOutcome.COMPLETED))
+    return value
+
+
+def test_seal_is_deterministic_and_verifiable(tmp_path: Path) -> None:
+    first, second = tmp_path / "first", tmp_path / "second"
+    one, two = builder().seal(first), builder().seal(second)
+    assert one.ok and two.ok
+    assert one.content_address == two.content_address
+    result = verify_package(first)
+    assert result.ok
+    assert result.content_address == one.content_address
+
+
+def test_verifier_rejects_manifest_before_parsing(tmp_path: Path) -> None:
+    destination = tmp_path / "package"
+    assert builder().seal(destination).ok
+    (destination / "package.json").write_bytes(b"not json")
+    result = verify_package(destination)
+    assert not result.ok
+    assert result.issues[0].code == "manifest-digest"
+
+
+def test_builder_rejects_unsafe_paths() -> None:
+    value = builder()
+    try:
+        value.add_artifact(Artifact("../escape", b"x", "bad", "text/plain"))
+    except ValueError as exc:
+        assert "unsafe" in str(exc)
+    else:
+        raise AssertionError("unsafe path accepted")


### PR DESCRIPTION
## Summary\n- structure item-record and optional run-receipt read failures as indeterminate_io\n- add stable io-item-read-failure and io-run-receipt-read-failure findings with safe relative references\n- force artifact-integrity to reopen and reread every inventoried artifact\n- add deterministic mutation seams proving stale semantic-stage bytes cannot yield verified\n\n## Validation\n- make check: 593 passed\n\n## Compatibility\n- Result schema remains 2.0.0.\n- VerifiedManifestClaims, stage order, existing finding codes, builder API, and contract text are unchanged.\n\n## Coordination\n- Conformance: https://github.com/ctrl-alt-keith/knowledge-adapters/pull/315\n\nKeep draft; do not merge.