### PR TITLE
feat: add bounded YouTube source package producer

### DIFF
--- a/docs/youtube-source-package-adapter.md
+++ b/docs/youtube-source-package-adapter.md
@@ -11,13 +11,21 @@ Language preference order, base-language fallback, caption policy, no-caption
 outcome, raw-caption retention, checkpoint paths, and retry attempts are typed
 and recorded in the canonical `AcquisitionRequest`.
 
+Explicit v1 bounds are at most 500 collection items, 16 language preferences,
+64 relevant caption candidates per video, 8 MiB per captured caption, and 4096
+UTF-8 bytes per consumed provider metadata string. Playlist and candidate data
+must have the expected shallow dict/list/scalar shape. The client downloads
+only the selected VTT candidate with a `limit + 1` read; excess candidates or
+bytes fail before normalization.
+
 `yt-dlp` is isolated behind `YouTubeClient` and is available only through the
 `youtube` optional dependency group. The embedded client supplies explicit
 options, requests no media download or postprocessing, permits no remote
 components, and consumes caption URLs only inside the client boundary. It does
-not require ffmpeg. Adapter identity records both the adapter version and
-observed yt-dlp version. Tests use `FakeClient`; `make check` neither imports
-yt-dlp nor accesses a provider.
+not require ffmpeg. Canonical adapter identity records the adapter version and
+caller-supplied build revision. The separate YouTube extension records the
+observed yt-dlp version; it is not represented as the adapter revision. Tests
+use `FakeClient`; `make check` neither imports yt-dlp nor accesses a provider.
 
 The live boundary follows yt-dlp's official documentation for
 [`--ignore-config`, `--flat-playlist`, `--skip-download`, and creator versus
@@ -60,23 +68,30 @@ omitted unless explicitly retained.
 
 ## Failure And Checkpoint Semantics
 
-Provider failures enter the producer as structured categories. Private,
-removed, age-restricted, geo-restricted, unavailable, timeout, throttling,
-transient, and cancellation observations map to bounded item errors. Timeout,
-HTTP 429, and HTTP 5xx evidence is retryable within `max_attempts`; other
+Provider failures enter the producer as structured categories. Fixture-backed
+contract mapping covers private, removed, age-restricted, geo-restricted,
+unavailable, timeout, throttling, transient, and cancellation outcomes. This
+does not claim yt-dlp supplies structured evidence for every category. The real
+boundary maps only explicit availability, status, or exception attributes it
+observes. Timeout, HTTP 429, and HTTP 5xx evidence is retryable within
+`max_attempts`; other
 unknown yt-dlp exceptions conservatively map to non-retryable unavailable
 without classifying from message text. Private and other access classifications
 are used only when yt-dlp exposes structured availability evidence; unsupported
 or absent evidence remains `provider-unavailable`. No captions is `skipped` or
 `failed` according to the effective request.
 
-Checkpoint JSON is mutable adapter-local state and is never inventoried. It is
-bounded and versioned and records a request fingerprint, adapter and contract
+Checkpoint JSON is mutable adapter-local state and is never inventoried. JSON
+is limited to 1 MiB, depth 8, and the 500-item collection bound. It is versioned
+and records a request fingerprint, adapter and contract
 versions, playlist identity, discovery IDs, completed IDs and digests,
 outcomes, attempts, pending IDs, continuation evidence, and last successful
 boundary. Resume validates schema, fingerprint, adapter version, and contract
-version, then reconciles rediscovery by video ID. A raw yt-dlp archive is not a
-canonical checkpoint.
+version, then reconciles rediscovery by video ID. Completed bytes live under
+checkpoint-owned relative paths in `<checkpoint-stem>.data/`; regular-file,
+path, 8 MiB, and SHA-256 checks run on load. Resume copies only matching
+verified bytes into the next checkpoint, drops disappeared IDs, and marks new
+IDs pending. A raw yt-dlp archive is not a canonical checkpoint.
 
 ## Collection Progress Gate
 

--- a/docs/youtube-source-package-adapter.md
+++ b/docs/youtube-source-package-adapter.md
@@ -86,39 +86,47 @@ is limited to 1 MiB, depth 8, and the 500-item collection bound. It is versioned
 and records a request fingerprint, adapter and contract
 versions, playlist identity, discovery IDs, completed IDs and digests,
 outcomes, attempts, pending IDs, continuation evidence, and last successful
-boundary. Resume validates schema, fingerprint, adapter version, and contract
-version, then reconciles rediscovery by video ID. Completed bytes live under
+boundary. Checkpoint schema 1.2 also stores the bounded typed identity,
+locator, observed metadata, caption selection, collection relationship, run,
+package, and prior-lineage fields required to reconstruct preserved completed
+items without copying a manifest model. Resume validates schema, fingerprint,
+adapter version, and contract version, then reconciles rediscovery by video ID.
+Completed bytes live under
 checkpoint-owned relative paths in `<checkpoint-stem>.data/`; regular-file,
 path, 8 MiB, and SHA-256 checks run on load. Resume copies only matching
 verified bytes into the next checkpoint, drops disappeared IDs, and marks new
-IDs pending. A raw yt-dlp archive is not a canonical checkpoint.
+IDs pending. Attempt counts are cumulative across checkpoints while the retry
+limit applies independently to the new run, so failure-to-success transitions
+record the additional attempt. A raw yt-dlp archive is not a canonical
+checkpoint.
 
-## Collection Progress Gate
+## Canonical Collection Progress And Resume
 
-Contract/core `1.0.0` cannot unambiguously seal partial or resumed collections.
-`AcquisitionRequest.scope.max_items` records requested intent, but not whether
-the observed bounded scope was exhausted or continuation remains. The public
-`PackageBuilder` reserves resume-lineage fields but exposes no way to populate
-them, and public verified claims expose neither request scope nor a collection
-progress value.
+Collection packages use contract 1.1 and the public `CollectionProgress` and
+`PackageLineage` models. A batch that leaves entries inside the requested bound
+seals with `continuation_remaining`. A run that terminally accounts for the
+entire bounded window seals with `exhausted`; this does not claim the provider's
+global playlist has no later entries.
 
-Therefore this adapter seals only:
+On resume, the adapter rediscovers the original bounded window, reuses only
+matching video IDs with verified cached bytes, assigns `unchanged` to those
+preserved package items, acquires the next bounded batch, and records the prior
+run/package IDs, cumulative attempts, and reconciliation counts through public
+`PackageLineage`. Disappeared IDs are counted as dropped and new IDs become
+pending or acquired according to the batch boundary.
 
-- one fully processed video; or
-- a fully processed bounded playlist observation.
+The producer verifies with an explicit public `ConsumerProfile` supporting the
+collection-progress capability. Handoff assertions use only public verified
+package, item-disposition, artifact-inventory, totals, progress, and lineage
+summaries. Provider extensions and content bytes are not read back or treated
+as verifier claims.
 
-If bounded discovery reports continuation inside the requested window, or
-`batch_size` leaves selected items pending, the adapter may write a checkpoint
-but raises `CollectionProgressBlocked` before creating a package. Resume state
-is validated but cannot be sealed until the canonical core exposes
-provider-neutral progress and lineage. Progress is not hidden in the YouTube
-extension.
-
-The embedded client passes `playlistend=max_items`; therefore its `exhausted`
-observation means discovery completed the requested bounded window, not that
-the provider playlist has no later members. A smaller `batch_size` is the
-explicit continuation-within-that-bound case. Its checkpoint records completed
-item digests and leaves the rest pending, but no partial package is sealed.
+The embedded client passes `playlistend=max_items`, so normal live discovery is
+complete relative to that window. `batch_size < max_items` is the actionable
+continuation case. A provider observation that says the window is not exhausted
+after every returned entry was attempted cannot advance through this adapter's
+safe rediscovery convention; it is explicitly blocked instead of emitting an
+endlessly resumable checkpoint or using an undocumented cursor.
 
 ## Prepared Live Pilot (Not Executed)
 

--- a/docs/youtube-source-package-adapter.md
+++ b/docs/youtube-source-package-adapter.md
@@ -1,0 +1,118 @@
+# YouTube Source Package Adapter
+
+Status: deterministic Wave 2 producer; live pilot not executed.
+
+## Boundary And Configuration
+
+The adapter accepts only explicit HTTPS YouTube video or playlist locators. A
+resource request has `max_items=1`; a collection request requires a positive
+`max_items`. Optional `batch_size` cannot exceed that collection bound.
+Language preference order, base-language fallback, caption policy, no-caption
+outcome, raw-caption retention, checkpoint paths, and retry attempts are typed
+and recorded in the canonical `AcquisitionRequest`.
+
+`yt-dlp` is isolated behind `YouTubeClient` and is available only through the
+`youtube` optional dependency group. The embedded client supplies explicit
+options, requests no media download or postprocessing, permits no remote
+components, and consumes caption URLs only inside the client boundary. It does
+not require ffmpeg. Adapter identity records both the adapter version and
+observed yt-dlp version. Tests use `FakeClient`; `make check` neither imports
+yt-dlp nor accesses a provider.
+
+The live boundary follows yt-dlp's official documentation for
+[`--ignore-config`, `--flat-playlist`, `--skip-download`, and creator versus
+automatic subtitle options](https://github.com/yt-dlp/yt-dlp/blob/master/README.md).
+The Python API receives parameters directly rather than invoking the CLI config
+loader. This source was checked on 2026-07-10. yt-dlp does not guarantee that
+`extract_info` returns JSON-serializable data, so the client copies only a
+small typed observation surface.
+
+## Identity, Selection, And Normalization
+
+Video IDs and playlist IDs are provider identities. Video item IDs are
+`youtube-video-<video-id>`. Canonical locators omit playlist context, tracking
+parameters, caption URLs, and other expiring query data. Playlist membership is
+parent provenance; observed positions remain YouTube-namespaced evidence.
+Duplicate positions sort by video ID and missing positions sort after observed
+positions. The canonical builder subsequently applies its own stable item-ID
+inventory ordering.
+
+Caption selection is deterministic:
+
+1. match ordered language preferences exactly, with base-language fallback
+   only when explicitly enabled;
+2. `creator-only` excludes automatic tracks;
+3. `creator-then-automatic` considers all preferred creator tracks before
+   automatic tracks;
+4. `automatic-allowed` applies language rank first, then prefers creator over
+   automatic within the same language rank.
+
+Candidate summaries contain language, kind, format, and an optional stable
+name. They never contain caption URLs.
+
+Normalizer `youtube-webvtt-to-markdown/1.0.0` decodes UTF-8 strictly,
+normalizes CRLF/CR to LF and Unicode to NFC, removes the WebVTT transport
+header and cue timestamps, converts WebVTT voice labels to bold Markdown
+speaker labels, strips remaining tags, collapses rolling automatic-caption
+cues, preserves spoken cue order, and emits exactly one trailing newline.
+Malformed WebVTT and unsupported formats fail deterministically. Raw WebVTT is
+omitted unless explicitly retained.
+
+## Failure And Checkpoint Semantics
+
+Provider failures enter the producer as structured categories. Private,
+removed, age-restricted, geo-restricted, unavailable, timeout, throttling,
+transient, and cancellation observations map to bounded item errors. Timeout,
+HTTP 429, and HTTP 5xx evidence is retryable within `max_attempts`; other
+unknown yt-dlp exceptions conservatively map to non-retryable unavailable
+without classifying from message text. Private and other access classifications
+are used only when yt-dlp exposes structured availability evidence; unsupported
+or absent evidence remains `provider-unavailable`. No captions is `skipped` or
+`failed` according to the effective request.
+
+Checkpoint JSON is mutable adapter-local state and is never inventoried. It is
+bounded and versioned and records a request fingerprint, adapter and contract
+versions, playlist identity, discovery IDs, completed IDs and digests,
+outcomes, attempts, pending IDs, continuation evidence, and last successful
+boundary. Resume validates schema, fingerprint, adapter version, and contract
+version, then reconciles rediscovery by video ID. A raw yt-dlp archive is not a
+canonical checkpoint.
+
+## Collection Progress Gate
+
+Contract/core `1.0.0` cannot unambiguously seal partial or resumed collections.
+`AcquisitionRequest.scope.max_items` records requested intent, but not whether
+the observed bounded scope was exhausted or continuation remains. The public
+`PackageBuilder` reserves resume-lineage fields but exposes no way to populate
+them, and public verified claims expose neither request scope nor a collection
+progress value.
+
+Therefore this adapter seals only:
+
+- one fully processed video; or
+- a fully processed bounded playlist observation.
+
+If bounded discovery reports continuation inside the requested window, or
+`batch_size` leaves selected items pending, the adapter may write a checkpoint
+but raises `CollectionProgressBlocked` before creating a package. Resume state
+is validated but cannot be sealed until the canonical core exposes
+provider-neutral progress and lineage. Progress is not hidden in the YouTube
+extension.
+
+The embedded client passes `playlistend=max_items`; therefore its `exhausted`
+observation means discovery completed the requested bounded window, not that
+the provider playlist has no later members. A smaller `batch_size` is the
+explicit continuation-within-that-bound case. Its checkpoint records completed
+item digests and leaves the rest pending, but no partial package is sealed.
+
+## Prepared Live Pilot (Not Executed)
+
+After deterministic producer-to-consumer integration passes and an operator
+explicitly authorizes live access, use a new disposable output directory and
+an explicit playlist locator with `max_items=3`, `batch_size=3`, bounded retry
+attempts, creator-then-automatic captions, ordered languages, base-language
+fallback disabled, and raw-caption retention disabled. Record the installed
+yt-dlp version, verify the sealed package through the public verifier, inspect
+only the bounded package for signed URLs or secrets, and hand the unchanged
+bytes to vault quarantine. Do not enumerate the full Running Remote playlist,
+auto-promote content, or treat a successful canary as conformance evidence.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+youtube = [
+  "yt-dlp>=2025.6.30,<2027",
+]
 dev = [
   "fastapi>=0.115",
   "pytest>=8.0",

--- a/src/knowledge_adapters/youtube/__init__.py
+++ b/src/knowledge_adapters/youtube/__init__.py
@@ -1,0 +1,26 @@
+"""Bounded YouTube Source Package producer."""
+
+from .client import YouTubeClient, YtDlpClient
+from .config import (
+    BaseLanguageFallback,
+    CaptionPolicy,
+    NoCaptionOutcome,
+    RetryPolicy,
+    ScopeKind,
+    YouTubeOptions,
+)
+from .producer import CollectionProgressBlocked, ProductionResult, produce_package
+
+__all__ = [
+    "BaseLanguageFallback",
+    "CaptionPolicy",
+    "CollectionProgressBlocked",
+    "NoCaptionOutcome",
+    "ProductionResult",
+    "RetryPolicy",
+    "ScopeKind",
+    "YouTubeClient",
+    "YouTubeOptions",
+    "YtDlpClient",
+    "produce_package",
+]

--- a/src/knowledge_adapters/youtube/captions.py
+++ b/src/knowledge_adapters/youtube/captions.py
@@ -1,0 +1,62 @@
+"""Deterministic caption-track selection."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .config import BaseLanguageFallback, CaptionPolicy, YouTubeOptions
+from .models import CaptionKind, CaptionTrack
+
+
+@dataclass(frozen=True)
+class CaptionSelection:
+    track: CaptionTrack
+    reason: str
+    candidates: tuple[dict[str, str], ...]
+
+
+def _language_rank(track: CaptionTrack, options: YouTubeOptions) -> int | None:
+    for index, preferred in enumerate(options.languages):
+        if track.language.lower() == preferred.lower():
+            return index * 2
+        if options.base_language_fallback is BaseLanguageFallback.ENABLED:
+            if track.language.split("-", 1)[0].lower() == preferred.split("-", 1)[0].lower():
+                return index * 2 + 1
+    return None
+
+
+def select_caption(
+    tracks: tuple[CaptionTrack, ...], options: YouTubeOptions
+) -> CaptionSelection | None:
+    eligible: list[tuple[CaptionTrack, int]] = []
+    for track in tracks:
+        rank = _language_rank(track, options)
+        if rank is not None:
+            eligible.append((track, rank))
+    if options.caption_policy is CaptionPolicy.CREATOR_ONLY:
+        eligible = [(track, rank) for track, rank in eligible if track.kind is CaptionKind.CREATOR]
+
+    def key(value: tuple[CaptionTrack, int]) -> tuple[int, int, str, str]:
+        track, rank = value
+        kind_rank = 0 if track.kind is CaptionKind.CREATOR else 1
+        if options.caption_policy is CaptionPolicy.CREATOR_THEN_AUTOMATIC:
+            return kind_rank, rank, track.language, track.name or ""
+        return rank, kind_rank, track.language, track.name or ""
+
+    candidates = tuple(
+        {
+            "language": track.language,
+            "kind": track.kind.value,
+            "format": track.format,
+            **({"name": track.name} if track.name else {}),
+        }
+        for track in sorted(
+            tracks, key=lambda item: (item.language, item.kind.value, item.name or "")
+        )
+    )
+    if not eligible:
+        return None
+    selected, rank = min(eligible, key=key)
+    match = "exact" if rank % 2 == 0 else "base-language-fallback"
+    reason = f"{options.caption_policy.value}:{match}:{selected.language}:{selected.kind.value}"
+    return CaptionSelection(selected, reason, candidates)

--- a/src/knowledge_adapters/youtube/captions.py
+++ b/src/knowledge_adapters/youtube/captions.py
@@ -36,12 +36,13 @@ def select_caption(
     if options.caption_policy is CaptionPolicy.CREATOR_ONLY:
         eligible = [(track, rank) for track, rank in eligible if track.kind is CaptionKind.CREATOR]
 
-    def key(value: tuple[CaptionTrack, int]) -> tuple[int, int, str, str]:
+    def key(value: tuple[CaptionTrack, int]) -> tuple[int, int, int, str, str]:
         track, rank = value
         kind_rank = 0 if track.kind is CaptionKind.CREATOR else 1
+        format_rank = 0 if track.format.lower() == "vtt" else 1
         if options.caption_policy is CaptionPolicy.CREATOR_THEN_AUTOMATIC:
-            return kind_rank, rank, track.language, track.name or ""
-        return rank, kind_rank, track.language, track.name or ""
+            return kind_rank, rank, format_rank, track.language, track.name or ""
+        return rank, kind_rank, format_rank, track.language, track.name or ""
 
     candidates = tuple(
         {

--- a/src/knowledge_adapters/youtube/checkpoint.py
+++ b/src/knowledge_adapters/youtube/checkpoint.py
@@ -14,7 +14,7 @@ from knowledge_adapters.source_package import canonical_json_bytes
 
 from .config import MAX_CAPTION_BYTES, MAX_COLLECTION_ITEMS, VIDEO_ID_RE
 
-CHECKPOINT_SCHEMA_VERSION = "1.1.0"
+CHECKPOINT_SCHEMA_VERSION = "1.2.0"
 MAX_CHECKPOINT_BYTES = 1024 * 1024
 MAX_CHECKPOINT_JSON_DEPTH = 8
 DIGEST_RE = re.compile(r"[0-9a-f]{64}\Z")
@@ -34,6 +34,16 @@ class CompletedCheckpointItem:
     attempts: int
     captured_path: str
     normalized_path: str
+    resolved_locator: str
+    title: str | None
+    channel: str | None
+    published_at: str | None
+    language: str
+    caption_kind: str
+    caption_format: str
+    caption_name: str | None
+    playlist_id: str | None
+    source_position: int | None
 
     def as_dict(self) -> dict[str, object]:
         return {
@@ -44,6 +54,16 @@ class CompletedCheckpointItem:
             "attempts": self.attempts,
             "captured_path": self.captured_path,
             "normalized_path": self.normalized_path,
+            "resolved_locator": self.resolved_locator,
+            "title": self.title,
+            "channel": self.channel,
+            "published_at": self.published_at,
+            "language": self.language,
+            "caption_kind": self.caption_kind,
+            "caption_format": self.caption_format,
+            "caption_name": self.caption_name,
+            "playlist_id": self.playlist_id,
+            "source_position": self.source_position,
         }
 
 
@@ -60,6 +80,10 @@ class YouTubeCheckpoint:
     pending_video_ids: tuple[str, ...]
     continuation: str | None
     last_successful_boundary: str
+    run_id: str
+    package_id: str
+    prior_run_ids: tuple[str, ...] = ()
+    prior_package_ids: tuple[str, ...] = ()
     schema_version: str = CHECKPOINT_SCHEMA_VERSION
 
     def as_dict(self) -> dict[str, object]:
@@ -76,6 +100,10 @@ class YouTubeCheckpoint:
             "pending_video_ids": list(self.pending_video_ids),
             "continuation": self.continuation,
             "last_successful_boundary": self.last_successful_boundary,
+            "run_id": self.run_id,
+            "package_id": self.package_id,
+            "prior_run_ids": list(self.prior_run_ids),
+            "prior_package_ids": list(self.prior_package_ids),
         }
 
 
@@ -191,6 +219,16 @@ def copy_completed_item(
         item.attempts,
         captured_path,
         normalized_path,
+        item.resolved_locator,
+        item.title,
+        item.channel,
+        item.published_at,
+        item.language,
+        item.caption_kind,
+        item.caption_format,
+        item.caption_name,
+        item.playlist_id,
+        item.source_position,
     )
 
 
@@ -232,6 +270,10 @@ def load_checkpoint(
             pending_video_ids=tuple(raw["pending_video_ids"]),
             continuation=raw.get("continuation"),
             last_successful_boundary=raw["last_successful_boundary"],
+            run_id=raw["run_id"],
+            package_id=raw["package_id"],
+            prior_run_ids=tuple(raw["prior_run_ids"]),
+            prior_package_ids=tuple(raw["prior_package_ids"]),
         )
     except (UnicodeDecodeError, json.JSONDecodeError, KeyError, TypeError) as exc:
         raise ValueError("corrupt checkpoint") from exc
@@ -274,7 +316,43 @@ def load_checkpoint(
             or not DIGEST_RE.fullmatch(item.captured_sha256)
             or not DIGEST_RE.fullmatch(item.normalized_sha256)
             or not VIDEO_ID_RE.fullmatch(item.video_id)
+            or not isinstance(item.resolved_locator, str)
+            or not item.resolved_locator
+            or len(item.resolved_locator) > 4096
+            or any(
+                value is not None and (not isinstance(value, str) or len(value) > 4096)
+                for value in (item.title, item.channel, item.published_at, item.caption_name)
+            )
+            or not isinstance(item.language, str)
+            or not item.language
+            or len(item.language) > 64
+            or item.caption_kind not in {"creator", "automatic"}
+            or not isinstance(item.caption_format, str)
+            or not item.caption_format
+            or len(item.caption_format) > 32
+            or (
+                item.playlist_id is not None
+                and (not isinstance(item.playlist_id, str) or len(item.playlist_id) > 200)
+            )
+            or (
+                item.source_position is not None
+                and (type(item.source_position) is not int or item.source_position <= 0)
+            )
             for item in checkpoint.completed
+        )
+        or not checkpoint.run_id
+        or not checkpoint.package_id
+        or len(checkpoint.run_id) > 200
+        or len(checkpoint.package_id) > 200
+        or len(set(checkpoint.prior_run_ids)) != len(checkpoint.prior_run_ids)
+        or len(set(checkpoint.prior_package_ids)) != len(checkpoint.prior_package_ids)
+        or any(
+            not isinstance(value, str) or not value or len(value) > 200
+            for value in checkpoint.prior_run_ids
+        )
+        or any(
+            not isinstance(value, str) or not value or len(value) > 200
+            for value in checkpoint.prior_package_ids
         )
     ):
         raise ValueError("corrupt checkpoint")

--- a/src/knowledge_adapters/youtube/checkpoint.py
+++ b/src/knowledge_adapters/youtube/checkpoint.py
@@ -1,0 +1,157 @@
+"""Bounded mutable checkpoint state outside Source Packages."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from knowledge_adapters.source_package import canonical_json_bytes
+
+CHECKPOINT_SCHEMA_VERSION = "1.0.0"
+DIGEST_RE = re.compile(r"[0-9a-f]{64}\Z")
+TERMINAL_OUTCOMES = frozenset({"completed", "unchanged", "skipped", "failed", "cancelled"})
+
+
+def request_fingerprint(value: object) -> str:
+    return hashlib.sha256(canonical_json_bytes(value)).hexdigest()
+
+
+@dataclass(frozen=True)
+class CompletedCheckpointItem:
+    video_id: str
+    captured_sha256: str
+    normalized_sha256: str
+    outcome: str
+    attempts: int
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "video_id": self.video_id,
+            "captured_sha256": self.captured_sha256,
+            "normalized_sha256": self.normalized_sha256,
+            "outcome": self.outcome,
+            "attempts": self.attempts,
+        }
+
+
+@dataclass(frozen=True)
+class YouTubeCheckpoint:
+    request_fingerprint: str
+    adapter_version: str
+    contract_version: str
+    playlist_id: str
+    observed_video_ids: tuple[str, ...]
+    completed: tuple[CompletedCheckpointItem, ...]
+    terminal_outcomes: dict[str, str]
+    attempts: dict[str, int]
+    pending_video_ids: tuple[str, ...]
+    continuation: str | None
+    last_successful_boundary: str
+    schema_version: str = CHECKPOINT_SCHEMA_VERSION
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "request_fingerprint": self.request_fingerprint,
+            "adapter_version": self.adapter_version,
+            "contract_version": self.contract_version,
+            "playlist_id": self.playlist_id,
+            "bounded_discovery": {"video_ids": list(self.observed_video_ids)},
+            "completed": [item.as_dict() for item in self.completed],
+            "terminal_outcomes": self.terminal_outcomes,
+            "attempts": self.attempts,
+            "pending_video_ids": list(self.pending_video_ids),
+            "continuation": self.continuation,
+            "last_successful_boundary": self.last_successful_boundary,
+        }
+
+
+def save_checkpoint(checkpoint: YouTubeCheckpoint, destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = destination.with_name(f".{destination.name}.tmp-{os.getpid()}")
+    temporary.write_bytes(canonical_json_bytes(checkpoint.as_dict()))
+    temporary.replace(destination)
+
+
+def load_checkpoint(
+    path: Path,
+    *,
+    expected_fingerprint: str,
+    expected_adapter_version: str | None = None,
+    expected_contract_version: str | None = None,
+) -> YouTubeCheckpoint:
+    try:
+        raw: Any = json.loads(path.read_bytes())
+        if not isinstance(raw, dict) or raw.get("schema_version") != CHECKPOINT_SCHEMA_VERSION:
+            raise ValueError("unsupported checkpoint schema")
+        if raw.get("request_fingerprint") != expected_fingerprint:
+            raise ValueError("checkpoint request fingerprint mismatch")
+        discovery = raw["bounded_discovery"]
+        completed = tuple(CompletedCheckpointItem(**item) for item in raw["completed"])
+        checkpoint = YouTubeCheckpoint(
+            request_fingerprint=raw["request_fingerprint"],
+            adapter_version=raw["adapter_version"],
+            contract_version=raw["contract_version"],
+            playlist_id=raw["playlist_id"],
+            observed_video_ids=tuple(discovery["video_ids"]),
+            completed=completed,
+            terminal_outcomes=dict(raw["terminal_outcomes"]),
+            attempts={key: int(value) for key, value in raw["attempts"].items()},
+            pending_video_ids=tuple(raw["pending_video_ids"]),
+            continuation=raw.get("continuation"),
+            last_successful_boundary=raw["last_successful_boundary"],
+        )
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, KeyError, TypeError) as exc:
+        raise ValueError("corrupt checkpoint") from exc
+    observed = set(checkpoint.observed_video_ids)
+    completed_ids = {item.video_id for item in checkpoint.completed}
+    pending = set(checkpoint.pending_video_ids)
+    if (
+        not checkpoint.playlist_id
+        or len(checkpoint.playlist_id) > 200
+        or not checkpoint.last_successful_boundary
+        or len(checkpoint.observed_video_ids) > 10_000
+        or len(observed) != len(checkpoint.observed_video_ids)
+        or len(completed_ids) != len(checkpoint.completed)
+        or pending - observed
+        or completed_ids - observed
+        or pending & completed_ids
+        or set(checkpoint.terminal_outcomes) - observed
+        or set(checkpoint.attempts) - observed
+        or any(value not in TERMINAL_OUTCOMES for value in checkpoint.terminal_outcomes.values())
+        or any(value <= 0 or value > 10 for value in checkpoint.attempts.values())
+        or any(
+            item.attempts <= 0
+            or item.attempts > 10
+            or item.outcome not in TERMINAL_OUTCOMES
+            or not DIGEST_RE.fullmatch(item.captured_sha256)
+            or not DIGEST_RE.fullmatch(item.normalized_sha256)
+            for item in checkpoint.completed
+        )
+    ):
+        raise ValueError("corrupt checkpoint")
+    if (
+        expected_adapter_version is not None
+        and checkpoint.adapter_version != expected_adapter_version
+    ):
+        raise ValueError("checkpoint adapter version mismatch")
+    if (
+        expected_contract_version is not None
+        and checkpoint.contract_version != expected_contract_version
+    ):
+        raise ValueError("checkpoint contract version mismatch")
+    return checkpoint
+
+
+def reconcile_video_ids(
+    checkpoint: YouTubeCheckpoint, rediscovered: tuple[str, ...]
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    completed = {item.video_id for item in checkpoint.completed}
+    preserved = tuple(video_id for video_id in rediscovered if video_id in completed)
+    pending = tuple(video_id for video_id in rediscovered if video_id not in completed)
+    return preserved, pending

--- a/src/knowledge_adapters/youtube/checkpoint.py
+++ b/src/knowledge_adapters/youtube/checkpoint.py
@@ -7,12 +7,16 @@ import json
 import os
 import re
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 from knowledge_adapters.source_package import canonical_json_bytes
 
-CHECKPOINT_SCHEMA_VERSION = "1.0.0"
+from .config import MAX_CAPTION_BYTES, MAX_COLLECTION_ITEMS, VIDEO_ID_RE
+
+CHECKPOINT_SCHEMA_VERSION = "1.1.0"
+MAX_CHECKPOINT_BYTES = 1024 * 1024
+MAX_CHECKPOINT_JSON_DEPTH = 8
 DIGEST_RE = re.compile(r"[0-9a-f]{64}\Z")
 TERMINAL_OUTCOMES = frozenset({"completed", "unchanged", "skipped", "failed", "cancelled"})
 
@@ -28,6 +32,8 @@ class CompletedCheckpointItem:
     normalized_sha256: str
     outcome: str
     attempts: int
+    captured_path: str
+    normalized_path: str
 
     def as_dict(self) -> dict[str, object]:
         return {
@@ -36,6 +42,8 @@ class CompletedCheckpointItem:
             "normalized_sha256": self.normalized_sha256,
             "outcome": self.outcome,
             "attempts": self.attempts,
+            "captured_path": self.captured_path,
+            "normalized_path": self.normalized_path,
         }
 
 
@@ -74,8 +82,116 @@ class YouTubeCheckpoint:
 def save_checkpoint(checkpoint: YouTubeCheckpoint, destination: Path) -> None:
     destination.parent.mkdir(parents=True, exist_ok=True)
     temporary = destination.with_name(f".{destination.name}.tmp-{os.getpid()}")
-    temporary.write_bytes(canonical_json_bytes(checkpoint.as_dict()))
+    data = canonical_json_bytes(checkpoint.as_dict())
+    if len(data) > MAX_CHECKPOINT_BYTES:
+        raise ValueError("checkpoint byte limit exceeded")
+    temporary.write_bytes(data)
     temporary.replace(destination)
+
+
+def _digest(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _json_depth(value: object, depth: int = 1) -> int:
+    if isinstance(value, dict):
+        return max((_json_depth(item, depth + 1) for item in value.values()), default=depth)
+    if isinstance(value, list):
+        return max((_json_depth(item, depth + 1) for item in value), default=depth)
+    return depth
+
+
+def _read_bounded(path: Path, limit: int) -> bytes:
+    if not path.is_file() or path.is_symlink():
+        raise ValueError("checkpoint artifact is not a regular file")
+    try:
+        if path.stat().st_size > limit:
+            raise ValueError("checkpoint byte limit exceeded")
+        with path.open("rb") as stream:
+            data = stream.read(limit + 1)
+    except OSError as exc:
+        raise ValueError("checkpoint read failure") from exc
+    if len(data) > limit:
+        raise ValueError("checkpoint byte limit exceeded")
+    return data
+
+
+def _artifact_path(checkpoint_path: Path, relative: str) -> Path:
+    pure = PurePosixPath(relative)
+    owned_root = f"{checkpoint_path.stem}.data"
+    if (
+        not relative
+        or "\\" in relative
+        or pure.is_absolute()
+        or ".." in pure.parts
+        or pure.as_posix() != relative
+        or not pure.parts
+        or pure.parts[0] != owned_root
+    ):
+        raise ValueError("unsafe checkpoint artifact path")
+    return checkpoint_path.parent.joinpath(*pure.parts)
+
+
+def save_checkpoint_artifacts(
+    checkpoint_path: Path,
+    *,
+    video_id: str,
+    captured: bytes,
+    normalized: bytes,
+) -> tuple[str, str]:
+    if not VIDEO_ID_RE.fullmatch(video_id):
+        raise ValueError("unsafe checkpoint video ID")
+    if len(captured) > MAX_CAPTION_BYTES or len(normalized) > MAX_CAPTION_BYTES:
+        raise ValueError("checkpoint artifact byte limit exceeded")
+    root_name = f"{checkpoint_path.stem}.data"
+    relative_root = PurePosixPath(root_name, f"youtube-video-{video_id}")
+    captured_relative = (relative_root / "captured.vtt").as_posix()
+    normalized_relative = (relative_root / "normalized.md").as_posix()
+    for relative, data in (
+        (captured_relative, captured),
+        (normalized_relative, normalized),
+    ):
+        destination = _artifact_path(checkpoint_path, relative)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        temporary = destination.with_name(f".{destination.name}.tmp-{os.getpid()}")
+        temporary.write_bytes(data)
+        temporary.replace(destination)
+    return captured_relative, normalized_relative
+
+
+def read_completed_artifacts(
+    checkpoint_path: Path, item: CompletedCheckpointItem
+) -> tuple[bytes, bytes]:
+    captured = _read_bounded(_artifact_path(checkpoint_path, item.captured_path), MAX_CAPTION_BYTES)
+    normalized = _read_bounded(
+        _artifact_path(checkpoint_path, item.normalized_path), MAX_CAPTION_BYTES
+    )
+    if _digest(captured) != item.captured_sha256 or _digest(normalized) != item.normalized_sha256:
+        raise ValueError("checkpoint artifact digest mismatch")
+    return captured, normalized
+
+
+def copy_completed_item(
+    source_checkpoint: Path,
+    destination_checkpoint: Path,
+    item: CompletedCheckpointItem,
+) -> CompletedCheckpointItem:
+    captured, normalized = read_completed_artifacts(source_checkpoint, item)
+    captured_path, normalized_path = save_checkpoint_artifacts(
+        destination_checkpoint,
+        video_id=item.video_id,
+        captured=captured,
+        normalized=normalized,
+    )
+    return CompletedCheckpointItem(
+        item.video_id,
+        item.captured_sha256,
+        item.normalized_sha256,
+        item.outcome,
+        item.attempts,
+        captured_path,
+        normalized_path,
+    )
 
 
 def load_checkpoint(
@@ -86,13 +202,24 @@ def load_checkpoint(
     expected_contract_version: str | None = None,
 ) -> YouTubeCheckpoint:
     try:
-        raw: Any = json.loads(path.read_bytes())
+        raw: Any = json.loads(_read_bounded(path, MAX_CHECKPOINT_BYTES))
         if not isinstance(raw, dict) or raw.get("schema_version") != CHECKPOINT_SCHEMA_VERSION:
             raise ValueError("unsupported checkpoint schema")
         if raw.get("request_fingerprint") != expected_fingerprint:
             raise ValueError("checkpoint request fingerprint mismatch")
+        if _json_depth(raw) > MAX_CHECKPOINT_JSON_DEPTH:
+            raise ValueError("checkpoint JSON depth limit exceeded")
         discovery = raw["bounded_discovery"]
+        if not isinstance(discovery, dict) or set(discovery) != {"video_ids"}:
+            raise TypeError
+        if not isinstance(raw["completed"], list):
+            raise TypeError
         completed = tuple(CompletedCheckpointItem(**item) for item in raw["completed"])
+        if not isinstance(raw["attempts"], dict) or any(
+            not isinstance(key, str) or type(value) is not int
+            for key, value in raw["attempts"].items()
+        ):
+            raise TypeError
         checkpoint = YouTubeCheckpoint(
             request_fingerprint=raw["request_fingerprint"],
             adapter_version=raw["adapter_version"],
@@ -101,13 +228,28 @@ def load_checkpoint(
             observed_video_ids=tuple(discovery["video_ids"]),
             completed=completed,
             terminal_outcomes=dict(raw["terminal_outcomes"]),
-            attempts={key: int(value) for key, value in raw["attempts"].items()},
+            attempts=dict(raw["attempts"]),
             pending_video_ids=tuple(raw["pending_video_ids"]),
             continuation=raw.get("continuation"),
             last_successful_boundary=raw["last_successful_boundary"],
         )
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError, KeyError, TypeError) as exc:
+    except (UnicodeDecodeError, json.JSONDecodeError, KeyError, TypeError) as exc:
         raise ValueError("corrupt checkpoint") from exc
+    if (
+        any(
+            not isinstance(video_id, str) or not VIDEO_ID_RE.fullmatch(video_id)
+            for video_id in checkpoint.observed_video_ids
+        )
+        or any(not isinstance(video_id, str) for video_id in checkpoint.pending_video_ids)
+        or not isinstance(checkpoint.terminal_outcomes, dict)
+        or any(
+            not isinstance(key, str) or not isinstance(value, str)
+            for key, value in checkpoint.terminal_outcomes.items()
+        )
+        or not isinstance(checkpoint.continuation, (str, type(None)))
+        or (isinstance(checkpoint.continuation, str) and len(checkpoint.continuation) > 4096)
+    ):
+        raise ValueError("corrupt checkpoint")
     observed = set(checkpoint.observed_video_ids)
     completed_ids = {item.video_id for item in checkpoint.completed}
     pending = set(checkpoint.pending_video_ids)
@@ -115,7 +257,7 @@ def load_checkpoint(
         not checkpoint.playlist_id
         or len(checkpoint.playlist_id) > 200
         or not checkpoint.last_successful_boundary
-        or len(checkpoint.observed_video_ids) > 10_000
+        or len(checkpoint.observed_video_ids) > MAX_COLLECTION_ITEMS
         or len(observed) != len(checkpoint.observed_video_ids)
         or len(completed_ids) != len(checkpoint.completed)
         or pending - observed
@@ -131,6 +273,7 @@ def load_checkpoint(
             or item.outcome not in TERMINAL_OUTCOMES
             or not DIGEST_RE.fullmatch(item.captured_sha256)
             or not DIGEST_RE.fullmatch(item.normalized_sha256)
+            or not VIDEO_ID_RE.fullmatch(item.video_id)
             for item in checkpoint.completed
         )
     ):
@@ -145,6 +288,8 @@ def load_checkpoint(
         and checkpoint.contract_version != expected_contract_version
     ):
         raise ValueError("checkpoint contract version mismatch")
+    for item in checkpoint.completed:
+        read_completed_artifacts(path, item)
     return checkpoint
 
 

--- a/src/knowledge_adapters/youtube/client.py
+++ b/src/knowledge_adapters/youtube/client.py
@@ -7,11 +7,14 @@ is requested; caption URLs are used transiently and never returned.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from importlib import import_module
-from typing import Any, Protocol, cast
+from typing import Any, BinaryIO, Protocol, cast
 
-from .config import YouTubeOptions, parse_locator
+from .captions import select_caption
+from .config import MAX_PROVIDER_TEXT_BYTES, YouTubeOptions, parse_locator
 from .models import (
+    CaptionCandidate,
     CaptionKind,
     CaptionTrack,
     Discovery,
@@ -28,7 +31,7 @@ class YouTubeClient(Protocol):
 
     def discover(self, options: YouTubeOptions) -> Discovery: ...
 
-    def enrich(self, video_id: str) -> VideoObservation: ...
+    def enrich(self, video_id: str, options: YouTubeOptions) -> VideoObservation: ...
 
 
 class YtDlpClient:
@@ -63,6 +66,8 @@ class YtDlpClient:
 
     @staticmethod
     def _translate_exception(exc: BaseException) -> ProviderFailure:
+        if isinstance(exc, ProviderFailure):
+            return exc
         current: BaseException | None = exc
         while current is not None:
             if isinstance(current, TimeoutError):
@@ -89,6 +94,45 @@ class YtDlpClient:
             retryable=False,
         )
 
+    @staticmethod
+    def _bounded_text(value: object, *, field: str, required: bool = False) -> str | None:
+        if value is None and not required:
+            return None
+        if (
+            not isinstance(value, str)
+            or not value
+            or len(value.encode("utf-8")) > MAX_PROVIDER_TEXT_BYTES
+        ):
+            raise ProviderFailure(
+                ProviderFailureCategory.UNAVAILABLE,
+                f"provider-shape:{field}",
+            )
+        return value
+
+    @staticmethod
+    def _read_bounded(response: BinaryIO, limit: int) -> bytes:
+        data = response.read(limit + 1)
+        if len(data) > limit:
+            raise ProviderFailure(
+                ProviderFailureCategory.UNAVAILABLE,
+                "caption-size-limit",
+            )
+        return data
+
+    @staticmethod
+    def _language_relevant(language: str, options: YouTubeOptions) -> bool:
+        observed = language.lower()
+        for preferred in options.languages:
+            wanted = preferred.lower()
+            if observed == wanted:
+                return True
+            if (
+                options.base_language_fallback.value == "enabled"
+                and observed.split("-", 1)[0] == wanted.split("-", 1)[0]
+            ):
+                return True
+        return False
+
     def discover(self, options: YouTubeOptions) -> Discovery:
         kind, resource_id = parse_locator(options.locator)
         if kind == "video":
@@ -104,12 +148,33 @@ class YtDlpClient:
                 info = cast(dict[str, Any], ydl.extract_info(options.locator, download=False))
         except Exception as exc:
             raise self._translate_exception(exc) from exc
+        if not isinstance(info, dict):
+            raise ProviderFailure(ProviderFailureCategory.UNAVAILABLE, "provider-shape:root")
+        raw_entries = info.get("entries") or ()
+        if (
+            not isinstance(raw_entries, Sequence)
+            or isinstance(raw_entries, (str, bytes))
+            or len(raw_entries) > options.max_items
+        ):
+            raise ProviderFailure(
+                ProviderFailureCategory.UNAVAILABLE, "provider-shape:playlist-entries"
+            )
         entries: list[PlaylistEntry] = []
-        for index, raw in enumerate(info.get("entries") or (), 1):
-            if not isinstance(raw, dict) or not isinstance(raw.get("id"), str):
-                continue
+        for index, raw in enumerate(raw_entries, 1):
+            if not isinstance(raw, dict):
+                raise ProviderFailure(
+                    ProviderFailureCategory.UNAVAILABLE, "provider-shape:playlist-entry"
+                )
+            video_id = self._bounded_text(raw.get("id"), field="video-id", required=True)
+            assert video_id is not None
             position = raw.get("playlist_index")
+            if position is not None and (not isinstance(position, int) or position <= 0):
+                position = None
             availability = raw.get("availability")
+            if availability is not None and not isinstance(availability, str):
+                raise ProviderFailure(
+                    ProviderFailureCategory.UNAVAILABLE, "provider-shape:availability"
+                )
             failure = None
             if availability == "private":
                 failure = ProviderFailureCategory.PRIVATE
@@ -117,69 +182,125 @@ class YtDlpClient:
                 failure = ProviderFailureCategory.UNAVAILABLE
             entries.append(
                 PlaylistEntry(
-                    raw["id"],
+                    video_id,
                     position if isinstance(position, int) else index,
                     failure is None,
                     failure,
                 )
             )
-        playlist_id = str(info.get("id") or resource_id)
+        playlist_id = self._bounded_text(
+            info.get("id") or resource_id, field="playlist-id", required=True
+        )
+        assert playlist_id is not None
+        resolved = self._bounded_text(info.get("webpage_url"), field="playlist-url")
         return Discovery(
             options.locator,
-            str(info.get("webpage_url") or f"https://www.youtube.com/playlist?list={playlist_id}"),
+            resolved or f"https://www.youtube.com/playlist?list={playlist_id}",
             playlist_id,
             tuple(entries[: options.max_items]),
             True,
         )
 
-    def enrich(self, video_id: str) -> VideoObservation:
+    def enrich(self, video_id: str, options: YouTubeOptions) -> VideoObservation:
         locator = f"https://www.youtube.com/watch?v={video_id}"
         try:
             with self._youtube_dl(noplaylist=True) as ydl:
                 info = cast(dict[str, Any], ydl.extract_info(locator, download=False))
-                tracks: list[CaptionTrack] = []
+                if not isinstance(info, dict):
+                    raise ProviderFailure(
+                        ProviderFailureCategory.UNAVAILABLE, "provider-shape:root"
+                    )
+                candidate_records: list[tuple[CaptionTrack, str | None]] = []
                 for field, kind in (
                     ("subtitles", CaptionKind.CREATOR),
                     ("automatic_captions", CaptionKind.AUTOMATIC),
                 ):
                     collection = info.get(field) or {}
                     if not isinstance(collection, dict):
-                        continue
-                    for language, candidates in collection.items():
-                        if not isinstance(language, str) or not isinstance(candidates, list):
-                            continue
-                        vtt = next(
-                            (
-                                item
-                                for item in candidates
-                                if isinstance(item, dict)
-                                and item.get("ext") == "vtt"
-                                and isinstance(item.get("url"), str)
-                            ),
-                            None,
+                        raise ProviderFailure(
+                            ProviderFailureCategory.UNAVAILABLE,
+                            f"provider-shape:{field}",
                         )
-                        if vtt is None:
+                    for language, candidates in collection.items():
+                        language_value = self._bounded_text(
+                            language, field="caption-language", required=True
+                        )
+                        assert language_value is not None
+                        if not self._language_relevant(language_value, options):
                             continue
-                        # The signed URL is consumed inside the boundary and discarded.
-                        with ydl.urlopen(vtt["url"]) as response:
-                            data = response.read()
-                        name = vtt.get("name")
-                        tracks.append(
-                            CaptionTrack(
-                                language,
-                                kind,
-                                "vtt",
-                                data,
-                                name if isinstance(name, str) else None,
+                        if not isinstance(candidates, list):
+                            raise ProviderFailure(
+                                ProviderFailureCategory.UNAVAILABLE,
+                                "provider-shape:caption-candidates",
                             )
+                        for candidate in candidates:
+                            if len(candidate_records) >= options.max_caption_candidates:
+                                raise ProviderFailure(
+                                    ProviderFailureCategory.UNAVAILABLE,
+                                    "caption-candidate-limit",
+                                )
+                            if not isinstance(candidate, dict):
+                                raise ProviderFailure(
+                                    ProviderFailureCategory.UNAVAILABLE,
+                                    "provider-shape:caption-candidate",
+                                )
+                            caption_format = self._bounded_text(
+                                candidate.get("ext") or "unknown",
+                                field="caption-format",
+                                required=True,
+                            )
+                            assert caption_format is not None
+                            name = self._bounded_text(candidate.get("name"), field="caption-name")
+                            url = self._bounded_text(candidate.get("url"), field="caption-url")
+                            candidate_records.append(
+                                (
+                                    CaptionTrack(
+                                        language_value, kind, caption_format, b"", name
+                                    ),
+                                    url,
+                                )
+                            )
+                metadata_tracks = tuple(record[0] for record in candidate_records)
+                selected = select_caption(metadata_tracks, options)
+                tracks: tuple[CaptionTrack, ...] = ()
+                if selected is not None:
+                    selected_url = next(
+                        url for track, url in candidate_records if track is selected.track
+                    )
+                    if selected.track.format.lower() != "vtt":
+                        tracks = (selected.track,)
+                    elif selected_url is None:
+                        raise ProviderFailure(
+                            ProviderFailureCategory.UNAVAILABLE, "caption-url-missing"
+                        )
+                    else:
+                        # The signed URL is consumed inside the boundary and discarded.
+                        with ydl.urlopen(selected_url) as response:
+                            data = self._read_bounded(response, options.max_caption_bytes)
+                        tracks = (
+                            CaptionTrack(
+                                selected.track.language,
+                                selected.track.kind,
+                                selected.track.format,
+                                data,
+                                selected.track.name,
+                            ),
                         )
         except Exception as exc:
             raise self._translate_exception(exc) from exc
+        resolved = self._bounded_text(info.get("webpage_url"), field="video-url")
+        title = self._bounded_text(info.get("title"), field="title")
+        channel = self._bounded_text(info.get("channel"), field="channel")
+        published_at = self._bounded_text(info.get("upload_date"), field="upload-date")
         return VideoObservation(
             video_id,
-            str(info.get("webpage_url") or locator),
-            info.get("title") if isinstance(info.get("title"), str) else None,
-            info.get("channel") if isinstance(info.get("channel"), str) else None,
-            info.get("upload_date") if isinstance(info.get("upload_date"), str) else None,
-            tuple(tracks),
+            resolved or locator,
+            title,
+            channel,
+            published_at,
+            tracks,
+            tuple(
+                CaptionCandidate(track.language, track.kind, track.format, track.name)
+                for track in metadata_tracks
+            ),
         )

--- a/src/knowledge_adapters/youtube/client.py
+++ b/src/knowledge_adapters/youtube/client.py
@@ -1,0 +1,185 @@
+"""Narrow optional yt-dlp boundary.
+
+The Python API receives explicit options and does not invoke yt-dlp's CLI config
+loader. ``ignoreconfig`` is also set defensively. No media or ffmpeg operation
+is requested; caption URLs are used transiently and never returned.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any, Protocol, cast
+
+from .config import YouTubeOptions, parse_locator
+from .models import (
+    CaptionKind,
+    CaptionTrack,
+    Discovery,
+    PlaylistEntry,
+    ProviderFailure,
+    ProviderFailureCategory,
+    VideoObservation,
+)
+
+
+class YouTubeClient(Protocol):
+    @property
+    def version(self) -> str: ...
+
+    def discover(self, options: YouTubeOptions) -> Discovery: ...
+
+    def enrich(self, video_id: str) -> VideoObservation: ...
+
+
+class YtDlpClient:
+    """Caption-only yt-dlp client; import succeeds only with the youtube extra."""
+
+    def __init__(self) -> None:
+        try:
+            self._module = import_module("yt_dlp")
+            version_module = import_module("yt_dlp.version")
+        except ModuleNotFoundError as exc:
+            raise RuntimeError("install knowledge-adapters[youtube] to use yt-dlp") from exc
+        self._version = str(getattr(version_module, "__version__", "unknown"))
+
+    @property
+    def version(self) -> str:
+        return self._version
+
+    def _youtube_dl(self, **overrides: object) -> Any:
+        params: dict[str, object] = {
+            "ignoreconfig": True,
+            "remote_components": set(),
+            "quiet": True,
+            "no_warnings": True,
+            "skip_download": True,
+            "noprogress": True,
+            "cachedir": False,
+            "writesubtitles": False,
+            "writeautomaticsub": False,
+        }
+        params.update(overrides)
+        return self._module.YoutubeDL(params)
+
+    @staticmethod
+    def _translate_exception(exc: BaseException) -> ProviderFailure:
+        current: BaseException | None = exc
+        while current is not None:
+            if isinstance(current, TimeoutError):
+                return ProviderFailure(
+                    ProviderFailureCategory.TIMEOUT, "yt-dlp:timeout", retryable=True
+                )
+            status = getattr(current, "status", None)
+            if status == 429:
+                return ProviderFailure(
+                    ProviderFailureCategory.THROTTLED,
+                    "yt-dlp:http-429",
+                    retryable=True,
+                )
+            if isinstance(status, int) and 500 <= status < 600:
+                return ProviderFailure(
+                    ProviderFailureCategory.TRANSIENT,
+                    f"yt-dlp:http-{status}",
+                    retryable=True,
+                )
+            current = current.__cause__
+        return ProviderFailure(
+            ProviderFailureCategory.UNAVAILABLE,
+            f"yt-dlp:{type(exc).__name__}",
+            retryable=False,
+        )
+
+    def discover(self, options: YouTubeOptions) -> Discovery:
+        kind, resource_id = parse_locator(options.locator)
+        if kind == "video":
+            return Discovery(
+                options.locator,
+                f"https://www.youtube.com/watch?v={resource_id}",
+                None,
+                (PlaylistEntry(resource_id, 1),),
+                True,
+            )
+        try:
+            with self._youtube_dl(extract_flat=True, playlistend=options.max_items) as ydl:
+                info = cast(dict[str, Any], ydl.extract_info(options.locator, download=False))
+        except Exception as exc:
+            raise self._translate_exception(exc) from exc
+        entries: list[PlaylistEntry] = []
+        for index, raw in enumerate(info.get("entries") or (), 1):
+            if not isinstance(raw, dict) or not isinstance(raw.get("id"), str):
+                continue
+            position = raw.get("playlist_index")
+            availability = raw.get("availability")
+            failure = None
+            if availability == "private":
+                failure = ProviderFailureCategory.PRIVATE
+            elif availability in {"needs_auth", "premium", "subscriber_only"}:
+                failure = ProviderFailureCategory.UNAVAILABLE
+            entries.append(
+                PlaylistEntry(
+                    raw["id"],
+                    position if isinstance(position, int) else index,
+                    failure is None,
+                    failure,
+                )
+            )
+        playlist_id = str(info.get("id") or resource_id)
+        return Discovery(
+            options.locator,
+            str(info.get("webpage_url") or f"https://www.youtube.com/playlist?list={playlist_id}"),
+            playlist_id,
+            tuple(entries[: options.max_items]),
+            True,
+        )
+
+    def enrich(self, video_id: str) -> VideoObservation:
+        locator = f"https://www.youtube.com/watch?v={video_id}"
+        try:
+            with self._youtube_dl(noplaylist=True) as ydl:
+                info = cast(dict[str, Any], ydl.extract_info(locator, download=False))
+                tracks: list[CaptionTrack] = []
+                for field, kind in (
+                    ("subtitles", CaptionKind.CREATOR),
+                    ("automatic_captions", CaptionKind.AUTOMATIC),
+                ):
+                    collection = info.get(field) or {}
+                    if not isinstance(collection, dict):
+                        continue
+                    for language, candidates in collection.items():
+                        if not isinstance(language, str) or not isinstance(candidates, list):
+                            continue
+                        vtt = next(
+                            (
+                                item
+                                for item in candidates
+                                if isinstance(item, dict)
+                                and item.get("ext") == "vtt"
+                                and isinstance(item.get("url"), str)
+                            ),
+                            None,
+                        )
+                        if vtt is None:
+                            continue
+                        # The signed URL is consumed inside the boundary and discarded.
+                        with ydl.urlopen(vtt["url"]) as response:
+                            data = response.read()
+                        name = vtt.get("name")
+                        tracks.append(
+                            CaptionTrack(
+                                language,
+                                kind,
+                                "vtt",
+                                data,
+                                name if isinstance(name, str) else None,
+                            )
+                        )
+        except Exception as exc:
+            raise self._translate_exception(exc) from exc
+        return VideoObservation(
+            video_id,
+            str(info.get("webpage_url") or locator),
+            info.get("title") if isinstance(info.get("title"), str) else None,
+            info.get("channel") if isinstance(info.get("channel"), str) else None,
+            info.get("upload_date") if isinstance(info.get("upload_date"), str) else None,
+            tuple(tracks),
+        )

--- a/src/knowledge_adapters/youtube/config.py
+++ b/src/knowledge_adapters/youtube/config.py
@@ -11,6 +11,11 @@ from urllib.parse import parse_qs, urlparse
 from knowledge_adapters.source_package import AcquisitionRequest
 
 YOUTUBE_EXTENSION = "org.ctrl-alt-keith.youtube"
+MAX_COLLECTION_ITEMS = 500
+MAX_LANGUAGE_PREFERENCES = 16
+MAX_CAPTION_CANDIDATES = 64
+MAX_CAPTION_BYTES = 8 * 1024 * 1024
+MAX_PROVIDER_TEXT_BYTES = 4096
 VIDEO_ID_RE = re.compile(r"[A-Za-z0-9_-]{6,64}\Z")
 PLAYLIST_ID_RE = re.compile(r"[A-Za-z0-9_-]{6,128}\Z")
 SECRET_QUERY_KEYS = frozenset({"cookie", "cookies", "token", "key", "password", "auth"})
@@ -60,14 +65,16 @@ class YouTubeOptions:
     checkpoint_input: Path | None = None
     checkpoint_output: Path | None = None
     retry: RetryPolicy = RetryPolicy()
+    max_caption_candidates: int = MAX_CAPTION_CANDIDATES
+    max_caption_bytes: int = MAX_CAPTION_BYTES
 
     def __post_init__(self) -> None:
         kind, _ = parse_locator(self.locator)
         expected = "video" if self.scope is ScopeKind.RESOURCE else "playlist"
         if kind != expected:
             raise ValueError(f"{self.scope.value} scope requires a {expected} locator")
-        if self.max_items <= 0:
-            raise ValueError("max_items must be positive")
+        if not 1 <= self.max_items <= MAX_COLLECTION_ITEMS:
+            raise ValueError(f"max_items must be between 1 and {MAX_COLLECTION_ITEMS}")
         if self.scope is ScopeKind.RESOURCE and self.max_items != 1:
             raise ValueError("resource scope requires max_items=1")
         if self.batch_size is not None and not 1 <= self.batch_size <= self.max_items:
@@ -76,6 +83,8 @@ class YouTubeOptions:
             not language or len(language) > 64 for language in self.languages
         ):
             raise ValueError("at least one bounded language preference is required")
+        if len(self.languages) > MAX_LANGUAGE_PREFERENCES:
+            raise ValueError("too many language preferences")
         if len(set(self.languages)) != len(self.languages):
             raise ValueError("language preferences must be unique")
         if self.checkpoint_input is not None and self.scope is ScopeKind.RESOURCE:
@@ -84,6 +93,10 @@ class YouTubeOptions:
             raise ValueError("checkpoint resume requires an output checkpoint path")
         if self.checkpoint_input is not None and self.checkpoint_input == self.checkpoint_output:
             raise ValueError("checkpoint input and output paths must differ")
+        if not 1 <= self.max_caption_candidates <= MAX_CAPTION_CANDIDATES:
+            raise ValueError("max_caption_candidates exceeds the supported bound")
+        if not 1 <= self.max_caption_bytes <= MAX_CAPTION_BYTES:
+            raise ValueError("max_caption_bytes exceeds the supported bound")
 
     def acquisition_request(self, request_id: str, output: Path) -> AcquisitionRequest:
         kind, resource_id = parse_locator(self.locator)
@@ -93,6 +106,8 @@ class YouTubeOptions:
             "caption_policy": self.caption_policy.value,
             "no_caption_outcome": self.no_caption_outcome.value,
             "retain_raw_captions": self.retain_raw_captions,
+            "max_caption_candidates": self.max_caption_candidates,
+            "max_caption_bytes": self.max_caption_bytes,
         }
         if self.batch_size is not None:
             selection["batch_size"] = self.batch_size

--- a/src/knowledge_adapters/youtube/config.py
+++ b/src/knowledge_adapters/youtube/config.py
@@ -1,0 +1,140 @@
+"""Typed, bounded YouTube acquisition configuration."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+from knowledge_adapters.source_package import AcquisitionRequest
+
+YOUTUBE_EXTENSION = "org.ctrl-alt-keith.youtube"
+VIDEO_ID_RE = re.compile(r"[A-Za-z0-9_-]{6,64}\Z")
+PLAYLIST_ID_RE = re.compile(r"[A-Za-z0-9_-]{6,128}\Z")
+SECRET_QUERY_KEYS = frozenset({"cookie", "cookies", "token", "key", "password", "auth"})
+
+
+class ScopeKind(StrEnum):
+    RESOURCE = "resource"
+    COLLECTION = "collection"
+
+
+class CaptionPolicy(StrEnum):
+    CREATOR_ONLY = "creator-only"
+    CREATOR_THEN_AUTOMATIC = "creator-then-automatic"
+    AUTOMATIC_ALLOWED = "automatic-allowed"
+
+
+class NoCaptionOutcome(StrEnum):
+    SKIP = "skip"
+    FAIL = "fail"
+
+
+class BaseLanguageFallback(StrEnum):
+    DISABLED = "disabled"
+    ENABLED = "enabled"
+
+
+@dataclass(frozen=True)
+class RetryPolicy:
+    max_attempts: int = 2
+
+    def __post_init__(self) -> None:
+        if not 1 <= self.max_attempts <= 10:
+            raise ValueError("max_attempts must be between 1 and 10")
+
+
+@dataclass(frozen=True)
+class YouTubeOptions:
+    locator: str
+    scope: ScopeKind
+    max_items: int
+    languages: tuple[str, ...] = ("en",)
+    base_language_fallback: BaseLanguageFallback = BaseLanguageFallback.DISABLED
+    caption_policy: CaptionPolicy = CaptionPolicy.CREATOR_THEN_AUTOMATIC
+    no_caption_outcome: NoCaptionOutcome = NoCaptionOutcome.SKIP
+    retain_raw_captions: bool = False
+    batch_size: int | None = None
+    checkpoint_input: Path | None = None
+    checkpoint_output: Path | None = None
+    retry: RetryPolicy = RetryPolicy()
+
+    def __post_init__(self) -> None:
+        kind, _ = parse_locator(self.locator)
+        expected = "video" if self.scope is ScopeKind.RESOURCE else "playlist"
+        if kind != expected:
+            raise ValueError(f"{self.scope.value} scope requires a {expected} locator")
+        if self.max_items <= 0:
+            raise ValueError("max_items must be positive")
+        if self.scope is ScopeKind.RESOURCE and self.max_items != 1:
+            raise ValueError("resource scope requires max_items=1")
+        if self.batch_size is not None and not 1 <= self.batch_size <= self.max_items:
+            raise ValueError("batch_size must be positive and no greater than max_items")
+        if not self.languages or any(
+            not language or len(language) > 64 for language in self.languages
+        ):
+            raise ValueError("at least one bounded language preference is required")
+        if len(set(self.languages)) != len(self.languages):
+            raise ValueError("language preferences must be unique")
+        if self.checkpoint_input is not None and self.scope is ScopeKind.RESOURCE:
+            raise ValueError("checkpoint input is supported only for collection scope")
+        if self.checkpoint_input is not None and self.checkpoint_output is None:
+            raise ValueError("checkpoint resume requires an output checkpoint path")
+        if self.checkpoint_input is not None and self.checkpoint_input == self.checkpoint_output:
+            raise ValueError("checkpoint input and output paths must differ")
+
+    def acquisition_request(self, request_id: str, output: Path) -> AcquisitionRequest:
+        kind, resource_id = parse_locator(self.locator)
+        selection: dict[str, object] = {
+            "languages": list(self.languages),
+            "base_language_fallback": self.base_language_fallback.value,
+            "caption_policy": self.caption_policy.value,
+            "no_caption_outcome": self.no_caption_outcome.value,
+            "retain_raw_captions": self.retain_raw_captions,
+        }
+        if self.batch_size is not None:
+            selection["batch_size"] = self.batch_size
+        return AcquisitionRequest(
+            request_id=request_id,
+            adapter_type="video-host",
+            targets=(self.locator,),
+            scope={"kind": self.scope.value, "max_items": self.max_items},
+            output_location=str(output),
+            checkpoint_reference=(
+                str(self.checkpoint_input) if self.checkpoint_input is not None else None
+            ),
+            selection=selection,
+            retry_policy={"max_attempts": self.retry.max_attempts},
+            expected_contract="1.x",
+            extensions={YOUTUBE_EXTENSION: {"locator_kind": kind, "resource_id": resource_id}},
+        )
+
+
+def parse_locator(locator: str) -> tuple[str, str]:
+    if len(locator) > 2048 or any(char.isspace() for char in locator):
+        raise ValueError("unsupported YouTube locator")
+    parsed = urlparse(locator)
+    if parsed.scheme != "https" or parsed.username or parsed.password or parsed.fragment:
+        raise ValueError("YouTube locators must be non-secret HTTPS URLs")
+    host = (parsed.hostname or "").lower()
+    if host not in {"youtube.com", "www.youtube.com", "m.youtube.com", "youtu.be"}:
+        raise ValueError("unsupported YouTube host")
+    query = parse_qs(parsed.query, keep_blank_values=True)
+    if SECRET_QUERY_KEYS & {key.lower() for key in query}:
+        raise ValueError("secrets must not be embedded in locators")
+    if host == "youtu.be":
+        value = parsed.path.strip("/")
+        if parsed.query or not VIDEO_ID_RE.fullmatch(value):
+            raise ValueError("unsupported short YouTube locator")
+        return "video", value
+    if parsed.path == "/watch" and set(query) == {"v"} and len(query["v"]) == 1:
+        value = query["v"][0]
+        if VIDEO_ID_RE.fullmatch(value):
+            return "video", value
+    if parsed.path == "/playlist" and set(query) == {"list"} and len(query["list"]) == 1:
+        value = query["list"][0]
+        if PLAYLIST_ID_RE.fullmatch(value):
+            return "playlist", value
+    raise ValueError("unsupported or ambiguous YouTube locator")

--- a/src/knowledge_adapters/youtube/models.py
+++ b/src/knowledge_adapters/youtube/models.py
@@ -1,0 +1,76 @@
+"""Adapter-local YouTube observations and failures."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class CaptionKind(StrEnum):
+    CREATOR = "creator"
+    AUTOMATIC = "automatic"
+
+
+class ProviderFailureCategory(StrEnum):
+    PRIVATE = "private"
+    REMOVED = "removed"
+    AGE_RESTRICTED = "age-restricted"
+    GEO_RESTRICTED = "geo-restricted"
+    UNAVAILABLE = "unavailable"
+    TIMEOUT = "timeout"
+    THROTTLED = "throttled"
+    TRANSIENT = "transient"
+    CANCELLED = "cancelled"
+
+
+@dataclass(frozen=True)
+class CaptionTrack:
+    language: str
+    kind: CaptionKind
+    format: str
+    data: bytes
+    name: str | None = None
+
+
+@dataclass(frozen=True)
+class PlaylistEntry:
+    video_id: str
+    position: int | None
+    available: bool = True
+    failure: ProviderFailureCategory | None = None
+
+
+@dataclass(frozen=True)
+class Discovery:
+    requested_locator: str
+    resolved_locator: str
+    playlist_id: str | None
+    entries: tuple[PlaylistEntry, ...]
+    exhausted: bool
+    continuation: str | None = None
+
+
+@dataclass(frozen=True)
+class VideoObservation:
+    video_id: str
+    resolved_locator: str
+    title: str | None
+    channel: str | None
+    published_at: str | None
+    captions: tuple[CaptionTrack, ...]
+
+
+class ProviderFailure(RuntimeError):
+    """Structured provider failure; message text never determines category."""
+
+    def __init__(
+        self,
+        category: ProviderFailureCategory,
+        code: str,
+        *,
+        retryable: bool = False,
+    ) -> None:
+        super().__init__(code)
+        self.category = category
+        self.code = code
+        self.retryable = retryable

--- a/src/knowledge_adapters/youtube/models.py
+++ b/src/knowledge_adapters/youtube/models.py
@@ -33,6 +33,14 @@ class CaptionTrack:
 
 
 @dataclass(frozen=True)
+class CaptionCandidate:
+    language: str
+    kind: CaptionKind
+    format: str
+    name: str | None = None
+
+
+@dataclass(frozen=True)
 class PlaylistEntry:
     video_id: str
     position: int | None
@@ -58,6 +66,7 @@ class VideoObservation:
     channel: str | None
     published_at: str | None
     captions: tuple[CaptionTrack, ...]
+    caption_candidates: tuple[CaptionCandidate, ...] = ()
 
 
 class ProviderFailure(RuntimeError):

--- a/src/knowledge_adapters/youtube/normalize.py
+++ b/src/knowledge_adapters/youtube/normalize.py
@@ -1,0 +1,87 @@
+"""Deterministic WebVTT-to-Markdown normalization."""
+
+from __future__ import annotations
+
+import html
+import re
+import unicodedata
+from dataclasses import dataclass
+
+NORMALIZER_NAME = "youtube-webvtt-to-markdown"
+NORMALIZER_VERSION = "1.0.0"
+TRANSFORMS = (
+    "utf8-strict",
+    "line-endings-lf",
+    "unicode-nfc",
+    "webvtt-transport-headers-removed",
+    "timestamps-omitted",
+    "speaker-labels-markdown-bold",
+    "rolling-cues-collapsed",
+    "one-trailing-newline",
+)
+TIMING_RE = re.compile(
+    r"^(?:\d{2}:)?\d{2}:\d{2}\.\d{3}\s+-->\s+(?:\d{2}:)?\d{2}:\d{2}\.\d{3}(?:\s+.*)?$"
+)
+VOICE_RE = re.compile(r"<v(?:\.[^ >]+)*\s+([^>]+)>(.*?)</v>", re.DOTALL | re.IGNORECASE)
+TAG_RE = re.compile(r"<[^>]+>")
+
+
+class CaptionNormalizationError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class NormalizedCaption:
+    data: bytes
+    transforms: tuple[str, ...] = TRANSFORMS
+
+
+def _clean_text(lines: list[str]) -> str:
+    value = " ".join(line.strip() for line in lines if line.strip())
+    value = VOICE_RE.sub(lambda match: f"**{match.group(1).strip()}:** {match.group(2)}", value)
+    value = TAG_RE.sub("", value)
+    return " ".join(html.unescape(value).split())
+
+
+def normalize_webvtt(data: bytes, *, automatic: bool) -> NormalizedCaption:
+    try:
+        text = data.decode("utf-8-sig")
+    except UnicodeDecodeError as exc:
+        raise CaptionNormalizationError("captions are not valid UTF-8") from exc
+    text = unicodedata.normalize("NFC", text.replace("\r\n", "\n").replace("\r", "\n"))
+    lines = text.split("\n")
+    if not lines or lines[0].strip() != "WEBVTT":
+        raise CaptionNormalizationError("missing WEBVTT header")
+    cues: list[str] = []
+    index = 1
+    # WebVTT permits transport metadata between the header and first blank line.
+    while index < len(lines) and lines[index].strip():
+        index += 1
+    while index < len(lines):
+        while index < len(lines) and not lines[index].strip():
+            index += 1
+        if index >= len(lines):
+            break
+        if lines[index].startswith(("NOTE", "STYLE", "REGION")):
+            while index < len(lines) and lines[index].strip():
+                index += 1
+            continue
+        if not TIMING_RE.fullmatch(lines[index].strip()):
+            index += 1
+            if index >= len(lines) or not TIMING_RE.fullmatch(lines[index].strip()):
+                raise CaptionNormalizationError("malformed WebVTT cue")
+        index += 1
+        body: list[str] = []
+        while index < len(lines) and lines[index].strip():
+            body.append(lines[index])
+            index += 1
+        cleaned = _clean_text(body)
+        if not cleaned:
+            continue
+        if automatic and cues and cleaned.startswith(cues[-1]):
+            cues[-1] = cleaned
+        elif not cues or cleaned != cues[-1]:
+            cues.append(cleaned)
+    if not cues:
+        raise CaptionNormalizationError("WebVTT contains no spoken cues")
+    return NormalizedCaption(("\n\n".join(cues) + "\n").encode())

--- a/src/knowledge_adapters/youtube/producer.py
+++ b/src/knowledge_adapters/youtube/producer.py
@@ -21,9 +21,12 @@ from .captions import select_caption
 from .checkpoint import (
     CompletedCheckpointItem,
     YouTubeCheckpoint,
+    copy_completed_item,
     load_checkpoint,
+    reconcile_video_ids,
     request_fingerprint,
     save_checkpoint,
+    save_checkpoint_artifacts,
 )
 from .client import YouTubeClient
 from .config import YOUTUBE_EXTENSION, NoCaptionOutcome, ScopeKind, YouTubeOptions
@@ -183,6 +186,15 @@ def _completed_item(
         **({"playlist_id": playlist_id} if playlist_id else {}),
         **({"source_position": entry.position} if entry.position is not None else {}),
     }
+    candidate_summary = [
+        {
+            "language": candidate.language,
+            "kind": candidate.kind.value,
+            "format": candidate.format,
+            **({"name": candidate.name} if candidate.name else {}),
+        }
+        for candidate in observation.caption_candidates
+    ]
     if playlist_id:
         common["parents"] = [
             {
@@ -196,7 +208,9 @@ def _completed_item(
                 "category": "captions-unavailable",
                 "policy": options.caption_policy.value,
             }
-            common["extensions"] = {YOUTUBE_EXTENSION: {**relation, "candidates": []}}
+            common["extensions"] = {
+                YOUTUBE_EXTENSION: {**relation, "available_candidates": candidate_summary}
+            }
             return PackageItem(item_id, "video", ItemOutcome.SKIPPED, common), ()
         failure = ProviderFailure(ProviderFailureCategory.UNAVAILABLE, "captions-unavailable")
         item, diagnostic = _failure_item(
@@ -223,6 +237,24 @@ def _completed_item(
             "attempts": 1,
             "retryable": False,
         }
+        youtube_evidence: dict[str, object] = {}
+        extensions_value = fields.get("extensions")
+        if isinstance(extensions_value, dict):
+            youtube_value = extensions_value.get(YOUTUBE_EXTENSION)
+            if isinstance(youtube_value, dict):
+                youtube_evidence.update(youtube_value)
+        youtube_evidence.update(
+            {
+                "available_candidates": candidate_summary,
+                "selected_track": {
+                    "language": track.language,
+                    "kind": track.kind.value,
+                    "format": track.format,
+                    **({"name": track.name} if track.name else {}),
+                },
+            }
+        )
+        fields["extensions"] = {YOUTUBE_EXTENSION: youtube_evidence}
         diagnostic = _diagnostic(
             item.item_id, "normalization-unsupported", "unsupported-caption-format", 1, False
         )
@@ -277,7 +309,7 @@ def _completed_item(
                         **({"name": track.name} if track.name else {}),
                     },
                     "selection_reason": selection.reason,
-                    "available_candidates": list(selection.candidates),
+                    "available_candidates": candidate_summary or list(selection.candidates),
                     **({"raw_caption_path": raw_path} if raw_path else {}),
                 }
             },
@@ -295,17 +327,50 @@ def produce_package(
     package_id: str,
     created_at: str,
     destination: Path,
+    adapter_revision: str | None = None,
 ) -> ProductionResult:
     request = options.acquisition_request(request_id, destination)
     fingerprint = _request_fingerprint(request.as_dict())
     discovery = client.discover(options)
     entries = _ordered_entries(discovery.entries[: options.max_items])
     if options.checkpoint_input is not None:
-        load_checkpoint(
+        checkpoint = load_checkpoint(
             options.checkpoint_input,
             expected_fingerprint=fingerprint,
             expected_adapter_version=ADAPTER_VERSION,
             expected_contract_version=CONTRACT_VERSION,
+        )
+        rediscovered = tuple(entry.video_id for entry in entries)
+        preserved_ids, pending_ids = reconcile_video_ids(checkpoint, rediscovered)
+        completed_by_id = {item.video_id: item for item in checkpoint.completed}
+        assert options.checkpoint_output is not None
+        preserved = tuple(
+            copy_completed_item(
+                options.checkpoint_input,
+                options.checkpoint_output,
+                completed_by_id[video_id],
+            )
+            for video_id in preserved_ids
+        )
+        save_checkpoint(
+            YouTubeCheckpoint(
+                fingerprint,
+                ADAPTER_VERSION,
+                CONTRACT_VERSION,
+                discovery.playlist_id or checkpoint.playlist_id,
+                rediscovered,
+                preserved,
+                {item.video_id: item.outcome for item in preserved},
+                {
+                    video_id: checkpoint.attempts.get(video_id, 1)
+                    for video_id in rediscovered
+                    if video_id in checkpoint.attempts
+                },
+                pending_ids,
+                discovery.continuation or checkpoint.continuation,
+                "resume-reconciled",
+            ),
+            options.checkpoint_output,
         )
         raise CollectionProgressBlocked(
             "resumed sealing requires canonical builder-supported resume lineage"
@@ -322,8 +387,10 @@ def produce_package(
             for entry in entries[:batch_size]:
                 checkpoint_attempts[entry.video_id] = 1
                 try:
-                    observation = client.enrich(entry.video_id)
-                    item, _ = _completed_item(entry, observation, options, discovery.playlist_id)
+                    observation = client.enrich(entry.video_id, options)
+                    item, artifacts = _completed_item(
+                        entry, observation, options, discovery.playlist_id
+                    )
                     outcomes[entry.video_id] = item.outcome.value
                     captured = item.fields.get("captured_sha256")
                     normalized = item.fields.get("normalized_sha256")
@@ -332,9 +399,28 @@ def produce_package(
                         and isinstance(captured, str)
                         and isinstance(normalized, str)
                     ):
+                        selection = select_caption(observation.captions, options)
+                        normalized_artifact = next(
+                            artifact
+                            for artifact in artifacts
+                            if artifact.role == "normalized-content"
+                        )
+                        assert selection is not None
+                        captured_path, normalized_path = save_checkpoint_artifacts(
+                            options.checkpoint_output,
+                            video_id=entry.video_id,
+                            captured=selection.track.data,
+                            normalized=normalized_artifact.data,
+                        )
                         completed.append(
                             CompletedCheckpointItem(
-                                entry.video_id, captured, normalized, item.outcome.value, 1
+                                entry.video_id,
+                                captured,
+                                normalized,
+                                item.outcome.value,
+                                1,
+                                captured_path,
+                                normalized_path,
                             )
                         )
                 except ProviderFailure as checkpoint_failure:
@@ -364,9 +450,7 @@ def produce_package(
         request=request,
         run_id=run_id,
         created_at=created_at,
-        adapter=AdapterIdentity(
-            "youtube-source-package", ADAPTER_VERSION, f"yt-dlp/{client.version}"
-        ),
+        adapter=AdapterIdentity("youtube-source-package", ADAPTER_VERSION, adapter_revision),
         contract_version=CONTRACT_VERSION,
         boundary={
             "deterministic": (
@@ -396,7 +480,7 @@ def produce_package(
         while True:
             attempts += 1
             try:
-                observation = client.enrich(entry.video_id)
+                observation = client.enrich(entry.video_id, options)
                 item, artifacts = _completed_item(
                     entry, observation, options, discovery.playlist_id
                 )

--- a/src/knowledge_adapters/youtube/producer.py
+++ b/src/knowledge_adapters/youtube/producer.py
@@ -1,0 +1,427 @@
+"""Bounded YouTube production through the canonical Source Package core."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+
+from knowledge_adapters.source_package import (
+    AdapterIdentity,
+    Artifact,
+    ItemOutcome,
+    PackageBuilder,
+    PackageItem,
+    VerificationResult,
+    canonical_json_bytes,
+    verify_package,
+)
+
+from .captions import select_caption
+from .checkpoint import (
+    CompletedCheckpointItem,
+    YouTubeCheckpoint,
+    load_checkpoint,
+    request_fingerprint,
+    save_checkpoint,
+)
+from .client import YouTubeClient
+from .config import YOUTUBE_EXTENSION, NoCaptionOutcome, ScopeKind, YouTubeOptions
+from .models import (
+    CaptionKind,
+    PlaylistEntry,
+    ProviderFailure,
+    ProviderFailureCategory,
+    VideoObservation,
+)
+from .normalize import (
+    NORMALIZER_NAME,
+    NORMALIZER_VERSION,
+    CaptionNormalizationError,
+    normalize_webvtt,
+)
+
+ADAPTER_VERSION = "0.1.0"
+CONTRACT_VERSION = "1.0.0"
+
+
+class CollectionProgressBlocked(RuntimeError):
+    """Partial/resumed sealing awaits a canonical collection-progress invariant."""
+
+
+@dataclass(frozen=True)
+class ProductionResult:
+    package_path: Path
+    content_address: str
+    verification: VerificationResult
+
+
+def _digest(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _request_fingerprint(request: dict[str, object]) -> str:
+    stable = dict(request)
+    for runtime_key in ("request_id", "output_location", "checkpoint_reference"):
+        stable.pop(runtime_key, None)
+    return request_fingerprint(stable)
+
+
+def _ordered_entries(entries: tuple[PlaylistEntry, ...]) -> tuple[PlaylistEntry, ...]:
+    return tuple(
+        sorted(
+            entries,
+            key=lambda item: (
+                item.position is None,
+                item.position if item.position is not None else 2**63,
+                item.video_id,
+            ),
+        )
+    )
+
+
+def _failure_mapping(category: ProviderFailureCategory) -> tuple[ItemOutcome, str, bool]:
+    values = {
+        ProviderFailureCategory.PRIVATE: (ItemOutcome.FAILED, "access-denied", False),
+        ProviderFailureCategory.REMOVED: (ItemOutcome.FAILED, "provider-removed", False),
+        ProviderFailureCategory.AGE_RESTRICTED: (
+            ItemOutcome.FAILED,
+            "access-restricted",
+            False,
+        ),
+        ProviderFailureCategory.GEO_RESTRICTED: (
+            ItemOutcome.FAILED,
+            "geo-restricted",
+            False,
+        ),
+        ProviderFailureCategory.UNAVAILABLE: (
+            ItemOutcome.FAILED,
+            "provider-unavailable",
+            False,
+        ),
+        ProviderFailureCategory.TIMEOUT: (ItemOutcome.FAILED, "provider-transient", True),
+        ProviderFailureCategory.THROTTLED: (ItemOutcome.FAILED, "provider-transient", True),
+        ProviderFailureCategory.TRANSIENT: (ItemOutcome.FAILED, "provider-transient", True),
+        ProviderFailureCategory.CANCELLED: (
+            ItemOutcome.CANCELLED,
+            "operator-cancelled",
+            False,
+        ),
+    }
+    return values[category]
+
+
+def _diagnostic(
+    item_id: str, category: str, provider_code: str, attempts: int, retryable: bool
+) -> Artifact:
+    return Artifact(
+        f"diagnostics/{item_id}.json",
+        canonical_json_bytes(
+            {
+                "schema_version": "1.0.0",
+                "category": category,
+                "provider_code": provider_code[:120],
+                "attempts": attempts,
+                "retryable": retryable,
+            }
+        ),
+        "diagnostic",
+        "application/json",
+    )
+
+
+def _failure_item(
+    entry: PlaylistEntry,
+    *,
+    playlist_id: str | None,
+    requested_locator: str,
+    failure: ProviderFailure,
+    attempts: int,
+) -> tuple[PackageItem, Artifact]:
+    outcome, category, retryable = _failure_mapping(failure.category)
+    item_id = f"youtube-video-{entry.video_id}"
+    diagnostic = _diagnostic(item_id, category, failure.code, attempts, retryable)
+    fields: dict[str, object] = {
+        "requested_locator": requested_locator,
+        "canonical_locator": f"https://www.youtube.com/watch?v={entry.video_id}",
+        "provenance": {"provider": "youtube", "provider_resource_id": entry.video_id},
+        "error": {"category": category, "attempts": attempts, "retryable": retryable},
+        "diagnostics": [diagnostic.path],
+        "extensions": {
+            YOUTUBE_EXTENSION: {
+                "provider_code": failure.code[:120],
+                **({"playlist_id": playlist_id} if playlist_id else {}),
+                **({"source_position": entry.position} if entry.position is not None else {}),
+            }
+        },
+    }
+    return PackageItem(item_id, "video", outcome, fields), diagnostic
+
+
+def _completed_item(
+    entry: PlaylistEntry,
+    observation: VideoObservation,
+    options: YouTubeOptions,
+    playlist_id: str | None,
+) -> tuple[PackageItem, tuple[Artifact, ...]]:
+    item_id = f"youtube-video-{entry.video_id}"
+    selection = select_caption(observation.captions, options)
+    common: dict[str, object] = {
+        "requested_locator": options.locator,
+        "resolved_locator": observation.resolved_locator,
+        "canonical_locator": f"https://www.youtube.com/watch?v={entry.video_id}",
+        "provenance": {"provider": "youtube", "provider_resource_id": entry.video_id},
+    }
+    for key, value in (
+        ("title", observation.title),
+        ("creator", observation.channel),
+        ("published_at", observation.published_at),
+    ):
+        if value is not None:
+            common[key] = value
+    relation = {
+        **({"playlist_id": playlist_id} if playlist_id else {}),
+        **({"source_position": entry.position} if entry.position is not None else {}),
+    }
+    if playlist_id:
+        common["parents"] = [
+            {
+                "resource_kind": "collection",
+                "canonical_locator": f"https://www.youtube.com/playlist?list={playlist_id}",
+            }
+        ]
+    if selection is None:
+        if options.no_caption_outcome is NoCaptionOutcome.SKIP:
+            common["skip_reason"] = {
+                "category": "captions-unavailable",
+                "policy": options.caption_policy.value,
+            }
+            common["extensions"] = {YOUTUBE_EXTENSION: {**relation, "candidates": []}}
+            return PackageItem(item_id, "video", ItemOutcome.SKIPPED, common), ()
+        failure = ProviderFailure(ProviderFailureCategory.UNAVAILABLE, "captions-unavailable")
+        item, diagnostic = _failure_item(
+            entry,
+            playlist_id=playlist_id,
+            requested_locator=options.locator,
+            failure=failure,
+            attempts=1,
+        )
+        return item, (diagnostic,)
+    track = selection.track
+    if track.format.lower() != "vtt":
+        failure = ProviderFailure(ProviderFailureCategory.UNAVAILABLE, "normalization-unsupported")
+        item, diagnostic = _failure_item(
+            entry,
+            playlist_id=playlist_id,
+            requested_locator=options.locator,
+            failure=failure,
+            attempts=1,
+        )
+        fields = dict(item.fields)
+        fields["error"] = {
+            "category": "normalization-unsupported",
+            "attempts": 1,
+            "retryable": False,
+        }
+        diagnostic = _diagnostic(
+            item.item_id, "normalization-unsupported", "unsupported-caption-format", 1, False
+        )
+        return PackageItem(item.item_id, item.resource_kind, item.outcome, fields), (diagnostic,)
+    try:
+        normalized = normalize_webvtt(track.data, automatic=track.kind is CaptionKind.AUTOMATIC)
+    except CaptionNormalizationError:
+        failure = ProviderFailure(ProviderFailureCategory.UNAVAILABLE, "normalization-malformed")
+        item, diagnostic = _failure_item(
+            entry,
+            playlist_id=playlist_id,
+            requested_locator=options.locator,
+            failure=failure,
+            attempts=1,
+        )
+        fields = dict(item.fields)
+        fields["error"] = {
+            "category": "normalization-malformed",
+            "attempts": 1,
+            "retryable": False,
+        }
+        diagnostic = _diagnostic(
+            item.item_id, "normalization-malformed", "malformed-webvtt", 1, False
+        )
+        return PackageItem(item.item_id, item.resource_kind, item.outcome, fields), (diagnostic,)
+    normalized_path = f"artifacts/{item_id}/normalized.md"
+    artifacts = [Artifact(normalized_path, normalized.data, "normalized-content", "text/markdown")]
+    raw_path: str | None = None
+    if options.retain_raw_captions:
+        raw_path = f"artifacts/{item_id}/captured.vtt"
+        artifacts.append(
+            Artifact(raw_path, track.data, f"{YOUTUBE_EXTENSION}/raw-caption", "text/vtt")
+        )
+    common.update(
+        {
+            "language": track.language,
+            "artifacts": [artifact.path for artifact in artifacts],
+            "captured_sha256": _digest(track.data),
+            "normalized_sha256": _digest(normalized.data),
+            "normalization": {
+                "name": NORMALIZER_NAME,
+                "version": NORMALIZER_VERSION,
+                "transforms": list(normalized.transforms),
+            },
+            "extensions": {
+                YOUTUBE_EXTENSION: {
+                    **relation,
+                    "caption_kind": track.kind.value,
+                    "selected_track": {
+                        "language": track.language,
+                        "format": track.format,
+                        **({"name": track.name} if track.name else {}),
+                    },
+                    "selection_reason": selection.reason,
+                    "available_candidates": list(selection.candidates),
+                    **({"raw_caption_path": raw_path} if raw_path else {}),
+                }
+            },
+        }
+    )
+    return PackageItem(item_id, "video", ItemOutcome.COMPLETED, common), tuple(artifacts)
+
+
+def produce_package(
+    options: YouTubeOptions,
+    client: YouTubeClient,
+    *,
+    request_id: str,
+    run_id: str,
+    package_id: str,
+    created_at: str,
+    destination: Path,
+) -> ProductionResult:
+    request = options.acquisition_request(request_id, destination)
+    fingerprint = _request_fingerprint(request.as_dict())
+    discovery = client.discover(options)
+    entries = _ordered_entries(discovery.entries[: options.max_items])
+    if options.checkpoint_input is not None:
+        load_checkpoint(
+            options.checkpoint_input,
+            expected_fingerprint=fingerprint,
+            expected_adapter_version=ADAPTER_VERSION,
+            expected_contract_version=CONTRACT_VERSION,
+        )
+        raise CollectionProgressBlocked(
+            "resumed sealing requires canonical builder-supported resume lineage"
+        )
+    if options.scope is ScopeKind.COLLECTION and (
+        not discovery.exhausted
+        or (options.batch_size is not None and options.batch_size < len(entries))
+    ):
+        if options.checkpoint_output is not None:
+            completed: list[CompletedCheckpointItem] = []
+            outcomes: dict[str, str] = {}
+            checkpoint_attempts: dict[str, int] = {}
+            batch_size = options.batch_size or 0
+            for entry in entries[:batch_size]:
+                checkpoint_attempts[entry.video_id] = 1
+                try:
+                    observation = client.enrich(entry.video_id)
+                    item, _ = _completed_item(entry, observation, options, discovery.playlist_id)
+                    outcomes[entry.video_id] = item.outcome.value
+                    captured = item.fields.get("captured_sha256")
+                    normalized = item.fields.get("normalized_sha256")
+                    if (
+                        item.outcome is ItemOutcome.COMPLETED
+                        and isinstance(captured, str)
+                        and isinstance(normalized, str)
+                    ):
+                        completed.append(
+                            CompletedCheckpointItem(
+                                entry.video_id, captured, normalized, item.outcome.value, 1
+                            )
+                        )
+                except ProviderFailure as checkpoint_failure:
+                    outcome, _, _ = _failure_mapping(checkpoint_failure.category)
+                    outcomes[entry.video_id] = outcome.value
+            save_checkpoint(
+                YouTubeCheckpoint(
+                    fingerprint,
+                    ADAPTER_VERSION,
+                    CONTRACT_VERSION,
+                    discovery.playlist_id or "unknown",
+                    tuple(entry.video_id for entry in entries),
+                    tuple(completed),
+                    outcomes,
+                    checkpoint_attempts,
+                    tuple(entry.video_id for entry in entries if entry.video_id not in outcomes),
+                    discovery.continuation or f"batch-after:{batch_size}",
+                    "bounded-discovery",
+                ),
+                options.checkpoint_output,
+            )
+        raise CollectionProgressBlocked(
+            "partial collection sealing requires canonical collection progress"
+        )
+    builder = PackageBuilder(
+        package_id=package_id,
+        request=request,
+        run_id=run_id,
+        created_at=created_at,
+        adapter=AdapterIdentity(
+            "youtube-source-package", ADAPTER_VERSION, f"yt-dlp/{client.version}"
+        ),
+        contract_version=CONTRACT_VERSION,
+        boundary={
+            "deterministic": (
+                f"captured captions normalized by {NORMALIZER_NAME}/{NORMALIZER_VERSION}"
+            ),
+            "live": "discovery, metadata, and caption acquisition through yt-dlp",
+        },
+        extensions={YOUTUBE_EXTENSION: {"yt_dlp_version": client.version}},
+    )
+    for entry in entries:
+        if not entry.available or entry.failure is not None:
+            failure = ProviderFailure(
+                entry.failure or ProviderFailureCategory.UNAVAILABLE,
+                "playlist-member-unavailable",
+            )
+            item, diagnostic = _failure_item(
+                entry,
+                playlist_id=discovery.playlist_id,
+                requested_locator=options.locator,
+                failure=failure,
+                attempts=1,
+            )
+            builder.add_item(item)
+            builder.add_artifact(diagnostic)
+            continue
+        attempts = 0
+        while True:
+            attempts += 1
+            try:
+                observation = client.enrich(entry.video_id)
+                item, artifacts = _completed_item(
+                    entry, observation, options, discovery.playlist_id
+                )
+                builder.add_item(item)
+                for artifact in artifacts:
+                    builder.add_artifact(artifact)
+                break
+            except ProviderFailure as failure:
+                _, _, retryable = _failure_mapping(failure.category)
+                if retryable and attempts < options.retry.max_attempts:
+                    continue
+                item, diagnostic = _failure_item(
+                    entry,
+                    playlist_id=discovery.playlist_id,
+                    requested_locator=options.locator,
+                    failure=failure,
+                    attempts=attempts,
+                )
+                builder.add_item(item)
+                builder.add_artifact(diagnostic)
+                break
+    sealed = builder.seal(destination)
+    if not sealed.ok or sealed.package_path is None or sealed.content_address is None:
+        raise RuntimeError(sealed.error or "package sealing failed")
+    verification = verify_package(sealed.package_path)
+    if not verification.ok or verification.content_address != sealed.content_address:
+        raise RuntimeError("sealed package failed public verification")
+    return ProductionResult(sealed.package_path, sealed.content_address, verification)

--- a/src/knowledge_adapters/youtube/producer.py
+++ b/src/knowledge_adapters/youtube/producer.py
@@ -7,11 +7,16 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from knowledge_adapters.source_package import (
+    COLLECTION_PROGRESS_CAPABILITY,
     AdapterIdentity,
     Artifact,
+    CollectionProgress,
+    CollectionProgressState,
+    ConsumerProfile,
     ItemOutcome,
     PackageBuilder,
     PackageItem,
+    PackageLineage,
     VerificationResult,
     canonical_json_bytes,
     verify_package,
@@ -23,6 +28,7 @@ from .checkpoint import (
     YouTubeCheckpoint,
     copy_completed_item,
     load_checkpoint,
+    read_completed_artifacts,
     reconcile_video_ids,
     request_fingerprint,
     save_checkpoint,
@@ -31,7 +37,9 @@ from .checkpoint import (
 from .client import YouTubeClient
 from .config import YOUTUBE_EXTENSION, NoCaptionOutcome, ScopeKind, YouTubeOptions
 from .models import (
+    CaptionCandidate,
     CaptionKind,
+    CaptionTrack,
     PlaylistEntry,
     ProviderFailure,
     ProviderFailureCategory,
@@ -49,7 +57,7 @@ CONTRACT_VERSION = "1.0.0"
 
 
 class CollectionProgressBlocked(RuntimeError):
-    """Partial/resumed sealing awaits a canonical collection-progress invariant."""
+    """Provider continuation cannot advance through bounded rediscovery safely."""
 
 
 @dataclass(frozen=True)
@@ -318,6 +326,161 @@ def _completed_item(
     return PackageItem(item_id, "video", ItemOutcome.COMPLETED, common), tuple(artifacts)
 
 
+def _checkpointed_item(
+    checkpoint_path: Path,
+    cached: CompletedCheckpointItem,
+    options: YouTubeOptions,
+) -> tuple[PackageItem, tuple[Artifact, ...]]:
+    captured, normalized = read_completed_artifacts(checkpoint_path, cached)
+    kind = CaptionKind(cached.caption_kind)
+    observation = VideoObservation(
+        cached.video_id,
+        cached.resolved_locator,
+        cached.title,
+        cached.channel,
+        cached.published_at,
+        (
+            CaptionTrack(
+                cached.language,
+                kind,
+                cached.caption_format,
+                captured,
+                cached.caption_name,
+            ),
+        ),
+        (
+            CaptionCandidate(
+                cached.language,
+                kind,
+                cached.caption_format,
+                cached.caption_name,
+            ),
+        ),
+    )
+    entry = PlaylistEntry(cached.video_id, cached.source_position)
+    item, artifacts = _completed_item(entry, observation, options, cached.playlist_id)
+    normalized_artifact = next(
+        artifact for artifact in artifacts if artifact.role == "normalized-content"
+    )
+    if normalized_artifact.data != normalized:
+        raise ValueError("checkpoint normalization replay mismatch")
+    return (
+        PackageItem(item.item_id, item.resource_kind, ItemOutcome.UNCHANGED, item.fields),
+        artifacts,
+    )
+
+
+def _cache_completed(
+    checkpoint_path: Path,
+    entry: PlaylistEntry,
+    observation: VideoObservation,
+    options: YouTubeOptions,
+    item: PackageItem,
+    artifacts: tuple[Artifact, ...],
+    *,
+    attempts: int,
+    playlist_id: str | None,
+) -> CompletedCheckpointItem | None:
+    if item.outcome is not ItemOutcome.COMPLETED:
+        return None
+    selection = select_caption(observation.captions, options)
+    if selection is None:
+        return None
+    normalized = next(
+        artifact.data for artifact in artifacts if artifact.role == "normalized-content"
+    )
+    captured_path, normalized_path = save_checkpoint_artifacts(
+        checkpoint_path,
+        video_id=entry.video_id,
+        captured=selection.track.data,
+        normalized=normalized,
+    )
+    return CompletedCheckpointItem(
+        entry.video_id,
+        _digest(selection.track.data),
+        _digest(normalized),
+        item.outcome.value,
+        attempts,
+        captured_path,
+        normalized_path,
+        observation.resolved_locator,
+        observation.title,
+        observation.channel,
+        observation.published_at,
+        selection.track.language,
+        selection.track.kind.value,
+        selection.track.format,
+        selection.track.name,
+        playlist_id,
+        entry.position,
+    )
+
+
+def _producer_profile(options: YouTubeOptions) -> ConsumerProfile:
+    item_bound = max(1, options.max_items)
+    return ConsumerProfile(
+        identifier="youtube-producer-v1",
+        supported_capabilities=(COLLECTION_PROGRESS_CAPABILITY,),
+        max_json_depth=32,
+        max_package_entries=item_bound * 8 + 10,
+        max_item_records=item_bound,
+        max_artifacts=item_bound * 4 + 1,
+        max_diagnostics=item_bound,
+        max_file_bytes=max(16 * 1024 * 1024, options.max_caption_bytes),
+        max_aggregate_bytes=512 * 1024 * 1024,
+        max_path_length=1024,
+        max_path_components=16,
+    )
+
+
+def _assert_verified_handoff(
+    verification: VerificationResult,
+    *,
+    package_id: str,
+    run_id: str,
+    expected_progress: CollectionProgress | None,
+    expected_items: tuple[PackageItem, ...],
+    expected_artifacts: tuple[Artifact, ...],
+) -> None:
+    claims = verification.verified_claims
+    if not verification.ok or claims is None or claims.totals is None:
+        raise RuntimeError("sealed package failed public verification")
+    if (
+        verification.consumer_profile != "youtube-producer-v1"
+        or claims.package_id != package_id
+        or claims.run_id != run_id
+        or claims.collection_progress != expected_progress
+        or claims.totals.item_records != len(expected_items)
+    ):
+        raise RuntimeError("verified package summary does not match producer handoff")
+    dispositions = {item.item_id: item for item in claims.item_dispositions}
+    if set(dispositions) != {item.item_id for item in expected_items}:
+        raise RuntimeError("verified item summary does not match producer handoff")
+    for expected_item in expected_items:
+        disposition = dispositions[expected_item.item_id]
+        provenance = expected_item.fields.get("provenance")
+        expected_provider_id = (
+            provenance.get("provider_resource_id") if isinstance(provenance, dict) else None
+        )
+        if (
+            disposition.outcome != expected_item.outcome.value
+            or disposition.provider != "youtube"
+            or disposition.provider_resource_id != expected_provider_id
+        ):
+            raise RuntimeError("verified item disposition does not match producer handoff")
+    inventory = {artifact.path: artifact for artifact in claims.artifact_inventory}
+    for expected_artifact in expected_artifacts:
+        verified = inventory.get(expected_artifact.path)
+        if (
+            verified is None
+            or verified.role != expected_artifact.role
+            or verified.media_type != expected_artifact.media_type
+            or verified.bytes != len(expected_artifact.data)
+            or verified.sha256 != _digest(expected_artifact.data)
+        ):
+            raise RuntimeError("verified artifact summary does not match producer handoff")
+
+
 def produce_package(
     options: YouTubeOptions,
     client: YouTubeClient,
@@ -333,134 +496,44 @@ def produce_package(
     fingerprint = _request_fingerprint(request.as_dict())
     discovery = client.discover(options)
     entries = _ordered_entries(discovery.entries[: options.max_items])
+    is_collection = options.scope is ScopeKind.COLLECTION
+    checkpoint = None
+    preserved_checkpoint_items: list[CompletedCheckpointItem] = []
+    package_items: list[PackageItem] = []
+    package_artifacts: list[Artifact] = []
+    attempts_by_id: dict[str, int] = {}
+    pending_entries = list(entries)
+    lineage = None
+
     if options.checkpoint_input is not None:
         checkpoint = load_checkpoint(
             options.checkpoint_input,
             expected_fingerprint=fingerprint,
             expected_adapter_version=ADAPTER_VERSION,
-            expected_contract_version=CONTRACT_VERSION,
+            expected_contract_version="1.1.0",
         )
         rediscovered = tuple(entry.video_id for entry in entries)
-        preserved_ids, pending_ids = reconcile_video_ids(checkpoint, rediscovered)
+        preserved_ids, _ = reconcile_video_ids(checkpoint, rediscovered)
         completed_by_id = {item.video_id: item for item in checkpoint.completed}
-        assert options.checkpoint_output is not None
-        preserved = tuple(
-            copy_completed_item(
-                options.checkpoint_input,
-                options.checkpoint_output,
-                completed_by_id[video_id],
-            )
-            for video_id in preserved_ids
-        )
-        save_checkpoint(
-            YouTubeCheckpoint(
-                fingerprint,
-                ADAPTER_VERSION,
-                CONTRACT_VERSION,
-                discovery.playlist_id or checkpoint.playlist_id,
-                rediscovered,
-                preserved,
-                {item.video_id: item.outcome for item in preserved},
-                {
-                    video_id: checkpoint.attempts.get(video_id, 1)
-                    for video_id in rediscovered
-                    if video_id in checkpoint.attempts
-                },
-                pending_ids,
-                discovery.continuation or checkpoint.continuation,
-                "resume-reconciled",
-            ),
-            options.checkpoint_output,
-        )
-        raise CollectionProgressBlocked(
-            "resumed sealing requires canonical builder-supported resume lineage"
-        )
-    if options.scope is ScopeKind.COLLECTION and (
-        not discovery.exhausted
-        or (options.batch_size is not None and options.batch_size < len(entries))
-    ):
-        if options.checkpoint_output is not None:
-            completed: list[CompletedCheckpointItem] = []
-            outcomes: dict[str, str] = {}
-            checkpoint_attempts: dict[str, int] = {}
-            batch_size = options.batch_size or 0
-            for entry in entries[:batch_size]:
-                checkpoint_attempts[entry.video_id] = 1
-                try:
-                    observation = client.enrich(entry.video_id, options)
-                    item, artifacts = _completed_item(
-                        entry, observation, options, discovery.playlist_id
-                    )
-                    outcomes[entry.video_id] = item.outcome.value
-                    captured = item.fields.get("captured_sha256")
-                    normalized = item.fields.get("normalized_sha256")
-                    if (
-                        item.outcome is ItemOutcome.COMPLETED
-                        and isinstance(captured, str)
-                        and isinstance(normalized, str)
-                    ):
-                        selection = select_caption(observation.captions, options)
-                        normalized_artifact = next(
-                            artifact
-                            for artifact in artifacts
-                            if artifact.role == "normalized-content"
-                        )
-                        assert selection is not None
-                        captured_path, normalized_path = save_checkpoint_artifacts(
-                            options.checkpoint_output,
-                            video_id=entry.video_id,
-                            captured=selection.track.data,
-                            normalized=normalized_artifact.data,
-                        )
-                        completed.append(
-                            CompletedCheckpointItem(
-                                entry.video_id,
-                                captured,
-                                normalized,
-                                item.outcome.value,
-                                1,
-                                captured_path,
-                                normalized_path,
-                            )
-                        )
-                except ProviderFailure as checkpoint_failure:
-                    outcome, _, _ = _failure_mapping(checkpoint_failure.category)
-                    outcomes[entry.video_id] = outcome.value
-            save_checkpoint(
-                YouTubeCheckpoint(
-                    fingerprint,
-                    ADAPTER_VERSION,
-                    CONTRACT_VERSION,
-                    discovery.playlist_id or "unknown",
-                    tuple(entry.video_id for entry in entries),
-                    tuple(completed),
-                    outcomes,
-                    checkpoint_attempts,
-                    tuple(entry.video_id for entry in entries if entry.video_id not in outcomes),
-                    discovery.continuation or f"batch-after:{batch_size}",
-                    "bounded-discovery",
-                ),
-                options.checkpoint_output,
-            )
-        raise CollectionProgressBlocked(
-            "partial collection sealing requires canonical collection progress"
-        )
-    builder = PackageBuilder(
-        package_id=package_id,
-        request=request,
-        run_id=run_id,
-        created_at=created_at,
-        adapter=AdapterIdentity("youtube-source-package", ADAPTER_VERSION, adapter_revision),
-        contract_version=CONTRACT_VERSION,
-        boundary={
-            "deterministic": (
-                f"captured captions normalized by {NORMALIZER_NAME}/{NORMALIZER_VERSION}"
-            ),
-            "live": "discovery, metadata, and caption acquisition through yt-dlp",
-        },
-        extensions={YOUTUBE_EXTENSION: {"yt_dlp_version": client.version}},
-    )
-    for entry in entries:
+        for video_id in preserved_ids:
+            cached = completed_by_id[video_id]
+            item, artifacts = _checkpointed_item(options.checkpoint_input, cached, options)
+            package_items.append(item)
+            package_artifacts.extend(artifacts)
+            preserved_checkpoint_items.append(cached)
+            attempts_by_id[video_id] = checkpoint.attempts.get(video_id, cached.attempts)
+        preserved_set = set(preserved_ids)
+        pending_entries = [entry for entry in entries if entry.video_id not in preserved_set]
+        for entry in pending_entries:
+            attempts_by_id[entry.video_id] = checkpoint.attempts.get(entry.video_id, 0)
+
+    batch_limit = options.batch_size or len(pending_entries)
+    attempted_entries = pending_entries[:batch_limit]
+    unattempted_entries = pending_entries[batch_limit:]
+    observations: dict[str, VideoObservation] = {}
+
+    for entry in attempted_entries:
+        prior_attempts = attempts_by_id.get(entry.video_id, 0)
         if not entry.available or entry.failure is not None:
             failure = ProviderFailure(
                 entry.failure or ProviderFailureCategory.UNAVAILABLE,
@@ -471,41 +544,167 @@ def produce_package(
                 playlist_id=discovery.playlist_id,
                 requested_locator=options.locator,
                 failure=failure,
-                attempts=1,
+                attempts=prior_attempts + 1,
             )
-            builder.add_item(item)
-            builder.add_artifact(diagnostic)
+            package_items.append(item)
+            package_artifacts.append(diagnostic)
+            attempts_by_id[entry.video_id] = prior_attempts + 1
             continue
-        attempts = 0
+        run_attempts = 0
         while True:
-            attempts += 1
+            run_attempts += 1
+            total_attempts = prior_attempts + run_attempts
             try:
                 observation = client.enrich(entry.video_id, options)
                 item, artifacts = _completed_item(
                     entry, observation, options, discovery.playlist_id
                 )
-                builder.add_item(item)
-                for artifact in artifacts:
-                    builder.add_artifact(artifact)
+                package_items.append(item)
+                package_artifacts.extend(artifacts)
+                observations[entry.video_id] = observation
+                attempts_by_id[entry.video_id] = total_attempts
                 break
             except ProviderFailure as failure:
                 _, _, retryable = _failure_mapping(failure.category)
-                if retryable and attempts < options.retry.max_attempts:
+                if retryable and run_attempts < options.retry.max_attempts:
                     continue
                 item, diagnostic = _failure_item(
                     entry,
                     playlist_id=discovery.playlist_id,
                     requested_locator=options.locator,
                     failure=failure,
-                    attempts=attempts,
+                    attempts=total_attempts,
                 )
-                builder.add_item(item)
-                builder.add_artifact(diagnostic)
+                package_items.append(item)
+                package_artifacts.append(diagnostic)
+                attempts_by_id[entry.video_id] = total_attempts
                 break
+
+    progress = None
+    if is_collection:
+        progress = CollectionProgress(
+            CollectionProgressState.CONTINUATION_REMAINING
+            if unattempted_entries or not discovery.exhausted
+            else CollectionProgressState.EXHAUSTED
+        )
+        if (
+            progress.state is CollectionProgressState.CONTINUATION_REMAINING
+            and not unattempted_entries
+            and not discovery.exhausted
+        ):
+            raise CollectionProgressBlocked(
+                "provider continuation is not actionable through bounded rediscovery"
+            )
+
+    if checkpoint is not None:
+        prior_run_ids = tuple((*checkpoint.prior_run_ids, checkpoint.run_id))
+        prior_package_ids = tuple((*checkpoint.prior_package_ids, checkpoint.package_id))
+        lineage = PackageLineage(
+            resumes_run_id=checkpoint.run_id,
+            prior_run_ids=prior_run_ids,
+            prior_package_ids=prior_package_ids,
+            reconciliation_summary={
+                "reused": len(preserved_checkpoint_items),
+                "dropped": len(checkpoint.completed) - len(preserved_checkpoint_items),
+                "acquired": len(observations),
+                "pending": len(unattempted_entries),
+            },
+            final_attempt_counts=attempts_by_id,
+        )
+
+    contract_version = "1.1.0" if is_collection else CONTRACT_VERSION
+    builder = PackageBuilder(
+        package_id=package_id,
+        request=request,
+        run_id=run_id,
+        created_at=created_at,
+        adapter=AdapterIdentity("youtube-source-package", ADAPTER_VERSION, adapter_revision),
+        contract_version=contract_version,
+        boundary={
+            "deterministic": (
+                f"captured captions normalized by {NORMALIZER_NAME}/{NORMALIZER_VERSION}"
+            ),
+            "live": "discovery, metadata, and caption acquisition through yt-dlp",
+        },
+        collection_progress=progress,
+        lineage=lineage,
+        extensions={YOUTUBE_EXTENSION: {"yt_dlp_version": client.version}},
+    )
+    for item in package_items:
+        builder.add_item(item)
+    for artifact in package_artifacts:
+        builder.add_artifact(artifact)
     sealed = builder.seal(destination)
     if not sealed.ok or sealed.package_path is None or sealed.content_address is None:
         raise RuntimeError(sealed.error or "package sealing failed")
-    verification = verify_package(sealed.package_path)
-    if not verification.ok or verification.content_address != sealed.content_address:
-        raise RuntimeError("sealed package failed public verification")
+    verification = verify_package(sealed.package_path, profile=_producer_profile(options))
+    if verification.content_address != sealed.content_address:
+        raise RuntimeError("verified content address does not match sealed package")
+    _assert_verified_handoff(
+        verification,
+        package_id=package_id,
+        run_id=run_id,
+        expected_progress=progress,
+        expected_items=tuple(package_items),
+        expected_artifacts=tuple(package_artifacts),
+    )
+
+    if is_collection and options.checkpoint_output is not None:
+        output_checkpoint = options.checkpoint_output
+        cached_items: list[CompletedCheckpointItem] = []
+        if checkpoint is not None and options.checkpoint_input is not None:
+            cached_items.extend(
+                copy_completed_item(options.checkpoint_input, output_checkpoint, item)
+                for item in preserved_checkpoint_items
+            )
+        items_by_id = {item.item_id.removeprefix("youtube-video-"): item for item in package_items}
+        artifacts_by_item = {
+            video_id: tuple(
+                artifact
+                for artifact in package_artifacts
+                if artifact.path.startswith(f"artifacts/youtube-video-{video_id}/")
+            )
+            for video_id in observations
+        }
+        entries_by_id = {entry.video_id: entry for entry in attempted_entries}
+        for video_id, observation in observations.items():
+            cached_result = _cache_completed(
+                output_checkpoint,
+                entries_by_id[video_id],
+                observation,
+                options,
+                items_by_id[video_id],
+                artifacts_by_item[video_id],
+                attempts=attempts_by_id[video_id],
+                playlist_id=discovery.playlist_id,
+            )
+            if cached_result is not None:
+                cached_items.append(cached_result)
+        save_checkpoint(
+            YouTubeCheckpoint(
+                fingerprint,
+                ADAPTER_VERSION,
+                contract_version,
+                discovery.playlist_id or "unknown",
+                tuple(entry.video_id for entry in entries),
+                tuple(cached_items),
+                {
+                    item.item_id.removeprefix("youtube-video-"): item.outcome.value
+                    for item in package_items
+                },
+                attempts_by_id,
+                tuple(entry.video_id for entry in unattempted_entries),
+                discovery.continuation,
+                "package-verified",
+                run_id,
+                package_id,
+                tuple((*checkpoint.prior_run_ids, checkpoint.run_id)) if checkpoint else (),
+                (
+                    tuple((*checkpoint.prior_package_ids, checkpoint.package_id))
+                    if checkpoint
+                    else ()
+                ),
+            ),
+            output_checkpoint,
+        )
     return ProductionResult(sealed.package_path, sealed.content_address, verification)

--- a/tests/fixtures/youtube/README.md
+++ b/tests/fixtures/youtube/README.md
@@ -1,0 +1,6 @@
+# Sanitized YouTube fixtures
+
+These hand-authored fixtures contain no provider response, cookie, credential,
+caption URL, signed query string, or media URL. They establish the deterministic
+boundary at captured WebVTT bytes and structured provider observations. Live
+yt-dlp canaries are deliberately outside `make check`.

--- a/tests/fixtures/youtube/automatic-rolling.vtt
+++ b/tests/fixtures/youtube/automatic-rolling.vtt
@@ -1,0 +1,11 @@
+WEBVTT
+Kind: captions
+
+00:00:00.000 --> 00:00:01.000
+Rolling
+
+00:00:01.000 --> 00:00:02.000
+Rolling captions
+
+00:00:02.000 --> 00:00:03.000
+Rolling captions settle.

--- a/tests/fixtures/youtube/creator-en.vtt
+++ b/tests/fixtures/youtube/creator-en.vtt
@@ -1,0 +1,7 @@
+WEBVTT
+
+00:00:00.000 --> 00:00:02.000
+Hello from the creator.
+
+00:00:02.000 --> 00:00:04.000
+<v Ada>Welcome aboard.</v>

--- a/tests/fixtures/youtube/malformed.vtt
+++ b/tests/fixtures/youtube/malformed.vtt
@@ -1,0 +1,4 @@
+WEBVTT
+
+this is not a cue
+broken

--- a/tests/fixtures/youtube/provider-cases.json
+++ b/tests/fixtures/youtube/provider-cases.json
@@ -1,8 +1,0 @@
-{
-  "age-restricted": "fixture-age",
-  "geo-restricted": "fixture-geo",
-  "private": "fixture-private",
-  "removed": "fixture-removed",
-  "throttled": "fixture-throttled",
-  "timeout": "fixture-timeout"
-}

--- a/tests/fixtures/youtube/provider-cases.json
+++ b/tests/fixtures/youtube/provider-cases.json
@@ -1,0 +1,8 @@
+{
+  "age-restricted": "fixture-age",
+  "geo-restricted": "fixture-geo",
+  "private": "fixture-private",
+  "removed": "fixture-removed",
+  "throttled": "fixture-throttled",
+  "timeout": "fixture-timeout"
+}

--- a/tests/youtube/__init__.py
+++ b/tests/youtube/__init__.py
@@ -1,0 +1,1 @@
+"""YouTube adapter tests."""

--- a/tests/youtube/test_youtube.py
+++ b/tests/youtube/test_youtube.py
@@ -1,0 +1,436 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from knowledge_adapters.source_package import verify_package
+from knowledge_adapters.youtube import (
+    BaseLanguageFallback,
+    CaptionPolicy,
+    CollectionProgressBlocked,
+    NoCaptionOutcome,
+    RetryPolicy,
+    ScopeKind,
+    YouTubeOptions,
+    produce_package,
+)
+from knowledge_adapters.youtube.captions import select_caption
+from knowledge_adapters.youtube.checkpoint import (
+    CompletedCheckpointItem,
+    YouTubeCheckpoint,
+    load_checkpoint,
+    reconcile_video_ids,
+    request_fingerprint,
+    save_checkpoint,
+)
+from knowledge_adapters.youtube.client import YtDlpClient
+from knowledge_adapters.youtube.models import (
+    CaptionKind,
+    CaptionTrack,
+    Discovery,
+    PlaylistEntry,
+    ProviderFailure,
+    ProviderFailureCategory,
+    VideoObservation,
+)
+from knowledge_adapters.youtube.normalize import CaptionNormalizationError, normalize_webvtt
+
+FIXTURES = Path(__file__).parents[1] / "fixtures" / "youtube"
+VIDEO = "https://www.youtube.com/watch?v=video_001"
+PLAYLIST = "https://www.youtube.com/playlist?list=playlist_001"
+
+
+class FakeClient:
+    version = "fixture-2026.07"
+
+    def __init__(
+        self,
+        discovery: Discovery,
+        videos: dict[str, VideoObservation | list[VideoObservation | ProviderFailure]],
+    ) -> None:
+        self.discovery = discovery
+        self.videos = videos
+        self.calls: list[str] = []
+
+    def discover(self, options: YouTubeOptions) -> Discovery:
+        del options
+        return self.discovery
+
+    def enrich(self, video_id: str) -> VideoObservation:
+        self.calls.append(video_id)
+        value = self.videos[video_id]
+        if isinstance(value, list):
+            current = value.pop(0)
+        else:
+            current = value
+        if isinstance(current, ProviderFailure):
+            raise current
+        return current
+
+
+def creator_track(language: str = "en") -> CaptionTrack:
+    return CaptionTrack(
+        language, CaptionKind.CREATOR, "vtt", (FIXTURES / "creator-en.vtt").read_bytes()
+    )
+
+
+def video(video_id: str, *tracks: CaptionTrack) -> VideoObservation:
+    return VideoObservation(
+        video_id,
+        f"https://www.youtube.com/watch?v={video_id}",
+        f"Title {video_id}",
+        "Fixture Channel",
+        "20260710",
+        tuple(tracks),
+    )
+
+
+def single_client(*tracks: CaptionTrack) -> FakeClient:
+    discovery = Discovery(VIDEO, VIDEO, None, (PlaylistEntry("video_001", 1),), True)
+    return FakeClient(discovery, {"video_001": video("video_001", *tracks)})
+
+
+def options(**changes: object) -> YouTubeOptions:
+    value = YouTubeOptions(VIDEO, ScopeKind.RESOURCE, 1)
+    return replace(value, **changes)  # type: ignore[arg-type]
+
+
+def produce(tmp_path: Path, client: FakeClient, opts: YouTubeOptions | None = None) -> Path:
+    destination = tmp_path / "package"
+    result = produce_package(
+        opts or options(),
+        client,
+        request_id="request-fixture",
+        run_id="run-fixture",
+        package_id="package-fixture",
+        created_at="2026-07-10T00:00:00Z",
+        destination=destination,
+    )
+    assert result.verification.ok
+    return destination
+
+
+@pytest.mark.parametrize(
+    ("change", "message"),
+    [
+        ({"max_items": 0}, "positive"),
+        ({"max_items": 2}, "max_items=1"),
+        ({"batch_size": 0}, "batch_size"),
+        ({"languages": ()}, "language"),
+        ({"languages": ("en", "en")}, "unique"),
+    ],
+)
+def test_invalid_bounded_configuration(change: dict[str, object], message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        replace(options(), **change)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "locator",
+    [
+        "http://www.youtube.com/watch?v=video_001",
+        "https://example.test/watch?v=video_001",
+        "https://user:secret@www.youtube.com/watch?v=video_001",
+        "https://www.youtube.com/watch?v=video_001&token=secret",
+        "https://www.youtube.com/watch?v=video_001&list=playlist_001",
+    ],
+)
+def test_rejects_unsupported_ambiguous_or_secret_locators(locator: str) -> None:
+    with pytest.raises(ValueError):
+        YouTubeOptions(locator, ScopeKind.RESOURCE, 1)
+
+
+def test_caption_selection_policy_and_language_preference() -> None:
+    tracks = (
+        CaptionTrack("en", CaptionKind.AUTOMATIC, "vtt", b"auto"),
+        CaptionTrack("fr", CaptionKind.CREATOR, "vtt", b"creator"),
+    )
+    creator_first = select_caption(
+        tracks,
+        options(languages=("en", "fr"), caption_policy=CaptionPolicy.CREATOR_THEN_AUTOMATIC),
+    )
+    language_first = select_caption(
+        tracks,
+        options(languages=("en", "fr"), caption_policy=CaptionPolicy.AUTOMATIC_ALLOWED),
+    )
+    assert creator_first is not None and creator_first.track.language == "fr"
+    assert language_first is not None and language_first.track.language == "en"
+
+
+def test_explicit_base_language_fallback() -> None:
+    track = CaptionTrack("en-US", CaptionKind.CREATOR, "vtt", b"x")
+    assert select_caption((track,), options(languages=("en",))) is None
+    selected = select_caption(
+        (track,),
+        options(languages=("en",), base_language_fallback=BaseLanguageFallback.ENABLED),
+    )
+    assert selected is not None and "base-language-fallback" in selected.reason
+
+
+def test_creator_webvtt_normalization_is_exact() -> None:
+    result = normalize_webvtt((FIXTURES / "creator-en.vtt").read_bytes(), automatic=False)
+    assert result.data == b"Hello from the creator.\n\n**Ada:** Welcome aboard.\n"
+
+
+def test_automatic_rolling_cues_are_collapsed() -> None:
+    result = normalize_webvtt((FIXTURES / "automatic-rolling.vtt").read_bytes(), automatic=True)
+    assert result.data == b"Rolling captions settle.\n"
+
+
+def test_malformed_webvtt_is_rejected() -> None:
+    with pytest.raises(CaptionNormalizationError):
+        normalize_webvtt((FIXTURES / "malformed.vtt").read_bytes(), automatic=False)
+
+
+def test_single_video_produces_publicly_verified_package_without_raw_caption(
+    tmp_path: Path,
+) -> None:
+    package = produce(tmp_path, single_client(creator_track()))
+    result = verify_package(package)
+    assert result.ok and result.verified_claims is not None
+    assert result.verified_claims.adapter is not None
+    assert result.verified_claims.adapter.revision == "yt-dlp/fixture-2026.07"
+    files = {path.relative_to(package).as_posix() for path in package.rglob("*") if path.is_file()}
+    assert not any(path.endswith("captured.vtt") for path in files)
+    all_bytes = b"".join(path.read_bytes() for path in package.rglob("*") if path.is_file())
+    assert b"signature=" not in all_bytes and b"secret" not in all_bytes
+
+
+def test_raw_caption_is_retained_only_by_opt_in(tmp_path: Path) -> None:
+    package = produce(tmp_path, single_client(creator_track()), options(retain_raw_captions=True))
+    raw = package / "artifacts/youtube-video-video_001/captured.vtt"
+    assert raw.read_bytes() == (FIXTURES / "creator-en.vtt").read_bytes()
+
+
+@pytest.mark.parametrize(
+    ("no_caption", "expected"),
+    [(NoCaptionOutcome.SKIP, "skipped"), (NoCaptionOutcome.FAIL, "failed")],
+)
+def test_configurable_no_caption_outcome(
+    tmp_path: Path, no_caption: NoCaptionOutcome, expected: str
+) -> None:
+    package = produce(tmp_path, single_client(), options(no_caption_outcome=no_caption))
+    item = json.loads((package / "items/youtube-video-video_001.json").read_bytes())
+    assert item["outcome"] == expected
+
+
+@pytest.mark.parametrize(
+    ("category", "mapped", "attempts"),
+    [
+        (ProviderFailureCategory.PRIVATE, "access-denied", 1),
+        (ProviderFailureCategory.REMOVED, "provider-removed", 1),
+        (ProviderFailureCategory.AGE_RESTRICTED, "access-restricted", 1),
+        (ProviderFailureCategory.GEO_RESTRICTED, "geo-restricted", 1),
+        (ProviderFailureCategory.TIMEOUT, "provider-transient", 2),
+        (ProviderFailureCategory.THROTTLED, "provider-transient", 2),
+        (ProviderFailureCategory.TRANSIENT, "provider-transient", 2),
+        (ProviderFailureCategory.CANCELLED, "operator-cancelled", 1),
+    ],
+)
+def test_structured_failure_mapping(
+    tmp_path: Path,
+    category: ProviderFailureCategory,
+    mapped: str,
+    attempts: int,
+) -> None:
+    failure = ProviderFailure(category, f"fixture-{category.value}", retryable=attempts > 1)
+    client = single_client(creator_track())
+    client.videos["video_001"] = [failure for _ in range(attempts)]
+    package = produce(tmp_path, client, options(retry=RetryPolicy(max_attempts=attempts)))
+    item = json.loads((package / "items/youtube-video-video_001.json").read_bytes())
+    assert item["error"] == {"attempts": attempts, "category": mapped, "retryable": attempts > 1}
+
+
+def test_unsupported_caption_format_and_malformed_caption_are_failed(
+    tmp_path: Path,
+) -> None:
+    unsupported = CaptionTrack("en", CaptionKind.CREATOR, "srt", b"unsupported")
+    package = produce(tmp_path, single_client(unsupported))
+    item = json.loads((package / "items/youtube-video-video_001.json").read_bytes())
+    assert item["error"]["category"] == "normalization-unsupported"
+    shutil.rmtree(package)
+    malformed = CaptionTrack(
+        "en", CaptionKind.CREATOR, "vtt", (FIXTURES / "malformed.vtt").read_bytes()
+    )
+    package = produce(tmp_path, single_client(malformed))
+    item = json.loads((package / "items/youtube-video-video_001.json").read_bytes())
+    assert item["error"]["category"] == "normalization-malformed"
+
+
+def test_playlist_order_duplicate_missing_position_and_unavailable_member(
+    tmp_path: Path,
+) -> None:
+    discovery = Discovery(
+        PLAYLIST,
+        PLAYLIST,
+        "playlist_001",
+        (
+            PlaylistEntry("video_003", None),
+            PlaylistEntry("video_002", 1, False, ProviderFailureCategory.UNAVAILABLE),
+            PlaylistEntry("video_001", 1),
+        ),
+        True,
+    )
+    client = FakeClient(
+        discovery,
+        {
+            "video_001": video("video_001", creator_track()),
+            "video_003": video("video_003", creator_track()),
+        },
+    )
+    opts = YouTubeOptions(PLAYLIST, ScopeKind.COLLECTION, 3)
+    package = produce(tmp_path, client, opts)
+    assert client.calls == ["video_001", "video_003"]
+    failed = json.loads((package / "items/youtube-video-video_002.json").read_bytes())
+    assert failed["error"]["category"] == "provider-unavailable"
+    first = json.loads((package / "items/youtube-video-video_001.json").read_bytes())
+    assert first["extensions"]["org.ctrl-alt-keith.youtube"]["source_position"] == 1
+
+
+def test_partial_batch_writes_checkpoint_but_does_not_seal(tmp_path: Path) -> None:
+    discovery = Discovery(
+        PLAYLIST,
+        PLAYLIST,
+        "playlist_001",
+        tuple(PlaylistEntry(f"video_00{index}", index) for index in range(1, 4)),
+        True,
+        "fixture-continuation",
+    )
+    checkpoint_path = tmp_path / "checkpoint.json"
+    opts = YouTubeOptions(
+        PLAYLIST,
+        ScopeKind.COLLECTION,
+        3,
+        batch_size=2,
+        checkpoint_output=checkpoint_path,
+    )
+    partial_videos = {
+        "video_001": video("video_001", creator_track()),
+        "video_002": video("video_002", creator_track()),
+    }
+    with pytest.raises(CollectionProgressBlocked, match="canonical collection progress"):
+        produce_package(
+            opts,
+            FakeClient(discovery, dict(partial_videos)),
+            request_id="request",
+            run_id="run",
+            package_id="package",
+            created_at="2026-07-10T00:00:00Z",
+            destination=tmp_path / "package",
+        )
+    assert checkpoint_path.is_file() and not (tmp_path / "package").exists()
+    checkpoint_json = json.loads(checkpoint_path.read_bytes())
+    assert [item["video_id"] for item in checkpoint_json["completed"]] == [
+        "video_001",
+        "video_002",
+    ]
+    assert checkpoint_json["pending_video_ids"] == ["video_003"]
+    assert all(len(item["normalized_sha256"]) == 64 for item in checkpoint_json["completed"])
+    resumed = replace(
+        opts,
+        checkpoint_input=checkpoint_path,
+        checkpoint_output=tmp_path / "checkpoint-next.json",
+    )
+    with pytest.raises(CollectionProgressBlocked, match="resume lineage"):
+        produce_package(
+            resumed,
+            FakeClient(discovery, dict(partial_videos)),
+            request_id="request-next",
+            run_id="run-next",
+            package_id="package-next",
+            created_at="2026-07-10T00:01:00Z",
+            destination=tmp_path / "package-next",
+        )
+
+
+def test_checkpoint_validation_and_changed_playlist_reconciliation(tmp_path: Path) -> None:
+    fingerprint = request_fingerprint({"request": "fixture"})
+    checkpoint = YouTubeCheckpoint(
+        fingerprint,
+        "0.1.0",
+        "1.0.0",
+        "playlist_001",
+        ("video_001", "video_002"),
+        (CompletedCheckpointItem("video_001", "a" * 64, "b" * 64, "completed", 1),),
+        {"video_001": "completed"},
+        {"video_001": 1},
+        ("video_002",),
+        None,
+        "item:video_001",
+    )
+    path = tmp_path / "checkpoint.json"
+    save_checkpoint(checkpoint, path)
+    loaded = load_checkpoint(path, expected_fingerprint=fingerprint)
+    assert reconcile_video_ids(loaded, ("video_003", "video_001")) == (
+        ("video_001",),
+        ("video_003",),
+    )
+    with pytest.raises(ValueError, match="fingerprint"):
+        load_checkpoint(path, expected_fingerprint="0" * 64)
+    with pytest.raises(ValueError, match="adapter version"):
+        load_checkpoint(
+            path,
+            expected_fingerprint=fingerprint,
+            expected_adapter_version="different",
+        )
+    corrupt = checkpoint.as_dict()
+    corrupt["pending_video_ids"] = ["video_unknown"]
+    path.write_text(json.dumps(corrupt))
+    with pytest.raises(ValueError, match="corrupt"):
+        load_checkpoint(path, expected_fingerprint=fingerprint)
+    corrupt = checkpoint.as_dict()
+    completed = corrupt["completed"]
+    assert isinstance(completed, list) and isinstance(completed[0], dict)
+    completed[0]["normalized_sha256"] = "not-a-digest"
+    path.write_text(json.dumps(corrupt))
+    with pytest.raises(ValueError, match="corrupt"):
+        load_checkpoint(path, expected_fingerprint=fingerprint)
+    path.write_text("not-json")
+    with pytest.raises(ValueError, match="corrupt"):
+        load_checkpoint(path, expected_fingerprint=fingerprint)
+
+
+def test_yt_dlp_exception_translation_uses_structured_evidence() -> None:
+    timeout = YtDlpClient._translate_exception(TimeoutError())
+    assert timeout.category is ProviderFailureCategory.TIMEOUT and timeout.retryable
+
+    class StructuredHttpError(RuntimeError):
+        status = 429
+
+    throttled = YtDlpClient._translate_exception(StructuredHttpError())
+    assert throttled.category is ProviderFailureCategory.THROTTLED and throttled.retryable
+    unknown = YtDlpClient._translate_exception(RuntimeError("private words ignored"))
+    assert unknown.category is ProviderFailureCategory.UNAVAILABLE
+
+
+def test_deterministic_replay_produces_identical_package_bytes(tmp_path: Path) -> None:
+    package = produce(tmp_path, single_client(creator_track()))
+    first = {
+        path.relative_to(package).as_posix(): path.read_bytes()
+        for path in package.rglob("*")
+        if path.is_file()
+    }
+    content_address = hashlib.sha256(first["package.json"]).hexdigest()
+    shutil.rmtree(package)
+    package = produce(tmp_path, single_client(creator_track()))
+    second = {
+        path.relative_to(package).as_posix(): path.read_bytes()
+        for path in package.rglob("*")
+        if path.is_file()
+    }
+    assert first == second
+    assert second["package.sha256"] == f"{content_address}\n".encode()
+
+
+def test_fake_client_suite_never_uses_network(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import socket
+
+    monkeypatch.setattr(socket, "create_connection", lambda *args, **kwargs: pytest.fail("network"))
+    produce(tmp_path, single_client(creator_track()))

--- a/tests/youtube/test_youtube.py
+++ b/tests/youtube/test_youtube.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import hashlib
+import io
 import json
 import shutil
 from dataclasses import replace
 from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
 
 import pytest
 
@@ -21,12 +24,14 @@ from knowledge_adapters.youtube import (
 )
 from knowledge_adapters.youtube.captions import select_caption
 from knowledge_adapters.youtube.checkpoint import (
+    MAX_CHECKPOINT_BYTES,
     CompletedCheckpointItem,
     YouTubeCheckpoint,
     load_checkpoint,
     reconcile_video_ids,
     request_fingerprint,
     save_checkpoint,
+    save_checkpoint_artifacts,
 )
 from knowledge_adapters.youtube.client import YtDlpClient
 from knowledge_adapters.youtube.models import (
@@ -61,7 +66,8 @@ class FakeClient:
         del options
         return self.discovery
 
-    def enrich(self, video_id: str) -> VideoObservation:
+    def enrich(self, video_id: str, options: YouTubeOptions) -> VideoObservation:
+        del options
         self.calls.append(video_id)
         value = self.videos[video_id]
         if isinstance(value, list):
@@ -110,6 +116,7 @@ def produce(tmp_path: Path, client: FakeClient, opts: YouTubeOptions | None = No
         package_id="package-fixture",
         created_at="2026-07-10T00:00:00Z",
         destination=destination,
+        adapter_revision="fixture-revision",
     )
     assert result.verification.ok
     return destination
@@ -118,7 +125,7 @@ def produce(tmp_path: Path, client: FakeClient, opts: YouTubeOptions | None = No
 @pytest.mark.parametrize(
     ("change", "message"),
     [
-        ({"max_items": 0}, "positive"),
+        ({"max_items": 0}, "between"),
         ({"max_items": 2}, "max_items=1"),
         ({"batch_size": 0}, "batch_size"),
         ({"languages": ()}, "language"),
@@ -194,7 +201,11 @@ def test_single_video_produces_publicly_verified_package_without_raw_caption(
     result = verify_package(package)
     assert result.ok and result.verified_claims is not None
     assert result.verified_claims.adapter is not None
-    assert result.verified_claims.adapter.revision == "yt-dlp/fixture-2026.07"
+    assert result.verified_claims.adapter.revision == "fixture-revision"
+    manifest = json.loads((package / "package.json").read_bytes())
+    assert manifest["extensions"]["org.ctrl-alt-keith.youtube"]["yt_dlp_version"] == (
+        "fixture-2026.07"
+    )
     files = {path.relative_to(package).as_posix() for path in package.rglob("*") if path.is_file()}
     assert not any(path.endswith("captured.vtt") for path in files)
     all_bytes = b"".join(path.read_bytes() for path in package.rglob("*") if path.is_file())
@@ -336,40 +347,82 @@ def test_partial_batch_writes_checkpoint_but_does_not_seal(tmp_path: Path) -> No
         checkpoint_input=checkpoint_path,
         checkpoint_output=tmp_path / "checkpoint-next.json",
     )
+    changed_discovery = replace(
+        discovery,
+        entries=(
+            PlaylistEntry("video_001", 1),
+            PlaylistEntry("video_003", 2),
+            PlaylistEntry("video_004", 3),
+        ),
+    )
+    resume_client = FakeClient(changed_discovery, {})
     with pytest.raises(CollectionProgressBlocked, match="resume lineage"):
         produce_package(
             resumed,
-            FakeClient(discovery, dict(partial_videos)),
+            resume_client,
             request_id="request-next",
             run_id="run-next",
             package_id="package-next",
             created_at="2026-07-10T00:01:00Z",
             destination=tmp_path / "package-next",
         )
+    assert resume_client.calls == []
+    next_path = tmp_path / "checkpoint-next.json"
+    next_json = json.loads(next_path.read_bytes())
+    assert [item["video_id"] for item in next_json["completed"]] == ["video_001"]
+    assert next_json["pending_video_ids"] == ["video_003", "video_004"]
+    completed = next_json["completed"][0]
+    assert (tmp_path / completed["captured_path"]).read_bytes() == creator_track().data
+    assert (tmp_path / completed["normalized_path"]).read_bytes() == (
+        b"Hello from the creator.\n\n**Ada:** Welcome aboard.\n"
+    )
 
 
 def test_checkpoint_validation_and_changed_playlist_reconciliation(tmp_path: Path) -> None:
     fingerprint = request_fingerprint({"request": "fixture"})
+    path = tmp_path / "checkpoint.json"
+    captured = b"captured fixture"
+    normalized = b"normalized fixture\n"
+    captured_path, normalized_path = save_checkpoint_artifacts(
+        path,
+        video_id="video_001",
+        captured=captured,
+        normalized=normalized,
+    )
     checkpoint = YouTubeCheckpoint(
         fingerprint,
         "0.1.0",
         "1.0.0",
         "playlist_001",
         ("video_001", "video_002"),
-        (CompletedCheckpointItem("video_001", "a" * 64, "b" * 64, "completed", 1),),
+        (
+            CompletedCheckpointItem(
+                "video_001",
+                hashlib.sha256(captured).hexdigest(),
+                hashlib.sha256(normalized).hexdigest(),
+                "completed",
+                1,
+                captured_path,
+                normalized_path,
+            ),
+        ),
         {"video_001": "completed"},
         {"video_001": 1},
         ("video_002",),
         None,
         "item:video_001",
     )
-    path = tmp_path / "checkpoint.json"
     save_checkpoint(checkpoint, path)
     loaded = load_checkpoint(path, expected_fingerprint=fingerprint)
     assert reconcile_video_ids(loaded, ("video_003", "video_001")) == (
         ("video_001",),
         ("video_003",),
     )
+    normalized_file = tmp_path / normalized_path
+    normalized_file.write_bytes(b"modified\n")
+    with pytest.raises(ValueError, match="digest mismatch"):
+        load_checkpoint(path, expected_fingerprint=fingerprint)
+    normalized_file.write_bytes(normalized)
     with pytest.raises(ValueError, match="fingerprint"):
         load_checkpoint(path, expected_fingerprint="0" * 64)
     with pytest.raises(ValueError, match="adapter version"):
@@ -395,6 +448,27 @@ def test_checkpoint_validation_and_changed_playlist_reconciliation(tmp_path: Pat
         load_checkpoint(path, expected_fingerprint=fingerprint)
 
 
+def test_checkpoint_read_and_depth_are_bounded(tmp_path: Path) -> None:
+    path = tmp_path / "checkpoint.json"
+    path.write_bytes(b"{" + b"x" * MAX_CHECKPOINT_BYTES + b"}")
+    with pytest.raises(ValueError, match="byte limit"):
+        load_checkpoint(path, expected_fingerprint="0" * 64)
+    nested: object = "leaf"
+    for _ in range(10):
+        nested = {"nested": nested}
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": "1.1.0",
+                "request_fingerprint": "0" * 64,
+                "bounded_discovery": nested,
+            }
+        )
+    )
+    with pytest.raises(ValueError, match="depth limit"):
+        load_checkpoint(path, expected_fingerprint="0" * 64)
+
+
 def test_yt_dlp_exception_translation_uses_structured_evidence() -> None:
     timeout = YtDlpClient._translate_exception(TimeoutError())
     assert timeout.category is ProviderFailureCategory.TIMEOUT and timeout.retryable
@@ -406,6 +480,80 @@ def test_yt_dlp_exception_translation_uses_structured_evidence() -> None:
     assert throttled.category is ProviderFailureCategory.THROTTLED and throttled.retryable
     unknown = YtDlpClient._translate_exception(RuntimeError("private words ignored"))
     assert unknown.category is ProviderFailureCategory.UNAVAILABLE
+
+
+class StubYtDlp:
+    def __init__(self, info: dict[str, object], response: bytes = b"") -> None:
+        self.info = info
+        self.response = response
+        self.opened_urls: list[str] = []
+
+    def __enter__(self) -> StubYtDlp:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        del args
+
+    def extract_info(self, locator: str, *, download: bool) -> dict[str, object]:
+        del locator, download
+        return self.info
+
+    def urlopen(self, url: str) -> io.BytesIO:
+        self.opened_urls.append(url)
+        return io.BytesIO(self.response)
+
+
+def stub_real_client(stub: StubYtDlp) -> YtDlpClient:
+    client = object.__new__(YtDlpClient)
+    cast(Any, client)._module = SimpleNamespace(YoutubeDL=lambda params: stub)
+    cast(Any, client)._version = "fixture-real-boundary"
+    return client
+
+
+def test_real_client_rejects_excess_candidates_before_acquisition() -> None:
+    candidates = [
+        {"ext": "vtt", "url": f"https://captions.test/{index}?signature=secret"}
+        for index in range(3)
+    ]
+    stub = StubYtDlp({"subtitles": {"en": candidates}})
+    client = stub_real_client(stub)
+    with pytest.raises(ProviderFailure, match="caption-candidate-limit"):
+        client.enrich("video_001", options(max_caption_candidates=2))
+    assert stub.opened_urls == []
+
+
+def test_real_client_caption_read_is_bounded() -> None:
+    signed = "https://captions.test/track?signature=secret"
+    stub = StubYtDlp(
+        {"subtitles": {"en": [{"ext": "vtt", "url": signed}]}},
+        b"x" * 9,
+    )
+    client = stub_real_client(stub)
+    with pytest.raises(ProviderFailure, match="caption-size-limit"):
+        client.enrich("video_001", options(max_caption_bytes=8))
+    assert stub.opened_urls == [signed]
+
+
+def test_real_client_preserves_unsupported_format_evidence_without_url() -> None:
+    signed = "https://captions.test/track?signature=secret"
+    stub = StubYtDlp({"subtitles": {"en": [{"ext": "ttml", "url": signed}]}})
+    observation = stub_real_client(stub).enrich("video_001", options())
+    assert observation.captions[0].format == "ttml"
+    assert observation.caption_candidates[0].format == "ttml"
+    assert stub.opened_urls == []
+    assert "signature" not in repr(observation)
+
+
+def test_real_client_rejects_discovery_beyond_requested_bound() -> None:
+    stub = StubYtDlp(
+        {
+            "id": "playlist_001",
+            "entries": [{"id": "video_001"}, {"id": "video_002"}],
+        }
+    )
+    client = stub_real_client(stub)
+    with pytest.raises(ProviderFailure, match="provider-shape:playlist-entries"):
+        client.discover(YouTubeOptions(PLAYLIST, ScopeKind.COLLECTION, 1))
 
 
 def test_deterministic_replay_produces_identical_package_bytes(tmp_path: Path) -> None:

--- a/tests/youtube/test_youtube.py
+++ b/tests/youtube/test_youtube.py
@@ -4,14 +4,18 @@ import hashlib
 import io
 import json
 import shutil
-from dataclasses import replace
+from dataclasses import asdict, replace
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
 
-from knowledge_adapters.source_package import verify_package
+from knowledge_adapters.source_package import (
+    CollectionProgress,
+    CollectionProgressState,
+    verify_package,
+)
 from knowledge_adapters.youtube import (
     BaseLanguageFallback,
     CaptionPolicy,
@@ -56,7 +60,10 @@ class FakeClient:
     def __init__(
         self,
         discovery: Discovery,
-        videos: dict[str, VideoObservation | list[VideoObservation | ProviderFailure]],
+        videos: dict[
+            str,
+            VideoObservation | ProviderFailure | list[VideoObservation | ProviderFailure],
+        ],
     ) -> None:
         self.discovery = discovery
         self.videos = videos
@@ -303,7 +310,9 @@ def test_playlist_order_duplicate_missing_position_and_unavailable_member(
     assert first["extensions"]["org.ctrl-alt-keith.youtube"]["source_position"] == 1
 
 
-def test_partial_batch_writes_checkpoint_but_does_not_seal(tmp_path: Path) -> None:
+def test_partial_batch_seals_continuation_and_checkpoints_completed_bytes(
+    tmp_path: Path,
+) -> None:
     discovery = Discovery(
         PLAYLIST,
         PLAYLIST,
@@ -324,17 +333,20 @@ def test_partial_batch_writes_checkpoint_but_does_not_seal(tmp_path: Path) -> No
         "video_001": video("video_001", creator_track()),
         "video_002": video("video_002", creator_track()),
     }
-    with pytest.raises(CollectionProgressBlocked, match="canonical collection progress"):
-        produce_package(
-            opts,
-            FakeClient(discovery, dict(partial_videos)),
-            request_id="request",
-            run_id="run",
-            package_id="package",
-            created_at="2026-07-10T00:00:00Z",
-            destination=tmp_path / "package",
-        )
-    assert checkpoint_path.is_file() and not (tmp_path / "package").exists()
+    initial = produce_package(
+        opts,
+        FakeClient(discovery, dict(partial_videos)),
+        request_id="request",
+        run_id="run",
+        package_id="package",
+        created_at="2026-07-10T00:00:00Z",
+        destination=tmp_path / "package",
+    )
+    assert initial.verification.verified_claims is not None
+    assert initial.verification.verified_claims.collection_progress == CollectionProgress(
+        CollectionProgressState.CONTINUATION_REMAINING
+    )
+    assert checkpoint_path.is_file() and (tmp_path / "package").is_dir()
     checkpoint_json = json.loads(checkpoint_path.read_bytes())
     assert [item["video_id"] for item in checkpoint_json["completed"]] == [
         "video_001",
@@ -355,27 +367,170 @@ def test_partial_batch_writes_checkpoint_but_does_not_seal(tmp_path: Path) -> No
             PlaylistEntry("video_004", 3),
         ),
     )
-    resume_client = FakeClient(changed_discovery, {})
-    with pytest.raises(CollectionProgressBlocked, match="resume lineage"):
-        produce_package(
-            resumed,
-            resume_client,
-            request_id="request-next",
-            run_id="run-next",
-            package_id="package-next",
-            created_at="2026-07-10T00:01:00Z",
-            destination=tmp_path / "package-next",
-        )
-    assert resume_client.calls == []
+    resume_client = FakeClient(
+        changed_discovery,
+        {
+            "video_003": video("video_003", creator_track()),
+            "video_004": video("video_004", creator_track()),
+        },
+    )
+    resumed_result = produce_package(
+        resumed,
+        resume_client,
+        request_id="request-next",
+        run_id="run-next",
+        package_id="package-next",
+        created_at="2026-07-10T00:01:00Z",
+        destination=tmp_path / "package-next",
+    )
+    assert resume_client.calls == ["video_003", "video_004"]
+    claims = resumed_result.verification.verified_claims
+    assert claims is not None
+    assert claims.collection_progress == CollectionProgress(CollectionProgressState.EXHAUSTED)
+    assert claims.resumes_run_id == "run"
+    assert claims.prior_run_ids == ("run",)
+    dispositions = {item.item_id: item.outcome for item in claims.item_dispositions}
+    assert dispositions["youtube-video-video_001"] == "unchanged"
+    assert "youtube-video-video_002" not in dispositions
     next_path = tmp_path / "checkpoint-next.json"
     next_json = json.loads(next_path.read_bytes())
-    assert [item["video_id"] for item in next_json["completed"]] == ["video_001"]
-    assert next_json["pending_video_ids"] == ["video_003", "video_004"]
+    assert [item["video_id"] for item in next_json["completed"]] == [
+        "video_001",
+        "video_003",
+        "video_004",
+    ]
+    assert next_json["pending_video_ids"] == []
     completed = next_json["completed"][0]
     assert (tmp_path / completed["captured_path"]).read_bytes() == creator_track().data
     assert (tmp_path / completed["normalized_path"]).read_bytes() == (
         b"Hello from the creator.\n\n**Ada:** Welcome aboard.\n"
     )
+
+
+def test_fully_processed_bounded_collection_claims_exhausted(tmp_path: Path) -> None:
+    discovery = Discovery(
+        PLAYLIST,
+        PLAYLIST,
+        "playlist_001",
+        (PlaylistEntry("video_001", 1), PlaylistEntry("video_002", 2)),
+        True,
+    )
+    result = produce_package(
+        YouTubeOptions(PLAYLIST, ScopeKind.COLLECTION, 2),
+        FakeClient(
+            discovery,
+            {
+                "video_001": video("video_001", creator_track()),
+                "video_002": video("video_002", creator_track()),
+            },
+        ),
+        request_id="request-exhausted",
+        run_id="run-exhausted",
+        package_id="package-exhausted",
+        created_at="2026-07-10T00:00:00Z",
+        destination=tmp_path / "package",
+    )
+    claims = result.verification.verified_claims
+    assert claims is not None
+    assert claims.collection_progress == CollectionProgress(CollectionProgressState.EXHAUSTED)
+    assert len(claims.item_dispositions) == 2
+
+
+def test_verification_summary_excludes_provider_extensions_and_content(tmp_path: Path) -> None:
+    result = produce_package(
+        options(),
+        single_client(creator_track()),
+        request_id="request-summary",
+        run_id="run-summary",
+        package_id="package-summary",
+        created_at="2026-07-10T00:00:00Z",
+        destination=tmp_path / "package",
+    )
+    serialized = json.dumps(asdict(result.verification), default=str, sort_keys=True)
+    assert "org.ctrl-alt-keith.youtube" not in serialized
+    assert "selection_reason" not in serialized
+    assert "Hello from the creator" not in serialized
+    claims = result.verification.verified_claims
+    assert claims is not None
+    assert claims.item_dispositions[0].provider == "youtube"
+
+
+def test_failure_resume_success_preserves_cumulative_attempt_count(tmp_path: Path) -> None:
+    discovery = Discovery(
+        PLAYLIST,
+        PLAYLIST,
+        "playlist_001",
+        (PlaylistEntry("video_001", 1), PlaylistEntry("video_002", 2)),
+        True,
+    )
+    first_checkpoint = tmp_path / "first.json"
+    first_options = YouTubeOptions(
+        PLAYLIST,
+        ScopeKind.COLLECTION,
+        2,
+        batch_size=1,
+        checkpoint_output=first_checkpoint,
+    )
+    produce_package(
+        first_options,
+        FakeClient(
+            discovery,
+            {
+                "video_001": ProviderFailure(
+                    ProviderFailureCategory.REMOVED, "fixture-removed"
+                )
+            },
+        ),
+        request_id="request-first",
+        run_id="run-first",
+        package_id="package-first",
+        created_at="2026-07-10T00:00:00Z",
+        destination=tmp_path / "package-first",
+    )
+    assert json.loads(first_checkpoint.read_bytes())["attempts"]["video_001"] == 1
+
+    next_checkpoint = tmp_path / "next.json"
+    resumed = replace(
+        first_options,
+        checkpoint_input=first_checkpoint,
+        checkpoint_output=next_checkpoint,
+    )
+    result = produce_package(
+        resumed,
+        FakeClient(discovery, {"video_001": video("video_001", creator_track())}),
+        request_id="request-next",
+        run_id="run-next",
+        package_id="package-next",
+        created_at="2026-07-10T00:01:00Z",
+        destination=tmp_path / "package-next",
+    )
+    claims = result.verification.verified_claims
+    assert claims is not None and claims.resumes_run_id == "run-first"
+    manifest = json.loads((result.package_path / "package.json").read_bytes())
+    assert manifest["final_attempt_counts"]["video_001"] == 2
+    assert json.loads(next_checkpoint.read_bytes())["attempts"]["video_001"] == 2
+
+
+def test_non_actionable_provider_continuation_is_explicitly_blocked(tmp_path: Path) -> None:
+    discovery = Discovery(
+        PLAYLIST,
+        PLAYLIST,
+        "playlist_001",
+        (PlaylistEntry("video_001", 1),),
+        False,
+        "opaque-continuation",
+    )
+    with pytest.raises(CollectionProgressBlocked, match="not actionable"):
+        produce_package(
+            YouTubeOptions(PLAYLIST, ScopeKind.COLLECTION, 1),
+            FakeClient(discovery, {"video_001": video("video_001", creator_track())}),
+            request_id="request",
+            run_id="run",
+            package_id="package",
+            created_at="2026-07-10T00:00:00Z",
+            destination=tmp_path / "package",
+        )
+    assert not (tmp_path / "package").exists()
 
 
 def test_checkpoint_validation_and_changed_playlist_reconciliation(tmp_path: Path) -> None:
@@ -404,6 +559,16 @@ def test_checkpoint_validation_and_changed_playlist_reconciliation(tmp_path: Pat
                 1,
                 captured_path,
                 normalized_path,
+                "https://www.youtube.com/watch?v=video_001",
+                "Fixture title",
+                "Fixture channel",
+                "20260710",
+                "en",
+                "creator",
+                "vtt",
+                None,
+                "playlist_001",
+                1,
             ),
         ),
         {"video_001": "completed"},
@@ -411,6 +576,8 @@ def test_checkpoint_validation_and_changed_playlist_reconciliation(tmp_path: Pat
         ("video_002",),
         None,
         "item:video_001",
+        "run-fixture",
+        "package-fixture",
     )
     save_checkpoint(checkpoint, path)
     loaded = load_checkpoint(path, expected_fingerprint=fingerprint)
@@ -459,7 +626,7 @@ def test_checkpoint_read_and_depth_are_bounded(tmp_path: Path) -> None:
     path.write_text(
         json.dumps(
             {
-                "schema_version": "1.1.0",
+                "schema_version": "1.2.0",
                 "request_fingerprint": "0" * 64,
                 "bounded_discovery": nested,
             }


### PR DESCRIPTION
## Summary

Adds the bounded YouTube Source Package producer using only the public builder, collection-progress, lineage, consumer-profile, and verified-summary APIs. PR #317 merged to `main` as `00d7181ba474b0d0e51d1126840c130b9cf0020f`; this branch is now restacked directly on that revision.

## Stacked API integration

- Collection packages use contract `1.1.0` and public `CollectionProgress`.
- Partial batches seal as `continuation_remaining`; fully accounted bounded windows seal as `exhausted`.
- Resumed packages use new run IDs and public `PackageLineage` with prior identities, reconciliation counts, and cumulative attempts.
- Matching checkpoint items are rebuilt as `unchanged` from bounded typed metadata and integrity-verified cached bytes.
- Changed-playlist reconciliation preserves matching IDs, drops disappeared IDs, and acquires or leaves new IDs according to `batch_size`.
- Non-actionable opaque provider continuation remains explicitly fail-closed because no safe cursor convention exists.

The producer parses no package manifest or item record after sealing. Handoff assertions consume only public verified identity, progress, lineage, item dispositions, artifact inventory, totals, content address, and profile identity. It inherits PR #319's descriptor-relative no-follow package reader through the public verifier and has no dependency on pathname-following or private verifier internals.

## Provider boundary and bounds

- `yt-dlp` remains behind `YouTubeClient` and the optional `youtube` dependency group.
- Bounds: 500 collection items, 16 languages, 64 relevant caption candidates, 8 MiB per caption, and 4096 UTF-8 bytes per consumed metadata string.
- Only the selected VTT URL is acquired through a `limit + 1` bounded read.
- Unsupported formats remain bounded evidence and map to `normalization-unsupported`.
- Signed URLs, cookies, credentials, and expiring media URLs are never returned, checkpointed, diagnosed, or packaged.
- Adapter identity and yt-dlp dependency identity remain separate.
- Deterministic tests use fake boundaries; no live provider access occurs in `make check`.

The boundary follows the [official yt-dlp README](https://github.com/yt-dlp/yt-dlp/blob/master/README.md) for config suppression, flat/bounded playlist behavior, skip-download, and subtitle behavior.

## Deterministic normalization

`youtube-webvtt-to-markdown/1.0.0` uses strict UTF-8, LF endings, Unicode NFC, transport-header and timestamp removal, Markdown speaker labels, rolling-caption collapse, spoken cue order, and exactly one trailing newline. Raw VTT is omitted unless explicitly requested.

## Checkpoint convention

Checkpoint schema `1.2.0` is mutable adapter-local state outside the package. JSON is limited to 1 MiB, depth 8, and 500 observed IDs. Captured and normalized bytes live under safe checkpoint-owned paths, are limited to 8 MiB, and are SHA-256 verified before reuse. Retry limits apply to each new run while canonical lineage counts remain cumulative.

## Fixture and failure coverage

Coverage includes creator and automatic captions, language precedence, rolling captions, absent/malformed/unsupported captions, playlist ordering and unavailable members, structured failures, bounded retries, partial/exhausted packages, resume lineage, changed playlists, cached-byte preservation, failure-to-success cumulative attempts, result-summary exclusions, raw-caption policy, deterministic replay, and public-verifier acceptance.

Fixture-backed categories do not claim yt-dlp exposes structured evidence for every provider outcome. Unknown real evidence remains conservatively unavailable without message-text inference.

## Restack reconciliation

After PR #317 merged, the three YouTube-owned commits were rebased onto `main` at `00d7181ba474b0d0e51d1126840c130b9cf0020f`. `git range-diff` showed a one-to-one patch-identical replay. No producer behavior, public package boundary, progress/lineage semantics, or fail-closed continuation behavior changed.

## Validation

- `TMPDIR=/Users/keith/src/ctrl-alt-keith/scratch/youtube-restack-temp make check`
- Ruff passed
- strict mypy passed across 123 source files
- pytest passed: 754 tests
- post-merge restack: 754 tests
- deterministic YouTube tests block network; no live provider or Running Remote access occurred

## Explicit non-goals and pilot questions

This PR does not run the Running Remote pilot, enumerate its playlist, add transcription, change vault behavior, write package internals, alter collection-progress semantics, or auto-promote content.

Before a bounded pilot: merge/restack the draft dependency chain in order, refresh the vault's exact verifier pin, rerun independent producer-to-consumer integration and canonical-reader probes, confirm installed yt-dlp and adapter revisions, and obtain explicit pilot authorization.
