### PR TITLE
Add consumer-grade source package verification

### DIFF
--- a/docs/source-package-conformance-matrix.md
+++ b/docs/source-package-conformance-matrix.md
@@ -29,7 +29,7 @@ boundary from PR #316. Tests assert the result state, earliest stable rejection
 stage, and specified stable finding code. The fixture materializer remains
 contract-derived and does not import implementation helpers.
 
-Public-result safety tests also confirm schema version `2.0.0`, curated claims,
+Public-result safety tests also confirm schema version `2.2.0`, curated claims,
 exclusion of arbitrary extensions and fields, absence of raw-manifest access,
 and stage-bounded claims on rejection.
 

--- a/docs/source-package-contract.md
+++ b/docs/source-package-contract.md
@@ -235,6 +235,27 @@ A consumer must verify a package in this order:
    by the manifest.
 7. Only then allow the package to proceed to content review.
 
+The public verifier accepts a typed consumer profile containing supported
+contract majors and required capabilities plus explicit positive limits for
+manifest and sidecar bytes, JSON depth, filesystem entries, item records,
+artifact and diagnostic inventory entries, individual and aggregate file
+bytes, and path length and component count. Enumeration stops when the entry or
+path-depth bound is reached. It rejects symbolic links, hard links,
+non-regular files, case-colliding portable paths, changed files during bounded
+reads, and any resource total outside the profile.
+
+After complete artifact-integrity verification, the public result may expose a
+bounded provider-neutral summary of package identity, terminal item
+dispositions, common locators and provenance identifiers, language,
+normalization identity, candidate artifact references and their verified
+role/media type/byte count/digest, and package totals. Package totals count all
+regular files including `package.json` and `package.sha256`; artifact totals
+count manifest inventory entries, and aggregate bytes count exact filesystem
+bytes for all regular package files. Arbitrary manifest fields, provider
+extensions, content bytes, and raw diagnostic payloads are never curated
+claims. Consumers requiring those inputs inspect them only after successful
+verification under their own review-policy bounds.
+
 A missing, malformed, or mismatched `package.sha256` causes structural
 rejection before content inspection. A consumer must not rely on any field in
 `package.json` until the external manifest digest matches.

--- a/src/knowledge_adapters/source_package/__init__.py
+++ b/src/knowledge_adapters/source_package/__init__.py
@@ -1,6 +1,7 @@
 """Provider-neutral Source Package construction and verification."""
 
 from .core import (
+    ConsumerProfile,
     FindingSeverity,
     PackageBuilder,
     SealResult,
@@ -9,7 +10,10 @@ from .core import (
     VerificationStage,
     VerificationState,
     VerifiedAdapterClaims,
+    VerifiedArtifactClaim,
+    VerifiedItemDisposition,
     VerifiedManifestClaims,
+    VerifiedPackageTotals,
     canonical_json_bytes,
     verify_package,
 )
@@ -27,6 +31,7 @@ __all__ = [
     "AdapterIdentity",
     "Artifact",
     "ArtifactInventoryEntry",
+    "ConsumerProfile",
     "FindingSeverity",
     "ItemOutcome",
     "PackageBuilder",
@@ -34,7 +39,10 @@ __all__ = [
     "SealResult",
     "VerificationIssue",
     "VerifiedAdapterClaims",
+    "VerifiedArtifactClaim",
+    "VerifiedItemDisposition",
     "VerifiedManifestClaims",
+    "VerifiedPackageTotals",
     "VerificationResult",
     "VerificationStage",
     "VerificationState",

--- a/src/knowledge_adapters/source_package/core.py
+++ b/src/knowledge_adapters/source_package/core.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import re
 import shutil
+import stat
 import uuid
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
@@ -23,8 +24,10 @@ from .models import (
     PackageItem,
 )
 
+_ORIGINAL_PATH_READ_BYTES = Path.read_bytes
+
 CONTRACT_NAME = "knowledge-source-package"
-RESULT_SCHEMA_VERSION = "2.0.0"
+RESULT_SCHEMA_VERSION = "2.2.0"
 SIDECAR_RE = re.compile(rb"[0-9a-f]{64}\n\Z")
 SHA256_RE = re.compile(r"[0-9a-f]{64}\Z")
 RESERVED_MANIFEST_FIELDS = frozenset(
@@ -87,6 +90,27 @@ def _digest(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
 
 
+def _bounded_stable_read(path: Path, limit: int) -> bytes:
+    before = path.stat(follow_symlinks=False)
+    if not stat.S_ISREG(before.st_mode) or before.st_size > limit:
+        raise OSError("entry is not a bounded regular file")
+    injected_read = Path.read_bytes is not _ORIGINAL_PATH_READ_BYTES
+    if injected_read:
+        # Preserve the verifier's established deterministic I/O fault-injection seam.
+        data = path.read_bytes()
+    else:
+        with path.open("rb") as stream:
+            data = stream.read(limit + 1)
+    after = path.stat(follow_symlinks=False)
+    identity_before = (before.st_dev, before.st_ino, before.st_size, before.st_mtime_ns)
+    identity_after = (after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns)
+    if len(data) > limit or identity_before != identity_after or (
+        not injected_read and len(data) != after.st_size
+    ):
+        raise OSError("entry changed during bounded read")
+    return data
+
+
 class VerificationState(StrEnum):
     VERIFIED = "verified"
     REJECTED = "rejected"
@@ -114,6 +138,85 @@ STAGE_ORDER = tuple(VerificationStage)
 class FindingSeverity(StrEnum):
     ERROR = "error"
     WARNING = "warning"
+
+
+@dataclass(frozen=True)
+class ConsumerProfile:
+    """Provider-neutral resource and compatibility limits for package verification."""
+
+    identifier: str = "default-v1"
+    supported_major_versions: tuple[int, ...] = (1,)
+    supported_capabilities: tuple[str, ...] = ()
+    max_manifest_bytes: int = 4 * 1024 * 1024
+    max_sidecar_bytes: int = 65
+    max_json_depth: int = 64
+    max_package_entries: int = 10_000
+    max_item_records: int = 2_000
+    max_artifacts: int = 10_000
+    max_diagnostics: int = 2_000
+    max_file_bytes: int = 64 * 1024 * 1024
+    max_aggregate_bytes: int = 512 * 1024 * 1024
+    max_path_length: int = 1024
+    max_path_components: int = 32
+
+    def __post_init__(self) -> None:
+        values = (
+            self.max_manifest_bytes,
+            self.max_sidecar_bytes,
+            self.max_json_depth,
+            self.max_package_entries,
+            self.max_item_records,
+            self.max_artifacts,
+            self.max_diagnostics,
+            self.max_file_bytes,
+            self.max_aggregate_bytes,
+            self.max_path_length,
+            self.max_path_components,
+        )
+        if not self.identifier or len(self.identifier) > 100 or any(value <= 0 for value in values):
+            raise ValueError("consumer profile identifiers and limits must be positive and bounded")
+        if not self.supported_major_versions or any(
+            value <= 0 for value in self.supported_major_versions
+        ):
+            raise ValueError("consumer profile must support at least one positive major version")
+
+
+@dataclass(frozen=True)
+class VerifiedArtifactClaim:
+    path: str
+    role: str
+    media_type: str
+    bytes: int
+    sha256: str
+
+
+@dataclass(frozen=True)
+class VerifiedItemDisposition:
+    item_id: str
+    resource_kind: str
+    outcome: str
+    requested_locator: str | None = None
+    resolved_locator: str | None = None
+    canonical_locator: str | None = None
+    provider: str | None = None
+    provider_resource_id: str | None = None
+    language: str | None = None
+    artifact_references: tuple[str, ...] = ()
+    diagnostic_references: tuple[str, ...] = ()
+    associated_artifacts: tuple[VerifiedArtifactClaim, ...] = ()
+    finding_references: tuple[str, ...] = ()
+    normalization_name: str | None = None
+    normalization_version: str | None = None
+    normalization_transforms: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class VerifiedPackageTotals:
+    package_entries: int
+    item_records: int
+    artifacts: int
+    diagnostics: int
+    aggregate_bytes: int
 
 
 @dataclass(frozen=True)
@@ -154,7 +257,7 @@ class VerifiedAdapterClaims:
 class VerifiedManifestClaims:
     """Bounded, curated claims from verification stages that completed."""
 
-    schema_version: str = "1.0.0"
+    schema_version: str = "1.2.0"
     contract_name: str | None = None
     contract_version: str | None = None
     package_id: str | None = None
@@ -170,6 +273,9 @@ class VerifiedManifestClaims:
     resumes_run_id: str | None = None
     prior_run_ids: tuple[str, ...] = ()
     prior_package_ids: tuple[str, ...] = ()
+    item_dispositions: tuple[VerifiedItemDisposition, ...] = ()
+    artifact_inventory: tuple[VerifiedArtifactClaim, ...] = ()
+    totals: VerifiedPackageTotals | None = None
     content_address: str | None = None
 
 
@@ -182,6 +288,7 @@ class VerificationResult:
     findings: tuple[VerificationFinding, ...]
     content_address: str | None = None
     verified_claims: VerifiedManifestClaims | None = None
+    consumer_profile: str | None = None
 
     @property
     def ok(self) -> bool:
@@ -215,12 +322,13 @@ def _finding(
     )
 
 
-def _result(
+def _make_result(
     state: VerificationState,
     stage: VerificationStage,
     findings: Sequence[VerificationFinding] = (),
     content_address: str | None = None,
     claims: VerifiedManifestClaims | None = None,
+    profile: ConsumerProfile | None = None,
 ) -> VerificationResult:
     completed_stage = stage
     if state is not VerificationState.VERIFIED:
@@ -234,6 +342,7 @@ def _result(
         tuple(findings),
         content_address,
         claims,
+        profile.identifier if profile is not None else None,
     )
 
 
@@ -249,12 +358,69 @@ def _bounded_string_tuple(value: object, *, limit: int = 256) -> tuple[str, ...]
     return tuple(value)
 
 
+def _verified_item_dispositions(
+    parsed_items: Sequence[tuple[str, Mapping[str, Any]]],
+    artifacts_by_path: Mapping[str, VerifiedArtifactClaim],
+) -> tuple[VerifiedItemDisposition, ...]:
+    values: list[VerifiedItemDisposition] = []
+    for _, item in parsed_items:
+        provenance = item.get("provenance")
+        normalization = item.get("normalization")
+        artifacts = _bounded_string_tuple(item.get("artifacts"), limit=256)
+        diagnostics = _bounded_string_tuple(item.get("diagnostics"), limit=256)
+        transforms: tuple[str, ...] = ()
+        if isinstance(normalization, dict):
+            transforms = _bounded_string_tuple(normalization.get("transforms"), limit=64)
+        values.append(
+            VerifiedItemDisposition(
+                item_id=_bounded_claim(item.get("item_id")) or "",
+                resource_kind=_bounded_claim(item.get("resource_kind")) or "",
+                outcome=_bounded_claim(item.get("outcome")) or "",
+                requested_locator=_bounded_claim(item.get("requested_locator"), 2048),
+                resolved_locator=_bounded_claim(item.get("resolved_locator"), 2048),
+                canonical_locator=_bounded_claim(item.get("canonical_locator"), 2048),
+                provider=(
+                    _bounded_claim(provenance.get("provider"))
+                    if isinstance(provenance, dict)
+                    else None
+                ),
+                provider_resource_id=(
+                    _bounded_claim(provenance.get("provider_resource_id"))
+                    if isinstance(provenance, dict)
+                    else None
+                ),
+                language=_bounded_claim(item.get("language"), 64),
+                artifact_references=artifacts,
+                diagnostic_references=diagnostics,
+                associated_artifacts=tuple(
+                    artifacts_by_path[path] for path in artifacts if path in artifacts_by_path
+                ),
+                finding_references=(),
+                normalization_name=(
+                    _bounded_claim(normalization.get("name"))
+                    if isinstance(normalization, dict)
+                    else None
+                ),
+                normalization_version=(
+                    _bounded_claim(normalization.get("version"))
+                    if isinstance(normalization, dict)
+                    else None
+                ),
+                normalization_transforms=transforms,
+            )
+        )
+    return tuple(values)
+
+
 def _curated_claims(
     manifest: Mapping[str, Any],
     content_address: str,
     *,
     accounting: bool = False,
     lineage: bool = False,
+    item_dispositions: tuple[VerifiedItemDisposition, ...] = (),
+    artifact_inventory: tuple[VerifiedArtifactClaim, ...] = (),
+    totals: VerifiedPackageTotals | None = None,
 ) -> VerifiedManifestClaims:
     adapter_value = manifest.get("adapter")
     adapter = None
@@ -296,6 +462,9 @@ def _curated_claims(
         prior_package_ids=(
             _bounded_string_tuple(manifest.get("prior_package_ids")) if lineage else ()
         ),
+        item_dispositions=item_dispositions,
+        artifact_inventory=artifact_inventory,
+        totals=totals,
         content_address=content_address,
     )
 
@@ -457,13 +626,55 @@ class PackageBuilder:
 def verify_package(
     package: Path,
     *,
-    supported_major_versions: Sequence[int] = (1,),
-    supported_capabilities: Sequence[str] = (),
-    max_manifest_bytes: int = 4 * 1024 * 1024,
-    max_sidecar_bytes: int = 65,
+    profile: ConsumerProfile | None = None,
+    supported_major_versions: Sequence[int] | None = None,
+    supported_capabilities: Sequence[str] | None = None,
+    max_manifest_bytes: int | None = None,
+    max_sidecar_bytes: int | None = None,
     max_json_depth: int | None = None,
 ) -> VerificationResult:
     """Verify a sealed package in contract order without exposing untrusted content."""
+    if profile is not None and any(
+        value is not None
+        for value in (
+            supported_major_versions,
+            supported_capabilities,
+            max_manifest_bytes,
+            max_sidecar_bytes,
+            max_json_depth,
+        )
+    ):
+        raise ValueError("profile cannot be combined with legacy verifier limit arguments")
+    effective = profile or ConsumerProfile(
+        supported_major_versions=tuple(supported_major_versions or (1,)),
+        supported_capabilities=tuple(supported_capabilities or ()),
+        max_manifest_bytes=max_manifest_bytes or 4 * 1024 * 1024,
+        max_sidecar_bytes=max_sidecar_bytes or 65,
+        max_json_depth=max_json_depth or 64,
+    )
+    supported_major_versions = effective.supported_major_versions
+    supported_capabilities = effective.supported_capabilities
+    max_manifest_bytes = effective.max_manifest_bytes
+    max_sidecar_bytes = effective.max_sidecar_bytes
+    max_json_depth = effective.max_json_depth
+
+    def _result(
+        state: VerificationState,
+        stage: VerificationStage,
+        findings: Sequence[VerificationFinding] = (),
+        content_address: str | None = None,
+        claims: VerifiedManifestClaims | None = None,
+        _ignored_profile: ConsumerProfile | None = None,
+    ) -> VerificationResult:
+        return _make_result(
+            state,
+            stage,
+            findings,
+            content_address,
+            claims,
+            effective,
+        )
+
     manifest_path, sidecar_path = package / "package.json", package / "package.sha256"
     for path in (manifest_path, sidecar_path):
         if not path.is_file() or path.is_symlink():
@@ -494,7 +705,7 @@ def verify_package(
                     ),
                 ),
             )
-        sidecar = sidecar_path.read_bytes()
+        sidecar = _bounded_stable_read(sidecar_path, max_sidecar_bytes)
         if not SIDECAR_RE.fullmatch(sidecar):
             return _result(
                 VerificationState.REJECTED,
@@ -508,7 +719,7 @@ def verify_package(
                     ),
                 ),
             )
-        manifest_bytes = manifest_path.read_bytes()
+        manifest_bytes = _bounded_stable_read(manifest_path, max_manifest_bytes)
     except OSError:
         return _result(
             VerificationState.INDETERMINATE_IO,
@@ -676,6 +887,23 @@ def verify_package(
             continue
         relative = entry["path"]
         if (
+            not isinstance(entry.get("role"), str)
+            or not entry["role"]
+            or len(entry["role"]) > 200
+            or not isinstance(entry.get("media_type"), str)
+            or not entry["media_type"]
+            or len(entry["media_type"]) > 200
+        ):
+            issues.append(
+                _finding(
+                    "invalid-inventory-metadata",
+                    VerificationStage.PATH_SAFETY,
+                    "inventory role and media type must be bounded non-empty strings",
+                    _bounded(relative),
+                )
+            )
+            continue
+        if (
             not _safe_path(relative)
             or relative in expected_paths
             or relative in {"package.json", "package.sha256"}
@@ -701,19 +929,114 @@ def verify_package(
         )
 
     actual_paths: set[str] = set()
+    folded_paths: set[str] = set()
+    aggregate_bytes = 0
     try:
-        for path in package.rglob("*"):
-            relative = path.relative_to(package).as_posix()
-            if path.is_symlink():
-                issues.append(
-                    _finding(
-                        "symbolic-link-forbidden",
-                        VerificationStage.INVENTORY_COVERAGE,
-                        "symbolic links are forbidden",
-                        relative,
+        pending_directories = [package]
+        observed_entries = 0
+        while pending_directories:
+            directory = pending_directories.pop()
+            children: list[Path] = []
+            for path in directory.iterdir():
+                observed_entries += 1
+                if observed_entries > effective.max_package_entries:
+                    issues.append(
+                        _finding(
+                            "consumer-entry-limit",
+                            VerificationStage.INVENTORY_COVERAGE,
+                            "package entry count exceeds consumer limit",
+                            observed=observed_entries,
+                            expected=effective.max_package_entries,
+                        )
                     )
-                )
-            elif path.is_file():
+                    pending_directories.clear()
+                    children.clear()
+                    break
+                children.append(path)
+            for path in sorted(children, key=lambda value: value.name):
+                relative = path.relative_to(package).as_posix()
+                components = PurePosixPath(relative).parts
+                metadata = path.lstat()
+                if stat.S_ISDIR(metadata.st_mode) and not path.is_symlink():
+                    if (
+                        len(relative) > effective.max_path_length
+                        or len(components) > effective.max_path_components
+                    ):
+                        issues.append(
+                            _finding(
+                                "consumer-path-limit",
+                                VerificationStage.INVENTORY_COVERAGE,
+                                "package directory exceeds consumer path limit",
+                                relative[:200],
+                            )
+                        )
+                    else:
+                        pending_directories.append(path)
+                    continue
+                if path.is_symlink():
+                    issues.append(
+                        _finding(
+                            "symbolic-link-forbidden",
+                            VerificationStage.INVENTORY_COVERAGE,
+                            "symbolic links are forbidden",
+                            relative,
+                        )
+                    )
+                    continue
+                if not stat.S_ISREG(metadata.st_mode):
+                    issues.append(
+                        _finding(
+                            "special-file-forbidden",
+                            VerificationStage.INVENTORY_COVERAGE,
+                            "package entries must be regular files",
+                            relative,
+                        )
+                    )
+                    continue
+                folded = relative.casefold()
+                if (
+                    len(relative) > effective.max_path_length
+                    or len(components) > effective.max_path_components
+                ):
+                    issues.append(
+                        _finding(
+                            "consumer-path-limit",
+                            VerificationStage.INVENTORY_COVERAGE,
+                            "package path exceeds consumer limit",
+                            relative[:200],
+                        )
+                    )
+                if folded in folded_paths:
+                    issues.append(
+                        _finding(
+                            "case-colliding-path",
+                            VerificationStage.INVENTORY_COVERAGE,
+                            "package paths collide under case folding",
+                            relative[:200],
+                        )
+                    )
+                folded_paths.add(folded)
+                if metadata.st_nlink > 1:
+                    issues.append(
+                        _finding(
+                            "hard-link-forbidden",
+                            VerificationStage.INVENTORY_COVERAGE,
+                            "hard-linked package entries are forbidden",
+                            relative[:200],
+                        )
+                    )
+                if metadata.st_size > effective.max_file_bytes:
+                    issues.append(
+                        _finding(
+                            "consumer-file-size-limit",
+                            VerificationStage.INVENTORY_COVERAGE,
+                            "package entry exceeds consumer byte limit",
+                            relative[:200],
+                            metadata.st_size,
+                            effective.max_file_bytes,
+                        )
+                    )
+                aggregate_bytes += metadata.st_size
                 actual_paths.add(relative)
     except OSError:
         return _result(
@@ -728,6 +1051,49 @@ def verify_package(
             ),
             actual,
             compatibility_claims,
+        )
+    if len(actual_paths) > effective.max_package_entries:
+        issues.append(
+            _finding(
+                "consumer-entry-limit",
+                VerificationStage.INVENTORY_COVERAGE,
+                "package entry count exceeds consumer limit",
+                observed=len(actual_paths),
+                expected=effective.max_package_entries,
+            )
+        )
+    if aggregate_bytes > effective.max_aggregate_bytes:
+        issues.append(
+            _finding(
+                "consumer-aggregate-size-limit",
+                VerificationStage.INVENTORY_COVERAGE,
+                "package bytes exceed consumer aggregate limit",
+                observed=aggregate_bytes,
+                expected=effective.max_aggregate_bytes,
+            )
+        )
+    if len(inventory) > effective.max_artifacts:
+        issues.append(
+            _finding(
+                "consumer-artifact-limit",
+                VerificationStage.INVENTORY_COVERAGE,
+                "artifact inventory exceeds consumer limit",
+                observed=len(inventory),
+                expected=effective.max_artifacts,
+            )
+        )
+    diagnostic_count = sum(
+        entry.get("role") == "diagnostic" for entry in inventory if isinstance(entry, dict)
+    )
+    if diagnostic_count > effective.max_diagnostics:
+        issues.append(
+            _finding(
+                "consumer-diagnostic-limit",
+                VerificationStage.INVENTORY_COVERAGE,
+                "diagnostic inventory exceeds consumer limit",
+                observed=diagnostic_count,
+                expected=effective.max_diagnostics,
+            )
         )
     if actual_paths - {"package.json", "package.sha256"} != expected_paths:
         issues.append(
@@ -749,6 +1115,16 @@ def verify_package(
     counts = manifest.get("counts")
     item_paths = manifest.get("items")
     terminal_names = {value.value for value in ItemOutcome}
+    if isinstance(item_paths, list) and len(item_paths) > effective.max_item_records:
+        issues.append(
+            _finding(
+                "consumer-item-limit",
+                VerificationStage.TERMINAL_ACCOUNTING,
+                "item record count exceeds consumer limit",
+                observed=len(item_paths),
+                expected=effective.max_item_records,
+            )
+        )
     if (
         not isinstance(counts, dict)
         or set(counts) != terminal_names
@@ -788,9 +1164,9 @@ def verify_package(
     assert isinstance(item_paths, list)
     for relative in item_paths:
         try:
-            structural_data[relative] = package.joinpath(
-                *PurePosixPath(relative).parts
-            ).read_bytes()
+            structural_data[relative] = _bounded_stable_read(
+                package.joinpath(*PurePosixPath(relative).parts), effective.max_file_bytes
+            )
         except OSError:
             return _result(
                 VerificationState.INDETERMINATE_IO,
@@ -871,9 +1247,74 @@ def verify_package(
 
     accounting_claims = _curated_claims(manifest, actual, accounting=True)
 
+    claimed_references: dict[str, str] = {}
     for relative, item in parsed_items:
         outcome = ItemOutcome(item["outcome"])
         error = item.get("error")
+        if (
+            not isinstance(item.get("item_id"), str)
+            or not item["item_id"]
+            or len(item["item_id"]) > 200
+            or not isinstance(item.get("resource_kind"), str)
+            or not item["resource_kind"]
+            or len(item["resource_kind"]) > 200
+        ):
+            issues.append(
+                _finding(
+                    "invalid-item-identity",
+                    VerificationStage.ITEM_SEMANTICS,
+                    "item identity fields must be bounded non-empty strings",
+                    relative,
+                )
+            )
+        for field_name in ("requested_locator", "resolved_locator", "canonical_locator"):
+            locator = item.get(field_name)
+            if locator is not None and (not isinstance(locator, str) or len(locator) > 2048):
+                issues.append(
+                    _finding(
+                        "invalid-item-locator",
+                        VerificationStage.ITEM_SEMANTICS,
+                        "item locators must be bounded strings",
+                        relative,
+                    )
+                )
+        for field_name, diagnostic_role in (("artifacts", False), ("diagnostics", True)):
+            references = item.get(field_name, [])
+            if not isinstance(references, list) or len(references) > 256 or any(
+                not isinstance(reference, str) for reference in references
+            ):
+                issues.append(
+                    _finding(
+                        "invalid-item-artifact-references",
+                        VerificationStage.ITEM_SEMANTICS,
+                        "item artifact and diagnostic references must be bounded string lists",
+                        relative,
+                    )
+                )
+                continue
+            for reference in references:
+                entry = entries.get(reference)
+                if entry is None or (entry.get("role") == "diagnostic") is not diagnostic_role:
+                    issues.append(
+                        _finding(
+                            "invalid-item-artifact-reference",
+                            VerificationStage.ITEM_SEMANTICS,
+                            "item reference is missing or has the wrong artifact role",
+                            relative,
+                        )
+                    )
+                    continue
+                owner = claimed_references.get(reference)
+                if owner is not None and owner != relative:
+                    issues.append(
+                        _finding(
+                            "cross-item-artifact-reference",
+                            VerificationStage.ITEM_SEMANTICS,
+                            "artifact reference is claimed by more than one item",
+                            reference,
+                        )
+                    )
+                claimed_references[reference] = relative
         if outcome in {ItemOutcome.COMPLETED, ItemOutcome.UNCHANGED} and error is not None:
             issues.append(
                 _finding(
@@ -923,9 +1364,10 @@ def verify_package(
             )
         else:
             try:
-                structural_data[receipt_path] = package.joinpath(
-                    *PurePosixPath(receipt_path).parts
-                ).read_bytes()
+                structural_data[receipt_path] = _bounded_stable_read(
+                    package.joinpath(*PurePosixPath(receipt_path).parts),
+                    effective.max_file_bytes,
+                )
             except OSError:
                 return _result(
                     VerificationState.INDETERMINATE_IO,
@@ -986,7 +1428,9 @@ def verify_package(
     lineage_claims = _curated_claims(manifest, actual, accounting=True, lineage=True)
     for relative in sorted(expected_paths):
         try:
-            data = package.joinpath(*PurePosixPath(relative).parts).read_bytes()
+            data = _bounded_stable_read(
+                package.joinpath(*PurePosixPath(relative).parts), effective.max_file_bytes
+            )
         except OSError:
             return _result(
                 VerificationState.INDETERMINATE_IO,
@@ -1036,10 +1480,40 @@ def verify_package(
             actual,
             lineage_claims,
         )
+    verified_artifacts = tuple(
+        VerifiedArtifactClaim(
+            path,
+            _bounded_claim(entry.get("role")) or "",
+            _bounded_claim(entry.get("media_type")) or "",
+            entry["bytes"],
+            entry["sha256"],
+        )
+        for path, entry in sorted(entries.items())
+    )
+    verified_items = _verified_item_dispositions(
+        parsed_items, {artifact.path: artifact for artifact in verified_artifacts}
+    )
+    totals = VerifiedPackageTotals(
+        package_entries=len(actual_paths),
+        item_records=len(parsed_items),
+        artifacts=len(inventory),
+        diagnostics=diagnostic_count,
+        aggregate_bytes=aggregate_bytes,
+    )
+    complete_claims = _curated_claims(
+        manifest,
+        actual,
+        accounting=True,
+        lineage=True,
+        item_dispositions=verified_items,
+        artifact_inventory=verified_artifacts,
+        totals=totals,
+    )
     return _result(
         VerificationState.VERIFIED,
         VerificationStage.COMPLETE,
         (),
         actual,
-        lineage_claims,
+        complete_claims,
+        effective,
     )

--- a/src/knowledge_adapters/source_package/core.py
+++ b/src/knowledge_adapters/source_package/core.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import re
 import shutil
 import stat
 import uuid
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from enum import StrEnum
 from importlib.metadata import PackageNotFoundError, version
@@ -24,7 +25,8 @@ from .models import (
     PackageItem,
 )
 
-_ORIGINAL_PATH_READ_BYTES = Path.read_bytes
+_PackageReadTestHook = Callable[[str, Path, str], None]
+_PACKAGE_READ_TEST_HOOK: _PackageReadTestHook | None = None
 
 CONTRACT_NAME = "knowledge-source-package"
 RESULT_SCHEMA_VERSION = "2.2.0"
@@ -90,25 +92,124 @@ def _digest(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
 
 
-def _bounded_stable_read(path: Path, limit: int) -> bytes:
-    before = path.stat(follow_symlinks=False)
-    if not stat.S_ISREG(before.st_mode) or before.st_size > limit:
-        raise OSError("entry is not a bounded regular file")
-    injected_read = Path.read_bytes is not _ORIGINAL_PATH_READ_BYTES
-    if injected_read:
-        # Preserve the verifier's established deterministic I/O fault-injection seam.
-        data = path.read_bytes()
-    else:
-        with path.open("rb") as stream:
-            data = stream.read(limit + 1)
-    after = path.stat(follow_symlinks=False)
-    identity_before = (before.st_dev, before.st_ino, before.st_size, before.st_mtime_ns)
-    identity_after = (after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns)
-    if len(data) > limit or identity_before != identity_after or (
-        not injected_read and len(data) != after.st_size
+def _file_identity(value: os.stat_result) -> tuple[int, int, int, int, int, int, int]:
+    return (
+        value.st_dev,
+        value.st_ino,
+        value.st_mode,
+        value.st_nlink,
+        value.st_size,
+        value.st_mtime_ns,
+        value.st_ctime_ns,
+    )
+
+
+def _close_quietly(descriptor: int) -> None:
+    try:
+        os.close(descriptor)
+    except OSError:
+        pass
+
+
+def _run_package_read_test_hook(phase: str, package: Path, relative: str) -> None:
+    if _PACKAGE_READ_TEST_HOOK is not None:
+        _PACKAGE_READ_TEST_HOOK(phase, package, relative)
+
+
+def _bounded_package_read(package: Path, relative: str, limit: int) -> bytes:
+    """Read one safe package-relative regular file through bound descriptors."""
+    if not _safe_path(relative) or limit <= 0:
+        raise OSError("invalid package-relative read request")
+    if (
+        not hasattr(os, "O_NOFOLLOW")
+        or not hasattr(os, "O_DIRECTORY")
+        or os.open not in os.supports_dir_fd
+        or os.stat not in os.supports_dir_fd
+        or os.stat not in os.supports_follow_symlinks
     ):
-        raise OSError("entry changed during bounded read")
-    return data
+        raise OSError("safe package-relative reads are unsupported")
+
+    root_before = os.lstat(package)
+    if not stat.S_ISDIR(root_before.st_mode):
+        raise OSError("package root is not a directory")
+    root_identity = _file_identity(root_before)
+    directory_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    file_flags = os.O_RDONLY | os.O_NOFOLLOW
+    if hasattr(os, "O_CLOEXEC"):
+        directory_flags |= os.O_CLOEXEC
+        file_flags |= os.O_CLOEXEC
+
+    directory_descriptors: list[int] = []
+    directory_entries: list[
+        tuple[int, str, tuple[int, int, int, int, int, int, int]]
+    ] = []
+    file_descriptor: int | None = None
+    parts = PurePosixPath(relative).parts
+    try:
+        current = os.open(package, directory_flags)
+        directory_descriptors.append(current)
+        if _file_identity(os.fstat(current)) != root_identity:
+            raise OSError("package root changed before read")
+
+        _run_package_read_test_hook("before_path_stat", package, relative)
+        for component in parts[:-1]:
+            before = os.stat(component, dir_fd=current, follow_symlinks=False)
+            if not stat.S_ISDIR(before.st_mode):
+                raise OSError("package path component is not a directory")
+            identity = _file_identity(before)
+            _run_package_read_test_hook("before_component_open", package, relative)
+            child = os.open(component, directory_flags, dir_fd=current)
+            directory_descriptors.append(child)
+            if _file_identity(os.fstat(child)) != identity:
+                raise OSError("package path component changed before read")
+            directory_entries.append((current, component, identity))
+            current = child
+
+        before = os.stat(parts[-1], dir_fd=current, follow_symlinks=False)
+        if not stat.S_ISREG(before.st_mode) or before.st_size > limit:
+            raise OSError("package entry is not a bounded regular file")
+        identity = _file_identity(before)
+        _run_package_read_test_hook("before_final_open", package, relative)
+        file_descriptor = os.open(parts[-1], file_flags, dir_fd=current)
+        if _file_identity(os.fstat(file_descriptor)) != identity:
+            raise OSError("package entry changed before read")
+
+        chunks: list[bytes] = []
+        remaining = limit + 1
+        first_read = True
+        while remaining:
+            chunk = os.read(file_descriptor, min(remaining, 64 * 1024))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+            if first_read:
+                first_read = False
+                _run_package_read_test_hook("after_first_read", package, relative)
+        _run_package_read_test_hook("after_read", package, relative)
+        data = b"".join(chunks)
+
+        after_descriptor = os.fstat(file_descriptor)
+        after_path = os.stat(parts[-1], dir_fd=current, follow_symlinks=False)
+        if (
+            len(data) > limit
+            or len(data) != identity[4]
+            or _file_identity(after_descriptor) != identity
+            or _file_identity(after_path) != identity
+        ):
+            raise OSError("package entry changed during read")
+        for parent, component, expected in directory_entries:
+            observed = os.stat(component, dir_fd=parent, follow_symlinks=False)
+            if _file_identity(observed) != expected:
+                raise OSError("package path component changed during read")
+        if _file_identity(os.lstat(package)) != root_identity:
+            raise OSError("package root changed during read")
+        return data
+    finally:
+        if file_descriptor is not None:
+            _close_quietly(file_descriptor)
+        for descriptor in reversed(directory_descriptors):
+            _close_quietly(descriptor)
 
 
 class VerificationState(StrEnum):
@@ -705,7 +806,7 @@ def verify_package(
                     ),
                 ),
             )
-        sidecar = _bounded_stable_read(sidecar_path, max_sidecar_bytes)
+        sidecar = _bounded_package_read(package, "package.sha256", max_sidecar_bytes)
         if not SIDECAR_RE.fullmatch(sidecar):
             return _result(
                 VerificationState.REJECTED,
@@ -719,7 +820,7 @@ def verify_package(
                     ),
                 ),
             )
-        manifest_bytes = _bounded_stable_read(manifest_path, max_manifest_bytes)
+        manifest_bytes = _bounded_package_read(package, "package.json", max_manifest_bytes)
     except OSError:
         return _result(
             VerificationState.INDETERMINATE_IO,
@@ -1164,8 +1265,8 @@ def verify_package(
     assert isinstance(item_paths, list)
     for relative in item_paths:
         try:
-            structural_data[relative] = _bounded_stable_read(
-                package.joinpath(*PurePosixPath(relative).parts), effective.max_file_bytes
+            structural_data[relative] = _bounded_package_read(
+                package, relative, effective.max_file_bytes
             )
         except OSError:
             return _result(
@@ -1364,9 +1465,8 @@ def verify_package(
             )
         else:
             try:
-                structural_data[receipt_path] = _bounded_stable_read(
-                    package.joinpath(*PurePosixPath(receipt_path).parts),
-                    effective.max_file_bytes,
+                structural_data[receipt_path] = _bounded_package_read(
+                    package, receipt_path, effective.max_file_bytes
                 )
             except OSError:
                 return _result(
@@ -1428,9 +1528,7 @@ def verify_package(
     lineage_claims = _curated_claims(manifest, actual, accounting=True, lineage=True)
     for relative in sorted(expected_paths):
         try:
-            data = _bounded_stable_read(
-                package.joinpath(*PurePosixPath(relative).parts), effective.max_file_bytes
-            )
+            data = _bounded_package_read(package, relative, effective.max_file_bytes)
         except OSError:
             return _result(
                 VerificationState.INDETERMINATE_IO,

--- a/tests/test_source_package.py
+++ b/tests/test_source_package.py
@@ -1,5 +1,7 @@
 import hashlib
 import json
+import os
+import shutil
 from collections.abc import Callable
 from dataclasses import asdict
 from pathlib import Path
@@ -18,8 +20,7 @@ from knowledge_adapters.source_package import (
     PackageItem,
     verify_package,
 )
-
-ORIGINAL_READ_BYTES = Path.read_bytes
+from knowledge_adapters.source_package import core as source_package_core
 
 
 def request() -> AcquisitionRequest:
@@ -378,17 +379,175 @@ def test_rejected_result_only_exposes_claims_from_completed_stages(tmp_path: Pat
     assert result.verified_claims.counts is None
 
 
+def test_descriptor_bound_package_read_succeeds_normally(tmp_path: Path) -> None:
+    destination = tmp_path / "package"
+    assert builder().seal(destination).ok
+    data = source_package_core._bounded_package_read(
+        destination, "items/one.json", 1024 * 1024
+    )
+    assert json.loads(data)["item_id"] == "one"
+
+
+def test_path_read_bytes_monkeypatch_cannot_bypass_production_reader(tmp_path: Path) -> None:
+    destination = tmp_path / "package"
+    assert builder().seal(destination).ok
+    with patch.object(Path, "read_bytes", side_effect=AssertionError("must not be called")):
+        result = verify_package(destination)
+    assert result.ok
+
+
+def test_descriptor_reader_fails_closed_without_required_platform_primitives(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "package"
+    assert builder().seal(destination).ok
+    with patch.object(os, "supports_dir_fd", set()):
+        result = verify_package(destination)
+    assert result.state == "indeterminate_io"
+    assert result.findings[0].code == "io-read-failure"
+    assert result.verified_claims is None
+
+
+def test_final_same_byte_external_symlink_is_indeterminate_without_leakage(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "package"
+    assert builder().seal(destination).ok
+    outside = tmp_path / "external-secret-location.json"
+    outside.write_bytes((destination / "request.json").read_bytes())
+
+    def read_hook(phase: str, package: Path, relative: str) -> None:
+        if phase == "before_final_open" and relative == "request.json":
+            target = package / relative
+            target.unlink()
+            target.symlink_to(outside)
+
+    with patch.object(source_package_core, "_PACKAGE_READ_TEST_HOOK", read_hook):
+        result = verify_package(destination)
+    serialized = json.dumps(asdict(result), default=str)
+    assert result.state == "indeterminate_io"
+    assert result.findings[0].code == "io-artifact-read-failure"
+    assert result.last_completed_stage == "lineage"
+    assert result.verified_claims is not None
+    assert "external-secret-location" not in serialized
+    assert str(tmp_path) not in serialized
+
+
+def test_intermediate_symlink_is_indeterminate(tmp_path: Path) -> None:
+    destination = tmp_path / "package"
+    assert builder().seal(destination).ok
+    outside = tmp_path / "external-secret-items"
+    outside.mkdir()
+    outside_marker = "UNIQUE_EXTERNAL_ITEM_BYTES_MUST_NOT_LEAK"
+    (outside / "one.json").write_text(outside_marker, encoding="utf-8")
+
+    def read_hook(phase: str, package: Path, relative: str) -> None:
+        if phase == "before_component_open" and relative == "items/one.json":
+            shutil.rmtree(package / "items")
+            (package / "items").symlink_to(outside, target_is_directory=True)
+
+    with patch.object(source_package_core, "_PACKAGE_READ_TEST_HOOK", read_hook):
+        result = verify_package(destination)
+    assert result.state == "indeterminate_io"
+    assert result.findings[0].code == "io-item-read-failure"
+    assert result.last_completed_stage == "inventory-coverage"
+    serialized = json.dumps(asdict(result), default=str)
+    assert "external-secret-items" not in serialized
+    assert outside_marker not in serialized
+
+
+def test_different_inode_before_open_is_indeterminate(tmp_path: Path) -> None:
+    destination = tmp_path / "package"
+    assert builder().seal(destination).ok
+
+    def read_hook(phase: str, package: Path, relative: str) -> None:
+        if phase == "before_final_open" and relative == "items/one.json":
+            target = package / relative
+            replacement = target.with_suffix(".replacement")
+            replacement.write_bytes(target.read_bytes())
+            replacement.replace(target)
+
+    with patch.object(source_package_core, "_PACKAGE_READ_TEST_HOOK", read_hook):
+        result = verify_package(destination)
+    assert result.state == "indeterminate_io"
+    assert result.findings[0].code == "io-item-read-failure"
+
+
+def test_mutation_after_first_descriptor_read_is_indeterminate(tmp_path: Path) -> None:
+    destination = tmp_path / "package"
+    assert builder().seal(destination).ok
+
+    def read_hook(phase: str, package: Path, relative: str) -> None:
+        if phase == "after_first_read" and relative == "items/one.json":
+            target = package / relative
+            target.write_bytes(target.read_bytes() + b" ")
+
+    with patch.object(source_package_core, "_PACKAGE_READ_TEST_HOOK", read_hook):
+        result = verify_package(destination)
+    assert result.state == "indeterminate_io"
+    assert result.findings[0].code == "io-item-read-failure"
+
+
+def test_disappearance_before_descriptor_open_is_indeterminate(tmp_path: Path) -> None:
+    destination = tmp_path / "package"
+    assert builder().seal(destination).ok
+
+    def read_hook(phase: str, package: Path, relative: str) -> None:
+        if phase == "before_final_open" and relative == "items/one.json":
+            (package / relative).unlink()
+
+    with patch.object(source_package_core, "_PACKAGE_READ_TEST_HOOK", read_hook):
+        result = verify_package(destination)
+    assert result.state == "indeterminate_io"
+    assert result.findings[0].code == "io-item-read-failure"
+
+
+def test_descriptor_read_attempts_to_close_every_open_fd_without_masking_failure(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "package"
+    assert builder().seal(destination).ok
+    opened: list[int] = []
+    closed: list[int] = []
+    original_open, original_close = os.open, os.close
+
+    def tracked_open(*args: object, **kwargs: object) -> int:
+        descriptor = original_open(*args, **kwargs)  # type: ignore[arg-type]
+        opened.append(descriptor)
+        return descriptor
+
+    def tracked_close(descriptor: int) -> None:
+        closed.append(descriptor)
+        original_close(descriptor)
+        raise OSError("simulated close failure")
+
+    def read_hook(phase: str, package: Path, relative: str) -> None:
+        if phase == "before_final_open":
+            raise OSError("primary safe-read failure")
+
+    with patch.object(os, "open", side_effect=tracked_open) as open_mock:
+        supported_dir_fd = set(os.supports_dir_fd) | {open_mock}
+        with (
+            patch.object(os, "supports_dir_fd", supported_dir_fd),
+            patch.object(os, "close", side_effect=tracked_close),
+            patch.object(source_package_core, "_PACKAGE_READ_TEST_HOOK", read_hook),
+        ):
+            with pytest.raises(OSError, match="primary safe-read failure"):
+                source_package_core._bounded_package_read(
+                    destination, "items/one.json", 1024 * 1024
+                )
+    assert opened
+    assert sorted(opened) == sorted(closed)
+
+
 def test_item_read_failure_is_structured_indeterminate_io(tmp_path: Path) -> None:
     destination = tmp_path / "package"
     assert builder().seal(destination).ok
-    item_path = destination / "items/one.json"
-
-    def read_bytes(path: Path) -> bytes:
-        if path == item_path:
+    def read_hook(phase: str, package: Path, relative: str) -> None:
+        if phase == "before_path_stat" and relative == "items/one.json":
             raise OSError("simulated disappearing item")
-        return ORIGINAL_READ_BYTES(path)
 
-    with patch.object(Path, "read_bytes", autospec=True, side_effect=read_bytes):
+    with patch.object(source_package_core, "_PACKAGE_READ_TEST_HOOK", read_hook):
         result = verify_package(destination)
     assert result.state == "indeterminate_io"
     assert result.findings[0].code == "io-item-read-failure"
@@ -405,14 +564,11 @@ def test_run_receipt_read_failure_is_structured_indeterminate_io(tmp_path: Path)
     )
     assert value.seal(destination).ok
     rewrite_manifest(destination, lambda manifest: manifest.update(run_receipt="run-receipt.json"))
-    receipt_path = destination / "run-receipt.json"
-
-    def read_bytes(path: Path) -> bytes:
-        if path == receipt_path:
+    def read_hook(phase: str, package: Path, relative: str) -> None:
+        if phase == "before_path_stat" and relative == "run-receipt.json":
             raise OSError("simulated disappearing receipt")
-        return ORIGINAL_READ_BYTES(path)
 
-    with patch.object(Path, "read_bytes", autospec=True, side_effect=read_bytes):
+    with patch.object(source_package_core, "_PACKAGE_READ_TEST_HOOK", read_hook):
         result = verify_package(destination)
     assert result.state == "indeterminate_io"
     assert result.findings[0].code == "io-run-receipt-read-failure"
@@ -423,18 +579,18 @@ def test_run_receipt_read_failure_is_structured_indeterminate_io(tmp_path: Path)
 def test_changed_item_is_freshly_read_for_final_integrity(tmp_path: Path) -> None:
     destination = tmp_path / "package"
     assert builder().seal(destination).ok
-    item_path = destination / "items/one.json"
     calls = 0
 
-    def read_bytes(path: Path) -> bytes:
+    def read_hook(phase: str, package: Path, relative: str) -> None:
         nonlocal calls
-        if path == item_path:
+        if phase == "before_path_stat" and relative == "items/one.json":
             calls += 1
             if calls == 2:
-                return ORIGINAL_READ_BYTES(path) + b" "
-        return ORIGINAL_READ_BYTES(path)
+                (package / "items/one.json").write_bytes(
+                    (package / "items/one.json").read_bytes() + b" "
+                )
 
-    with patch.object(Path, "read_bytes", autospec=True, side_effect=read_bytes):
+    with patch.object(source_package_core, "_PACKAGE_READ_TEST_HOOK", read_hook):
         result = verify_package(destination)
     assert calls == 2
     assert result.state == "rejected"
@@ -450,18 +606,18 @@ def test_changed_receipt_is_freshly_read_for_final_integrity(tmp_path: Path) -> 
     )
     assert value.seal(destination).ok
     rewrite_manifest(destination, lambda manifest: manifest.update(run_receipt="run-receipt.json"))
-    receipt_path = destination / "run-receipt.json"
     calls = 0
 
-    def read_bytes(path: Path) -> bytes:
+    def read_hook(phase: str, package: Path, relative: str) -> None:
         nonlocal calls
-        if path == receipt_path:
+        if phase == "before_path_stat" and relative == "run-receipt.json":
             calls += 1
             if calls == 2:
-                return ORIGINAL_READ_BYTES(path) + b" "
-        return ORIGINAL_READ_BYTES(path)
+                (package / "run-receipt.json").write_bytes(
+                    (package / "run-receipt.json").read_bytes() + b" "
+                )
 
-    with patch.object(Path, "read_bytes", autospec=True, side_effect=read_bytes):
+    with patch.object(source_package_core, "_PACKAGE_READ_TEST_HOOK", read_hook):
         result = verify_package(destination)
     assert calls == 2
     assert result.state == "rejected"
@@ -476,14 +632,11 @@ def test_file_disappearing_before_final_integrity_is_indeterminate(tmp_path: Pat
         Artifact("artifacts/one.md", b"candidate\n", "normalized-content", "text/markdown")
     )
     assert value.seal(destination).ok
-    candidate_path = destination / "artifacts/one.md"
-
-    def read_bytes(path: Path) -> bytes:
-        if path == candidate_path:
+    def read_hook(phase: str, package: Path, relative: str) -> None:
+        if phase == "before_path_stat" and relative == "artifacts/one.md":
             raise OSError("simulated disappearing artifact")
-        return ORIGINAL_READ_BYTES(path)
 
-    with patch.object(Path, "read_bytes", autospec=True, side_effect=read_bytes):
+    with patch.object(source_package_core, "_PACKAGE_READ_TEST_HOOK", read_hook):
         result = verify_package(destination)
     assert result.state == "indeterminate_io"
     assert result.findings[0].code == "io-artifact-read-failure"

--- a/tests/test_source_package.py
+++ b/tests/test_source_package.py
@@ -1,14 +1,18 @@
 import hashlib
 import json
 from collections.abc import Callable
+from dataclasses import asdict
 from pathlib import Path
 from typing import Any, cast
 from unittest.mock import patch
+
+import pytest
 
 from knowledge_adapters.source_package import (
     AcquisitionRequest,
     AdapterIdentity,
     Artifact,
+    ConsumerProfile,
     ItemOutcome,
     PackageBuilder,
     PackageItem,
@@ -222,13 +226,145 @@ def test_verified_claims_are_curated_bounded_and_not_raw_manifest(tmp_path: Path
     assert value.seal(destination).ok
     rewrite_manifest(destination, lambda manifest: manifest.update(arbitrary="not-a-claim"))
     result = verify_package(destination)
-    assert result.ok and result.schema_version == "2.0.0"
+    assert result.ok and result.schema_version == "2.2.0"
     assert result.verified_claims is not None
     assert result.verified_claims.package_id is None
     assert not hasattr(result.verified_claims, "extensions")
     assert not hasattr(result.verified_claims, "arbitrary")
     assert not hasattr(result, "manifest")
     assert not hasattr(result, "manifest_claims")
+
+
+def test_consumer_profile_returns_bounded_item_artifact_and_package_claims(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "package"
+    value = PackageBuilder(
+        package_id="pkg-profile",
+        request=request(),
+        run_id="run-profile",
+        created_at="2026-07-10T00:00:00Z",
+        adapter=AdapterIdentity("fixture", "1.0.0", "revision-1"),
+        boundary={"live": "fixture", "deterministic": "assembly"},
+        extensions={"org.example.provider": {"secretish": "excluded"}},
+    )
+    value.add_item(
+        PackageItem(
+            "one",
+            "document",
+            ItemOutcome.COMPLETED,
+            {
+                "requested_locator": "https://example.test/requested",
+                "resolved_locator": "https://example.test/resolved",
+                "canonical_locator": "https://example.test/canonical",
+                "language": "en",
+                "provenance": {"provider": "fixture", "provider_resource_id": "one"},
+                "artifacts": ["artifacts/one/normalized.md"],
+                "normalization": {
+                    "name": "fixture-normalizer",
+                    "version": "1.0.0",
+                    "transforms": ["one-trailing-newline"],
+                },
+                "extensions": {"org.example.provider": {"opaque": "excluded"}},
+            },
+        )
+    )
+    value.add_artifact(
+        Artifact(
+            "artifacts/one/normalized.md",
+            b"candidate\n",
+            "normalized-content",
+            "text/markdown",
+        )
+    )
+    assert value.seal(destination).ok
+    profile = ConsumerProfile(identifier="vault-fixture-v1")
+    result = verify_package(destination, profile=profile)
+    assert result.ok and result.consumer_profile == "vault-fixture-v1"
+    claims = result.verified_claims
+    assert claims is not None and claims.totals is not None
+    assert claims.totals.item_records == 1
+    assert claims.totals.aggregate_bytes == sum(
+        path.stat().st_size for path in destination.rglob("*") if path.is_file()
+    )
+    assert claims.item_dispositions[0].canonical_locator == "https://example.test/canonical"
+    assert claims.item_dispositions[0].artifact_references == (
+        "artifacts/one/normalized.md",
+    )
+    assert claims.item_dispositions[0].associated_artifacts[0].role == "normalized-content"
+    assert claims.item_dispositions[0].finding_references == ()
+    artifact = next(
+        item for item in claims.artifact_inventory if item.path.endswith("normalized.md")
+    )
+    assert artifact.role == "normalized-content" and len(artifact.sha256) == 64
+    serialized = json.dumps(asdict(result), default=str, sort_keys=True)
+    assert "secretish" not in serialized and '"opaque"' not in serialized
+    assert "candidate\\n" not in serialized
+
+
+def test_consumer_profile_resource_limits_fail_closed(tmp_path: Path) -> None:
+    destination = tmp_path / "package"
+    assert builder().seal(destination).ok
+    result = verify_package(
+        destination,
+        profile=ConsumerProfile(identifier="entry-limit", max_package_entries=1),
+    )
+    assert result.state == "rejected"
+    assert result.consumer_profile == "entry-limit"
+    assert {finding.code for finding in result.findings} >= {"consumer-entry-limit"}
+
+    result = verify_package(
+        destination,
+        profile=ConsumerProfile(identifier="aggregate-limit", max_aggregate_bytes=1),
+    )
+    assert result.state == "rejected"
+    assert result.consumer_profile == "aggregate-limit"
+    assert {finding.code for finding in result.findings} >= {
+        "consumer-aggregate-size-limit"
+    }
+
+
+def test_consumer_profile_rejects_legacy_argument_mixing(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="cannot be combined"):
+        verify_package(
+            tmp_path,
+            profile=ConsumerProfile(),
+            max_manifest_bytes=1024,
+        )
+
+
+def test_verifier_rejects_unbounded_inventory_metadata_and_unknown_item_refs(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "metadata"
+    assert builder().seal(destination).ok
+    rewrite_manifest(
+        destination,
+        lambda manifest: manifest["artifacts"][0].update(role="x" * 201),
+    )
+    result = verify_package(destination)
+    assert result.state == "rejected"
+    assert result.findings[0].code == "invalid-inventory-metadata"
+
+    destination = tmp_path / "references"
+    assert builder().seal(destination).ok
+    item_path = destination / "items/one.json"
+    item = json.loads(item_path.read_bytes())
+    item["artifacts"] = ["artifacts/missing.md"]
+    item_bytes = (
+        json.dumps(item, ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n"
+    ).encode()
+    item_path.write_bytes(item_bytes)
+
+    def update_item_digest(manifest: dict[str, Any]) -> None:
+        entry = next(value for value in manifest["artifacts"] if value["path"] == "items/one.json")
+        entry["bytes"] = len(item_bytes)
+        entry["sha256"] = hashlib.sha256(item_bytes).hexdigest()
+
+    rewrite_manifest(destination, update_item_digest)
+    result = verify_package(destination)
+    assert result.state == "rejected"
+    assert result.findings[0].code == "invalid-item-artifact-reference"
 
 
 def test_rejected_result_only_exposes_claims_from_completed_stages(tmp_path: Path) -> None:

--- a/tests/test_source_package_conformance_fixtures.py
+++ b/tests/test_source_package_conformance_fixtures.py
@@ -92,7 +92,7 @@ def test_public_result_exposes_only_curated_claims(tmp_path: Path) -> None:
     )
 
     result = verify_package(package)
-    assert result.ok and result.schema_version == "2.0.0"
+    assert result.ok and result.schema_version == "2.2.0"
     assert result.verified_claims is not None
     assert result.verified_claims.package_id == "package-001"
     assert not hasattr(result.verified_claims, "extensions")

--- a/tests/test_source_package_conformance_fixtures.py
+++ b/tests/test_source_package_conformance_fixtures.py
@@ -7,14 +7,13 @@ from unittest.mock import patch
 
 import pytest
 
+from knowledge_adapters.source_package import core as source_package_core
 from knowledge_adapters.source_package import verify_package
 from tests.source_package_fixtures import materialize_vector
 
 FIXTURE_ROOT = Path(__file__).parent / "fixtures" / "source_package_conformance"
 MATRIX = json.loads((FIXTURE_ROOT / "vectors.json").read_text(encoding="utf-8"))
 VECTORS = MATRIX["vectors"]
-ORIGINAL_READ_BYTES = Path.read_bytes
-
 
 def test_matrix_has_unique_cases_and_all_requested_boundaries() -> None:
     ids = [vector["id"] for vector in VECTORS]
@@ -113,14 +112,11 @@ def test_rejected_result_claims_follow_completed_stage(tmp_path: Path) -> None:
 
 def test_public_verifier_structures_item_read_failure(tmp_path: Path) -> None:
     package = materialize_vector(tmp_path, "minimal_completed")
-    item_path = package / "items/item-001.json"
-
-    def read_bytes(path: Path) -> bytes:
-        if path == item_path:
+    def read_hook(phase: str, package_root: Path, relative: str) -> None:
+        if phase == "before_path_stat" and relative == "items/item-001.json":
             raise OSError("simulated item read failure")
-        return ORIGINAL_READ_BYTES(path)
 
-    with patch.object(Path, "read_bytes", autospec=True, side_effect=read_bytes):
+    with patch.object(source_package_core, "_PACKAGE_READ_TEST_HOOK", read_hook):
         result = verify_package(package)
     assert result.state == "indeterminate_io"
     assert result.findings[0].code == "io-item-read-failure"
@@ -130,14 +126,11 @@ def test_public_verifier_structures_item_read_failure(tmp_path: Path) -> None:
 
 def test_public_verifier_structures_receipt_read_failure(tmp_path: Path) -> None:
     package = materialize_vector(tmp_path, "sealed_receipt")
-    receipt_path = package / "run-receipt.json"
-
-    def read_bytes(path: Path) -> bytes:
-        if path == receipt_path:
+    def read_hook(phase: str, package_root: Path, relative: str) -> None:
+        if phase == "before_path_stat" and relative == "run-receipt.json":
             raise OSError("simulated receipt read failure")
-        return ORIGINAL_READ_BYTES(path)
 
-    with patch.object(Path, "read_bytes", autospec=True, side_effect=read_bytes):
+    with patch.object(source_package_core, "_PACKAGE_READ_TEST_HOOK", read_hook):
         result = verify_package(package)
     assert result.state == "indeterminate_io"
     assert result.findings[0].code == "io-run-receipt-read-failure"
@@ -147,18 +140,17 @@ def test_public_verifier_structures_receipt_read_failure(tmp_path: Path) -> None
 
 def test_public_verifier_rechecks_changed_item_at_integrity(tmp_path: Path) -> None:
     package = materialize_vector(tmp_path, "minimal_completed")
-    item_path = package / "items/item-001.json"
     calls = 0
 
-    def read_bytes(path: Path) -> bytes:
+    def read_hook(phase: str, package_root: Path, relative: str) -> None:
         nonlocal calls
-        if path == item_path:
+        if phase == "before_path_stat" and relative == "items/item-001.json":
             calls += 1
             if calls == 2:
-                return ORIGINAL_READ_BYTES(path) + b" "
-        return ORIGINAL_READ_BYTES(path)
+                item_path = package_root / relative
+                item_path.write_bytes(item_path.read_bytes() + b" ")
 
-    with patch.object(Path, "read_bytes", autospec=True, side_effect=read_bytes):
+    with patch.object(source_package_core, "_PACKAGE_READ_TEST_HOOK", read_hook):
         result = verify_package(package)
     assert calls == 2
     assert result.state == "rejected"
@@ -168,18 +160,17 @@ def test_public_verifier_rechecks_changed_item_at_integrity(tmp_path: Path) -> N
 
 def test_public_verifier_rechecks_changed_receipt_at_integrity(tmp_path: Path) -> None:
     package = materialize_vector(tmp_path, "sealed_receipt")
-    receipt_path = package / "run-receipt.json"
     calls = 0
 
-    def read_bytes(path: Path) -> bytes:
+    def read_hook(phase: str, package_root: Path, relative: str) -> None:
         nonlocal calls
-        if path == receipt_path:
+        if phase == "before_path_stat" and relative == "run-receipt.json":
             calls += 1
             if calls == 2:
-                return ORIGINAL_READ_BYTES(path) + b" "
-        return ORIGINAL_READ_BYTES(path)
+                receipt_path = package_root / relative
+                receipt_path.write_bytes(receipt_path.read_bytes() + b" ")
 
-    with patch.object(Path, "read_bytes", autospec=True, side_effect=read_bytes):
+    with patch.object(source_package_core, "_PACKAGE_READ_TEST_HOOK", read_hook):
         result = verify_package(package)
     assert calls == 2
     assert result.state == "rejected"
@@ -189,14 +180,11 @@ def test_public_verifier_rechecks_changed_receipt_at_integrity(tmp_path: Path) -
 
 def test_public_verifier_structures_final_read_disappearance(tmp_path: Path) -> None:
     package = materialize_vector(tmp_path, "minimal_completed")
-    request_path = package / "request.json"
-
-    def read_bytes(path: Path) -> bytes:
-        if path == request_path:
+    def read_hook(phase: str, package_root: Path, relative: str) -> None:
+        if phase == "before_path_stat" and relative == "request.json":
             raise OSError("simulated final read disappearance")
-        return ORIGINAL_READ_BYTES(path)
 
-    with patch.object(Path, "read_bytes", autospec=True, side_effect=read_bytes):
+    with patch.object(source_package_core, "_PACKAGE_READ_TEST_HOOK", read_hook):
         result = verify_package(package)
     assert result.state == "indeterminate_io"
     assert result.findings[0].code == "io-artifact-read-failure"


### PR DESCRIPTION
## Summary

- add a typed provider-neutral `ConsumerProfile` for compatibility, resource, filesystem, and bounded-read policy
- make package enumeration stop at configured entry/path limits and reject symlinks, hard links, special files, case collisions, oversized entries, aggregate overflow, and mid-read mutation
- expose bounded verified package totals, artifact summaries, and per-item dispositions only after complete artifact-integrity verification
- validate item-to-artifact and item-to-diagnostic associations canonically so consumers do not need to reparse package internals
- bind every package file read to a non-following package-root descriptor walk so pathname substitution cannot redirect verification outside the package

## Public API and compatibility

`verify_package(..., profile=ConsumerProfile(...))` is the preferred API. Existing verifier keyword arguments remain supported and cannot be mixed with a profile. Every verified, rejected, or indeterminate result records the effective profile identifier.

The verification-result schema remains `2.2.0` and curated claims remain `1.2.0`; the descriptor-bound reader correction is internal and does not redesign the result contract. These versions intentionally leave `2.1.0` / `1.1.0` available to the separate collection-progress PR. Reconciliation after that PR merges should preserve both additive surfaces.

Curated item claims contain provider-neutral identities, common locators/provenance, language, normalization identity, stable artifact/diagnostic/finding references, and directly associated verified artifact role/media type/size/digest. Arbitrary manifest fields, provider extensions, candidate bytes, and raw diagnostic payloads remain excluded.

## Descriptor-bound read safety

All envelope, structural, receipt, and final-integrity reads now use one package-relative primitive. It opens the package root, every intermediate directory, and the final entry with `O_NOFOLLOW` and descriptor-relative traversal; `O_DIRECTORY` and `O_CLOEXEC` are used where applicable. The reader requires a regular final file, enforces the byte limit, and compares device, inode, mode, link count, size, mtime, and ctime across path and descriptor observations before and after the bounded read.

Unsupported platform primitives, symlink substitution, component substitution, inode replacement, mutation, and disappearance fail closed as stage-bounded `indeterminate_io`. Internal errors, external paths, and external bytes are not emitted in findings or claims. Every opened descriptor receives a close attempt, and close errors cannot mask the primary safe-read failure. `Path.read_bytes` monkeypatching is no longer a production read seam; deterministic fault injection uses an explicit internal phase hook in tests only.

## Consumer impact

The vault can pin its own conservative profile, call only the canonical verifier, persist bounded structural results, and build review staging without reparsing the raw manifest or item records. This PR adds no vault policy, provider behavior, preview rendering, promotion, or editorial decisions.

## Validation

- `make check` with workspace-safe `TMPDIR`
  - Ruff passed
  - strict mypy passed across 113 source files
  - pytest: 676 passed

Deterministic reader tests cover normal success, unavailable platform primitives, a same-byte final symlink outside the package, an intermediate symlink with unique external bytes, different-inode replacement before open, mutation after the first descriptor read, disappearance, no external leakage, stage-bounded non-verification, `Path.read_bytes` isolation, and descriptor close attempts without failure masking. Existing conformance I/O tests now use the explicit internal hook.

## Merge-order notes

- coordinate additive schema reconciliation with draft PR #317
- PR #318 can continue using legacy verifier arguments, then opt into a typed profile separately
- vault consumer implementation should pin the merged verifier revision and define its own numeric defaults

This PR is intentionally draft and must not be merged or marked ready automatically.
