### PR TITLE
Fix automatic caption WebVTT parsing

### DIFF
--- a/src/knowledge_adapters/youtube/normalize.py
+++ b/src/knowledge_adapters/youtube/normalize.py
@@ -71,6 +71,14 @@ def normalize_webvtt(data: bytes, *, automatic: bool) -> NormalizedCaption:
             if index >= len(lines) or not TIMING_RE.fullmatch(lines[index].strip()):
                 raise CaptionNormalizationError("malformed WebVTT cue")
         index += 1
+        if (
+            automatic
+            and index + 1 < len(lines)
+            and not lines[index].strip()
+            and lines[index + 1].strip()
+            and not TIMING_RE.fullmatch(lines[index + 1].strip())
+        ):
+            index += 1
         body: list[str] = []
         while index < len(lines) and lines[index].strip():
             body.append(lines[index])

--- a/tests/fixtures/youtube/README.md
+++ b/tests/fixtures/youtube/README.md
@@ -4,3 +4,10 @@ These hand-authored fixtures contain no provider response, cookie, credential,
 caption URL, signed query string, or media URL. They establish the deterministic
 boundary at captured WebVTT bytes and structured provider observations. Live
 yt-dlp canaries are deliberately outside `make check`.
+
+`automatic-timing-blank-text.vtt` is a hand-authored structural reduction of a
+private 2026-07-11 diagnostic capture. Transcript wording, video identity,
+titles, names, URLs, tokens, and unrelated metadata were removed. The fixture
+preserves only the `Kind`/`Language` headers, valid timing lines, the observed
+single blank between timing and cue text, repeated occurrences, and minimal
+rolling inline timestamp/class tags needed to exercise deterministic collapse.

--- a/tests/fixtures/youtube/automatic-timing-blank-text.vtt
+++ b/tests/fixtures/youtube/automatic-timing-blank-text.vtt
@@ -1,0 +1,14 @@
+WEBVTT
+Kind: captions
+Language: en
+
+00:00:00.000 --> 00:00:01.000 align:start position:0%
+
+Synthetic words
+
+00:00:01.000 --> 00:00:02.000 align:start position:0%
+
+Synthetic words<00:00:01.500><c> extend</c>
+
+00:00:02.000 --> 00:00:03.000 align:start position:0%
+Final synthetic cue.

--- a/tests/youtube/test_youtube.py
+++ b/tests/youtube/test_youtube.py
@@ -92,6 +92,15 @@ def creator_track(language: str = "en") -> CaptionTrack:
     )
 
 
+def observed_automatic_track() -> CaptionTrack:
+    return CaptionTrack(
+        "en",
+        CaptionKind.AUTOMATIC,
+        "vtt",
+        (FIXTURES / "automatic-timing-blank-text.vtt").read_bytes(),
+    )
+
+
 def video(video_id: str, *tracks: CaptionTrack) -> VideoObservation:
     return VideoObservation(
         video_id,
@@ -196,6 +205,36 @@ def test_automatic_rolling_cues_are_collapsed() -> None:
     assert result.data == b"Rolling captions settle.\n"
 
 
+def test_automatic_timing_blank_text_shape_is_normalized_deterministically() -> None:
+    data = (FIXTURES / "automatic-timing-blank-text.vtt").read_bytes()
+
+    first = normalize_webvtt(data, automatic=True)
+    second = normalize_webvtt(data, automatic=True)
+
+    assert first.data == b"Synthetic words extend\n\nFinal synthetic cue.\n"
+    assert second.data == first.data
+
+
+def test_timing_blank_text_shape_remains_invalid_for_creator_captions() -> None:
+    with pytest.raises(CaptionNormalizationError, match="malformed WebVTT cue"):
+        normalize_webvtt(
+            (FIXTURES / "automatic-timing-blank-text.vtt").read_bytes(), automatic=False
+        )
+
+
+def test_standalone_text_without_timing_context_is_rejected() -> None:
+    with pytest.raises(CaptionNormalizationError, match="malformed WebVTT cue"):
+        normalize_webvtt(b"WEBVTT\n\nstandalone text\n", automatic=True)
+
+
+def test_multiple_blanks_after_timing_remain_malformed() -> None:
+    with pytest.raises(CaptionNormalizationError, match="malformed WebVTT cue"):
+        normalize_webvtt(
+            b"WEBVTT\n\n00:00:00.000 --> 00:00:01.000\n\n\nstandalone text\n",
+            automatic=True,
+        )
+
+
 def test_malformed_webvtt_is_rejected() -> None:
     with pytest.raises(CaptionNormalizationError):
         normalize_webvtt((FIXTURES / "malformed.vtt").read_bytes(), automatic=False)
@@ -217,6 +256,18 @@ def test_single_video_produces_publicly_verified_package_without_raw_caption(
     assert not any(path.endswith("captured.vtt") for path in files)
     all_bytes = b"".join(path.read_bytes() for path in package.rglob("*") if path.is_file())
     assert b"signature=" not in all_bytes and b"secret" not in all_bytes
+
+
+def test_observed_automatic_shape_produces_verified_normalized_artifact(
+    tmp_path: Path,
+) -> None:
+    package = produce(tmp_path, single_client(observed_automatic_track()))
+    result = verify_package(package)
+    normalized = package / "artifacts/youtube-video-video_001/normalized.md"
+
+    assert result.ok
+    assert normalized.read_bytes() == b"Synthetic words extend\n\nFinal synthetic cue.\n"
+    assert not any(path.suffix == ".vtt" for path in package.rglob("*"))
 
 
 def test_raw_caption_is_retained_only_by_opt_in(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- accept the observed YouTube automatic-caption timing → single blank → cue-text structure
- preserve creator-caption behavior and strict malformed-input rejection
- add a sanitized deterministic WebVTT fixture and verified package-production regression
- document how the private live shape was structurally sanitized

## Live evidence

A separately authorized single-caption diagnostic captured genuine UTF-8 `text/vtt` from yt-dlp 2026.07.04. The payload begins with `WEBVTT`, carries `Kind: captions` and `Language: en`, and uses valid timing lines. Five cues contain a single blank immediately after timing before cue text. The private raw bytes remain outside Git and no live rerun occurred for this PR.

## Root cause

The parser treated the blank after a valid timing line as the end of an empty cue. It then encountered the following cue text without an active timing context and raised `malformed WebVTT cue`.

## Minimal fix

For automatic captions only, after a valid timing line, the parser skips exactly one blank when the immediately following line is nonblank cue text and not another timing line. It then parses that text under the existing timing context. The parser does not broadly strip blank lines.

Creator captions retain their prior behavior. Standalone text, malformed timestamps, arbitrary non-WebVTT payloads, and multiple blanks after timing remain rejected.

## Sanitized fixture

`automatic-timing-blank-text.vtt` is hand-authored from structural metadata only. It removes transcript wording, video identity, titles, names, URLs, tokens, and unrelated metadata. It retains synthetic `Kind`/`Language` headers, valid timing lines, repeated timing → blank → text occurrences, and minimal rolling inline timestamp/class tags.

## Rejected alternatives

- broadly removing blank lines before parsing, which would weaken cue validation
- accepting standalone text without timing context
- changing provider format selection, because the response was genuine `text/vtt`
- committing or copying the private transcript bytes

## Tests

Coverage proves deterministic Markdown bytes, no empty cue, correct timing association, repeated occurrence handling, rolling-caption collapse, unchanged creator behavior, strict malformed and standalone-text rejection, rejection of multiple blanks, raw-caption omission, and publicly verified package production from the sanitized fixture.

## Scratch tooling

The Attempt 3 scratch runner was corrected outside repository production semantics to require canonical `package.json` instead of `manifest.json`; no alias or second naming convention was added.

## Validation

- Ruff passed
- strict mypy passed for 123 source files
- 759 tests passed
- validation used the approved installed toolchain offline with this worktree's `src` on `PYTHONPATH`
- no YouTube, provider, live yt-dlp, canary, vault, or ingestion operation occurred