### PR TITLE
Fix YouTube checkpoint raw caption retention

### DIFF
--- a/docs/youtube-source-package-adapter.md
+++ b/docs/youtube-source-package-adapter.md
@@ -86,19 +86,29 @@ is limited to 1 MiB, depth 8, and the 500-item collection bound. It is versioned
 and records a request fingerprint, adapter and contract
 versions, playlist identity, discovery IDs, completed IDs and digests,
 outcomes, attempts, pending IDs, continuation evidence, and last successful
-boundary. Checkpoint schema 1.2 also stores the bounded typed identity,
+boundary. Checkpoint schema 1.3 also stores the bounded typed identity,
 locator, observed metadata, caption selection, collection relationship, run,
 package, and prior-lineage fields required to reconstruct preserved completed
-items without copying a manifest model. Resume validates schema, fingerprint,
-adapter version, and contract version, then reconciles rediscovery by video ID.
-Completed bytes live under
+items without copying a manifest model. `retain_raw_captions` governs every
+durable adapter-managed surface. When false, raw caption bytes are omitted from
+the package, checkpoint, diagnostics, receipts, and logs; completed checkpoints
+retain only normalized bytes, digests, bounded selected-track metadata,
+normalization provenance, and structural resume state. When explicitly true,
+the checkpoint may retain raw bytes so resume can preserve the opted-in package
+artifact without reacquisition.
+
+Resume validates schema, fingerprint, adapter version, contract version, and
+retention mode, then reconciles rediscovery by video ID. Completed bytes live under
 checkpoint-owned relative paths in `<checkpoint-stem>.data/`; regular-file,
 path, 8 MiB, and SHA-256 checks run on load. Resume copies only matching
 verified bytes into the next checkpoint, drops disappeared IDs, and marks new
 IDs pending. Attempt counts are cumulative across checkpoints while the retry
 limit applies independently to the new run, so failure-to-success transitions
 record the additional attempt. A raw yt-dlp archive is not a canonical
-checkpoint.
+checkpoint. Schema 1.2 checkpoints are rejected rather than silently migrated,
+preventing legacy raw-caption state from crossing a disabled-retention boundary.
+Work interrupted before successful normalization is not completed and is
+reacquired on resume.
 
 ## Canonical Collection Progress And Resume
 

--- a/docs/youtube-source-package-implementation-plan.md
+++ b/docs/youtube-source-package-implementation-plan.md
@@ -124,7 +124,7 @@ curated verifier claims.
 
 ## Checkpoint, Batching, And Resume
 
-Checkpoint state is mutable and adapter-local, never inventoried. It should contain schema version, request fingerprint, contract and adapter versions, playlist ID, discovery observation, next source position/cursor when safe, completed video IDs with captured/normalized digests, terminal outcomes, attempt counts, pending IDs, and the last successful boundary.
+Checkpoint state is mutable and adapter-local, never inventoried. It should contain schema version, request fingerprint, contract and adapter versions, playlist ID, discovery observation, next source position/cursor when safe, completed video IDs with captured/normalized digests, terminal outcomes, attempt counts, pending IDs, and the last successful boundary. Raw-caption retention applies to this mutable durable state as well as the sealed package: disabled retention permits normalized bytes and bounded structural metadata but no raw caption bytes; enabled retention may preserve raw bytes needed to reproduce the opted-in package artifact.
 
 Because playlist membership and order can change, a raw yt-dlp archive is
 insufficient as the canonical checkpoint. On resume, rediscover within the
@@ -132,6 +132,9 @@ requested bound unless a documented provider cursor is proven safe, reconcile
 by video ID, verify saved artifact digests, preserve matching completed work,
 and start a new `run_id` with builder-owned manifest lineage. `batch_size`
 limits attempted items in one run; `max_items` limits total collection scope.
+Incomplete acquisition, reads, or normalization do not become completed
+checkpoint items and are reacquired. Incompatible legacy checkpoint schemas or
+retention modes fail closed instead of silently carrying raw bytes forward.
 
 The shared representation is contract 1.1 `CollectionProgress`: record the
 bounded scope and batch limit in the typed request, then record either

--- a/src/knowledge_adapters/youtube/checkpoint.py
+++ b/src/knowledge_adapters/youtube/checkpoint.py
@@ -14,7 +14,7 @@ from knowledge_adapters.source_package import canonical_json_bytes
 
 from .config import MAX_CAPTION_BYTES, MAX_COLLECTION_ITEMS, VIDEO_ID_RE
 
-CHECKPOINT_SCHEMA_VERSION = "1.2.0"
+CHECKPOINT_SCHEMA_VERSION = "1.3.0"
 MAX_CHECKPOINT_BYTES = 1024 * 1024
 MAX_CHECKPOINT_JSON_DEPTH = 8
 DIGEST_RE = re.compile(r"[0-9a-f]{64}\Z")
@@ -32,7 +32,7 @@ class CompletedCheckpointItem:
     normalized_sha256: str
     outcome: str
     attempts: int
-    captured_path: str
+    captured_path: str | None
     normalized_path: str
     resolved_locator: str
     title: str | None
@@ -82,6 +82,7 @@ class YouTubeCheckpoint:
     last_successful_boundary: str
     run_id: str
     package_id: str
+    retain_raw_captions: bool = False
     prior_run_ids: tuple[str, ...] = ()
     prior_package_ids: tuple[str, ...] = ()
     schema_version: str = CHECKPOINT_SCHEMA_VERSION
@@ -102,6 +103,7 @@ class YouTubeCheckpoint:
             "last_successful_boundary": self.last_successful_boundary,
             "run_id": self.run_id,
             "package_id": self.package_id,
+            "retain_raw_captions": self.retain_raw_captions,
             "prior_run_ids": list(self.prior_run_ids),
             "prior_package_ids": list(self.prior_package_ids),
         }
@@ -164,21 +166,25 @@ def save_checkpoint_artifacts(
     checkpoint_path: Path,
     *,
     video_id: str,
-    captured: bytes,
+    captured: bytes | None,
     normalized: bytes,
-) -> tuple[str, str]:
+) -> tuple[str | None, str]:
     if not VIDEO_ID_RE.fullmatch(video_id):
         raise ValueError("unsafe checkpoint video ID")
-    if len(captured) > MAX_CAPTION_BYTES or len(normalized) > MAX_CAPTION_BYTES:
+    if (captured is not None and len(captured) > MAX_CAPTION_BYTES) or len(
+        normalized
+    ) > MAX_CAPTION_BYTES:
         raise ValueError("checkpoint artifact byte limit exceeded")
     root_name = f"{checkpoint_path.stem}.data"
     relative_root = PurePosixPath(root_name, f"youtube-video-{video_id}")
-    captured_relative = (relative_root / "captured.vtt").as_posix()
+    captured_relative = (
+        (relative_root / "captured.vtt").as_posix() if captured is not None else None
+    )
     normalized_relative = (relative_root / "normalized.md").as_posix()
-    for relative, data in (
-        (captured_relative, captured),
-        (normalized_relative, normalized),
-    ):
+    artifacts = [(normalized_relative, normalized)]
+    if captured_relative is not None and captured is not None:
+        artifacts.append((captured_relative, captured))
+    for relative, data in artifacts:
         destination = _artifact_path(checkpoint_path, relative)
         destination.parent.mkdir(parents=True, exist_ok=True)
         temporary = destination.with_name(f".{destination.name}.tmp-{os.getpid()}")
@@ -189,12 +195,18 @@ def save_checkpoint_artifacts(
 
 def read_completed_artifacts(
     checkpoint_path: Path, item: CompletedCheckpointItem
-) -> tuple[bytes, bytes]:
-    captured = _read_bounded(_artifact_path(checkpoint_path, item.captured_path), MAX_CAPTION_BYTES)
+) -> tuple[bytes | None, bytes]:
+    captured = (
+        _read_bounded(_artifact_path(checkpoint_path, item.captured_path), MAX_CAPTION_BYTES)
+        if item.captured_path is not None
+        else None
+    )
     normalized = _read_bounded(
         _artifact_path(checkpoint_path, item.normalized_path), MAX_CAPTION_BYTES
     )
-    if _digest(captured) != item.captured_sha256 or _digest(normalized) != item.normalized_sha256:
+    if (
+        captured is not None and _digest(captured) != item.captured_sha256
+    ) or _digest(normalized) != item.normalized_sha256:
         raise ValueError("checkpoint artifact digest mismatch")
     return captured, normalized
 
@@ -238,6 +250,7 @@ def load_checkpoint(
     expected_fingerprint: str,
     expected_adapter_version: str | None = None,
     expected_contract_version: str | None = None,
+    expected_retain_raw_captions: bool | None = None,
 ) -> YouTubeCheckpoint:
     try:
         raw: Any = json.loads(_read_bounded(path, MAX_CHECKPOINT_BYTES))
@@ -272,6 +285,7 @@ def load_checkpoint(
             last_successful_boundary=raw["last_successful_boundary"],
             run_id=raw["run_id"],
             package_id=raw["package_id"],
+            retain_raw_captions=raw["retain_raw_captions"],
             prior_run_ids=tuple(raw["prior_run_ids"]),
             prior_package_ids=tuple(raw["prior_package_ids"]),
         )
@@ -344,6 +358,11 @@ def load_checkpoint(
         or not checkpoint.package_id
         or len(checkpoint.run_id) > 200
         or len(checkpoint.package_id) > 200
+        or type(checkpoint.retain_raw_captions) is not bool
+        or any(
+            (item.captured_path is None) == checkpoint.retain_raw_captions
+            for item in checkpoint.completed
+        )
         or len(set(checkpoint.prior_run_ids)) != len(checkpoint.prior_run_ids)
         or len(set(checkpoint.prior_package_ids)) != len(checkpoint.prior_package_ids)
         or any(
@@ -366,6 +385,11 @@ def load_checkpoint(
         and checkpoint.contract_version != expected_contract_version
     ):
         raise ValueError("checkpoint contract version mismatch")
+    if (
+        expected_retain_raw_captions is not None
+        and checkpoint.retain_raw_captions != expected_retain_raw_captions
+    ):
+        raise ValueError("checkpoint raw-caption retention mismatch")
     for item in checkpoint.completed:
         read_completed_artifacts(path, item)
     return checkpoint

--- a/src/knowledge_adapters/youtube/producer.py
+++ b/src/knowledge_adapters/youtube/producer.py
@@ -48,6 +48,7 @@ from .models import (
 from .normalize import (
     NORMALIZER_NAME,
     NORMALIZER_VERSION,
+    TRANSFORMS,
     CaptionNormalizationError,
     normalize_webvtt,
 )
@@ -332,6 +333,69 @@ def _checkpointed_item(
     options: YouTubeOptions,
 ) -> tuple[PackageItem, tuple[Artifact, ...]]:
     captured, normalized = read_completed_artifacts(checkpoint_path, cached)
+    if captured is None:
+        item_id = f"youtube-video-{cached.video_id}"
+        normalized_path = f"artifacts/{item_id}/normalized.md"
+        artifact = Artifact(
+            normalized_path, normalized, "normalized-content", "text/markdown"
+        )
+        fields: dict[str, object] = {
+            "requested_locator": options.locator,
+            "resolved_locator": cached.resolved_locator,
+            "canonical_locator": f"https://www.youtube.com/watch?v={cached.video_id}",
+            "provenance": {"provider": "youtube", "provider_resource_id": cached.video_id},
+            "language": cached.language,
+            "artifacts": [normalized_path],
+            "captured_sha256": cached.captured_sha256,
+            "normalized_sha256": cached.normalized_sha256,
+            "normalization": {
+                "name": NORMALIZER_NAME,
+                "version": NORMALIZER_VERSION,
+                "transforms": list(TRANSFORMS),
+            },
+            "extensions": {
+                YOUTUBE_EXTENSION: {
+                    **({"playlist_id": cached.playlist_id} if cached.playlist_id else {}),
+                    **(
+                        {"source_position": cached.source_position}
+                        if cached.source_position is not None
+                        else {}
+                    ),
+                    "caption_kind": cached.caption_kind,
+                    "selected_track": {
+                        "language": cached.language,
+                        "format": cached.caption_format,
+                        **({"name": cached.caption_name} if cached.caption_name else {}),
+                    },
+                    "selection_reason": "checkpoint-preserved-normalized-content",
+                    "available_candidates": [
+                        {
+                            "language": cached.language,
+                            "kind": cached.caption_kind,
+                            "format": cached.caption_format,
+                            **({"name": cached.caption_name} if cached.caption_name else {}),
+                        }
+                    ],
+                }
+            },
+        }
+        for key, value in (
+            ("title", cached.title),
+            ("creator", cached.channel),
+            ("published_at", cached.published_at),
+        ):
+            if value is not None:
+                fields[key] = value
+        if cached.playlist_id:
+            fields["parents"] = [
+                {
+                    "resource_kind": "collection",
+                    "canonical_locator": (
+                        f"https://www.youtube.com/playlist?list={cached.playlist_id}"
+                    ),
+                }
+            ]
+        return PackageItem(item_id, "video", ItemOutcome.UNCHANGED, fields), (artifact,)
     kind = CaptionKind(cached.caption_kind)
     observation = VideoObservation(
         cached.video_id,
@@ -392,7 +456,7 @@ def _cache_completed(
     captured_path, normalized_path = save_checkpoint_artifacts(
         checkpoint_path,
         video_id=entry.video_id,
-        captured=selection.track.data,
+        captured=selection.track.data if options.retain_raw_captions else None,
         normalized=normalized,
     )
     return CompletedCheckpointItem(
@@ -511,6 +575,7 @@ def produce_package(
             expected_fingerprint=fingerprint,
             expected_adapter_version=ADAPTER_VERSION,
             expected_contract_version="1.1.0",
+            expected_retain_raw_captions=options.retain_raw_captions,
         )
         rediscovered = tuple(entry.video_id for entry in entries)
         preserved_ids, _ = reconcile_video_ids(checkpoint, rediscovered)
@@ -698,6 +763,7 @@ def produce_package(
                 "package-verified",
                 run_id,
                 package_id,
+                options.retain_raw_captions,
                 tuple((*checkpoint.prior_run_ids, checkpoint.run_id)) if checkpoint else (),
                 (
                     tuple((*checkpoint.prior_package_ids, checkpoint.package_id))

--- a/tests/youtube/test_youtube.py
+++ b/tests/youtube/test_youtube.py
@@ -404,7 +404,24 @@ def test_partial_batch_seals_continuation_and_checkpoints_completed_bytes(
         "video_002",
     ]
     assert checkpoint_json["pending_video_ids"] == ["video_003"]
+    assert checkpoint_json["schema_version"] == "1.3.0"
+    assert checkpoint_json["retain_raw_captions"] is False
     assert all(len(item["normalized_sha256"]) == 64 for item in checkpoint_json["completed"])
+    assert all(item["captured_path"] is None for item in checkpoint_json["completed"])
+    checkpoint_files = [path for path in tmp_path.rglob("*") if path.is_file()]
+    checkpoint_bytes = b"".join(
+        path.read_bytes()
+        for path in checkpoint_files
+        if path == checkpoint_path or ".data" in path.as_posix()
+    )
+    assert b"WEBVTT" not in checkpoint_bytes
+    assert b"00:00:00.000 -->" not in checkpoint_bytes
+    assert creator_track().data not in checkpoint_bytes
+    assert not any(path.suffix == ".vtt" for path in checkpoint_files)
+    assert not any(
+        token in checkpoint_bytes.lower()
+        for token in (b"signature=", b"cookie=", b"authorization=", b"credential=", b"token=")
+    )
     resumed = replace(
         opts,
         checkpoint_input=checkpoint_path,
@@ -452,10 +469,71 @@ def test_partial_batch_seals_continuation_and_checkpoints_completed_bytes(
     ]
     assert next_json["pending_video_ids"] == []
     completed = next_json["completed"][0]
-    assert (tmp_path / completed["captured_path"]).read_bytes() == creator_track().data
+    assert completed["captured_path"] is None
     assert (tmp_path / completed["normalized_path"]).read_bytes() == (
         b"Hello from the creator.\n\n**Ada:** Welcome aboard.\n"
     )
+
+
+def test_raw_retention_opt_in_applies_to_package_and_checkpoint(tmp_path: Path) -> None:
+    checkpoint_path = tmp_path / "checkpoint.json"
+    result = produce_package(
+        YouTubeOptions(
+            PLAYLIST,
+            ScopeKind.COLLECTION,
+            1,
+            retain_raw_captions=True,
+            checkpoint_output=checkpoint_path,
+        ),
+        single_client(creator_track()),
+        request_id="request",
+        run_id="run",
+        package_id="package",
+        created_at="2026-07-10T00:00:00Z",
+        destination=tmp_path / "package",
+    )
+    assert result.verification.verified_claims is not None
+    checkpoint = json.loads(checkpoint_path.read_bytes())
+    assert checkpoint["retain_raw_captions"] is True
+    completed = checkpoint["completed"][0]
+    assert (tmp_path / completed["captured_path"]).read_bytes() == creator_track().data
+    assert (tmp_path / "package/artifacts/youtube-video-video_001/captured.vtt").is_file()
+
+
+def test_legacy_raw_checkpoint_and_retention_mode_change_fail_closed(tmp_path: Path) -> None:
+    checkpoint_path = tmp_path / "checkpoint.json"
+    opts = YouTubeOptions(
+        PLAYLIST,
+        ScopeKind.COLLECTION,
+        1,
+        checkpoint_output=checkpoint_path,
+    )
+    produce_package(
+        opts,
+        single_client(creator_track()),
+        request_id="request",
+        run_id="run",
+        package_id="package",
+        created_at="2026-07-10T00:00:00Z",
+        destination=tmp_path / "package",
+    )
+    fingerprint = request_fingerprint(opts.acquisition_request("ignored", tmp_path).as_dict())
+    current = json.loads(checkpoint_path.read_bytes())
+    current["schema_version"] = "1.2.0"
+    current["completed"][0]["captured_path"] = "checkpoint.data/video/captured.vtt"
+    checkpoint_path.write_text(json.dumps(current))
+    with pytest.raises(ValueError, match="unsupported checkpoint schema"):
+        load_checkpoint(checkpoint_path, expected_fingerprint=fingerprint)
+
+    current["schema_version"] = "1.3.0"
+    current["completed"][0]["captured_path"] = None
+    checkpoint_path.write_text(json.dumps(current))
+    with pytest.raises(ValueError, match="raw-caption retention mismatch"):
+        load_checkpoint(
+            checkpoint_path,
+            expected_fingerprint=current["request_fingerprint"],
+            expected_retain_raw_captions=True,
+        )
 
 
 def test_fully_processed_bounded_collection_claims_exhausted(tmp_path: Path) -> None:
@@ -629,6 +707,7 @@ def test_checkpoint_validation_and_changed_playlist_reconciliation(tmp_path: Pat
         "item:video_001",
         "run-fixture",
         "package-fixture",
+        True,
     )
     save_checkpoint(checkpoint, path)
     loaded = load_checkpoint(path, expected_fingerprint=fingerprint)
@@ -677,7 +756,7 @@ def test_checkpoint_read_and_depth_are_bounded(tmp_path: Path) -> None:
     path.write_text(
         json.dumps(
             {
-                "schema_version": "1.2.0",
+                "schema_version": "1.3.0",
                 "request_fingerprint": "0" * 64,
                 "bounded_discovery": nested,
             }


### PR DESCRIPTION
## Summary

- define `retain_raw_captions=false` as excluding raw caption bytes from every durable adapter-managed surface, including checkpoints
- bump the YouTube checkpoint schema from `1.2.0` to `1.3.0`
- cache only normalized bytes and bounded structural metadata by default while preserving deterministic completed-work resume
- retain raw checkpoint bytes only for the existing explicit raw-retention opt-in
- reject legacy schemas and retention-mode mismatches fail-closed

## Attempt 5 evidence and root cause

Running Remote bounded canary Attempt 5 configured `retain_raw_captions=false`. All three automatic captions normalized successfully, the sealed package correctly omitted raw artifacts, public verification succeeded, and vault admission succeeded. Final artifact inventory found three raw `captured.vtt` files beneath mutable checkpoint state.

The producer's completed-item cache called `save_checkpoint_artifacts` with captured bytes unconditionally. Package artifact construction honored the request, but checkpoint persistence did not.

## Retention invariant

When raw-caption retention is disabled, raw caption bytes must not enter the sealed package, checkpoint, diagnostics, receipts, logs, or other durable adapter-managed state. Transient in-memory normalization remains allowed. Checkpoints may retain verified normalized bytes, raw and normalized digests, bounded selected-track metadata, normalization provenance, and structural resume state.

When raw-caption retention is explicitly enabled, the checkpoint may retain raw bytes so a resumed package can reproduce the opted-in raw artifact without reacquisition.

## Schema and resume behavior

Checkpoint schema `1.3.0` adds the explicit retention mode and makes the captured artifact path optional. Completed disabled-retention items resume from digest-verified normalized bytes without calling the provider again. Items interrupted before successful normalization are not recorded as completed and are reacquired on a later run. Request fingerprint, video-ID reconciliation, cumulative attempts, artifact digest verification, canonical lineage, and bounded fail-closed parsing remain intact.

Schema `1.2.0` checkpoints are rejected rather than silently migrated because they can contain raw caption bytes without an explicit checkpoint retention contract. Explicit retention-mode mismatches are also rejected. Corrupt normalized bytes continue to fail closed.

No Source Package schema changed.

## Privacy assertions

Synthetic tests confirm disabled-retention checkpoint output contains no `.vtt`, complete raw fixture bytes, WebVTT header, cue timestamp, signed URL, cookie, authorization, credential, or token marker. Raw and normalized SHA-256 digests remain one-way integrity metadata and do not reconstruct raw content.

## Validation

`make check` passed offline:

- Ruff passed
- strict mypy passed for 123 source files
- 761 tests passed

No YouTube access, live yt-dlp invocation, canary rerun, provider call, or vault change occurred.
