### PR TITLE
Fix resumed checkpoint attempt serialization

### DIFF
--- a/docs/youtube-source-package-adapter.md
+++ b/docs/youtube-source-package-adapter.md
@@ -104,8 +104,11 @@ path, 8 MiB, and SHA-256 checks run on load. Resume copies only matching
 verified bytes into the next checkpoint, drops disappeared IDs, and marks new
 IDs pending. Attempt counts are cumulative across checkpoints while the retry
 limit applies independently to the new run, so failure-to-success transitions
-record the additional attempt. A raw yt-dlp archive is not a canonical
-checkpoint. Schema 1.2 checkpoints are rejected rather than silently migrated,
+record the additional attempt. The attempts map contains only identities that
+have actually been attempted, and every stored count is positive;
+never-attempted pending identities are omitted rather than recorded with zero.
+A raw yt-dlp archive is not a canonical checkpoint. Schema 1.2 checkpoints are
+rejected rather than silently migrated,
 preventing legacy raw-caption state from crossing a disabled-retention boundary.
 Work interrupted before successful normalization is not completed and is
 reacquired on resume.

--- a/src/knowledge_adapters/youtube/producer.py
+++ b/src/knowledge_adapters/youtube/producer.py
@@ -590,7 +590,9 @@ def produce_package(
         preserved_set = set(preserved_ids)
         pending_entries = [entry for entry in entries if entry.video_id not in preserved_set]
         for entry in pending_entries:
-            attempts_by_id[entry.video_id] = checkpoint.attempts.get(entry.video_id, 0)
+            prior_attempts = checkpoint.attempts.get(entry.video_id)
+            if prior_attempts is not None:
+                attempts_by_id[entry.video_id] = prior_attempts
 
     batch_limit = options.batch_size or len(pending_entries)
     attempted_entries = pending_entries[:batch_limit]

--- a/tests/youtube/test_youtube.py
+++ b/tests/youtube/test_youtube.py
@@ -404,6 +404,7 @@ def test_partial_batch_seals_continuation_and_checkpoints_completed_bytes(
         "video_002",
     ]
     assert checkpoint_json["pending_video_ids"] == ["video_003"]
+    assert checkpoint_json["attempts"] == {"video_001": 1, "video_002": 1}
     assert checkpoint_json["schema_version"] == "1.3.0"
     assert checkpoint_json["retain_raw_captions"] is False
     assert all(len(item["normalized_sha256"]) == 64 for item in checkpoint_json["completed"])
@@ -472,6 +473,110 @@ def test_partial_batch_seals_continuation_and_checkpoints_completed_bytes(
     assert completed["captured_path"] is None
     assert (tmp_path / completed["normalized_path"]).read_bytes() == (
         b"Hello from the creator.\n\n**Ada:** Welcome aboard.\n"
+    )
+
+
+def test_two_partial_batches_write_reloadable_checkpoint_without_zero_attempts(
+    tmp_path: Path,
+) -> None:
+    discovery = Discovery(
+        PLAYLIST,
+        PLAYLIST,
+        "playlist_001",
+        tuple(PlaylistEntry(f"video_00{index}", index) for index in range(1, 6)),
+        True,
+    )
+    videos = cast(
+        dict[
+            str,
+            VideoObservation | ProviderFailure | list[VideoObservation | ProviderFailure],
+        ],
+        {
+            f"video_00{index}": video(f"video_00{index}", creator_track())
+            for index in range(1, 6)
+        },
+    )
+    first_checkpoint = tmp_path / "checkpoint-1.json"
+    first_options = YouTubeOptions(
+        PLAYLIST,
+        ScopeKind.COLLECTION,
+        5,
+        batch_size=2,
+        checkpoint_output=first_checkpoint,
+    )
+    produce_package(
+        first_options,
+        FakeClient(discovery, videos),
+        request_id="request-1",
+        run_id="run-1",
+        package_id="package-1",
+        created_at="2026-07-10T00:00:00Z",
+        destination=tmp_path / "package-1",
+    )
+    first_json = json.loads(first_checkpoint.read_bytes())
+    assert first_json["attempts"] == {"video_001": 1, "video_002": 1}
+    assert first_json["pending_video_ids"] == ["video_003", "video_004", "video_005"]
+
+    second_checkpoint = tmp_path / "checkpoint-2.json"
+    second_client = FakeClient(discovery, videos)
+    second_result = produce_package(
+        replace(
+            first_options,
+            checkpoint_input=first_checkpoint,
+            checkpoint_output=second_checkpoint,
+        ),
+        second_client,
+        request_id="request-2",
+        run_id="run-2",
+        package_id="package-2",
+        created_at="2026-07-10T00:01:00Z",
+        destination=tmp_path / "package-2",
+    )
+
+    assert second_client.calls == ["video_003", "video_004"]
+    second_json = json.loads(second_checkpoint.read_bytes())
+    assert second_json["attempts"] == {
+        "video_001": 1,
+        "video_002": 1,
+        "video_003": 1,
+        "video_004": 1,
+    }
+    assert second_json["pending_video_ids"] == ["video_005"]
+    assert all(value > 0 for value in second_json["attempts"].values())
+    loaded = load_checkpoint(
+        second_checkpoint,
+        expected_fingerprint=second_json["request_fingerprint"],
+        expected_adapter_version="0.1.0",
+        expected_contract_version="1.1.0",
+        expected_retain_raw_captions=False,
+    )
+    assert [item.video_id for item in loaded.completed] == [
+        "video_001",
+        "video_002",
+        "video_003",
+        "video_004",
+    ]
+    assert loaded.pending_video_ids == ("video_005",)
+    manifest = json.loads((second_result.package_path / "package.json").read_bytes())
+    assert manifest["resumes_run_id"] == "run-1"
+    assert manifest["prior_run_ids"] == ["run-1"]
+    assert manifest["prior_package_ids"] == ["package-1"]
+    assert manifest["reconciliation_summary"] == {
+        "acquired": 2,
+        "dropped": 0,
+        "pending": 1,
+        "reused": 2,
+    }
+    assert manifest["final_attempt_counts"] == second_json["attempts"]
+    checkpoint_bytes = second_checkpoint.read_bytes() + b"".join(
+        path.read_bytes()
+        for path in sorted((tmp_path / "checkpoint-2.data").rglob("*"))
+        if path.is_file()
+    )
+    assert b"WEBVTT" not in checkpoint_bytes
+    assert not any(
+        token in checkpoint_bytes.lower()
+        for token in (b"signature=", b"cookie=", b"authorization=", b"credential=", b"token=")
     )
 
 
@@ -715,6 +820,24 @@ def test_checkpoint_validation_and_changed_playlist_reconciliation(tmp_path: Pat
         ("video_001",),
         ("video_003",),
     )
+    pending_attempted = json.loads(json.dumps(checkpoint.as_dict()))
+    attempts = pending_attempted["attempts"]
+    assert isinstance(attempts, dict)
+    attempts["video_002"] = 1
+    path.write_text(json.dumps(pending_attempted))
+    assert load_checkpoint(path, expected_fingerprint=fingerprint).attempts == {
+        "video_001": 1,
+        "video_002": 1,
+    }
+    for invalid_attempt in (0, -1, 1.5, "1"):
+        invalid = json.loads(json.dumps(checkpoint.as_dict()))
+        invalid_attempts = invalid["attempts"]
+        assert isinstance(invalid_attempts, dict)
+        invalid_attempts["video_002"] = invalid_attempt
+        path.write_text(json.dumps(invalid))
+        with pytest.raises(ValueError, match="corrupt"):
+            load_checkpoint(path, expected_fingerprint=fingerprint)
+    save_checkpoint(checkpoint, path)
     normalized_file = tmp_path / normalized_path
     normalized_file.write_bytes(b"modified\n")
     with pytest.raises(ValueError, match="digest mismatch"):


### PR DESCRIPTION
## Summary

- omit never-attempted pending identities from resumed checkpoint `attempts`
- preserve positive cumulative counts for identities that were actually attempted
- keep schema 1.3 and strict loader rejection of zero, negative, and non-integer counts
- add synthetic two-batch continuation and checkpoint validation coverage

## Root cause and evidence

The bounded Running Remote batch-2 experiment successfully reused 10 completed items, acquired 10 new items, sealed a publicly verified package, and wrote 20 valid normalized checkpoint artifacts. The new checkpoint nevertheless failed canonical loading because resume initialization inserted all remaining pending identities into `attempts_by_id` with a default value of zero.

That created a writer/loader mismatch: the schema 1.3 loader intentionally accepts only positive stored attempt counts, while the resumed writer serialized zero for never-attempted pending items.

The preserved package remains valid evidence at content address `cf04bfbd4734d9c5090872e4542450134e5bcc1c1cac6d12dae96997c98e0a20`. The preserved invalid checkpoint was used only for diagnosis and was not modified or treated as canonical resume state.

## Attempts-map invariant

The `attempts` map contains entries only for identities that have actually been attempted. Every stored count is a positive integer. Never-attempted pending identities are omitted rather than represented as zero.

The loader behavior is unchanged: explicit zero, negative, and non-integer values remain invalid.

## Implementation

Resume initialization now copies a pending identity's prior cumulative attempt count only when that count exists. Attempted entries continue to use a missing count as an in-memory zero baseline and write their new positive cumulative count after the attempt. Package lineage, reconciliation summaries, Source Package schemas, checkpoint schema 1.3, retention behavior, and vault behavior are unchanged.

## Regression coverage

- fresh partial checkpoints omit never-attempted pending identities from `attempts`
- a synthetic two-batch continuation writes and canonically reloads its second checkpoint
- completed and previously attempted identities retain positive cumulative counts
- a pending identity with one prior attempt remains loadable with count 1
- explicit zero, negative, float, and string attempt values remain rejected
- completed/pending order, first pending identity, normalized artifact reuse, digests, lineage, reconciliation, and final attempt counts remain stable
- checkpoint bytes remain free of raw captions and sensitive provider material

## Validation

`make check`

- Ruff: passed
- strict mypy: passed for 123 source files
- pytest: 762 passed

All validation was offline and synthetic. No YouTube access, live yt-dlp invocation, batch replay, vault change, or batch-3 continuation occurred.
