### PR TITLE
chore: prepare 0.9.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,80 @@ Formal changelog coverage begins at `0.2.0`, when this repository started using
 
 ## Unreleased
 
-- Added `public_webpage` and `public_pdf` adapters for producing unreviewed
-  markdown-first candidate artifacts from public webpage/article and PDF/report
-  URLs without retaining raw fetched bytes.
-- Added `pypdf` as the PDF text extraction dependency and documented the
-  extraction limitations surfaced in generated candidate output.
+## 0.9.0
+
+This minor release marks the project's transition from a collection of
+ingestion adapters into a verifiable acquisition platform. Acquisitions can now
+cross a provider-neutral, versioned producer-to-consumer interchange boundary,
+while operators gain explicit controls for artifact discovery, verification,
+resume, and cleanup. The Source Package contract is still experimental within
+this 0.9.0 project release; it is not a project-level 1.0 compatibility promise.
+
+### Public-source acquisition
+
+- Added `public_webpage` and `public_pdf` adapters that discover canonical public
+  sources and produce inspectable, markdown-first candidate artifacts without
+  retaining raw fetched bytes by default.
+- Improved deterministic webpage and PDF normalization, including wrapper-target
+  selection, canonical source resolution, conservative line-wrap and footer-noise
+  handling, replay-quality metadata, and regression fixtures derived from public
+  webpage and DORA report failure shapes.
+- Added public replay acceptance checks so operators can evaluate source
+  resolution, extraction quality, reviewability, limitations, and promotion
+  readiness against explicit evidence instead of treating a successful fetch as
+  sufficient.
+
+### Verifiable producer-to-consumer handoff
+
+- Added the provider-neutral Source Package contract and public construction and
+  verification APIs, including `PackageBuilder`, `verify_package`, typed package
+  models, canonical JSON, package sealing, and a verification CLI.
+- Added consumer profiles, bounded structural and resource verification,
+  compatibility and capability checks, path and digest integrity checks, curated
+  verified claims, explicit valid/invalid/indeterminate outcomes, and shared
+  conformance vectors for producer and consumer implementations.
+- Defined the chain-of-custody boundary between acquisition and editorial
+  retention: a valid package is eligible for consumer review, but does not assert
+  that its content is trusted, approved, retained, or publishable.
+
+### Bounded and resumable collection
+
+- Added a bounded YouTube Source Package producer for explicit video and playlist
+  requests, with deterministic caption selection and normalization, retry limits,
+  item and byte bounds, and no media download.
+- Added canonical collection progress, continuation checkpoints, immutable resume
+  lineage, reconciliation and attempt accounting, and integrity-checked reuse of
+  completed normalized artifacts across resumed runs.
+- Hardened creator and automatic WebVTT caption parsing, checkpoint reconstruction,
+  and raw-caption retention so raw caption bytes remain absent from every durable
+  adapter-managed surface unless retention is explicitly enabled.
+
+### Artifact lifecycle and repeat runs
+
+- Added safe stale-artifact pruning with dry-run previews and bounded deletion of
+  generated artifacts previously recorded in a manifest.
+- Added orphaned-artifact discovery and pruning across adapter-specific output
+  layouts, including the nested `github_metadata` layout, while preserving
+  non-generated files and refusing unsafe paths.
+- Added config-run dry-run and cleanup controls so operators can preview an entire
+  run file, pass cleanup policy through repeatable runs, and inspect remaining
+  artifacts without modifying the stored configuration.
+- Extracted shared incremental-sync classification and strategy-selection
+  abstractions, reducing behavioral drift across Confluence and GitHub metadata
+  adapters.
+
+### Reliability and release operations
+
+- Hardened GitHub metadata acquisition with lifecycle and pull-request conversation
+  receipts, normalized comment metadata, source-aware incremental behavior, and
+  layout-correct cleanup; hardened Confluence authentication selection, response
+  validation, failure classification, and missing-page behavior.
+- Added adapter readiness reports, reusable adapter contract tests, deterministic
+  and replayable chaos testing, lightweight run reports, broader CLI and fixture
+  coverage, and an expanded canonical validation path.
+- Improved release publication and recovery workflows with canonical validation in
+  release checks, focused changelog extraction, safe partial-release inspection,
+  and recovery paths that do not move or recreate public tags.
 
 ## 0.8.0
 

--- a/Makefile
+++ b/Makefile
@@ -156,25 +156,17 @@ release-check: check-gh-env ## Run local release readiness checks for VERSION.
 				exit 1; \
 			} \
 		}' CHANGELOG.md >/dev/null
+	@if [ -n "$$(git status --porcelain)" ]; then \
+		echo "Error: working tree must be clean before release validation." >&2; \
+		git status --short; \
+		exit 1; \
+	fi
 	@echo "Running canonical validation: make check"
 	@$(MAKE) check || { \
 		echo "Error: canonical validation failed; release-check requires 'make check' to pass." >&2; \
 		exit 1; \
 	}
-	@if [ "$$(git branch --show-current)" != "main" ]; then \
-		echo "Error: release must run from main after the release PR is merged." >&2; \
-		exit 1; \
-	fi
-	@if [ -n "$$(git status --porcelain)" ]; then \
-		echo "Error: working tree must be clean before release." >&2; \
-		git status --short; \
-		exit 1; \
-	fi
 	@git fetch origin main >/dev/null
-	@if [ "$$(git rev-parse HEAD)" != "$$(git rev-parse origin/main)" ]; then \
-		echo "Error: local main must match origin/main. Run 'git pull --ff-only origin main' and retry." >&2; \
-		exit 1; \
-	fi
 	@if git rev-parse --verify --quiet "refs/tags/$(RELEASE_TAG)" >/dev/null; then \
 		echo "Error: local tag $(RELEASE_TAG) already exists." >&2; \
 		exit 1; \
@@ -290,6 +282,14 @@ release-create-from-tag: check-gh-env ## Create a missing GitHub release from an
 	echo "Created GitHub release $(RELEASE_TAG) from existing remote tag."
 
 release-publish: release-check ## Publish VERSION as a tag and GitHub release.
+	@if [ "$$(git branch --show-current)" != "main" ]; then \
+		echo "Error: release publication must run from main after the release PR is merged." >&2; \
+		exit 1; \
+	fi
+	@if [ "$$(git rev-parse HEAD)" != "$$(git rev-parse origin/main)" ]; then \
+		echo "Error: local main must match origin/main. Run 'git pull --ff-only origin main' and retry." >&2; \
+		exit 1; \
+	fi
 	@set -e; \
 	notes_file=$$(mktemp); \
 	trap 'rm -f "$$notes_file"' EXIT; \

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -14,15 +14,16 @@ For shared branch, PR, validation, and current-main workflow, follow
 
 1. confirm the version bump is present
 2. confirm `CHANGELOG.md` is updated
-3. validate the post-merge release prerequisites without creating a tag or
-   GitHub release; this also runs the repository's canonical `make check`
-   validation:
+3. from the clean release branch, validate the release metadata and remote
+   publication state without creating a tag or GitHub release; this also runs
+   the repository's canonical `make check` validation:
 
    ```bash
    make release-check VERSION=0.8.1
    ```
 
-4. after the release PR lands, publish the post-merge tag and GitHub release:
+4. after the release PR lands, update local `main` to match `origin/main`, then
+   publish the post-merge tag and GitHub release:
 
    ```bash
    make release-publish VERSION=0.8.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "knowledge-adapters"
-version = "0.8.0"
+version = "0.9.0"
 description = "Generic adapters for acquiring and normalizing knowledge sources into local LLM-ready artifacts."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/knowledge_adapters/__init__.py
+++ b/src/knowledge_adapters/__init__.py
@@ -1,3 +1,3 @@
 """knowledge_adapters package."""
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"


### PR DESCRIPTION
## Summary

- bump the project version from 0.8.0 to 0.9.0 in both authoritative declarations
- replace the prior two-item Unreleased notes with a complete, outcome-focused 0.9.0 changelog entry while preserving an empty Unreleased section
- allow `release-check` to validate a clean release branch while keeping main/current-origin guards on post-merge `release-publish`

## Why

0.9.0 marks knowledge-adapters' transition from a collection of ingestion adapters into a verifiable acquisition platform with explicit artifact lifecycle controls and a provider-neutral producer-to-consumer interchange boundary. The Source Package contract remains experimental within this 0.9.0 project release and is not presented as a project-level 1.0 compatibility promise.

The release workflow adjustment is required because the documented pre-merge `release-check` previously rejected every non-`main` release branch.

## Validation

- `make check` — passed: Ruff, MyPy (123 source files), 767 tests
- `make release-check VERSION=0.9.0` — passed, including canonical validation and remote tag/release conflict checks

No `v0.9.0` tag or GitHub release was created.