### PR TITLE
Ignore pytest temp workspaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ __pycache__/
 
 # Virtual environments
 .venv/
+
+# Local pytest temp workspaces
+pytest-of-root/

--- a/tests/test_gitignore.py
+++ b/tests/test_gitignore.py
@@ -1,0 +1,14 @@
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_pytest_temp_workspace_is_ignored() -> None:
+    completed = subprocess.run(
+        ["git", "check-ignore", "--quiet", "pytest-of-root/example/session.txt"],
+        cwd=REPO_ROOT,
+        check=False,
+    )
+
+    assert completed.returncode == 0


### PR DESCRIPTION
## What I inspected
- Repo-local AGENTS guidance and current `.gitignore` behavior
- GitHub default branch state on Monday, July 20, 2026
- Local canonical validation via `make check`

## Selected improvement
Ignore pytest's top-level temp workspace and cover it with a regression test.

## Why this was the highest-leverage small change
An actual local run had already left `pytest-of-root/` as untracked repo noise. Making that path explicitly ignored keeps future validation runs from dirtying the checkout and gives both humans and agents a cleaner default workflow.

## Files touched
- `.gitignore`
- `tests/test_gitignore.py`

## Validation
- `make check`