### PR TITLE
chore: add weekly hosted chaos validation

### DIFF
--- a/.github/workflows/weekly-chaos-validation.yml
+++ b/.github/workflows/weekly-chaos-validation.yml
@@ -1,0 +1,104 @@
+name: Weekly chaos validation
+run-name: Weekly chaos validation · ${{ github.event_name }} · ${{ github.sha }}
+
+on:
+  schedule:
+    # GitHub cron is interpreted in UTC. 17:00 UTC is Monday 10:00 during
+    # Pacific daylight time and Monday 09:00 during Pacific standard time.
+    - cron: "0 17 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: weekly-chaos-validation-${{ github.ref }}
+  cancel-in-progress: false
+  queue: max
+
+jobs:
+  chaos-all:
+    name: make chaos-all
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out exact tested commit
+        id: checkout
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Verify and report tested commit
+        id: checkout-verification
+        shell: bash
+        run: |
+          checked_out_sha="$(git rev-parse HEAD)"
+          if [[ "$checked_out_sha" != "$GITHUB_SHA" ]]; then
+            echo "Checked out $checked_out_sha, expected $GITHUB_SHA." >&2
+            exit 1
+          fi
+          echo "sha=$checked_out_sha" >> "$GITHUB_OUTPUT"
+          echo "Repository: $GITHUB_REPOSITORY"
+          echo "Workflow run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          echo "Event: $GITHUB_EVENT_NAME"
+          echo "Tested commit: $checked_out_sha"
+          echo "Runner: $RUNNER_NAME ($RUNNER_OS/$RUNNER_ARCH)"
+          echo "Command: make chaos-all"
+
+      - name: Set up Python
+        id: python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      # Setup is mandatory. If it is unavailable or fails, validation is
+      # skipped and the job fails without being reclassified as a clean pass.
+      - name: Install dependencies through make dev
+        id: dependencies
+        run: make dev
+
+      - name: Run make chaos-all
+        id: validation
+        run: make chaos-all
+
+      - name: Verify repository state is unchanged
+        id: repository-state
+        if: ${{ always() && steps.checkout-verification.outcome == 'success' }}
+        shell: bash
+        run: |
+          git diff --exit-code
+          git diff --cached --exit-code
+          if [[ -n "$(git status --porcelain --untracked-files=all)" ]]; then
+            echo "Validation left unexpected repository changes:" >&2
+            git status --short >&2
+            exit 1
+          fi
+
+      # GitHub's run and job conclusions remain authoritative. This summary is
+      # derived operator context; the complete retained evidence is in the run
+      # and step logs under the repository's Actions retention settings.
+      - name: Write run summary
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          {
+            echo "## Weekly chaos validation"
+            echo
+            echo "- Repository: \`$GITHUB_REPOSITORY\`"
+            echo "- Workflow run: [$GITHUB_RUN_ID]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)"
+            echo "- Event: \`$GITHUB_EVENT_NAME\`"
+            echo "- Requested commit: \`$GITHUB_SHA\`"
+            echo "- Tested commit: \`${{ steps.checkout-verification.outputs.sha || 'unavailable' }}\`"
+            echo "- Runner: \`$RUNNER_NAME ($RUNNER_OS/$RUNNER_ARCH)\`"
+            echo "- Command: \`make chaos-all\`"
+            echo "- Checkout: \`${{ steps.checkout.outcome }}\`"
+            echo "- Commit verification: \`${{ steps.checkout-verification.outcome }}\`"
+            echo "- Python setup: \`${{ steps.python.outcome }}\`"
+            echo "- Dependency setup: \`${{ steps.dependencies.outcome }}\`"
+            echo "- Chaos validation: \`${{ steps.validation.outcome }}\`"
+            echo "- Repository-state check: \`${{ steps.repository-state.outcome }}\`"
+            echo
+            echo "The GitHub Actions run and job conclusion is the authoritative outcome."
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Adds the first CAK-72 hosted migration as a focused repository-native GitHub Actions workflow for `knowledge-adapters`.

- Execution locality: **Hosted**
- Authority class: **Observe and report**
- Canonical command: `make chaos-all`
- Owning repository: `ctrl-alt-keith/knowledge-adapters`

## Workflow contract

- Runs every Monday at **17:00 UTC** and supports `workflow_dispatch`.
- The fixed UTC schedule is 10:00 during Pacific daylight time and 09:00 during Pacific standard time. It intentionally avoids seasonal timezone maintenance.
- Checks out and verifies the exact `github.sha` selected by the scheduled or manual event.
- Reuses the repository setup contract: Python 3.13 followed by `make dev`.
- Runs exactly `make chaos-all`.
- Uses `contents: read`, disables persisted checkout credentials, reads no secrets, and has no provider or repository write path.
- Allows one run per ref, queues up to the hosted limit, does not cancel an in-progress run, and times out after 30 minutes.
- Treats checkout, setup, validation, and repository-state failures as job failures. Setup failure leaves validation skipped rather than reporting a clean pass.
- Uses the GitHub Actions run/job conclusion and step logs as the authoritative outcome. The job summary is derived operator context only.
- Preserves repository, run identity, event, tested SHA, runner, command, setup/validation outcomes, timeout/cancellation state, and logs in the Actions run. The current repository retention setting keeps Actions logs for 90 days.

## Validation

- `make check` — passed (Ruff, MyPy, 774 tests)
- `make chaos-all` — passed (11 chaos tests; 763 deselected)
- Workflow YAML and required contract structure parser assertions — passed
- `git diff --check` — passed
- Final scope/security audit — no secrets, write permissions, workstation paths, duplicated setup logic, or local scheduler references

## First hosted-run boundary

This PR proves the repository contract locally and makes the hosted workflow available after merge. A representative scheduled or manual run still needs to occur after merge before hosted behavior is considered proven. The GitHub Actions run and job conclusion will be the authoritative evidence.

## Deliberate non-changes

- Does not change the existing pull-request validation workflow.
- Does not disable, delete, or edit `knowledge-adapters-weekly-chaos-all-validation`.
- Does not disable, delete, or edit `run-weekly-chaos-all-validation`.
- Does not create issues, additional reports, commits, pull requests, or provider mutations from the workflow.
- Does not merge this PR or enable auto-merge.