### PR TITLE
docs: align constitutional terminology

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,20 @@ Each adapter should:
 
 ## Design Principles
 
+Before placing a feature, apply the Product boundary in
+[`docs/chain-of-custody.md`](docs/chain-of-custody.md):
+
+- Does it strengthen the Source Acquisition Product Candidate's bounded
+  transaction or shared Source Package semantics?
+- Is it Runtime Producer or normative-contract-host implementation work that
+  currently belongs in this repository?
+- Does it instead make a consequential retention, analysis, or publication
+  decision owned by another Product boundary and an authorized human role?
+
+Repository placement does not create Product authority. Keep source-adapter
+execution, contract meaning, consumer-local policy, transport, and human
+decisions distinct.
+
 ### 1. Public-Safe by Default
 - Do not commit secrets, tokens, or credentials
 - Do not include internal URLs or identifiers

--- a/README.md
+++ b/README.md
@@ -3,6 +3,23 @@
 Generic adapters for acquiring knowledge from external sources and normalizing
 them into one predictable local artifact layout.
 
+The **Source Acquisition Product Candidate** is the **Semantic Contract
+Producer** for the Source Package contract: it owns the bounded acquisition
+transaction and shared contract semantics. This repository currently hosts its
+primary implementation and the normative
+[Source Package Contract](docs/source-package-contract.md). Source adapters are
+Runtime Producers: they perform acquisition and emit candidate artifacts or
+conforming Source Packages, but they do not approve retention or publication.
+An authorized human reviewer makes consequential retention decisions under the
+consuming Product's policy.
+
+Google Docs can appear on either side of this boundary. Acquiring a configured
+Google Doc as source material is Source Acquisition work. Delivering an
+authorized artifact to Google Docs is work of the **Publication Product
+Candidate** and its destination implementation, not a source-adapter
+responsibility. See the
+[Google Docs destination design](docs/google-docs-destination.md).
+
 ---
 
 ## Choose Your Command Context
@@ -653,8 +670,8 @@ This repository contains only generic tooling, abstractions, and documentation.
 4. Add tests and automation around the contract
 5. Expand only after shared patterns become clear
 
-For the product boundary around acquisition artifacts, manifests, diagnostics,
-and downstream handoff, see
+For the Product Candidate boundary around acquisition artifacts, manifests,
+diagnostics, and downstream handoff, see
 [`docs/chain-of-custody.md`](docs/chain-of-custody.md).
 
 ---

--- a/docs/chain-of-custody.md
+++ b/docs/chain-of-custody.md
@@ -1,17 +1,22 @@
 # Chain Of Custody Boundary
 
-This document names the product boundary for `knowledge-adapters`.
+This document names the Source Acquisition boundary currently implemented in
+`knowledge-adapters`.
 
-`knowledge-adapters` owns the acquisition transaction. It turns configured
-source inputs into deterministic, inspectable, replayable local artifacts and
-metadata that downstream systems or reviewers can evaluate.
+The **Source Acquisition Product Candidate** is the **Semantic Contract
+Producer** for the Source Package contract: it owns the bounded acquisition
+transaction and shared contract semantics. `knowledge-adapters` currently hosts
+the primary implementation and normative Source Package contract. Its source
+adapters perform acquisition and emit deterministic, inspectable, replayable
+local artifacts and metadata that downstream systems or reviewers can evaluate.
 
-It does not decide whether acquired content is true, worth keeping, safe to
-publish, or ready for long-term retention.
+Neither Source Acquisition nor this repository decides whether acquired
+content is true, worth keeping, authorized for publication, or ready for
+long-term retention.
 
-## Product Role
+## Product Candidate Role
 
-`knowledge-adapters` is responsible for acquisition work:
+Source Acquisition owns the meaning and boundary of acquisition work:
 
 - source resolution;
 - fetch or acquisition from configured sources;
@@ -21,9 +26,11 @@ publish, or ready for long-term retention.
 - replay evidence that lets a later run be compared with an earlier run;
 - review handoff packaging, including bundles.
 
-The repository should make the acquisition event clear enough that another
-system or human can review it. It should avoid becoming the place that judges
-the acquired material.
+Source adapters are the Runtime Producers for these outputs. The repository
+currently implements those adapters, exposes their commands, and records their
+accepted source, validation, review, and merge facts. The implementation should
+make the acquisition event clear enough that another system or human can
+review it without assigning content judgment to the repository or adapter.
 
 ## Core Invariant
 
@@ -57,19 +64,30 @@ changed resources, skipped resources, and handoff readiness. They must not be
 treated as approval that the content should be kept, trusted, published, or
 promoted.
 
-## Repository Boundaries
+## Product And Repository Boundaries
 
-Adjacent repositories own later lifecycle steps:
+Adjacent Product Candidates own later bounded questions while repositories
+currently host their implementations and evidence:
 
-- `knowledge-vault` owns retention, review status, cataloging,
-  no-promotion decisions, and committed reviewed knowledge.
-- `trusted-ai-environment` owns evidence bundle contracts, chunking,
-  relations, findings, synthesis, and analysis over trusted evidence.
-- `ka-destinations` owns publication, destination credentials, destination
-  IDs, sharing, sync, and publish state.
+- The **Knowledge Record Product Candidate** owns the editorial-retention
+  authority boundary. An authorized human reviewer decides retention,
+  restriction, rejection, or deferral. `knowledge-vault` currently hosts the
+  consumer implementation and records accepted editorial decisions.
+- The **Evidence Synthesis Product Candidate** owns an identified analytical
+  attempt over a frozen accepted-evidence set. Its runtime components perform
+  chunking, relation extraction, finding production, and synthesis without
+  turning execution into analytical approval.
+- The **Publication Product Candidate** owns the authorized external-delivery
+  transaction and publication-receipt semantics. A publication authorizer
+  decides what exact artifact and destination are authorized.
+  `ka-destinations` currently implements destination behavior and records
+  publication receipts.
 
-`knowledge-adapters` may prepare handoff material for those systems, but it
-should not store their lifecycle state or make their decisions.
+An operator or orchestrator may transport a sealed Source Package or bundle
+between implementations. Transport does not own Source Acquisition semantics,
+consumer-local policy, Publication semantics, or consequential human
+decisions. `knowledge-adapters` may prepare handoff material, but it should not
+store later lifecycle state or make later Product or human decisions.
 
 ## Diagnostic Vocabulary
 
@@ -92,28 +110,33 @@ readiness. For example, `review-ready` means the acquisition result appears
 inspectable enough for review; it does not mean the content has passed review.
 `unsafe-to-promote` is an acquisition-side diagnostic that may indicate
 additional review outside `knowledge-adapters` is required. It does not mean
-this repository tracks, owns, or waits for downstream decisions, and it does
-not decide retention or promotion policy.
+this repository tracks or waits for downstream decisions, and it does not
+decide retention or promotion policy.
 
 ## Product Decision Filter
 
 Use these questions when deciding whether a proposed capability belongs in this
 repository:
 
-- Does this strengthen the integrity of the acquisition transaction?
+- Does this strengthen Source Acquisition's bounded transaction or shared
+  contract meaning?
 - Does this make acquisition more deterministic, reproducible, inspectable, or
   handoff-ready?
+- Is the work a Runtime Producer or normative-contract-host implementation
+  change that currently belongs in this repository?
 - Does this start deciding whether the content is true, valuable, retained, or
   published?
 - Does this store destination or retention state that belongs elsewhere?
 
-Capabilities that improve acquisition integrity usually fit. Capabilities that
+Capabilities that improve acquisition integrity usually fit the Source
+Acquisition boundary and may currently fit this repository. Capabilities that
 make content judgments, retention decisions, publication decisions, or
-downstream analysis usually belong in another repository.
+downstream analysis belong to the applicable Product boundary and its current
+implementation, regardless of repository convenience.
 
 ## Non-Goals
 
-`knowledge-adapters` does not own:
+Source Acquisition does not own:
 
 - content truth judgment;
 - retention approval;

--- a/docs/google-docs-destination.md
+++ b/docs/google-docs-destination.md
@@ -6,6 +6,13 @@ This document defines how Google Docs should fit into the
 `knowledge-adapters` workflow without changing the existing ingestion,
 artifact, manifest, and bundle architecture.
 
+The boundary depends on the direction of the transaction. The **Source
+Acquisition Product Candidate** owns acquisition semantics when a configured
+Google Doc is acquired and normalized as source material. The **Publication
+Product Candidate** owns an authorized external-delivery transaction and
+publication-receipt semantics when a caller-supplied artifact is delivered to
+Google Docs. This document addresses the Publication direction only.
+
 The target workflow is:
 
 ```text
@@ -20,10 +27,12 @@ knowledge, not a new responsibility inside `knowledge-adapters`.
 Google Docs integration should live outside `knowledge-adapters` as a separate
 destination tool or thin publication layer.
 
-`knowledge-adapters` should continue to own source ingestion, normalization into
-local artifacts, manifest writing, and deterministic bundling. A Google Docs
-publication layer should consume bundle output and publish that output into
-Google Docs for use by Gemini or human collaborators.
+Source Acquisition should continue to own source-ingestion and Source Package
+semantics. `knowledge-adapters` currently implements source acquisition,
+normalization into local artifacts, manifest writing, and deterministic
+bundling. A Google Docs destination implementation should consume caller-
+supplied bundle output and perform the authorized delivery into Google Docs for
+use by Gemini or human collaborators.
 
 This keeps the boundary clean:
 
@@ -33,6 +42,9 @@ This keeps the boundary clean:
   not leak into adapter or bundle code.
 - The same bundle output can support Google Docs, manual upload, or another
   destination without changing adapter contracts.
+- A publication authorizer selects the exact artifact and destination; a
+  destination driver performs the API operation and records the observed
+  result. Successful execution does not authorize publication.
 
 ## System Placement
 
@@ -99,6 +111,14 @@ and update policy. Those are destination concerns, not packaging concerns.
 
 The Google Docs destination layer should consume bundle output as its primary
 input.
+
+For this boundary, the bundle command emits a local bundle file and the
+Publication Product Candidate consumes it as caller-supplied downstream input.
+This design does not declare a new Source Package or bundle interchange
+contract. The Google Docs destination driver is the runtime component that
+performs external delivery. An operator or orchestrator may transport the file
+and invoke the driver, but does not thereby acquire Source Acquisition,
+Publication, or publication-authorization authority.
 
 ### Required Input
 
@@ -246,7 +266,7 @@ The separate Google Docs destination layer should:
 - preserve source attribution from bundle headers
 - report the Google Doc URL after publication
 - keep destination configuration outside this repository
-- own Google-specific auth, API retries, and workspace errors
+- implement Google-specific auth, API retries, and workspace error handling
 - keep any publish state in its own local or destination-specific state file
 
 ### Google Docs Destination Layer Should Not Do
@@ -304,7 +324,7 @@ The v1 trigger should be explicit.
 Recommended triggers, in order:
 
 1. A separate CLI outside this repository.
-2. A local script owned by the operator or workspace automation.
+2. A local script maintained by the operator or workspace automation.
 3. Manual upload or copy into Google Docs for early validation.
 
 `knowledge-adapters` should not grow a `google_docs` subcommand for v1.
@@ -359,9 +379,10 @@ Features to avoid inside `knowledge-adapters`:
 - comment or suggestion import
 - Gemini chat orchestration
 
-The architecture stays healthy when `knowledge-adapters` remains a deterministic
-producer of local artifacts and bundles, and the destination layer remains an
-explicit consumer of those local files.
+The architecture stays healthy when `knowledge-adapters` remains the current
+host of runtime components that emit deterministic local artifacts and bundles,
+while the destination layer remains an explicit consumer of those local files
+and a runtime implementation of Publication delivery.
 
 ## Future Evolution
 
@@ -376,7 +397,7 @@ Potential later additions outside `knowledge-adapters`:
   manifest `canonical_id`
 - support full-document replacement for known document IDs
 - add destination tools for Notion, SharePoint, or other document stores
-- add an operator-owned sync tool that watches bundle output directories
+- add an operator-maintained sync tool that watches bundle output directories
 
 Potential later additions inside `knowledge-adapters`, only if real use proves
 the need:

--- a/docs/project-map.md
+++ b/docs/project-map.md
@@ -4,6 +4,11 @@ This document provides a concise, human-readable view of the current state of
 the repository, active work, and upcoming arcs. It complements GitHub issues by
 grouping them into meaningful lanes.
 
+This repository currently implements the **Source Acquisition Product
+Candidate**. The Product Candidate owns the bounded acquisition transaction and
+Source Package semantics; this repository controls only its accepted source,
+current implementation, validation, review, and merge facts.
+
 ## Current State
 
 - Confluence adapter: mature (single-page, tree traversal, incremental sync,
@@ -14,7 +19,8 @@ grouping them into meaningful lanes.
   GitHub/GHE issues, pull requests, releases, optional issue comments, and
   optional pull request comments/review comments)
 - Google Docs destination: design completed as a separate post-bundle
-  publication layer, not a `knowledge-adapters` adapter or bundle subcommand
+  implementation of the **Publication Product Candidate**, not a
+  `knowledge-adapters` source adapter or bundle subcommand
 - Bundle command:
   - v1 complete (#147)
   - ordering controls added (#153)

--- a/docs/source-package-contract.md
+++ b/docs/source-package-contract.md
@@ -11,6 +11,12 @@ consumed by a review system such as `knowledge-vault`. It describes one bounded
 acquisition run, the resources considered, candidate representations produced,
 and failures or limitations encountered.
 
+The **Source Acquisition Product Candidate** is the **Semantic Contract
+Producer** for the Source Package contract: it owns shared contract meaning,
+emission semantics, and compatible evolution. A source adapter is the Runtime
+Producer that emits a contract instance. `knowledge-adapters` currently hosts
+the normative contract and producer implementation.
+
 The stable boundary is:
 
 ```text
@@ -19,17 +25,22 @@ source request -> adapter acquisition -> immutable source package
                                       -> retained editorial judgment
 ```
 
-The adapter owns acquisition. The consumer owns review and retention. A valid
-package is eligible to enter review; it is never approval to retain, trust, or
-publish its content. This extends the boundary in
+Source Acquisition owns acquisition semantics. A consuming Product owns its
+accepted versions and consumer-local policy, while an authorized human reviewer
+makes consequential retention decisions. A valid package is eligible to enter
+review; it is never approval to retain, trust, or publish its content. This
+extends the boundary in
 [`chain-of-custody.md`](chain-of-custody.md) without replacing it.
 
-## Normative Ownership
+## Normative Contract Host
 
-`knowledge-adapters` owns this normative Source Package Contract. This document
-is the canonical source for shared interchange vocabulary, package structure,
-package semantics, compatibility rules, lifecycle definitions, integrity
-requirements, and producer/consumer handoff behavior.
+This document, currently hosted in `knowledge-adapters`, is the normative Source
+Package Contract and the canonical source for shared interchange vocabulary,
+package structure, package semantics, compatibility rules, lifecycle
+definitions, integrity requirements, and producer/consumer handoff behavior.
+Repository Authority is limited to the accepted contract bytes, current
+implementation, validation, review, and merge facts recorded here; hosting does
+not transfer semantic ownership from Source Acquisition to the repository.
 
 Consumers such as `knowledge-vault` may document derived summaries and
 consumer-specific review policy, but they do not independently redefine this
@@ -37,22 +48,32 @@ contract. If a consumer summary conflicts with this document, this document
 governs. The companion vault expectations are documented in
 [`knowledge-vault`](https://github.com/ctrl-alt-keith/knowledge-vault/blob/main/docs/source-package-consumer-contract.md).
 
-## Participants
+## Participants And Authority
 
-The interchange has three roles:
+The interchange keeps these roles distinct:
 
-- the adapter is the producer and owns the acquisition transaction and sealed
-  package;
-- the vault is the consumer and owns validation for review, editorial review,
-  and retention decisions; and
-- the operator or orchestrator invokes adapters, supplies runtime credential
-  references, selects supported compatibility ranges, transfers sealed
-  packages, manages quarantine, preserves package bytes during transfer and
-  review, and initiates review.
+- **Semantic Contract Producer:** Source Acquisition owns shared Source Package
+  meaning, emission semantics, and compatible evolution.
+- **Runtime Producer:** a source adapter performs the producer-side operation
+  and emits a sealed package conforming to Source Acquisition semantics.
+- **Normative contract host:** `knowledge-adapters` currently hosts this
+  contract, the producer implementation, and producer conformance validation.
+- **Contract consumer:** the **Knowledge Record Product Candidate** consumes
+  Source Packages under its accepted-version, editorial, and retention policy.
+- **Consumer implementation:** `knowledge-vault` currently hosts package
+  verification, review workflow, and retained decision records.
+- **Transport or orchestration:** the operator or orchestrator invokes
+  adapters, supplies runtime credential references, selects supported
+  compatibility ranges, transfers sealed packages, manages quarantine,
+  preserves package bytes during transfer and review, and initiates review.
+- **Consequential human authority:** an authorized human reviewer decides
+  editorial retention; Repository merge authority decides whether a proposed
+  contract or implementation change may merge.
 
-The operator does not make editorial or retention decisions. A person or
-system may perform more than one role operationally, but the responsibilities
-remain distinct.
+Transport does not make editorial or retention decisions and does not own
+producer or consumer semantics. A person or system may perform more than one
+role operationally, but the responsibilities and authority questions remain
+distinct.
 
 ## Adapter Responsibilities
 


### PR DESCRIPTION
## Summary

- Align current documentation with the [Constitutional Vocabulary Guide](https://github.com/ctrl-alt-keith/ai-workflow-playbook/blob/main/docs/constitutional-vocabulary-guide.md) and the accepted [Human Constitutional Terminology Ratification Decision](https://github.com/ctrl-alt-keith/ai-workflow-playbook/blob/main/docs/constitutional-terminology-ratification-decision.md).
- Represent the **Source Acquisition Product Candidate** as owner of the bounded acquisition transaction and Source Package semantics.
- Replace repository-first authority language with current hosting and implementation language.
- Distinguish the **Semantic Contract Producer**, Runtime Producers, normative contract host, Knowledge Record contract consumer and consumer implementation, transport/orchestration, and consequential human authority.
- Separate Google Docs source acquisition from Publication delivery without declaring a new bundle interchange contract.
- Add contributor-facing Product-boundary decision filters.

## Historical and semantic boundary

Historical receipts, prompts, reviews, ADRs, decisions, and research evidence remain unchanged. This is documentation-only. It does not change architecture, Product status, contract semantics, schemas, authorization mechanics, or implementation/runtime behavior.

## Validation

- `make check` — passed (Ruff, MyPy, 774 tests)
- `git diff --check` — passed
- Changed-document links — manually verified; the canonical gate has no Markdown link checker

## Coordinated alignment set

- [knowledge-adapters #329](https://github.com/ctrl-alt-keith/knowledge-adapters/pull/329)
- [ka-destinations #48](https://github.com/ctrl-alt-keith/ka-destinations/pull/48)
- [knowledge-vault #83](https://github.com/ctrl-alt-keith/knowledge-vault/pull/83)

## Tracking

References [CAK-82](https://linear.app/ctrl-alt-keith/issue/CAK-82/complete-constitutional-governance-alignment-across-the-ecosystem); does not close it.