### PR TITLE
docs: synchronize Product status after promotion

### DIFF
--- a/docs/chain-of-custody.md
+++ b/docs/chain-of-custody.md
@@ -66,13 +66,15 @@ promoted.
 
 ## Product And Repository Boundaries
 
-Adjacent Product Candidates own later bounded questions while repositories
+Adjacent Product identities own later bounded questions while repositories
 currently host their implementations and evidence:
 
-- The **Knowledge Record Product Candidate** owns the editorial-retention
-  authority boundary. An authorized human reviewer decides retention,
-  restriction, rejection, or deferral. `knowledge-vault` currently hosts the
-  consumer implementation and records accepted editorial decisions.
+- The **Knowledge Record Enduring Product** owns the editorial-retention
+  authority boundary. **Human Product Promotion Decision #1**, effective
+  2026-07-24, controls its promoted status without changing that boundary. An
+  authorized human reviewer decides retention, restriction, rejection, or
+  deferral. `knowledge-vault` currently hosts the consumer implementation and
+  records accepted editorial decisions.
 - The **Evidence Synthesis Product Candidate** owns an identified analytical
   attempt over a frozen accepted-evidence set. Its runtime components perform
   chunking, relation extraction, finding production, and synthesis without

--- a/docs/source-package-contract.md
+++ b/docs/source-package-contract.md
@@ -58,8 +58,10 @@ The interchange keeps these roles distinct:
   and emits a sealed package conforming to Source Acquisition semantics.
 - **Normative contract host:** `knowledge-adapters` currently hosts this
   contract, the producer implementation, and producer conformance validation.
-- **Contract consumer:** the **Knowledge Record Product Candidate** consumes
+- **Contract consumer:** the **Knowledge Record Enduring Product** consumes
   Source Packages under its accepted-version, editorial, and retention policy.
+  **Human Product Promotion Decision #1**, effective 2026-07-24, controls its
+  promoted status without changing the consumer or contract boundary.
 - **Consumer implementation:** `knowledge-vault` currently hosts package
   verification, review workflow, and retained decision records.
 - **Transport or orchestration:** the operator or orchestrator invokes


### PR DESCRIPTION
## Summary

- Synchronize current Knowledge Record status references with its promotion to Enduring Product.
- Preserve Source Acquisition, Evidence Synthesis, and Publication as Product Candidates.
- Keep the editorial-retention boundary, Source Package semantics, repository authority, and contract participants unchanged.

## Controlling status

Human Product Promotion Decision #1 is the controlling Product-status record. It promoted Knowledge Record to Enduring Product effective 2026-07-24 without changing the Product identity, authority boundary, repository topology, Source Package contract, or implementation behavior.

## Validation

- `make check` — passed (`ruff`, `mypy`, 774 tests)
- `make check-gh-env` — passed
- `git diff --check` — passed
- Focused current-document status scan — Knowledge Record is Enduring Product where status is material; Source Acquisition, Evidence Synthesis, and Publication remain Product Candidates
- Markdown link review — no links were added or changed, and the repository documents no separate link-check target beyond canonical validation
- Final scope inspection — only the two current documentation files named in this PR changed; historical evidence is untouched

## Planning reference

Related to CAK-82. This PR does not close the planning item.

## Coordinated PRs

- [knowledge-vault #84](https://github.com/ctrl-alt-keith/knowledge-vault/pull/84)
- [knowledge-adapters #330](https://github.com/ctrl-alt-keith/knowledge-adapters/pull/330)
- [ka-destinations #49](https://github.com/ctrl-alt-keith/ka-destinations/pull/49)