### PR TITLE
Classify GitHub request timeouts

### DIFF
--- a/docs/github-metadata-v1.md
+++ b/docs/github-metadata-v1.md
@@ -154,7 +154,7 @@ Basic error behavior:
   configuration
 - `auth`: `401` or non-rate-limit `403` responses
 - `expected_retryable`: GitHub rate-limit responses, including `403` or `429`
-  with rate-limit headers, and transport failures
+  with rate-limit headers, transport failures, and request timeouts
 - `permanent`: `404`, invalid response payloads, and other non-retryable
   request errors
 - `provider`: GitHub `5xx` provider-side failures

--- a/src/knowledge_adapters/github_metadata/client.py
+++ b/src/knowledge_adapters/github_metadata/client.py
@@ -1038,6 +1038,11 @@ def _request_json_list(
             f"GitHub request failed while reading {repo} from {api_root}: {exc.reason}.",
             classification=AdapterFailureClassification(AdapterFailureClass.EXPECTED_RETRYABLE),
         ) from exc
+    except TimeoutError as exc:
+        raise GitHubMetadataRequestError(
+            f"GitHub request timed out while reading {repo} from {api_root}.",
+            classification=AdapterFailureClassification(AdapterFailureClass.EXPECTED_RETRYABLE),
+        ) from exc
     except json.JSONDecodeError as exc:
         raise ValueError("Response error: invalid JSON payload.") from exc
 

--- a/tests/test_github_metadata.py
+++ b/tests/test_github_metadata.py
@@ -359,6 +359,32 @@ def test_github_metadata_classifies_request_failures(
     assert exc_info.value.classification.retry_after == expected_retry_after
 
 
+def test_github_metadata_classifies_request_timeout_as_expected_retryable(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    def raise_timeout(api_request: request.Request, timeout: int) -> None:
+        del api_request, timeout
+        raise TimeoutError("synthetic request timeout")
+
+    monkeypatch.setenv("GH_TOKEN", "secret-token")
+    monkeypatch.setattr(
+        "knowledge_adapters.github_metadata.client.request.urlopen",
+        raise_timeout,
+    )
+
+    with pytest.raises(
+        GitHubMetadataRequestError,
+        match=(
+            r"GitHub request timed out while reading octo/project "
+            r"from https://api\.github\.com\."
+        ),
+    ) as exc_info:
+        list_repository_issues(repo="octo/project", token_env="GH_TOKEN")
+
+    assert exc_info.value.classification is not None
+    assert exc_info.value.classification.failure_class == AdapterFailureClass.EXPECTED_RETRYABLE
+
+
 def test_github_metadata_cli_reports_configuration_failure_class(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,


### PR DESCRIPTION
## Summary
- convert Python request timeouts at the GitHub REST boundary into `GitHubMetadataRequestError`
- classify the failure as `expected_retryable`, matching other transient transport failures
- document and test the stable adapter behavior

## Validation
- `make check` (Ruff, strict MyPy, 775 tests passed)

A leaked ignored `pytest-of-root/` directory initially caused MyPy duplicate-module discovery; it was removed as disposable test output before the clean canonical run.