### PR TITLE
Remove unused private helpers

### DIFF
--- a/src/knowledge_adapters/failures.py
+++ b/src/knowledge_adapters/failures.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import Protocol
 
 
 class AdapterFailureClass(StrEnum):
@@ -24,12 +23,6 @@ class AdapterFailureClassification:
     failure_class: AdapterFailureClass
     provider_status_code: int | None = None
     retry_after: str | None = None
-
-
-class ClassifiedAdapterError(Protocol):
-    """Protocol for exceptions that carry adapter failure classification."""
-
-    classification: AdapterFailureClassification | None
 
 
 def response_or_config_failure(exc: Exception) -> AdapterFailureClassification:

--- a/src/knowledge_adapters/public_pdf/normalize.py
+++ b/src/knowledge_adapters/public_pdf/normalize.py
@@ -180,10 +180,6 @@ def normalize_to_markdown(page: Mapping[str, object]) -> str:
 """
 
 
-def _normalize_broken_url_spacing(text: str) -> str:
-    return _normalize_broken_url_spacing_with_count(text)[0]
-
-
 def _normalize_broken_url_spacing_with_count(text: str) -> tuple[str, int]:
     return _BROKEN_URL_SCHEME_RE.subn(_join_broken_url_scheme, text)
 
@@ -263,10 +259,6 @@ def _is_one_letter_split_word_pair(
         and next_line[0].islower()
         and any(character.isalpha() for character in next_line[1:])
     )
-
-
-def _suppress_repeated_footer_lines(page_texts: list[str]) -> list[str]:
-    return _suppress_repeated_footer_lines_with_metadata(page_texts)[0]
 
 
 def _suppress_high_coverage_text_footer_lines_with_metadata(


### PR DESCRIPTION
## Summary
- remove an unused failure-classification Protocol
- remove two unused private PDF normalization wrappers
- retain the metadata-returning implementations used by the active pipeline

## Testing
- make check (ruff, mypy, 777 tests passed)