### PR TITLE
CAK-97: link canonical Product authority

### DIFF
--- a/docs/chain-of-custody.md
+++ b/docs/chain-of-custody.md
@@ -70,11 +70,13 @@ Adjacent Product identities own later bounded questions while repositories
 currently host their implementations and evidence:
 
 - The **Knowledge Record Enduring Product** owns the editorial-retention
-  authority boundary. **Human Product Promotion Decision #1**, effective
-  2026-07-24, controls its promoted status without changing that boundary. An
-  authorized human reviewer decides retention, restriction, rejection, or
-  deferral. `knowledge-vault` currently hosts the consumer implementation and
-  records accepted editorial decisions.
+  authority boundary. The Playbook's [Product Status](https://github.com/ctrl-alt-keith/ai-workflow-playbook/blob/main/docs/product-status.md#knowledge-record)
+  records its current accepted status, and [Human Product Promotion Decision
+  #1](https://github.com/ctrl-alt-keith/ai-workflow-playbook/blob/main/docs/product-promotion-decisions/human-product-promotion-decision-001.md),
+  effective 2026-07-24, records the historical governance event that established
+  it without changing that boundary. An authorized human reviewer decides
+  retention, restriction, rejection, or deferral. `knowledge-vault` currently
+  hosts the consumer implementation and records accepted editorial decisions.
 - The **Evidence Synthesis Product Candidate** owns an identified analytical
   attempt over a frozen accepted-evidence set. Its runtime components perform
   chunking, relation extraction, finding production, and synthesis without

--- a/docs/source-package-contract.md
+++ b/docs/source-package-contract.md
@@ -60,8 +60,11 @@ The interchange keeps these roles distinct:
   contract, the producer implementation, and producer conformance validation.
 - **Contract consumer:** the **Knowledge Record Enduring Product** consumes
   Source Packages under its accepted-version, editorial, and retention policy.
-  **Human Product Promotion Decision #1**, effective 2026-07-24, controls its
-  promoted status without changing the consumer or contract boundary.
+  The Playbook's [Product Status](https://github.com/ctrl-alt-keith/ai-workflow-playbook/blob/main/docs/product-status.md#knowledge-record)
+  records its current accepted status, and [Human Product Promotion Decision
+  #1](https://github.com/ctrl-alt-keith/ai-workflow-playbook/blob/main/docs/product-promotion-decisions/human-product-promotion-decision-001.md),
+  effective 2026-07-24, records the historical governance event that established
+  it without changing the consumer or contract boundary.
 - **Consumer implementation:** `knowledge-vault` currently hosts package
   verification, review workflow, and retained decision records.
 - **Transport or orchestration:** the operator or orchestrator invokes


### PR DESCRIPTION
## Summary

- link the canonical Playbook Product Status surface for the Knowledge Record current accepted state
- link Playbook Human Product Promotion Decision #1 as historical governance provenance
- preserve knowledge-adapters ownership of Source Acquisition implementation and the Source Package contract

## Canonical source

Playbook PR #319 / squash commit 8f9d2874aa8e5a7d8940d8e57e8992f23b0e0cc8 established the canonical Product-state and Decision #1 provenance surfaces used here.

## Validation

- make check (Ruff passed; mypy passed for 124 source files; pytest: 784 passed)
- make check-gh-env