### PR TITLE
Bound Confluence provider requests

### DIFF
--- a/src/knowledge_adapters/confluence/client.py
+++ b/src/knowledge_adapters/confluence/client.py
@@ -15,6 +15,8 @@ from knowledge_adapters.confluence.models import ResolvedTarget
 from knowledge_adapters.confluence.traversal import DISCOVERY_PROGRESS_INTERVAL
 from knowledge_adapters.failures import AdapterFailureClass, AdapterFailureClassification
 
+DEFAULT_REQUEST_TIMEOUT_SECONDS = 30
+
 
 class ConfluenceRequestError(RuntimeError):
     """Stable request failure with Confluence-specific debug context."""
@@ -430,7 +432,11 @@ def _request_json(
             request_pacer()
         if request_counter is not None:
             request_counter()
-        with request.urlopen(api_request, context=request_auth.ssl_context) as response:
+        with request.urlopen(
+            api_request,
+            context=request_auth.ssl_context,
+            timeout=DEFAULT_REQUEST_TIMEOUT_SECONDS,
+        ) as response:
             raw_payload = json.loads(response.read().decode("utf-8"))
     except (HTTPError, URLError) as exc:
         raise ConfluenceRequestError(

--- a/tests/confluence/test_client.py
+++ b/tests/confluence/test_client.py
@@ -129,6 +129,26 @@ def test_real_child_list_does_not_report_progress_for_small_results(
     assert progress_updates == []
 
 
+def test_real_client_bounds_provider_requests(monkeypatch: MonkeyPatch) -> None:
+    observed_timeout: list[object] = []
+
+    def fake_urlopen(*args: object, **kwargs: object) -> _FakeHTTPResponse:
+        del args
+        observed_timeout.append(kwargs["timeout"])
+        return _FakeHTTPResponse(_valid_confluence_payload())
+
+    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    fetch_real_page(
+        _real_target(),
+        base_url="https://example.com/wiki",
+        auth_method="bearer-env",
+    )
+
+    assert observed_timeout == [30]
+
+
 def test_real_space_page_list_reports_periodic_progress_during_pagination(
     monkeypatch: MonkeyPatch,
 ) -> None:

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -2382,8 +2382,13 @@ def test_run_command_uses_same_real_client_ca_bundle_as_direct_cli(
         observed_cafiles.append(cafile)
         return FakeSSLContext()
 
-    def fake_urlopen(api_request: object, context: object | None = None) -> _FakeHTTPResponse:
+    def fake_urlopen(
+        api_request: object,
+        context: object | None = None,
+        timeout: int | None = None,
+    ) -> _FakeHTTPResponse:
         del context
+        assert timeout == 30
         observed_request_urls.append(str(cast(Any, api_request).full_url))
         return _FakeHTTPResponse(
             {


### PR DESCRIPTION
## Summary

- apply a 30-second timeout to every real Confluence HTTP request
- verify the bound at the client boundary
- assert direct CLI and run-config execution preserve the same timeout

## Why

The real Confluence adapter previously called `urlopen` without a timeout, allowing a stalled provider or network connection to hang an acquisition indefinitely. Other network adapters already use bounded requests; this closes the same operational safety gap for Confluence.

## Validation

- `make check`
- Ruff passed
- MyPy passed across 124 source files
- 785 tests passed