### PR TITLE
Ignore hidden webpage target markup

### DIFF
--- a/src/knowledge_adapters/public_webpage/client.py
+++ b/src/knowledge_adapters/public_webpage/client.py
@@ -154,6 +154,11 @@ class _ReadableHTMLExtractor(HTMLParser):
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         normalized_tag = tag.lower()
+        if normalized_tag in self._IGNORED_TAGS:
+            self._ignored_depth += 1
+            return
+        if self._ignored_depth > 0:
+            return
         attr_map = {key.lower(): value or "" for key, value in attrs}
         if normalized_tag == "title":
             self._in_title = True
@@ -182,14 +187,16 @@ class _ReadableHTMLExtractor(HTMLParser):
                         source="meta_url",
                     )
                 )
-        if normalized_tag in self._IGNORED_TAGS:
-            self._ignored_depth += 1
-            return
         if normalized_tag in self._BLOCK_TAGS:
             self._append_break()
 
     def handle_endtag(self, tag: str) -> None:
         normalized_tag = tag.lower()
+        if normalized_tag in self._IGNORED_TAGS and self._ignored_depth > 0:
+            self._ignored_depth -= 1
+            return
+        if self._ignored_depth > 0:
+            return
         if normalized_tag == "title":
             self._in_title = False
         if normalized_tag == "a":
@@ -203,9 +210,6 @@ class _ReadableHTMLExtractor(HTMLParser):
                 )
             self._active_link_href = ""
             self._active_link_text = []
-        if normalized_tag in self._IGNORED_TAGS and self._ignored_depth > 0:
-            self._ignored_depth -= 1
-            return
         if normalized_tag in self._BLOCK_TAGS:
             self._append_break()
 

--- a/tests/test_public_sources.py
+++ b/tests/test_public_sources.py
@@ -29,7 +29,11 @@ from knowledge_adapters.public_sources import (
     output_name_for_url,
     validate_public_http_url,
 )
-from knowledge_adapters.public_webpage.client import PublicWebpageDocument, fetch_webpage
+from knowledge_adapters.public_webpage.client import (
+    PublicWebpageDocument,
+    _ReadableHTMLExtractor,
+    fetch_webpage,
+)
 from knowledge_adapters.public_webpage.normalize import normalize_to_markdown as normalize_webpage
 from knowledge_adapters.public_webpage.writer import markdown_path as webpage_markdown_path
 from tests.artifact_assertions import assert_manifest_entries, assert_markdown_document
@@ -279,6 +283,30 @@ def test_fetch_webpage_extracts_title_and_visible_text(monkeypatch: MonkeyPatch)
     assert "Review still matters." in document.content
     assert "doNotKeep" not in document.content
     assert "Unreviewed candidate material" in document.extraction_notes
+
+
+def test_webpage_extractor_ignores_hidden_markup_links_and_metadata() -> None:
+    extractor = _ReadableHTMLExtractor()
+    extractor.feed(
+        """
+        <html>
+          <head><title>Visible page title</title></head>
+          <body>
+            <template>
+              <a href="https://example.com/report.pdf">Download report</a>
+              <link href="https://example.com/canonical-report.pdf" rel="canonical">
+              <meta property="citation_pdf_url" content="https://example.com/paper.pdf">
+            </template>
+            <p>Visible article text.</p>
+          </body>
+        </html>
+        """
+    )
+    extractor.close()
+
+    assert extractor.title == "Visible page title"
+    assert extractor.markdown_text() == "Visible article text."
+    assert extractor.target_links() == ()
 
 
 def test_public_webpage_normalizer_marks_candidate_status() -> None:


### PR DESCRIPTION
## Summary

- prevent ignored HTML containers from contributing titles, links, or metadata to webpage extraction
- add a deterministic regression for template-contained report links and metadata

## Why

Hidden markup must not become an observed target candidate used by bounded webpage target discovery.

## Validation

- make check
- Ruff passed
- MyPy passed across 124 source files
- 785 tests passed
- git diff --check