### PR TITLE
Constrain Confluence pagination links

### DIFF
--- a/src/knowledge_adapters/confluence/client.py
+++ b/src/knowledge_adapters/confluence/client.py
@@ -93,14 +93,35 @@ def _space_page_api_url(
 
 def _absolute_api_url(base_url: str, url: str) -> str:
     parsed_base = parse.urlparse(base_url)
-    resolved_url = parse.urljoin(f"{base_url.rstrip('/')}/", url)
+    parsed_next = parse.urlparse(url)
+    decoded_next_path = parse.unquote(parsed_next.path)
+    if any(segment in {".", ".."} for segment in decoded_next_path.split("/")):
+        raise ValueError("Response error: pagination link is outside the Confluence base URL.")
+
+    normalized_base_path = posixpath.normpath(parsed_base.path or "/")
+    if parsed_next.scheme or parsed_next.netloc:
+        resolved_url = url
+    elif parsed_next.path.startswith("/"):
+        if _path_is_under_base(parsed_next.path, normalized_base_path):
+            resolved_path = parsed_next.path
+        else:
+            resolved_path = f"{normalized_base_path.rstrip('/')}/{parsed_next.path.lstrip('/')}"
+        resolved_url = parse.urlunparse(
+            parsed_base._replace(
+                path=resolved_path,
+                params=parsed_next.params,
+                query=parsed_next.query,
+                fragment=parsed_next.fragment,
+            )
+        )
+    else:
+        resolved_url = parse.urljoin(f"{base_url.rstrip('/')}/", url)
     parsed_url = parse.urlparse(resolved_url)
     decoded_path = parse.unquote(parsed_url.path)
     if any(segment in {".", ".."} for segment in decoded_path.split("/")):
         raise ValueError("Response error: pagination link is outside the Confluence base URL.")
 
     normalized_path = posixpath.normpath(parsed_url.path)
-    normalized_base_path = posixpath.normpath(parsed_base.path or "/")
     if (
         parsed_url.scheme != parsed_base.scheme
         or parsed_url.netloc != parsed_base.netloc

--- a/src/knowledge_adapters/confluence/client.py
+++ b/src/knowledge_adapters/confluence/client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import posixpath
 import socket
 import ssl
 from collections.abc import Callable
@@ -91,35 +92,28 @@ def _space_page_api_url(
 
 
 def _absolute_api_url(base_url: str, url: str) -> str:
-    parsed_url = parse.urlparse(url)
-    if parsed_url.scheme and parsed_url.netloc:
-        parsed_base = parse.urlparse(base_url)
-        if (
-            parsed_url.scheme != parsed_base.scheme
-            or parsed_url.netloc != parsed_base.netloc
-            or not _path_is_under_base(parsed_url.path, parsed_base.path)
-        ):
-            raise ValueError("Response error: pagination link is outside the Confluence base URL.")
-        return url
+    parsed_base = parse.urlparse(base_url)
+    resolved_url = parse.urljoin(f"{base_url.rstrip('/')}/", url)
+    parsed_url = parse.urlparse(resolved_url)
+    decoded_path = parse.unquote(parsed_url.path)
+    if any(segment in {".", ".."} for segment in decoded_path.split("/")):
+        raise ValueError("Response error: pagination link is outside the Confluence base URL.")
 
-    normalized_base = base_url.rstrip("/")
-    if url.startswith("/"):
-        parsed_base = parse.urlparse(normalized_base)
-        normalized_base_path = parsed_base.path.rstrip("/")
-        if normalized_base_path and (
-            url == normalized_base_path or url.startswith(f"{normalized_base_path}/")
-        ):
-            return f"{parsed_base.scheme}://{parsed_base.netloc}{url}"
-        return f"{normalized_base}{url}"
-    return f"{normalized_base}/{url.lstrip('/')}"
+    normalized_path = posixpath.normpath(parsed_url.path)
+    normalized_base_path = posixpath.normpath(parsed_base.path or "/")
+    if (
+        parsed_url.scheme != parsed_base.scheme
+        or parsed_url.netloc != parsed_base.netloc
+        or not _path_is_under_base(normalized_path, normalized_base_path)
+    ):
+        raise ValueError("Response error: pagination link is outside the Confluence base URL.")
+    return parse.urlunparse(parsed_url._replace(path=normalized_path))
 
 
 def _path_is_under_base(path: str, base_path: str) -> bool:
     """Return whether a URL path stays within the configured instance path."""
-    normalized_path = path or "/"
-    normalized_base_path = base_path.rstrip("/") or "/"
-    return normalized_path == normalized_base_path or normalized_path.startswith(
-        f"{normalized_base_path.rstrip('/')}/"
+    return path == base_path or path.startswith(
+        f"{base_path.rstrip('/')}/"
     )
 
 

--- a/src/knowledge_adapters/confluence/client.py
+++ b/src/knowledge_adapters/confluence/client.py
@@ -93,6 +93,13 @@ def _space_page_api_url(
 def _absolute_api_url(base_url: str, url: str) -> str:
     parsed_url = parse.urlparse(url)
     if parsed_url.scheme and parsed_url.netloc:
+        parsed_base = parse.urlparse(base_url)
+        if (
+            parsed_url.scheme != parsed_base.scheme
+            or parsed_url.netloc != parsed_base.netloc
+            or not _path_is_under_base(parsed_url.path, parsed_base.path)
+        ):
+            raise ValueError("Response error: pagination link is outside the Confluence base URL.")
         return url
 
     normalized_base = base_url.rstrip("/")
@@ -105,6 +112,15 @@ def _absolute_api_url(base_url: str, url: str) -> str:
             return f"{parsed_base.scheme}://{parsed_base.netloc}{url}"
         return f"{normalized_base}{url}"
     return f"{normalized_base}/{url.lstrip('/')}"
+
+
+def _path_is_under_base(path: str, base_path: str) -> bool:
+    """Return whether a URL path stays within the configured instance path."""
+    normalized_path = path or "/"
+    normalized_base_path = base_path.rstrip("/") or "/"
+    return normalized_path == normalized_base_path or normalized_path.startswith(
+        f"{normalized_base_path.rstrip('/')}/"
+    )
 
 
 def _require_string(payload: dict[str, object], key: str) -> str:

--- a/tests/confluence/test_client.py
+++ b/tests/confluence/test_client.py
@@ -245,6 +245,43 @@ def test_real_space_page_list_accepts_absolute_same_origin_pagination_link(
     assert requested_urls[1] == "https://example.com/wiki/rest/api/content?start=1"
 
 
+@pytest.mark.parametrize(
+    "next_url",
+    [
+        "https://example.com/wiki/../outside",
+        "/wiki/../outside",
+        "../outside",
+        "https://example.com/wiki/%2e%2e/outside",
+    ],
+)
+def test_real_space_page_list_rejects_pagination_path_traversal(
+    monkeypatch: MonkeyPatch,
+    next_url: str,
+) -> None:
+    payloads = [
+        _valid_space_page_list_payload(page_ids=["100"], next_url=next_url),
+    ]
+    request_count = 0
+
+    def fake_urlopen(*args: object, **kwargs: object) -> _FakeHTTPResponse:
+        nonlocal request_count
+        del args, kwargs
+        request_count += 1
+        return _FakeHTTPResponse(payloads.pop(0))
+
+    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    with pytest.raises(ValueError, match="pagination link is outside"):
+        list_real_space_page_ids(
+            "ENG",
+            base_url="https://example.com/wiki",
+            auth_method="bearer-env",
+        )
+
+    assert request_count == 1
+
+
 def test_real_space_page_list_does_not_report_progress_for_small_runs(
     monkeypatch: MonkeyPatch,
 ) -> None:

--- a/tests/confluence/test_client.py
+++ b/tests/confluence/test_client.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import json
-from typing import Literal
+from typing import Any, Literal
 
+import pytest
 from pytest import MonkeyPatch
 
 from knowledge_adapters.confluence.client import (
@@ -184,6 +185,64 @@ def test_real_space_page_list_reports_periodic_progress_during_pagination(
 
     assert len(page_ids) == 1100
     assert progress_updates == [500, 1000]
+
+
+def test_real_space_page_list_rejects_cross_origin_pagination_link(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    payloads = [
+        _valid_space_page_list_payload(
+            page_ids=["100"],
+            next_url="https://attacker.example/collect?token=leak",
+        )
+    ]
+    requested_urls: list[str] = []
+
+    def fake_urlopen(api_request: Any, **kwargs: object) -> _FakeHTTPResponse:
+        del kwargs
+        requested_urls.append(api_request.full_url)
+        return _FakeHTTPResponse(payloads.pop(0))
+
+    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    with pytest.raises(ValueError, match="pagination link is outside"):
+        list_real_space_page_ids(
+            "ENG",
+            base_url="https://example.com/wiki",
+            auth_method="bearer-env",
+        )
+
+    assert len(requested_urls) == 1
+    assert "attacker.example" not in requested_urls[0]
+
+
+def test_real_space_page_list_accepts_absolute_same_origin_pagination_link(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    payloads = [
+        _valid_space_page_list_payload(
+            page_ids=["100"],
+            next_url="https://example.com/wiki/rest/api/content?start=1",
+        ),
+        _valid_space_page_list_payload(page_ids=["200"]),
+    ]
+    requested_urls: list[str] = []
+
+    def fake_urlopen(api_request: Any, **kwargs: object) -> _FakeHTTPResponse:
+        del kwargs
+        requested_urls.append(api_request.full_url)
+        return _FakeHTTPResponse(payloads.pop(0))
+
+    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    assert list_real_space_page_ids(
+        "ENG",
+        base_url="https://example.com/wiki",
+        auth_method="bearer-env",
+    ) == ["100", "200"]
+    assert requested_urls[1] == "https://example.com/wiki/rest/api/content?start=1"
 
 
 def test_real_space_page_list_does_not_report_progress_for_small_runs(

--- a/tests/confluence/test_client.py
+++ b/tests/confluence/test_client.py
@@ -246,6 +246,52 @@ def test_real_space_page_list_accepts_absolute_same_origin_pagination_link(
 
 
 @pytest.mark.parametrize(
+    ("base_url", "next_url", "expected_next_url"),
+    [
+        (
+            "https://example.com/confluence",
+            "/rest/api/content?start=1",
+            "https://example.com/confluence/rest/api/content?start=1",
+        ),
+        (
+            "https://example.com/wiki",
+            "/wiki/rest/api/content?start=1",
+            "https://example.com/wiki/rest/api/content?start=1",
+        ),
+    ],
+)
+def test_real_space_page_list_resolves_root_relative_pagination_under_instance_path(
+    monkeypatch: MonkeyPatch,
+    base_url: str,
+    next_url: str,
+    expected_next_url: str,
+) -> None:
+    payloads = [
+        _valid_space_page_list_payload(page_ids=["100"], next_url=next_url),
+        _valid_space_page_list_payload(page_ids=["200"]),
+    ]
+    requested_urls: list[str] = []
+
+    def fake_urlopen(api_request: Any, **kwargs: object) -> _FakeHTTPResponse:
+        del kwargs
+        requested_urls.append(api_request.full_url)
+        return _FakeHTTPResponse(payloads.pop(0))
+
+    monkeypatch.setenv("CONFLUENCE_BEARER_TOKEN", "test-token")
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    assert list_real_space_page_ids(
+        "ENG",
+        base_url=base_url,
+        auth_method="bearer-env",
+    ) == ["100", "200"]
+    assert requested_urls == [
+        f"{base_url}/rest/api/content?spaceKey=ENG&type=page&start=0&limit=100",
+        expected_next_url,
+    ]
+
+
+@pytest.mark.parametrize(
     "next_url",
     [
         "https://example.com/wiki/../outside",


### PR DESCRIPTION
## Summary

- Constrain Confluence pagination links to the configured origin and normalized instance path.
- Preserve Data Center root-relative pagination for path-mounted instances: `/rest/api/...` under `https://example.com/confluence` now requests `/confluence/rest/api/...`.
- Preserve root-relative links that already include the instance path, absolute same-origin links, and query strings.
- Reject cross-origin, raw traversal, and percent-encoded traversal before any authenticated follow-up request.

## Provider semantics

Atlassian’s [Confluence REST API pagination example](https://developer.atlassian.com/server/confluence/confluence-rest-api-examples/) returns root-relative `_links.next` alongside a path-mounted `base` and `context`; this compatibility correction follows that documented shape.

## Validation

- `make check` passed: Ruff, mypy, and 796 tests.
- Focused coverage verifies `/rest/api/content?start=1` resolves beneath `/confluence`, while `/wiki/rest/api/content?start=1` does not duplicate `/wiki`.
- Retained traversal regressions prove only the initial request is made for invalid links.
- Hosted Check run [32787552404](https://github.com/ctrl-alt-keith/knowledge-adapters/actions/runs/32787552404) passed.
- Tested commit: `dd0e1f54d7f77de63ce373c774cca2ea6eee2d78`.

## Residual risk

Decoded dot segments remain conservatively rejected. The client continues to use bounded standard URL parsing and does not broaden authentication behavior.

## Review boundary

This remains one proposal-only security and compatibility change. Human review and merge are required; no merge or auto-merge was performed.