### PR TITLE
docs: add Claude Code startup router

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,14 @@
+# CLAUDE.md
+
+This file routes Claude Code sessions to the canonical instruction sources.
+It is not an authority layer and contains no doctrine of its own.
+
+Read, in order:
+
+1. [`AGENTS.md`](AGENTS.md) — canonical repository execution layer.
+2. [Playbook startup](https://github.com/ctrl-alt-keith/ai-workflow-playbook/blob/main/docs/start-here.md) — canonical startup route.
+3. [Claude adapter](https://github.com/ctrl-alt-keith/ai-workflow-playbook/blob/main/docs/tool-adapters/claude.md) — executor-specific guidance.
+
+If anything here conflicts with those authoritative sources, they win and this
+file is wrong.
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,12 +3,14 @@
 This file routes Claude Code sessions to the canonical instruction sources.
 It is not an authority layer and contains no doctrine of its own.
 
-Read, in order:
+Read these routing sources in startup order:
 
-1. [`AGENTS.md`](AGENTS.md) — canonical repository execution layer.
-2. [Playbook startup](https://github.com/ctrl-alt-keith/ai-workflow-playbook/blob/main/docs/start-here.md) — canonical startup route.
+1. [Playbook startup](https://github.com/ctrl-alt-keith/ai-workflow-playbook/blob/main/docs/start-here.md) — canonical startup route.
+2. [`AGENTS.md`](AGENTS.md) — repository execution layer.
 3. [Claude adapter](https://github.com/ctrl-alt-keith/ai-workflow-playbook/blob/main/docs/tool-adapters/claude.md) — executor-specific guidance.
+
+This list is startup order, not instruction precedence; the Playbook's
+Repository Instruction Hierarchy governs precedence.
 
 If anything here conflicts with those authoritative sources, they win and this
 file is wrong.
-


### PR DESCRIPTION
Adds a root CLAUDE.md that routes Claude Code to canonical instruction sources without duplicating doctrine. Validation: make check.