### PR TITLE
Harden public URL validation

### DIFF
--- a/src/knowledge_adapters/public_sources.py
+++ b/src/knowledge_adapters/public_sources.py
@@ -92,9 +92,9 @@ def validate_public_http_url(url: str) -> None:
     if parsed.username or parsed.password:
         raise ValueError("URL must not include embedded credentials.")
     try:
-        hostname = parsed.hostname
+        hostname, _ = parsed.hostname, parsed.port
     except ValueError as exc:
-        raise ValueError("URL host is invalid.") from exc
+        raise ValueError("URL host or port is invalid.") from exc
     if hostname is None or not hostname.strip():
         raise ValueError("URL must include a host.")
 
@@ -103,6 +103,8 @@ def validate_public_http_url(url: str) -> None:
 
 def _validate_public_hostname(hostname: str) -> None:
     normalized_hostname = hostname.rstrip(".").lower()
+    if "%" in normalized_hostname:
+        raise ValueError("URL host must not include an IPv6 zone identifier.")
     if normalized_hostname == "localhost":
         raise ValueError("URL host must not be localhost.")
     if normalized_hostname.endswith(".local"):

--- a/tests/test_public_sources.py
+++ b/tests/test_public_sources.py
@@ -165,6 +165,7 @@ def test_fetch_public_url_rejects_oversized_streamed_response_with_bounded_read(
     "url",
     (
         "https://example.com/article",
+        "https://example.com:8443/article",
         "http://subdomain.example.org/report",
         "https://8.8.8.8/dns-over-https",
         "https://[2606:4700:4700::1111]/",
@@ -203,6 +204,9 @@ def test_validate_public_http_url_accepts_public_http_targets(url: str) -> None:
         "https://[::]/report",
         "https://240.0.0.1/report",
         "https://[2001:db8::1]/report",
+        "https://[fe80::1%25en0]/report",
+        "https://example.com:99999/report",
+        "https://example.com:not-a-port/report",
     ),
 )
 def test_validate_public_http_url_rejects_local_private_internal_targets(url: str) -> None:


### PR DESCRIPTION
## Summary
- reject malformed URL ports before public-source fetches
- reject scoped IPv6 literals that are not valid public source hosts
- cover valid explicit ports and rejected malformed/scoped hosts

## Testing
- make check (Ruff, mypy, 803 tests)
- make check-gh-env