### PR TITLE
test: reject malformed public response sizes

### DIFF
--- a/src/knowledge_adapters/public_sources.py
+++ b/src/knowledge_adapters/public_sources.py
@@ -54,11 +54,16 @@ def fetch_public_url(
             content_charset = headers.get_content_charset()
             _validate_content_type(content_type, accepted_content_types)
             content_length = headers.get("Content-Length")
-            if content_length is not None and int(content_length) > max_bytes:
-                raise ValueError(
-                    f"Response is too large: {content_length} bytes exceeds "
-                    f"{max_bytes} byte limit."
-                )
+            if content_length is not None:
+                try:
+                    declared_size = int(content_length)
+                except ValueError as exc:
+                    raise ValueError("Response Content-Length header is invalid.") from exc
+                if declared_size > max_bytes:
+                    raise ValueError(
+                        f"Response is too large: {content_length} bytes exceeds "
+                        f"{max_bytes} byte limit."
+                    )
             content = response.read(max_bytes + 1)
     except HTTPError as exc:
         raise ValueError(f"HTTP request failed for {url}: {exc.code} {exc.reason}.") from exc

--- a/src/knowledge_adapters/public_sources.py
+++ b/src/knowledge_adapters/public_sources.py
@@ -55,10 +55,14 @@ def fetch_public_url(
             _validate_content_type(content_type, accepted_content_types)
             content_length = headers.get("Content-Length")
             if content_length is not None:
-                try:
-                    declared_size = int(content_length)
-                except ValueError as exc:
-                    raise ValueError("Response Content-Length header is invalid.") from exc
+                effective_content_length = content_length.strip(" \t")
+                if (
+                    not effective_content_length
+                    or not effective_content_length.isascii()
+                    or not effective_content_length.isdecimal()
+                ):
+                    raise ValueError("Response Content-Length header is invalid.")
+                declared_size = int(effective_content_length)
                 if declared_size > max_bytes:
                     raise ValueError(
                         f"Response is too large: {content_length} bytes exceeds "

--- a/tests/test_public_sources.py
+++ b/tests/test_public_sources.py
@@ -137,15 +137,20 @@ def test_fetch_public_url_rejects_oversized_declared_response_before_reading(
     assert response.read_amounts == []
 
 
-def test_fetch_public_url_rejects_malformed_declared_response_size_before_reading(
+@pytest.mark.parametrize(
+    "content_length",
+    ("not-a-size", "-1", "+1", "1_0", "", "١"),
+)
+def test_fetch_public_url_rejects_invalid_declared_response_size_before_reading(
     monkeypatch: MonkeyPatch,
+    content_length: str,
 ) -> None:
     response = _FakeResponse(
         url=MEANINGFULTECH_URL,
         content=b"not read",
         content_type="text/html",
     )
-    response.headers.replace_header("Content-Length", "not-a-size")
+    response.headers.replace_header("Content-Length", content_length)
     monkeypatch.setattr(
         "knowledge_adapters.public_sources.urlopen",
         lambda request, timeout: response,
@@ -159,6 +164,36 @@ def test_fetch_public_url_rejects_malformed_declared_response_size_before_readin
         )
 
     assert response.read_amounts == []
+
+
+@pytest.mark.parametrize(
+    ("content_length", "content"),
+    (("0", b""), ("0005", b"hello"), (" \t5\t ", b"hello")),
+)
+def test_fetch_public_url_accepts_decimal_declared_response_size_with_http_whitespace(
+    monkeypatch: MonkeyPatch,
+    content_length: str,
+    content: bytes,
+) -> None:
+    response = _FakeResponse(
+        url=MEANINGFULTECH_URL,
+        content=content,
+        content_type="text/html",
+    )
+    response.headers.replace_header("Content-Length", content_length)
+    monkeypatch.setattr(
+        "knowledge_adapters.public_sources.urlopen",
+        lambda request, timeout: response,
+    )
+
+    fetched = fetch_public_url(
+        MEANINGFULTECH_URL,
+        accepted_content_types=("text/html",),
+        max_bytes=1000,
+    )
+
+    assert fetched.content == content
+    assert response.read_amounts == [1001]
 
 
 def test_fetch_public_url_rejects_oversized_streamed_response_with_bounded_read(

--- a/tests/test_public_sources.py
+++ b/tests/test_public_sources.py
@@ -137,6 +137,30 @@ def test_fetch_public_url_rejects_oversized_declared_response_before_reading(
     assert response.read_amounts == []
 
 
+def test_fetch_public_url_rejects_malformed_declared_response_size_before_reading(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    response = _FakeResponse(
+        url=MEANINGFULTECH_URL,
+        content=b"not read",
+        content_type="text/html",
+    )
+    response.headers.replace_header("Content-Length", "not-a-size")
+    monkeypatch.setattr(
+        "knowledge_adapters.public_sources.urlopen",
+        lambda request, timeout: response,
+    )
+
+    with pytest.raises(ValueError, match="Content-Length header is invalid"):
+        fetch_public_url(
+            MEANINGFULTECH_URL,
+            accepted_content_types=("text/html",),
+            max_bytes=1000,
+        )
+
+    assert response.read_amounts == []
+
+
 def test_fetch_public_url_rejects_oversized_streamed_response_with_bounded_read(
     monkeypatch: MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- Preserve the original diagnostic improvement: nonnumeric `Content-Length` already failed before any response-body read.
- Harden the accepted grammar to ASCII decimal digits only, after the parser-permitted surrounding space/tab whitespace.
- Add mocked regressions for invalid values, valid zero/leading-zero values, and permitted surrounding whitespace.

## HTTP contract

- RFC 9110 §8.6: `Content-Length = 1*DIGIT` — https://www.rfc-editor.org/rfc/rfc9110.html#section-8.6
- RFC 9112 §5.1: field extraction excludes only surrounding optional whitespace — https://www.rfc-editor.org/rfc/rfc9112.html#section-5.1

This is grammar hardening and regression coverage; it does not describe the pre-existing gap as a newly introduced size-limit bypass.

## Testing

- make check (808 passed)
- git diff --check
- make check-gh-env

Human review and merge remain required.